### PR TITLE
change view processor json URL

### DIFF
--- a/_settings/processors.json
+++ b/_settings/processors.json
@@ -5,7 +5,7 @@
     "mappings" :  "_defaults/posts_mappings.json"
   },
   "views" : {
-    "url" :       "$WORDPRESS/?json=1&post_type=view",
+    "url" :       "$WORDPRESS/api/get_recent_posts/?post_type=view",
     "processor" : "wordpress_view_processor"
   }
 }


### PR DESCRIPTION
Something changed on the wordpress side that makes the old URL no longer work-- but this does.
