### PR TITLE
Fixes share_twitter_url error on blog pages.

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,4 +1,6 @@
 
+{% import "macros.html" as macros %}
+
 <article class="post">
     <header>
         {% if post.category.0 %}
@@ -34,36 +36,7 @@
                 {{ post.date|date("%b %d, %Y") }}
             </span>
         </div>
-        <ul class="post_share list__horizontal">
-            <li class="list_item">
-                <a class="share-icon"
-                   href="http://api.addthis.com/oexchange/0.8/forward/email/offer?url={{ request.url|urlencode }}&amp;title={{ post.title }}&amp;pubid=ra-4da354ee346886d2">
-                    <span class="cf-icon cf-icon-email-social-square"></span>
-                    <span class="u-visually-hidden">Share by email</span>
-                </a>
-            </li>
-            <li class="list_item">
-                <a class="share-icon"
-                   href="https://www.facebook.com/dialog/share?app_id=210516218981921&amp;display=page&amp;href={{ request.url|urlencode }}&amp;redirect_uri={{ request.url|urlencode }}">
-                    <span class="cf-icon cf-icon-facebook-square"></span>
-                    <span class="u-visually-hidden">Share on Facebook</span>
-                </a>
-            </li>
-            <li class="list_item">
-                <a class="share-icon"
-                   href="{{ share_twitter_url() }}"
-                   target="_blank">
-                    <span class="cf-icon cf-icon-twitter-square"></span>
-                    <span class="u-visually-hidden">Share on Twitter</span>
-                </a>
-            </li>
-            <!-- <li class="list_item">
-                <a class="share-icon" href="#">
-                    <span class="cf-icon cf-icon-linkedin-square"></span>
-                    <span class="u-visually-hidden">Share on LinkedIn</span>
-                </a>
-            </li> -->
-        </ul>
+        {{ macros.share(self.title(), false) }}
     {% if post.thumbnail.images %}
         <img class="post_featured-img"
              src="{{ post.thumbnail.images.full.url }}"

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,8 +23,6 @@
 <!--[if IE 8]>         <html lang="en" class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
 
-{% from "macros.html" import share_twitter_url with context %}
-
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">
 
 <!--
@@ -134,7 +132,7 @@
     =================
 -->
 
-{% block body scoped %}
+{% block body %}
 
 <div class="beta-banner expandable" id="beta-banner">
     <div class="wrapper wrapper__match-content">
@@ -164,7 +162,7 @@
     {% include "header.html" %}
 
     <!-- PRIMARY CONTENT -->
-    {% block content scoped %}
+    {% block content %}
         This will be replaced in templates that extend this template and override "content".
     {% endblock content %}
     <!-- /PRIMARY CONTENT -->


### PR DESCRIPTION
There were two issues here. The issue that caused this to appear was that I made a recent update that nested the `content` block inside of one called `body` and didn't add the `scoped` attribute. The other issue was that `article.html` was never updated to use the share macro. This PR finally updates `article.html` which also removes the need to import the twitter share macro on every page.
