### PR TITLE
Adds manual order to calendar filters.

### DIFF
--- a/_layouts/post-macros.html
+++ b/_layouts/post-macros.html
@@ -186,10 +186,6 @@
 
         Allows you to disable showing the count label.
 
-   user_options.calendar_filter_order:
-
-        An array of values used in ordering the calendar filters.
-
    user_options.id_prefix:
 
         ID's are automatically added to certain elements that need them, but if
@@ -222,7 +218,6 @@
     'show_current_filters':     true,
     'show_unfiltered_count':    false,
     'show_filters_label':       true,
-    'calendar_filter_order':    [],
     'id_prefix':                '',
     'id_tags':                  'filter_tags',
     'id_author':                'filter_author',
@@ -395,23 +390,18 @@
                 <label class="form-label-header">
                     Calendars
                 </label>
-            {% set calendars = query.possible_values_for('calendar')|sort(attribute='term') -%}
-            {% set ordered_calendars = [] -%}
-            {% set non_ordered_calendars = [] -%}
-            {% for id in options.calendar_filter_order -%}
-                {% for calendar in calendars -%}
-                    {% if calendar.term == id -%}
-                        {% set _ignore = ordered_calendars.append(calendar) %}
-                        {% set _ignore = calendars.pop(loop.index0) %}
-                    {% endif %}
-                {% endfor %}
-            {% endfor %}
-            {%- set _ignore = ordered_calendars.extend(calendars) -%}
-            {% for calendar in ordered_calendars -%}
                 <label class="form-group_item">
-                    {{ filter_checkbox('calendar', calendar.term)|safe }}
+                    {{ filter_checkbox('calendar', 'Richard Cordray')|safe }}
                 </label>
-            {% endfor %}
+                <label class="form-group_item">
+                    {{ filter_checkbox('calendar', 'Steve Antonakes')|safe }}
+                </label>
+                <label class="form-group_item">
+                    {{ filter_checkbox('calendar', 'Raj Date')|safe }}
+                </label>
+                <label class="form-group_item">
+                    {{ filter_checkbox('calendar', 'Elizabeth Warren')|safe }}
+                </label>
             </div>
         </div>
 

--- a/the-bureau/leadership-calendar/index.html
+++ b/the-bureau/leadership-calendar/index.html
@@ -71,15 +71,7 @@
 
                         {{ post_macros.filters(
                             ['calendar', 'range_date'], query, posts, 'calendar_event',
-                            {
-                                'expand_label': 'Filter calendars',
-                                'calendar_filter_order': [
-                                    'Richard Cordray',
-                                    'Steve Antonakes',
-                                    'Raj Date',
-                                    'Elizabeth Warren'
-                                ]
-                            }
+                            { 'expand_label': 'Filter calendars' }
                         ) }}
 
                     {% import "leadership-calendar-table.html" as calendar %}
@@ -104,12 +96,6 @@
                                 'id_prefix': 'download',
                                 'expand_label': 'Download options',
                                 'show_current_filters': false,
-                                'calendar_filter_order': [
-                                    'Richard Cordray',
-                                    'Steve Antonakes',
-                                    'Raj Date',
-                                    'Elizabeth Warren'
-                                ],
                                 'action': 'pdf/',
                                 'submit_label': 'Download PDF'
                             }


### PR DESCRIPTION
There was a request by @jameshupp to order the calendar filters in a more meaningful way. This PR does that. The only drawback is that when new calendars are added, we will need to manually add it to the list of filters. Not a big deal though since that will happen infrequently.
