### PR TITLE
Add more browser test coverage and clean up test code

### DIFF
--- a/_tests/fixtures/newsroom.json
+++ b/_tests/fixtures/newsroom.json
@@ -44,7 +44,7 @@
         "slug": "batman"
       }
     ],
-    "id": 45929,
+    "id": 45934,
     "custom_fields": {},
     "category": [
       "Op-Ed"
@@ -87,13 +87,13 @@
       }
     ],
     "date": "2010-09-17T04:41:50Z",
-    "slug": "fighting-to-protect-testers",
+    "slug": "fighting-to-protect-testers-1",
     "comment_status": "closed",
     "title_plain": "Fighting to Protect Testers",
     "title": "Fighting to Protect Testers",
     "modified": "2010-09-17 04:41:50",
     "dek": "Test dek",
-    "_id": "fighting-to-protect-testers",
+    "_id": "fighting-to-protect-testers-1",
     "order": 0
   },
   {
@@ -127,7 +127,7 @@
         "slug": "batman"
       }
     ],
-    "id": 45893,
+    "id": 45898,
     "custom_fields": {},
     "category": [
       "Op-Ed"
@@ -154,13 +154,13 @@
       }
     ],
     "date": "2010-11-10T12:00:52Z",
-    "slug": "ttttttest",
+    "slug": "ttttttest-3",
     "comment_status": "closed",
     "title_plain": "Ttttttest",
     "title": "Ttttttest",
     "modified": "2010-11-10 12:00:52",
     "dek": "The dek goes here",
-    "_id": "ttttttest",
+    "_id": "ttttttest-3",
     "order": 0
   },
   {
@@ -226,13 +226,13 @@
       }
     ],
     "date": "2011-01-06T04:51:16Z",
-    "slug": "this-is-for-testing-purposes",
+    "slug": "this-is-for-testing-purposes-1",
     "comment_status": "closed",
     "title_plain": "This is for testing purposes",
     "title": "This is for testing purposes",
     "modified": "2011-01-06 04:51:16",
     "dek": "Some sort of dek info",
-    "_id": "this-is-for-testing-purposes",
+    "_id": "this-is-for-testing-purposes-1",
     "order": 0
   },
   {
@@ -308,13 +308,1203 @@
       }
     ],
     "date": "2011-01-06T20:50:14Z",
-    "slug": "just-more-testing",
+    "slug": "just-more-testing-1",
     "comment_status": "closed",
     "title_plain": "Blah blah blah",
     "title": "Blah blah blah",
     "modified": "2011-01-06 20:50:14",
     "dek": "Dek info here",
-    "_id": "just-more-testing",
+    "_id": "just-more-testing-1",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "This is just an excerpt of the content",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 26,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 188,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45930,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Some test content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Foreclosure",
+      "Mortgages"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 29,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 255,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "date": "2010-09-17T04:41:50Z",
+    "slug": "fighting-to-protect-testers-2",
+    "comment_status": "closed",
+    "title_plain": "Fighting to Protect Testers",
+    "title": "Fighting to Protect Testers",
+    "modified": "2010-09-17 04:41:50",
+    "dek": "Test dek",
+    "_id": "fighting-to-protect-testers-2",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Test excerpt for this post",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 97,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45894,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Here is a bunch of content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Banking"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 98,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "date": "2010-11-10T12:00:52Z",
+    "slug": "ttttttest-4",
+    "comment_status": "closed",
+    "title_plain": "Ttttttest",
+    "title": "Ttttttest",
+    "modified": "2010-11-10 12:00:52",
+    "dek": "The dek goes here",
+    "_id": "ttttttest-4",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpts are shorter versions of the real thing",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 28,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Press Release",
+        "post_count": 245,
+        "slug": "pressrelease",
+        "id": 425
+      }
+    ],
+    "taxonomy_author": [],
+    "id": 45928,
+    "custom_fields": {},
+    "category": [
+      "Press Release"
+    ],
+    "author": [],
+    "content": "Some content would be cool to go here",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Personnel",
+      "Servicemembers"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 69,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "date": "2011-01-06T04:51:16Z",
+    "slug": "this-is-for-testing-purposes-2",
+    "comment_status": "closed",
+    "title_plain": "This is for testing purposes",
+    "title": "This is for testing purposes",
+    "modified": "2011-01-06 04:51:16",
+    "dek": "Some sort of dek info",
+    "_id": "this-is-for-testing-purposes-2",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpt Excerpt Excerpt",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45924,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "More blog content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Personnel"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "date": "2011-01-06T20:50:14Z",
+    "slug": "just-more-testing-2",
+    "comment_status": "closed",
+    "title_plain": "Blah blah blah",
+    "title": "Blah blah blah",
+    "modified": "2011-01-06 20:50:14",
+    "dek": "Dek info here",
+    "_id": "just-more-testing-2",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "This is just an excerpt of the content",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 26,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 188,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45931,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Some test content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Foreclosure",
+      "Mortgages"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 29,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 255,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "date": "2010-09-17T04:41:50Z",
+    "slug": "fighting-to-protect-testers-3",
+    "comment_status": "closed",
+    "title_plain": "Fighting to Protect Testers",
+    "title": "Fighting to Protect Testers",
+    "modified": "2010-09-17 04:41:50",
+    "dek": "Test dek",
+    "_id": "fighting-to-protect-testers-3",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Test excerpt for this post",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 97,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45895,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Here is a bunch of content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Banking"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 98,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "date": "2010-11-10T12:00:52Z",
+    "slug": "ttttttest-5",
+    "comment_status": "closed",
+    "title_plain": "Ttttttest",
+    "title": "Ttttttest",
+    "modified": "2010-11-10 12:00:52",
+    "dek": "The dek goes here",
+    "_id": "ttttttest-5",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpts are shorter versions of the real thing",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 28,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Press Release",
+        "post_count": 245,
+        "slug": "pressrelease",
+        "id": 425
+      }
+    ],
+    "taxonomy_author": [],
+    "id": 45929,
+    "custom_fields": {},
+    "category": [
+      "Press Release"
+    ],
+    "author": [],
+    "content": "Some content would be cool to go here",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Personnel",
+      "Servicemembers"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 69,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "date": "2011-01-06T04:51:16Z",
+    "slug": "this-is-for-testing-purposes-3",
+    "comment_status": "closed",
+    "title_plain": "This is for testing purposes",
+    "title": "This is for testing purposes",
+    "modified": "2011-01-06 04:51:16",
+    "dek": "Some sort of dek info",
+    "_id": "this-is-for-testing-purposes-3",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpt Excerpt Excerpt",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45925,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "More blog content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Personnel"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "date": "2011-01-06T20:50:14Z",
+    "slug": "just-more-testing-3",
+    "comment_status": "closed",
+    "title_plain": "Blah blah blah",
+    "title": "Blah blah blah",
+    "modified": "2011-01-06 20:50:14",
+    "dek": "Dek info here",
+    "_id": "just-more-testing-3",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "This is just an excerpt of the content",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 26,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 188,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45932,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Some test content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Foreclosure",
+      "Mortgages"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 29,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 255,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "date": "2010-09-17T04:41:50Z",
+    "slug": "fighting-to-protect-testers-4",
+    "comment_status": "closed",
+    "title_plain": "Fighting to Protect Testers",
+    "title": "Fighting to Protect Testers",
+    "modified": "2010-09-17 04:41:50",
+    "dek": "Test dek",
+    "_id": "fighting-to-protect-testers-4",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Test excerpt for this post",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 97,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45896,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Here is a bunch of content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Banking"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 98,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "date": "2010-11-10T12:00:52Z",
+    "slug": "ttttttest-1",
+    "comment_status": "closed",
+    "title_plain": "Ttttttest",
+    "title": "Ttttttest",
+    "modified": "2010-11-10 12:00:52",
+    "dek": "The dek goes here",
+    "_id": "ttttttest-1",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpts are shorter versions of the real thing",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 28,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Press Release",
+        "post_count": 245,
+        "slug": "pressrelease",
+        "id": 425
+      }
+    ],
+    "taxonomy_author": [],
+    "id": 45930,
+    "custom_fields": {},
+    "category": [
+      "Press Release"
+    ],
+    "author": [],
+    "content": "Some content would be cool to go here",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Personnel",
+      "Servicemembers"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 69,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "date": "2011-01-06T04:51:16Z",
+    "slug": "this-is-for-testing-purposes-4",
+    "comment_status": "closed",
+    "title_plain": "This is for testing purposes",
+    "title": "This is for testing purposes",
+    "modified": "2011-01-06 04:51:16",
+    "dek": "Some sort of dek info",
+    "_id": "this-is-for-testing-purposes-4",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpt Excerpt Excerpt",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45926,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "More blog content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Personnel"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      }
+    ],
+    "date": "2011-01-06T20:50:14Z",
+    "slug": "just-more-testing-4",
+    "comment_status": "closed",
+    "title_plain": "Blah blah blah",
+    "title": "Blah blah blah",
+    "modified": "2011-01-06 20:50:14",
+    "dek": "Dek info here",
+    "_id": "just-more-testing-4",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "This is just an excerpt of the content",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 88,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 26,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 188,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45933,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Some test content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Credit cards",
+      "Foreclosure",
+      "Mortgages"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 112,
+        "description": "",
+        "title": "Credit cards",
+        "id": 19,
+        "slug": "credit-cards"
+      },
+      {
+        "post_count": 29,
+        "description": "",
+        "title": "Foreclosure",
+        "id": 441,
+        "slug": "foreclosure"
+      },
+      {
+        "post_count": 255,
+        "description": "",
+        "title": "Mortgages",
+        "id": 23,
+        "slug": "mortgages"
+      }
+    ],
+    "date": "2010-09-17T04:41:50Z",
+    "slug": "fighting-to-protect-testers-5",
+    "comment_status": "closed",
+    "title_plain": "Fighting to Protect Testers",
+    "title": "Fighting to Protect Testers",
+    "modified": "2010-09-17 04:41:50",
+    "dek": "Test dek",
+    "_id": "fighting-to-protect-testers-5",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Test excerpt for this post",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 97,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Op-Ed",
+        "post_count": 17,
+        "slug": "op-ed",
+        "id": 443
+      }
+    ],
+    "taxonomy_author": [
+      {
+        "post_count": 30,
+        "description": "",
+        "title": "Batman",
+        "id": 779,
+        "slug": "batman"
+      }
+    ],
+    "id": 45897,
+    "custom_fields": {},
+    "category": [
+      "Op-Ed"
+    ],
+    "author": [
+      "Batman"
+    ],
+    "content": "Here is a bunch of content",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Banking"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 98,
+        "description": "",
+        "title": "Banking",
+        "id": 435,
+        "slug": "banking-2"
+      }
+    ],
+    "date": "2010-11-10T12:00:52Z",
+    "slug": "ttttttest-2",
+    "comment_status": "closed",
+    "title_plain": "Ttttttest",
+    "title": "Ttttttest",
+    "modified": "2010-11-10 12:00:52",
+    "dek": "The dek goes here",
+    "_id": "ttttttest-2",
+    "order": 0
+  },
+  {
+    "attachments": [],
+    "excerpt": "Excerpts are shorter versions of the real thing",
+    "taxonomy_cfpb_newsroom_tag_taxonomy": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 28,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "taxonomy_cfpb_newsroom_cat_taxonomy": [
+      {
+        "description": "",
+        "parent": 0,
+        "title": "Press Release",
+        "post_count": 245,
+        "slug": "pressrelease",
+        "id": 425
+      }
+    ],
+    "taxonomy_author": [],
+    "id": 45931,
+    "custom_fields": {},
+    "category": [
+      "Press Release"
+    ],
+    "author": [],
+    "content": "Some content would be cool to go here",
+    "comment_count": 0,
+    "categories": [],
+    "type": "cfpb_newsroom",
+    "status": "publish",
+    "parent": 0,
+    "tags": [
+      "Personnel",
+      "Servicemembers"
+    ],
+    "taxonomy_fj_tag": [
+      {
+        "post_count": 32,
+        "description": "",
+        "title": "Personnel",
+        "id": 433,
+        "slug": "personnel"
+      },
+      {
+        "post_count": 69,
+        "description": "",
+        "title": "Servicemembers",
+        "id": 32,
+        "slug": "servicemembers"
+      }
+    ],
+    "date": "2011-01-06T04:51:16Z",
+    "slug": "this-is-for-testing-purposes-5",
+    "comment_status": "closed",
+    "title_plain": "This is for testing purposes",
+    "title": "This is for testing purposes",
+    "modified": "2011-01-06 04:51:16",
+    "dek": "Some sort of dek info",
+    "_id": "this-is-for-testing-purposes-5",
     "order": 0
   }
 ]

--- a/_tests/test.py
+++ b/_tests/test.py
@@ -4,12 +4,8 @@ import datetime
 from nose.plugins.attrib import attr
 from selenium import webdriver
 from flask.ext.testing import LiveServerTestCase
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 from .test_helpers import *
-
 from sheer.wsgi import app_with_config
 
 SAUCE_TESTING = os.environ.get('SAUCE_TESTING')
@@ -52,181 +48,254 @@ class NewsroomTestCase(LiveServerTestCase):
                 command_executor=sauce_url)
         else:
             self.driver = webdriver.Chrome()
+        
         self.driver.set_window_size(1400, 850)
+        self.driver.implicitly_wait(10)
         self.driver.get('http://localhost:31337/newsroom/')
         self.filter_dropdown_button = self.driver.find_element_by_xpath('//button[contains(text(), "Filter posts")]')
         click_filter_posts(self)
 
-    @attr('test')
-    def test_filter_display_button(self):
-        filter_posts_display_button = self.driver.find_element_by_xpath(
-            '//button[contains(text(), "Filter posts")]'
-        )
-        assert filter_posts_display_button.is_displayed()
+	def test_filter_display_button(self):
+		filter_posts_display_button = self.driver.find_element_by_xpath(
+			'//button[contains(text(), "Filter posts")]'
+		)
+		assert filter_posts_display_button.is_displayed()
 
 
-    @attr('checkbox')
-    def test_filter_checkboxes(self):
-        category_list = ["Op-Ed", "Press Release"]
-        for cat in category_list:
-            checkbox = WebDriverWait(self.driver, 10).until(
-                EC.visibility_of_element_located((
-                    By.XPATH, '//label/span[contains(text(), "{0}")]/..'.format(cat)
-                ))
-            )
-            # checkbox = self.driver.find_element_by_xpath(
-            #     '//label/span[contains(text(), "{0}")]/..'.format(cat))
-            checkbox.click()
-            assert "is-checked" in checkbox.get_attribute('class')
-            checkbox.click()
-            assert "is-checkedFocus" in checkbox.get_attribute('class')
+	@attr('checkbox')
+	def test_filter_checkboxes(self):
+		category_list = ["Op-Ed", "Press Release"]
+		for cat in category_list:
+			checkbox = self.driver.find_element_by_xpath('//label/span[contains(text(), "'+ cat +'")]/..')
+			checkbox.click()
+			assert "is-checked" in checkbox.get_attribute('class')
+			checkbox.click()
+			assert "is-checkedFocus" in checkbox.get_attribute('class')
 
-    @attr('search')
-    @attr('category')
-    def test_filter_category_search(self):
-        category_list = ["Op-Ed", "Press Release"]
-        for cat in category_list:
-            click_filter_posts(self)
-            checkbox = WebDriverWait(self.driver, 10).until(
-                EC.visibility_of_element_located((
-                    By.XPATH, '//label/span[contains(text(), "{0}")]/..'.format(cat)))
-            )
-            checkbox.click()
-            filter_results_button = WebDriverWait(self.driver, 10).until(
-                EC.visibility_of_element_located((
-                    By.XPATH, '//input[@value="Apply filters"]'))
-            )
-            filter_results_button.click()
-            cat = coerce_category_for_dom(cat)
-            cat_type_elem = WebDriverWait(self.driver, 10).until(
-                EC.visibility_of_element_located((
-                    By.XPATH, '//a[@href="?filter_category={0}"]'.format(cat)))
-            )
-            assert cat_type_elem
-            click_filter_posts(self)
-            cat = coerce_category_for_dom(cat)
-            checkbox = WebDriverWait(self.driver, 10).until(
-                EC.visibility_of_element_located((
-                    By.XPATH, '//label/span[contains(text(), "{0}")]/..'.format(cat)))
-            )
-            checkbox.click()
+	@attr('search')
+	@attr('category')
+	def test_filter_category_search(self):
+		category_list = ["Op-Ed", "Press Release"]
+		for cat in category_list:
+			click_filter_posts(self)
+			checkbox = self.driver.find_element_by_xpath('//label/span[contains(text(), "'+ cat +'")]/..')
+			checkbox.click()
+			filter_results_button = self.driver.find_element_by_xpath('//input[@value="Apply filters"]')
+			filter_results_button.click()
+			cat = coerce_category(cat)
+			cat_type_elem = self.driver.find_element_by_xpath('//a[@href="?filter_category='+ cat +'"]')
+			assert cat_type_elem
+			results_num = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_header"]')
+			if cat == "Op-Ed":
+				assert "14" in results_num.text
+			elif cat == "Press Release":
+				assert "5" in results_num.text
+			click_filter_posts(self)
+			cat = coerce_category(cat)
+			checkbox = self.driver.find_element_by_xpath('//label/span[contains(text(), "'+ cat +'")]/..')
+			checkbox.click()
 
-    @attr('search')
-    @attr('topics')
-    def test_filter_topic_search(self):
-        topic_input = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, '//input[@value="Search for topics"]'
-            ))
-        )
-        topic_input.click()
-        topic_input.send_keys("for")
-        topic_choice_results = self.driver.find_element_by_xpath(
-            '//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]'
-        )
-        assert topic_choice_results.is_displayed()
-        choice = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, 
-                '//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"For")]/..'
-            ))
-        )
-        choice.click()
-        topic_elem = self.driver.find_element_by_xpath(
-            '//div[@id="filter_tags_chosen"]/ul/li/span[contains(text(), "Foreclosure")]'
-        )
-        assert topic_elem
+	@attr('search')
+	@attr('topic')
+	def test_filter_topic_search(self):
+		topic_input = self.driver.find_element_by_xpath('//input[@value="Search for topics"]')
+		topic_input.click()
+		topic_input.send_keys("for")
+		topic_choice_results = self.driver.find_element_by_xpath(
+			'//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]'
+		)
+		assert topic_choice_results.is_displayed()
+		choice = self.driver.find_element_by_xpath('//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"For")]/..')
+		choice.click()
+		topic_elem = self.driver.find_element_by_xpath(
+			'//div[@id="filter_tags_chosen"]/ul/li/span[contains(text(), "Foreclosure")]'
+		)
+		assert topic_elem
+		self.driver.find_element_by_xpath('//input[@value="Apply filters"]').click()
+		results_num = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_header"]')
+		results_filter = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_filter"]')
+		assert "5" in results_num.text
+		assert "Foreclosure" in results_filter.text
 
-    @attr('search')
-    @attr('authors')
-    def test_filter_author_search(self):
-        author_input = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, '//input[@value="Search for authors"]'
-            ))
-        )
-        author_input.click()
-        author_input.send_keys("bat")
-        author_choice_results = self.driver.find_element_by_xpath(
-            '//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]'
-        )
-        assert author_choice_results.is_displayed()
-        choice = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, 
-                '//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"Bat")]/..'
-            ))
-        )
-        choice.click()
-        author_elem = self.driver.find_element_by_xpath(
-            '//div[@id="filter_author_chosen"]/ul/li/span[contains(text(), "Batman")]'
-        )
-        assert author_elem
-        filter_results_button = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, '//input[@value="Apply filters"]'
-            ))
-        )
-        filter_results_button.click()
-        author = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, '//p[@class="summary_byline"][contains(text(), "Bat")]'
-            ))
-        )
-        assert author
 
-    @attr('search')
-    @attr('date')
-    def test_filter_date_search(self):
-        scroll_to_element(self.driver, WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, 
-                '//span[@class="header-slug_inner"][contains(text(), "Stay informed")]'
-            ))
-        ))
-        WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, 
-                '//div[@class="input-group_item custom-select is-enabled"]'
-            ))
-        )
-        
-        # click 'from month'
-        self.driver.find_element_by_xpath(
-            '//select[@id="filter_from-month"]/option[@value="01"]'
-        ).click() 
-        # click 'from year'
-        self.driver.find_element_by_xpath(
-            '//select[@id="filter_from-year"]/option[@value="2011"]'
-        ).click()
-        
-        # click 'to month'
-        self.driver.find_element_by_xpath(
-            '//select[@id="filter_to-month"]/option[@value="02"]'
-        ).click()
-        # click 'to year'
-        self.driver.find_element_by_xpath(
-            '//select[@id="filter_to-year"]/option[@value="2011"]'
-        ).click()
+	@attr('search')
+	@attr('author')
+	def test_filter_author_search(self):
+		author_input = self.driver.find_element_by_xpath('//input[@value="Search for authors"]')
+		author_input.click()
+		author_input.send_keys("bat")
+		author_choice_results = self.driver.find_element_by_xpath(
+			'//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]'
+		)
+		assert author_choice_results.is_displayed()
+		choice = self.driver.find_element_by_xpath('//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"Bat")]/..')
+		choice.click()
+		author_elem = self.driver.find_element_by_xpath(
+			'//div[@id="filter_author_chosen"]/ul/li/span[contains(text(), "Batman")]'
+		)
+		assert author_elem
+		filter_results_button = self.driver.find_element_by_xpath('//input[@value="Apply filters"]')
+		filter_results_button.click()
+		author = self.driver.find_element_by_xpath('//p[@class="summary_byline"][contains(text(), "Bat")]')
+		assert author
+		results_num = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_header"]')
+		results_filter = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_filter"]')
+		assert "14" in results_num.text
+		assert "Batman" in results_filter.text
 
-        # Search
-        WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH, '//input[@value="Apply filters"]'
-            ))
-        ).click()
+	@attr('search')
+	@attr('date')
+	def test_filter_date_search(self):
+		self.driver.find_element_by_xpath('//div[@class="input-group_item custom-select is-enabled"]')
+		
+		# click 'from month'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-month"]/option[@value="01"]'
+		).click() 
+		# click 'from year'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-year"]/option[@value="2011"]'
+		).click()
+		
+		# click 'to month'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-month"]/option[@value="02"]'
+		).click()
+		# click 'to year'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-year"]/option[@value="2011"]'
+		).click()
 
-        filtered_article_date = WebDriverWait(self.driver, 10).until(
-            EC.visibility_of_element_located((
-                By.XPATH,
-                '//div[@id="pagination_content"]/article[1]/div[1]/span[1]'
-            ))
-        )
-        filtered = 'jan' in filtered_article_date.text.lower() or 'feb' in filtered_article_date.text.lower()
-        assert filtered
+		# Search
+		self.driver.find_element_by_xpath('//input[@value="Apply filters"]').click()
 
-    def tearDown(self):
-        self.driver.close()
+		results_num = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_header"]')
+		results_filter = self.driver.find_element_by_xpath('//li[@class="list_item filtered-by_filter"]')
+		filtered_article_date = self.driver.find_element_by_xpath('//div[@id="pagination_content"]/article[1]/div[1]/span[1]')
+		
+		filtered = 'jan' in filtered_article_date.text.lower() or 'feb' in filtered_article_date.text.lower()
+		assert filtered
+		assert '9' in results_num.text
+		assert 'January 2011' in results_filter.text
+		assert 'February 2011' in results_filter.text
+
+	@attr('clear')
+	def test_clear_filters_button(self):
+		category_list = ["Op-Ed", "Press Release"]
+		for cat in category_list:
+			checkbox = self.driver.find_element_by_xpath('//label/span[contains(text(), "'+ cat +'")]/..')
+			checkbox.click()
+			assert "is-checked" in checkbox.get_attribute('class')
+		topic_input = self.driver.find_element_by_xpath('//input[@value="Search for topics"]')
+		topic_input.click()
+		topic_input.send_keys("for")
+		topic_choice_results = self.driver.find_element_by_xpath(
+			'//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]'
+		)
+		assert topic_choice_results.is_displayed()
+		choice = self.driver.find_element_by_xpath( 
+				'//div[@id="filter_tags_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"For")]/..'
+		)
+		choice.click()
+		topic_elem = self.driver.find_element_by_xpath(
+			'//div[@id="filter_tags_chosen"]/ul/li/span[contains(text(), "Foreclosure")]'
+		)
+		assert topic_elem
+		author_input = self.driver.find_element_by_xpath('//input[@value="Search for authors"]')
+		author_input.click()
+		author_input.send_keys("bat")
+		author_choice_results = self.driver.find_element_by_xpath(
+			'//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]'
+		)
+		assert author_choice_results.is_displayed()
+		choice = self.driver.find_element_by_xpath('//div[@id="filter_author_chosen"]/div/ul[@class="chosen-results"]/li/em[contains(text(),"Bat")]/..')
+		choice.click()
+		author_elem = self.driver.find_element_by_xpath(
+			'//div[@id="filter_author_chosen"]/ul/li/span[contains(text(), "Batman")]'
+		)
+		assert author_elem
+
+		# click 'from month'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-month"]/option[@value="01"]'
+		).click() 
+		# click 'from year'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-year"]/option[@value="2011"]'
+		).click()
+		
+		# click 'to month'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-month"]/option[@value="02"]'
+		).click()
+		# click 'to year'
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-year"]/option[@value="2011"]'
+		).click()
+
+		self.driver.find_element_by_xpath('//input[@value="Apply filters"]').click()
+		click_filter_posts(self)
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-month"]/option[@value="01"]'
+		).is_selected() 
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_from-year"]/option[@value="2011"]'
+		).is_selected()		
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-month"]/option[@value="02"]'
+		).is_selected()
+		self.driver.find_element_by_xpath(
+			'//select[@id="filter_to-year"]/option[@value="2011"]'
+		).is_selected()
+
+		self.driver.find_element_by_xpath('//input[@value="Clear filters"]').click()
+		for cat in category_list:
+			checkbox = self.driver.find_element_by_xpath('//label/span[contains(text(), "'+ cat +'")]/..')
+			unchecked = not "is-checked" in checkbox.get_attribute('class')
+			assert unchecked
+		self.driver.implicitly_wait(0)
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_tags_chosen"]/ul/li[@class="search-choice"]')) == 0
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_author_chosen"]/ul/li[@class="search-choice"]')) == 0
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_from-month"]/option[@selected="selected"]')) == 0
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_from-year"]/option[@selected="selected"]')) == 0
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_to-month"]/option[@selected="selected"]')) == 0
+		assert len(self.driver.find_elements_by_xpath('//div[@id="filter_to-year"]/option[@selected="selected"]')) == 0
+
+	@attr('pagination')
+	def test_pagination_display(self):
+		self.driver.find_element_by_xpath('//label/span[contains(text(), "Op-Ed")]/..').click()
+		self.driver.find_element_by_xpath('//input[@value="Apply filters"]')
+		assert self.driver.find_element_by_xpath('//nav[@class="post-pagination pagination"]/..').is_displayed()
+		
+		click_filter_posts(self)
+		self.driver.find_element_by_xpath('//label/span[contains(text(), "Op-Ed")]/..').click()
+		self.driver.find_element_by_xpath('//label/span[contains(text(), "Press Release")]/..').click()
+		self.driver.find_element_by_xpath('//input[@value="Apply filters"]').click()
+		self.driver.implicitly_wait(0)
+		assert len(self.driver.find_elements_by_xpath('//nav[@class="post-pagination pagination"]/..')) == 0
+
+	@attr('pagination')
+	def test_pagination_form(self):
+		next = self.driver.find_element_by_xpath('//a[@class="btn btn__super pagination_next"]')
+		scroll_to_element(self.driver, next)
+		next.click()
+		current_page_input = self.driver.find_element_by_id('pagination_current-page')
+		assert current_page_input.get_attribute('value') == '2'
+
+		prev = self.driver.find_element_by_xpath('//a[@class="btn btn__super pagination_prev"]')
+		scroll_to_element(self.driver, prev)
+		prev.click()
+		current_page_input = self.driver.find_element_by_id('pagination_current-page')
+		assert current_page_input.get_attribute('value') == '1'
+
+		self.driver.execute_script("window.document.getElementById('pagination_current-page').value = 2;")
+		self.driver.find_element_by_id('pagination_submit').click()
+		scroll_to_element(self.driver, self.driver.find_element_by_id('pagination_submit'))
+		current_page_input = self.driver.find_element_by_id('pagination_current-page')
+		assert current_page_input.get_attribute('value') == '2'
+
+	def tearDown(self):
+		self.driver.close()
 
 if __name__ == '__main__':
    nose.main()

--- a/_tests/test_helpers.py
+++ b/_tests/test_helpers.py
@@ -1,9 +1,12 @@
+from time import sleep
+
 def click_filter_posts(test):
     test.filter_dropdown_button = test.driver.find_element_by_xpath('//button[contains(text(), "Filter posts")]/..')
     if test.filter_dropdown_button.get_attribute('aria-pressed') == 'false':
         test.filter_dropdown_button.click()
+        sleep(1)
 
-def coerce_category_for_dom(category):
+def coerce_category(category):
     if category.find(' ') != -1:
         category = category.replace(' ', '+')
     elif category.find('+') != -1:


### PR DESCRIPTION
This adds browser tests for the Newsroom page to provide as much coverage as possible while cleaning up some code. These tests cover filtering articles based on Category, Topic, Author, and Date as well as testing the pagination of the results.
