### PR TITLE
Use PostgreSQL version 10 and cfpb username

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -52,7 +52,7 @@ export ALLOW_ADMIN_URL=True
 #########################################################################
 
 export DATABASE_URL=sqlite:///db.sqlite3
-#export DATABASE_URL=postgres://postgres@localhost/cfgov
+#export DATABASE_URL=postgres://cfpb@localhost/cfgov
 #export DATABASE_URL=mysql://root@localhost/v1
 
 # Required for existing MySQL-specific database scripts.

--- a/.python_env_SAMPLE
+++ b/.python_env_SAMPLE
@@ -16,9 +16,9 @@
 #########################################################################
 # DATABASE_URL=sqlite:///db.sqlite3
 
-# DATABASE_URL=postgres://cfgov:cfgov@postgres/cfgov
+# DATABASE_URL=postgres://cfpb:cfpb@postgres/cfgov
 # Required for Postgres dbshell in Django < 1.9.
-# PGPASSWORD=cfgov
+# PGPASSWORD=cfpb
 
 DATABASE_URL=mysql://v1:v1@mysql/v1
 # Required for existing MySQL-specific database scripts.

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ services:
   - postgresql
 
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
+  apt:
+    packages:
+    - postgresql-10
+    - postgresql-client-10
   chrome: stable
 
 cache:
@@ -33,7 +37,7 @@ branches:
     - master
 
 before_script:
-  - psql -c 'create database travis_ci_test;' -U postgres
+  - psql -c "ALTER USER travis WITH PASSWORD 'travis';"
 
 script:
   - ./travis_run.sh
@@ -43,6 +47,7 @@ env:
     - DJANGO_SETTINGS_MODULE=cfgov.settings.test
     - DJANGO_STAGING_HOSTNAME=content.localhost
     - COVERALLS_PARALLEL=true
+    - PGPORT=5433
 
 jobs:
   fast_finish: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,12 @@ services:
             - "9200:9200"
             - "9300:9300"
     postgres:
-        image: postgres:9.6
+        image: postgres:10.3
         restart: always
         environment:
-            POSTGRES_USER: cfgov
-            POSTGRES_PASSWORD: cfgov
+            POSTGRES_USER: cfpb
+            POSTGRES_PASSWORD: cfpb
+            POSTGRES_DB: cfgov
     python:
         build: .
         ports:

--- a/travis_run.sh
+++ b/travis_run.sh
@@ -9,7 +9,7 @@ if [ "$RUNTEST" == "frontend" ]; then
     bash <(curl -s https://codecov.io/bash) -F frontend -X coveragepy
 elif [ "$RUNTEST" == "backend" ]; then
     tox -e lint
-    TEST_DATABASE_URL=postgres://postgres@localhost/travis_ci_test tox -e fast
+    TEST_DATABASE_URL=postgres://travis:travis@localhost:5433/travis tox -e fast
     tox -e missing-migrations
     bash <(curl -s https://codecov.io/bash) -F backend
 


### PR DESCRIPTION
This change bumps the version of the PostgreSQL database created in Docker from 9.6 to 10.

It bumps Travis to version 10 as well, using the travis database and user that are created as part of v10 setup there.

It also standardizes the default Postgres username to `cfpb`, to be more consistent with the data dumps generated by https://github.com/cfpb/cfgov-mysql-to-postgres.

## Changes

- Use Postgres 10 in Docker and for testing in Travis.
- Standardize Postgres username to `cfpb` and database to `cfgov` everywhere.

## Testing

See Travis unit tests. You can also run the Docker setup with the Postgres `DATABASE_URL` in `.python_env_SAMPLE`.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: