### PR TITLE
Bump retirement satellite app to version 0.7.4

### DIFF
--- a/requirements/optional-public.txt
+++ b/requirements/optional-public.txt
@@ -1,6 +1,6 @@
 https://github.com/cfpb/college-costs/releases/download/2.4.3/college_costs-2.4.3-py2-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.11.3/owning_a_home_api-0.11.3-py2-none-any.whl
-https://github.com/cfpb/retirement/releases/download/0.7.3/retirement-0.7.3-py2-none-any.whl
+https://github.com/cfpb/retirement/releases/download/0.7.4/retirement-0.7.4-py2-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.1.0/ccdb5_api-1.1.0-py2-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/1.1.0/ccdb5_ui-1.1.0-py2-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.8.0/comparisontool-1.8.0-py2-none-any.whl


### PR DESCRIPTION
This change bumps the version of the optional satellite app [retirement](https://github.com/cfpb/retirement) from version 0.7.3 to the latest version [0.7.4](https://github.com/cfpb/retirement/releases/tag/0.7.4).

This new version includes an upgrade to the latest version of Capital Framework.

It also should fix the currently-broken Vagrant setup for cf.gov which is contained in another (private) repository.

## Testing

Run the server locally and visit http://localhost:8000/consumer-tools/retirement/before-you-claim/ and its linked pages.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: