### PR TITLE
Add new clusters to Ask CFPB H1 split testing group

### DIFF
--- a/cfgov/core/split_testing_clusters.py
+++ b/cfgov/core/split_testing_clusters.py
@@ -1,4 +1,6 @@
 ASK_CFPB_H1 = {
+    # Initial clusters that went live on 12/4/18,
+    # testing the full set of pages in each cluster:
     18: [
         103, 160, 187, 337, 731, 767, 951, 1157, 1161, 1403, 1405, 1439, 1447,
         1567, 1695,
@@ -16,6 +18,12 @@ ASK_CFPB_H1 = {
     93: [
         146, 226, 237, 318, 338, 545, 633, 811, 1215, 1463, 1507,
     ],
+    # New clusters to go live on 1/2/19, using a random half of each cluster:
+    83: [46, 178, 243, 1145, 1397, 1555, ],
+    96: [137, 204, 585, 763, ],
+    166: [1469, 1539, 2023, 2055, ],
+    280: [1113, 1987, 1993, ],
+    302: [31, 1263, 1865, ],
 }
 
 CLUSTERS = {


### PR DESCRIPTION
When originally setting up this test in #4543, I neglected to cut the clusters in half so that there was a control group _within_ each cluster. So, this PR adds a new set of clusters to the test, using only a subset of each cluster (randomized by Jabari), so that each cluster can be analyzed with its own internal control group.

## Additions

- More clusters to the Ask CFPB H1 split testing group

## Testing

1. Pull branch
1. Load up an Ask answer in the new clusters, like https://www.consumerfinance.gov/ask-cfpb/what-is-a-daily-periodic-rate-on-a-credit-card-en-46/
1. Inspect the question text and confirm that it's using `<h1 class="h2">` instead of `<h2>`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: