### PR TITLE
Remove non_field_errors from FilterableListControls

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -227,11 +227,6 @@
                 {% endfor %}
             {% endif %}
         {% endfor %}
-        {% if form.non_field_errors() %}
-            {% for error in form.non_field_errors() %}
-                    {{ notification.render('error', true, error) }}
-            {% endfor %}
-        {% endif %}
         {% if 'filterable-list' in controls.form_type and posts is defined %}
             {% if form.is_valid() %}
                 {% set count = posts.paginator.count %}


### PR DESCRIPTION
In the [Django documentation](https://docs.djangoproject.com/en/2.1/ref/forms/validation/):

> Note that any errors raised by your Form.clean() override will not be associated with any field in particular. They go into a special “field” (called __all__), which you can access via the non_field_errors() method if you need to. If you want to attach errors to a specific field in the form, you need to call add_error().

As I understand it, `forms.py` implements clean [here](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/v1/forms.py#L165-L172), which deals with swapping the date fields if they are in a state that would otherwise raise a non_field error. Therefore, we don't have a scenario where these kind of errors would appear.

## Removals

- Remove `form.non_field_errors()` from filterable-list-controls template.

## Testing

1. Filters should load as before. These errors were not possible to be generated, so there should be no change to existing functionality.
