### PR TITLE
Stop using symlinked wsgi.py in deployable zipfiles

### DIFF
--- a/cfgov/apache/conf.d/wsgi.conf
+++ b/cfgov/apache/conf.d/wsgi.conf
@@ -5,7 +5,7 @@ LoadModule wsgi_module modules/mod_${PYTHON_VERSION}-wsgi.so
 WSGIApplicationGroup %{GLOBAL}
 WSGIDaemonProcess django home=${CFGOV_CURRENT} python-home=${CFGOV_CURRENT}/venv processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP}
 WSGIProcessGroup django
-WSGIScriptAlias / ${CFGOV_CURRENT}/wsgi.py
+WSGIScriptAlias / ${CFGOV_CURRENT}/cfgov/cfgov/wsgi.py
 
 <Directory ${CFGOV_PATH}>
     Require all granted

--- a/cfgov/deployable_zipfile/setup.py
+++ b/cfgov/deployable_zipfile/setup.py
@@ -26,21 +26,8 @@ def get_supported_wheels(wheel_directory):
     return [req.link.path for req in requirement_set.requirements.values()]
 
 
-def find_wsgi_py(search_root):
-    for root, dirnames, filenames in os.walk(search_root):
-        if 'wsgi.py' in filenames:
-            return os.path.join(root, 'wsgi.py')
-
-
 def setup_virtualenv():
     extract_location = os.path.realpath(os.path.dirname(__file__))
-
-    # If there's a wsgi.py file in the deployed code, create a symlink for it
-    # from the root. This makes it easier to target using Apache.
-    wsgi_py_filename = find_wsgi_py(extract_location)
-
-    if wsgi_py_filename:
-        os.symlink(wsgi_py_filename, os.path.join(extract_location, 'wsgi.py'))
 
     # Identify this virtual environment's site-packages. At this point before
     # any packages have been installed, this will always be the last entry in


### PR DESCRIPTION
As part of the transition from drama-free-django to deployable zipfiles generated by cfgov-refresh, we wanted to support forcing a wsgi.py in the root of the deployed zip. To support this, the deployed zips generated a symlink from the root to the real wsgi.py file in cfgov/cfgov. See #5185 for background.

Now that we've transitioned, we no longer need to do this, and can have Apache directly point to the real wsgi.py.

Because the change to the Apache config is included here along with removal of the symlink, this won't break any old deploys and will work going forward.

## Testing

The best way to test this is to generate a deployable zipfile using

```sh
$ docker/deployable-zipfile/build.sh
```

and then test it using our (internal) Ansible Docker setup.

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: