### PR TITLE
Revert to Wagtail 2.9.3 for now

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==2.10
+wagtail==2.9.3


### PR DESCRIPTION
We're not *quite* ready to ship 2.10. This change temporarily reverts to 2.9.3.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
