### PR TITLE
HMDA Explorer: Update sunset message

### DIFF
--- a/cfgov/hmda/templates/hmda/orange-explorer.html
+++ b/cfgov/hmda/templates/hmda/orange-explorer.html
@@ -742,7 +742,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
         <p class="message">This tool will sunset on 9/25/2020.</p>
         <p>
-          <a href="/data-research/hmda/api-retirement/">Learn more</a>.
+          <a href="/data-research/hmda/hmda-explorer/">Learn more</a>.
           You can continue to analyze and download HMDA data using the following
           resources:
         </p>

--- a/cfgov/hmda/templates/hmda/orange-explorer.html
+++ b/cfgov/hmda/templates/hmda/orange-explorer.html
@@ -740,8 +740,29 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
       <div class="cf-error" id="msa-note">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm-49.7 234.6c0-27.6 22.4-50 50-50s50 22.4 50 50v328.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V339.8zm50 582.5c-39.6 0-71.7-32.1-71.7-71.7s32.1-71.7 71.7-71.7S572 811 572 850.6s-32.1 71.7-71.7 71.7z"></path></svg>
-        <p class="message">This tool will sunset in the coming months.</p>
-        <p><a href="/data-research/hmda-api-retirement/">Learn more about what to expect</a></p>
+        <p class="message">This tool will sunset on 9/25/2020.</p>
+        <p>
+          <a href="/data-research/hmda/api-retirement/">Learn more</a>.
+          You can continue to analyze and download HMDA data using
+          the following resources:
+        </p>
+        <ul>
+          <li>
+            <a href="https://ffiec.cfpb.gov/data-publication/">
+              FFIEC Data Publication Products (2017 &amp; later)
+            </a>
+          </li>
+          <li>
+            <a href="https://ffiec.cfpb.gov/data-browser/">
+              HMDA Data Browser (2017 &amp; later)
+            </a>
+          </li>
+          <li>
+            <a href="/data-research/hmda/historic-data/">
+              Historic HMDA Data (2007–2017)
+            </a>
+          </li>
+        </ul>
       </div>
 
       <h2>Filter the data</h2>

--- a/cfgov/hmda/templates/hmda/orange-explorer.html
+++ b/cfgov/hmda/templates/hmda/orange-explorer.html
@@ -743,24 +743,27 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <p class="message">This tool will sunset on 9/25/2020.</p>
         <p>
           <a href="/data-research/hmda/api-retirement/">Learn more</a>.
-          You can continue to analyze and download HMDA data using
-          the following resources:
+          You can continue to analyze and download HMDA data using the following
+          resources:
         </p>
         <ul>
           <li>
             <a href="https://ffiec.cfpb.gov/data-publication/">
-              FFIEC Data Publication Products (2017 &amp; later)
+              FFIEC Data Publication Products
             </a>
+            (2017 &amp; later)
           </li>
           <li>
             <a href="https://ffiec.cfpb.gov/data-browser/">
-              HMDA Data Browser (2017 &amp; later)
+              HMDA Data Browser and API
             </a>
+            (2018 &amp; later)
           </li>
           <li>
             <a href="/data-research/hmda/historic-data/">
-              Historic HMDA Data (2007–2017)
+              Historic HMDA Data
             </a>
+            (2007-2017)
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Now that we have a date for the HMDA Explorer sunsetting, we need to update our messages about the sunset to show the date and links to additional resources.

Some slight content tweaks might still be coming, so we can hold on this review for now.

## Changes

- Update HMDA Explorer sunset message

## How to test this PR

1. Visit `/data-research/hmda/explore`.
2. Make sure the banner at the top matches the screenshot below.
3. Make sure the links in the banner go to the right places.

## Screenshots

![hmda-explorer](https://user-images.githubusercontent.com/1862695/91070687-15038a80-e605-11ea-81f4-89bc11278d22.png)

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)