### PR TITLE
[TDP] Remove the top border on the TDP Activity Index page

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
@@ -47,7 +47,7 @@
                 {%- endfor %}
             </div>
         </section>
-        <div class="block block__padded-top block__border-top u-mt0 u-mb30">
+        <div class="block block__padded-top u-mt0 u-mb30">
             <h2>Search for activities</h2>
             <form class="u-mt30" method="get" action="." data-js-hook="behavior_submit-search">
                 <div class="o-form__input-w-btn">

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_index_page.html
@@ -47,7 +47,7 @@
                 {%- endfor %}
             </div>
         </section>
-        <div class="block block__padded-top u-mt0 u-mb30">
+        <div class="block block__padded-top block__flush-top u-mb30">
             <h2>Search for activities</h2>
             <form class="u-mt30" method="get" action="." data-js-hook="behavior_submit-search">
                 <div class="o-form__input-w-btn">


### PR DESCRIPTION
Since the Notification block has been removed from the TDP Activity Search page, the top border is no longer necessary between the hero and the the search form.


---


## Removals

- Removed the top border from the search block on the TDP Activity Index page.



## Screenshots

### Before:

![Screen Shot 2020-08-24 at 1 23 22 PM](https://user-images.githubusercontent.com/2914091/91077732-93fdc080-e60f-11ea-9765-efc644c6de99.png)

### After:

![Screen Shot 2020-08-24 at 1 37 10 PM](https://user-images.githubusercontent.com/2914091/91077753-9fe98280-e60f-11ea-848c-507e2787cf43.png)


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
