### PR TITLE
Redirect to /admin/ from /login/ when already logged in

### DIFF
--- a/cfgov/v1/tests/views/test_login_views.py
+++ b/cfgov/v1/tests/views/test_login_views.py
@@ -51,7 +51,7 @@ class LoginViewsTestCase(TestCase):
         response = self.client.get('/login/')
         self.assertRedirects(
             response,
-            '/login/check_permissions/?next=',
+            '/login/check_permissions/?next=/admin/',
             target_status_code=302,
             fetch_redirect_response=False,
         )

--- a/cfgov/v1/views/__init__.py
+++ b/cfgov/v1/views/__init__.py
@@ -73,8 +73,8 @@ def login_with_lockout(request, template_name='wagtailadmin/login.html'):
     Displays the login form and handles the login action.
     """
     redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
-                                   request.GET.get(REDIRECT_FIELD_NAME, ''))
-
+                                   request.GET.get(REDIRECT_FIELD_NAME,
+                                                   '/admin/'))
     # Redirects to https://example.com should not be allowed.
     if redirect_to:
         if '//' in redirect_to:


### PR DESCRIPTION
Addresses https://github.local/CFGOV/platform/issues/3863

Very well may be that a more global solution to this problem is preferred, but this fixes the bug as it stands with no side-effects that I'm aware of.