### PR TITLE
Global Search: Set aria-label on search/close button

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -18,14 +18,14 @@
      data-js-hook="behavior_flyout-menu">
     <button class="m-global-search_trigger"
             data-js-hook="behavior_flyout-menu_trigger"
-            aria-label="Search">
+            aria-label="{{ _("Search") }}">
         <span class="m-global-search_trigger-open-label">
             {{ svg_icon('search') }}
-            <span class="u-hide-on-mobile">{{ _('Search') }}</span>
+            <span class="u-hide-on-mobile">{{ _("Search") }}</span>
         </span>
         <span class="m-global-search_trigger-close-label">
             {{ svg_icon('delete') }}
-            <span class="u-hide-on-mobile">{{ _('Close') }}</span>
+            <span class="u-hide-on-mobile">{{ _("Close") }}</span>
         </span>
     </button>
     <div class="m-global-search_content

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -17,7 +17,8 @@
 <div class="m-global-search"
      data-js-hook="behavior_flyout-menu">
     <button class="m-global-search_trigger"
-            data-js-hook="behavior_flyout-menu_trigger">
+            data-js-hook="behavior_flyout-menu_trigger"
+            aria-label="Search">
         <span class="m-global-search_trigger-open-label">
             {{ svg_icon('search') }}
             <span class="u-hide-on-mobile">{{ _('Search') }}</span>

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -18,14 +18,14 @@
      data-js-hook="behavior_flyout-menu">
     <button class="m-global-search_trigger"
             data-js-hook="behavior_flyout-menu_trigger"
-            aria-label="{{ _("Search") }}">
+            aria-label="{{ _('Search') }}">
         <span class="m-global-search_trigger-open-label">
             {{ svg_icon('search') }}
-            <span class="u-hide-on-mobile">{{ _("Search") }}</span>
+            <span class="u-hide-on-mobile">{{ _('Search') }}</span>
         </span>
         <span class="m-global-search_trigger-close-label">
             {{ svg_icon('delete') }}
-            <span class="u-hide-on-mobile">{{ _("Close") }}</span>
+            <span class="u-hide-on-mobile">{{ _('Close') }}</span>
         </span>
     </button>
     <div class="m-global-search_content

--- a/cfgov/locale/es/LC_MESSAGES/django.po
+++ b/cfgov/locale/es/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-17 10:20-0400\n"
+"POT-Creation-Date: 2020-08-26 10:02-0400\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -49,11 +49,11 @@ msgstr "Ver todos los resultados para"
 msgid "Export Ask data"
 msgstr ""
 
-#: cfgov/settings/base.py:248
+#: cfgov/settings/base.py:242
 msgid "English"
 msgstr ""
 
-#: cfgov/settings/base.py:249
+#: cfgov/settings/base.py:243
 msgid "Spanish"
 msgstr ""
 
@@ -105,47 +105,48 @@ msgstr ""
 msgid "Submit a Complaint"
 msgstr "Enviar una queja"
 
-#: jinja2/v1/_includes/molecules/global-search.html:23
-#: jinja2/v1/_includes/molecules/global-search.html:58
-#: jinja2/v1/_includes/molecules/global-search.html:77
+#: jinja2/v1/_includes/molecules/global-search.html:21
+#: jinja2/v1/_includes/molecules/global-search.html:24
+#: jinja2/v1/_includes/molecules/global-search.html:59
+#: jinja2/v1/_includes/molecules/global-search.html:78
 #: jinja2/v1/_includes/organisms/ask-search.html:62
 #: jinja2/v1/ask-cfpb/see-all.html:52
 msgid "Search"
 msgstr "Buscar"
 
-#: jinja2/v1/_includes/molecules/global-search.html:27
+#: jinja2/v1/_includes/molecules/global-search.html:28
 msgid "Close"
 msgstr "Cerrar"
 
-#: jinja2/v1/_includes/molecules/global-search.html:63
-#: jinja2/v1/_includes/molecules/global-search.html:66
+#: jinja2/v1/_includes/molecules/global-search.html:64
+#: jinja2/v1/_includes/molecules/global-search.html:67
 msgid "Search the CFPB"
 msgstr "Buscar la CFPB"
 
-#: jinja2/v1/_includes/molecules/global-search.html:72
+#: jinja2/v1/_includes/molecules/global-search.html:73
 #: jinja2/v1/ask-cfpb/see-all.html:56
 msgid "Clear search"
 msgstr "Borrar búsqueda"
 
-#: jinja2/v1/_includes/molecules/global-search.html:82
+#: jinja2/v1/_includes/molecules/global-search.html:83
 msgid "Suggested search terms:"
 msgstr ""
 
-#: jinja2/v1/_includes/molecules/global-search.html:86
+#: jinja2/v1/_includes/molecules/global-search.html:87
 #, fuzzy
 #| msgid "Related questions"
 msgid "Regulations"
 msgstr "Otras preguntas"
 
-#: jinja2/v1/_includes/molecules/global-search.html:91
+#: jinja2/v1/_includes/molecules/global-search.html:92
 msgid "Compliance guides"
 msgstr ""
 
-#: jinja2/v1/_includes/molecules/global-search.html:96
+#: jinja2/v1/_includes/molecules/global-search.html:97
 msgid "Mortgage"
 msgstr "Hipoteca"
 
-#: jinja2/v1/_includes/molecules/global-search.html:101
+#: jinja2/v1/_includes/molecules/global-search.html:102
 #, fuzzy
 #| msgid "Auto loans"
 msgid "College loans"

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -23,12 +23,12 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   const _dom = checkDom( element, BASE_CLASS );
   const _contentDom = _dom.querySelector( `.${ BASE_CLASS }_content` );
   const _triggerDom = _dom.querySelector( `.${ BASE_CLASS }_trigger` );
-  const _triggerCloseLabelDom = _triggerDom.querySelector(
+  const _triggerCloseLabelText = _triggerDom.querySelector(
     `.${ BASE_CLASS }_trigger-close-label`
-  );
-  const _triggerOpenLabelDom = _triggerDom.querySelector(
+  ).innerText.trim();
+  const _triggerOpenLabelText = _triggerDom.querySelector(
     `.${ BASE_CLASS }_trigger-open-label`
-  );
+  ).innerText.trim();
   const _flyoutMenu = new FlyoutMenu( _dom );
   let _searchInputDom;
   let _searchBtnDom;
@@ -147,7 +147,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
 
     _searchInputDom.select();
 
-    _triggerDom.setAttribute( 'aria-label', _triggerCloseLabelDom.innerText );
+    _triggerDom.setAttribute( 'aria-label', _triggerCloseLabelText );
 
     document.body.addEventListener( 'mousedown', _handleBodyClick );
   }
@@ -157,7 +157,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
-    _triggerDom.setAttribute( 'aria-label', _triggerOpenLabelDom.innerText );
+    _triggerDom.setAttribute( 'aria-label', _triggerOpenLabelText );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -21,7 +21,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
 
   const BASE_CLASS = 'm-global-search';
   const _dom = checkDom( element, BASE_CLASS );
-  const _contentDom = _dom.querySelector( '.' + BASE_CLASS + '_content' );
+  const _contentDom = _dom.querySelector( `.${ BASE_CLASS }_content` );
+  const _triggerDom = _dom.querySelector( `.${ BASE_CLASS }_trigger` );
   const _flyoutMenu = new FlyoutMenu( _dom );
   let _searchInputDom;
   let _searchBtnDom;
@@ -140,6 +141,8 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
 
     _searchInputDom.select();
 
+    _triggerDom.setAttribute( 'aria-label', 'Close' );
+
     document.body.addEventListener( 'mousedown', _handleBodyClick );
   }
 
@@ -148,6 +151,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
+    _triggerDom.setAttribute( 'aria-label', 'Search' );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 

--- a/cfgov/unprocessed/js/molecules/GlobalSearch.js
+++ b/cfgov/unprocessed/js/molecules/GlobalSearch.js
@@ -23,6 +23,12 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
   const _dom = checkDom( element, BASE_CLASS );
   const _contentDom = _dom.querySelector( `.${ BASE_CLASS }_content` );
   const _triggerDom = _dom.querySelector( `.${ BASE_CLASS }_trigger` );
+  const _triggerCloseLabelDom = _triggerDom.querySelector(
+    `.${ BASE_CLASS }_trigger-close-label`
+  );
+  const _triggerOpenLabelDom = _triggerDom.querySelector(
+    `.${ BASE_CLASS }_trigger-open-label`
+  );
   const _flyoutMenu = new FlyoutMenu( _dom );
   let _searchInputDom;
   let _searchBtnDom;
@@ -141,7 +147,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
 
     _searchInputDom.select();
 
-    _triggerDom.setAttribute( 'aria-label', 'Close' );
+    _triggerDom.setAttribute( 'aria-label', _triggerCloseLabelDom.innerText );
 
     document.body.addEventListener( 'mousedown', _handleBodyClick );
   }
@@ -151,7 +157,7 @@ function GlobalSearch( element ) { // eslint-disable-line max-statements, no-inl
    * Use this to perform post-collapseBegin actions.
    */
   function _handleCollapseBegin() {
-    _triggerDom.setAttribute( 'aria-label', 'Search' );
+    _triggerDom.setAttribute( 'aria-label', _triggerOpenLabelDom.innerText );
     document.body.removeEventListener( 'mousedown', _handleBodyClick );
   }
 


### PR DESCRIPTION
The button that expands the search contains the text "Search" … but for mobile use-cases, it also contain the "Close". This PR adds logic to set the aria-label attribute of that button to whatever state the global search is in (expanded or collapsed).

## Changes

- Set `aria-label` on global search button.


## How to test this PR

1. Visit the live homepage and run a lighthouse report and see "Buttons do not have an accessible name" error.
2. Pull and run this branch and generate a lighthouse report for it and see that the accessibility error is gone.
