### PR TITLE
Add category and tag fields to the page metadata export

### DIFF
--- a/cfgov/v1/templates/v1/_list_page_metadata.html
+++ b/cfgov/v1/templates/v1/_list_page_metadata.html
@@ -1,10 +1,13 @@
 {% extends 'wagtailadmin/reports/listing/_list_page_report.html' %}
 
+ 
 {% block extra_columns %}
     <th>URL</th>
     <th>First Published</th>
     <th>Last Published</th>
     <th>Search Description</th>
+    <th>Tags</th>
+    <th>Categories</th>
 {% endblock %}
 
 {% block extra_page_data %}
@@ -19,6 +22,15 @@
     </td>
     <td valign="top">
         {{ page.search_description }}
+    </td>
+    <td valign="top">
+        {{ page.tags.names|join:", " }}
+    </td>
+    <td valign="top">
+        {% for cat in page.categories.all %}
+        {% if cat.get_name_display and not forloop.last %}
+        {{ cat.get_name_display }}, {% else %}{{ cat.get_name_display }}
+        {% endif %}{% endfor %}
     </td>
 {% endblock %}
 

--- a/cfgov/v1/tests/views/test_metadata_report_view.py
+++ b/cfgov/v1/tests/views/test_metadata_report_view.py
@@ -1,0 +1,43 @@
+from datetime import date
+
+from django.test import TestCase
+
+from wagtail.core.models import Site
+
+from model_bakery import baker
+from taggit.models import Tag
+
+from v1.models import BlogPage, CFGOVPageCategory
+from v1.util.ref import categories
+from v1.views.reports import PageMetadataReportView, process_categories
+
+
+class ServeViewTestCase(TestCase):
+    def setUp(self):
+        self.view = PageMetadataReportView()
+        self.tag1 = baker.make(Tag, name="tag1")
+        self.tag2 = baker.make(Tag, name="tag2")
+        self.site = Site.objects.get(is_default_site=True)
+        self.root_page = self.site.root_page
+        self.blog_page = BlogPage(title='Blogojevich', live=True)
+        self.root_page.add_child(instance=self.blog_page)
+        self.category_tuple = categories[0][1][0]
+        self.category = CFGOVPageCategory(name=self.category_tuple[1])
+        self.blog_page.categories.add(self.category)
+        self.blog_page.tags.add(self.tag1, self.tag2)
+
+    def test_process_categories(self):
+        category_string = process_categories(self.blog_page.categories.all())
+        self.assertIn(
+            self.category.get_name_display(), category_string)
+        self.assertEqual(
+            self.category.get_name_display(), self.category_tuple[1])
+
+    def test_metadata_report_get_filename(self):
+        today = date.today()
+        self.assertEqual(
+            self.view.get_filename(),
+            f"spreadsheet-export-{today}")
+
+    def test_get_queryset(self):
+        self.assertEqual(self.view.get_queryset().count(), 2)

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -1,28 +1,49 @@
+from datetime import date
+
 from wagtail.admin.views.reports import PageReportView
 
 from v1.models import CFGOVPage
 
 
+def process_categories(queryset):
+    """Prep the set of categories associated with a page."""
+    return ", ".join([cat.get_name_display() for cat in queryset])
+
+
 class PageMetadataReportView(PageReportView):
-    header_icon = 'doc-empty-inverse'
+    header_icon = "doc-empty-inverse"
     title = "Metadata for live pages"
 
     list_export = PageReportView.list_export + [
-        'url',
-        'first_published_at',
-        'last_published_at',
-        'search_description'
+        "url",
+        "first_published_at",
+        "last_published_at",
+        "search_description",
+        "tags.names",
+        "categories.all",
     ]
-    export_headings = dict(
-        url='URL',
-        first_published_at='First published',
-        last_published_at='Last published',
-        search_description='Search description',
-        **PageReportView.export_headings
+    export_headings = dict([
+        ("url", "URL"),
+        ("first_published_at", "First published"),
+        ("last_published_at", "Last published"),
+        ("search_description", "Search description"),
+        ("tags.names", "Tags"),
+        ("categories.all", "Categories")],
+        **PageReportView.export_headings,
     )
 
-    template_name = 'v1/page_metadata_report.html'
+    custom_field_preprocess = {
+        "categories.all": {
+            "csv": process_categories, "xlsx": process_categories
+        }
+    }
+
+    template_name = "v1/page_metadata_report.html"
+
+    def get_filename(self):
+        """ Get a dated base filename for the exported spreadsheet."""
+        return f"spreadsheet-export-{date.today()}"
 
     def get_queryset(self):
-        # We don't really need test coverage of the object manger
-        return CFGOVPage.objects.filter(live=True)  # pragma: no cover
+        return CFGOVPage.objects.filter(live=True).prefetch_related(
+            "tags", "categories")


### PR DESCRIPTION
This satisfies https://github.local/CFGOV/platform/issues/3862, a request to add
category and tag fields to the Wagtail page metadata report.

## Testing

visit http://localhost:8000/admin/reports/page-metadata/ and note two new
columns at top right, TAGS and CATEGORIES.

The XLSX and CSV download options should deliver spreadsheets with the new fields.
The download of all cfgov pages takes up to a minute.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Admin documentation has been updated at https://github.local/CFPB/hubcap/wiki#download-page-metadata