### PR TITLE
Create new CSP allowlist for media files

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -148,7 +148,7 @@ MIDDLEWARE = (
     "core.middleware.DownstreamCacheControlMiddleware",
     "flags.middleware.FlagConditionsMiddleware",
     "core.middleware.SelfHealingMiddleware",
-    "wagtail.contrib.redirects.middleware.RedirectMiddleware",    
+    "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "core.middleware.DeactivateTranslationsMiddleware",
 )
 
@@ -513,7 +513,7 @@ if ENABLE_CLOUDFRONT_CACHE_PURGE:
         },
     }
 
-# CSP Whitelists
+# CSP Allowlists
 
 # These specify what is allowed in <script> tags
 CSP_SCRIPT_SRC = (
@@ -521,7 +521,6 @@ CSP_SCRIPT_SRC = (
     "'unsafe-inline'",
     "'unsafe-eval'",
     "*.consumerfinance.gov",
-    "files.consumerfinance.gov",
     "*.google-analytics.com",
     "*.googletagmanager.com",
     "tagmanager.google.com",
@@ -564,7 +563,6 @@ CSP_STYLE_SRC = (
 CSP_IMG_SRC = (
     "'self'",
     "*.consumerfinance.gov",
-    "files.consumerfinance.gov",
     "www.ecfr.gov",
     "s3.amazonaws.com",
     "www.gstatic.com",
@@ -610,7 +608,6 @@ CSP_FONT_SRC = (
     "'self'",
     "data:",
     "*.consumerfinance.gov",
-    "files.consumerfinance.gov",
     "fast.fonts.net",
     "fonts.google.com",
     "fonts.gstatic.com",
@@ -620,7 +617,6 @@ CSP_FONT_SRC = (
 CSP_CONNECT_SRC = (
     "'self'",
     "*.consumerfinance.gov",
-    "files.consumerfinance.gov",
     "*.google-analytics.com",
     "*.tiles.mapbox.com",
     "bam.nr-data.net",
@@ -629,6 +625,12 @@ CSP_CONNECT_SRC = (
     "n2.mouseflow.com",
     "api.iperceptions.com",
     "*.qualtrics.com",
+)
+
+# These specify valid media sources (e.g., MP3 files)
+CSP_IMG_SRC = (
+    "'self'",
+    "*.consumerfinance.gov",
 )
 
 # Feature flags

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -628,7 +628,7 @@ CSP_CONNECT_SRC = (
 )
 
 # These specify valid media sources (e.g., MP3 files)
-CSP_IMG_SRC = (
+CSP_MEDIA_SRC = (
     "'self'",
     "*.consumerfinance.gov",
 )


### PR DESCRIPTION
This is needed to be able to use our new audio players that serve files uploaded to the Wagtail Media library, landing on files.consumerfinance.gov.

## Additions

- `CSP_MEDIA_SRC` setting for django-csp


## Removals

- `files.consumerfinance.gov` entries in other CSP lists, when the `*.consumerfinance.gov` wildcard should handle it just fine (we had added the explicit reference in a fit of haphazard troubleshooting, but the problem was not that)


## How to test this PR

Don't think we really can until it gets to production, unless the buildfiles bucket actually works somewhere that this branch can be deployed to.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
