### PR TITLE
Install wagtail-autocomplete from fork

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,7 +37,6 @@ requests_toolbelt==0.8.0
 sha3==0.2.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
-wagtail-autocomplete==0.6
 wagtail-flags==4.2.2
 wagtail-inventory==1.1.1
 wagtail-sharing==2.2.1
@@ -45,6 +44,7 @@ wagtail-treemodeladmin==1.2.1
 wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
+git+https://github.com/cfpb/wagtail-autocomplete.git
 https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home_api-0.16.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,6 +37,7 @@ requests_toolbelt==0.8.0
 sha3==0.2.1
 unipath>=1.1,<=2.0
 urllib3==1.25.2
+# wagtail-autocomplete==0.6 TODO: Restore when wagtail-autocomplete #77 is merged
 wagtail-flags==4.2.2
 wagtail-inventory==1.1.1
 wagtail-sharing==2.2.1


### PR DESCRIPTION
We need to temporarily install a CFPB fork of wagtail-autocomplete to
facilitate the editing of Ask CFPB content while the project's origin repo 
works on [a PR](https://github.com/wagtail/wagtail-autocomplete/pull/77) we pushed to them.

The PR has been approved, but it may take some time to get it merged and for
a new release to be issued to PyPI.

This is a temporary fix for https://github.local/CFGOV/platform/issues/3862

## Testing

1. In current master, open http://localhost:8000/admin/pages/5804/edit/ and note the server error(s) generated by the autocomplete API calls. They will show up in your local server window and in the network pane of dev tools.
Also note that the related-questions and redirect-to-page fields don't work.
2. Pull in this branch, install libraries with `pip install -r requirements/local.txt`
This will install our forked version of wagtail-autocomplete. 
3. Restart your local server
4. Note that the server errors go away when editing an Ask CFPB page, and the
autocomplete panels now function.
