### PR TITLE
Bump for ccdb5-UI IE11 Bugfix

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -48,6 +48,6 @@ wagtailmedia==0.6.0
 https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home_api-0.16.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/2.3.0/ccdb5_ui-2.3.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl


### PR DESCRIPTION
Updates the CCDB5-UI package to include IE11 bugfixes.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- None


## Removals

- None


## Changes

- CCDB5-ui Library package update


## How to test this PR

1. Make sure CCDB5 Search loads in IE11

