### PR TITLE
Replace master branch with main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,10 +76,10 @@ pipeline {
         }
 
         stage('Push Image') {
-            // Push image only on master branch or deploy is set to true
+            // Push image only on main branch or deploy is set to true
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'main'
                     expression { return params.DEPLOY }
                 }
             }
@@ -97,10 +97,10 @@ pipeline {
         }
 
         stage('Deploy Stack') {
-            // Deploys only on master branch or deploy is set to true
+            // Deploys only on main branch or deploy is set to true
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'main'
                     expression { return params.DEPLOY }
                 }
             }
@@ -116,7 +116,7 @@ pipeline {
         stage('Run Functional Tests') {
             when {
                 anyOf {
-                    branch 'master'
+                    branch 'main'
                     expression { return params.DEPLOY }
                 }
             }
@@ -134,7 +134,7 @@ pipeline {
     post {
         success {
             script {
-                if (env.GIT_BRANCH != 'master') {
+                if (env.GIT_BRANCH != 'main') {
                     notify("${NOTIFICATION_CHANNEL}", ":white_check_mark: Branch $env.GIT_BRANCH PR $env.CHANGE_URL deployed by $env.CHANGE_AUTHOR_EMAIL via $env.BUILD_URL and available at https://$env.CFGOV_HOSTNAME.")
                 }
                 else {


### PR DESCRIPTION
This change replaces all references to the `master` branch in our `Jenkinsfile` to `main`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
