### PR TITLE
Reports as webpages: Table of contents for small screens, with sticky nav & expandables

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
@@ -23,58 +23,64 @@
 
 <nav class="o-report-sidenav o-secondary-navigation"
      aria-label="Section navigation">
-      {% import 'molecules/nav-link.html' as nav_link %}
+    {% import 'molecules/nav-link.html' as nav_link %}
 
-      {% set sec_nav_settings = {
+    {% set sec_nav_settings = {
         'label': _('Table of contents'),
         'is_midtone': true,
         'is_bordered': false,
         'is_expanded': false
-      } %}
-      {% from 'organisms/expandable.html' import expandable with context %}
-      {% call() expandable(sec_nav_settings) %}
+    } %}
+    {% from 'organisms/expandable.html' import expandable with context %}
+    {% call() expandable(sec_nav_settings) %}
         {% import 'molecules/nav-link.html' as nav_link %}
 
-      <ul class="o-secondary-navigation_list
-                 o-secondary-navigation_list__parents">
-      {%- for item in report_sections %}
-          <li>
-            {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
-          {% if item.children %}
-              <ul class="o-secondary-navigation_list
-                         o-secondary-navigation_list__children">
-              {%- for child in item.children -%}
-                  <li>
-                      {{ nav_link.render(child.title, "#" + child.id, false) }}
-                  </li>
-              {%- endfor %}
-              </ul>
-          {% endif %}
-          </li>
-      {%- endfor %}
-      </ul>
-      {% if report_appendices %}
-        <h4>Appendices</h4>
-      {% endif %}
-      <ul class="o-secondary-navigation_list
-                 o-secondary-navigation_list__parents
-                 o-report-sidenav__appendix">
-       {%- for item in report_appendices %}
-          <li class="m-list_item">
-            {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
-          {%- if item.children -%}
-              <ul class="o-secondary-navigation_list
-                         o-secondary-navigation_list__children">
-              {%- for child in item.children -%}
-                  <li>
-                      {{ nav_link.render(child.title, "#" + child.id, false) }}
-                  </li>
-              {%- endfor %}
-              </ul>
-          {%- endif -%}
-          </li>
-      {%- endfor %}
-      </ul>
-      {% endcall %}
+        <ul class="m-list
+                   m-list__unstyled
+                   o-secondary-navigation_list
+                   o-secondary-navigation_list__parents">
+        {%- for item in report_sections %}
+            <li class="m-list_item">
+              {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
+            {% if item.children %}
+                <ul class="m-list
+                           m-list__unstyled
+                           o-secondary-navigation_list
+                           o-secondary-navigation_list__children">
+                {%- for child in item.children -%}
+                    <li class="m-list_item">
+                        {{ nav_link.render(child.title, "#" + child.id, false) }}
+                    </li>
+                {%- endfor %}
+                </ul>
+            {% endif %}
+            </li>
+        {%- endfor %}
+        </ul>
+        {% if report_appendices %}
+          <h4>Appendices</h4>
+        {% endif %}
+        <ul class="m-list
+                   m-list__unstyled
+                   o-secondary-navigation_list
+                   o-secondary-navigation_list__parents
+                   o-report-sidenav__appendix">
+         {%- for item in report_appendices %}
+            <li class="m-list_item">
+              {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
+            {%- if item.children -%}
+                <ul class="o-secondary-navigation_list
+                           o-secondary-navigation_list__children">
+                {%- for child in item.children -%}
+                    <li class="m-list_item">
+                        {{ nav_link.render(child.title, "#" + child.id, false) }}
+                    </li>
+                {%- endfor %}
+                </ul>
+            {%- endif -%}
+            </li>
+        {%- endfor %}
+        </ul>
+    {% endcall %}
 </nav>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
@@ -21,24 +21,30 @@
    ========================================================================== #}
 {% macro _render_secondary_navigation() %}
 
-<nav class="o-report-sidenav o-secondary-navigation o-secondary-navigation__no-children"
+<nav class="o-report-sidenav o-secondary-navigation"
      aria-label="Section navigation">
       {% import 'molecules/nav-link.html' as nav_link %}
-      <h3>Table of contents</h3>
-      <ul class="m-list
-                 m-list__unstyled
-                 o-secondary-navigation_list
+
+      {% set sec_nav_settings = {
+        'label': _('Table of contents'),
+        'is_midtone': true,
+        'is_bordered': false,
+        'is_expanded': false
+      } %}
+      {% from 'organisms/expandable.html' import expandable with context %}
+      {% call() expandable(sec_nav_settings) %}
+        {% import 'molecules/nav-link.html' as nav_link %}
+
+      <ul class="o-secondary-navigation_list
                  o-secondary-navigation_list__parents">
-       {%- for item in report_sections %}
-          <li class="m-list_item">
+      {%- for item in report_sections %}
+          <li>
             {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
           {% if item.children %}
-              <ul class="m-list
-                         m-list__unstyled
-                         o-secondary-navigation_list
+              <ul class="o-secondary-navigation_list
                          o-secondary-navigation_list__children">
               {%- for child in item.children -%}
-                  <li class="m-list_item">
+                  <li>
                       {{ nav_link.render(child.title, "#" + child.id, false) }}
                   </li>
               {%- endfor %}
@@ -50,21 +56,17 @@
       {% if report_appendices %}
         <h4>Appendices</h4>
       {% endif %}
-      <ul class="m-list
-                 m-list__unstyled
-                 o-secondary-navigation_list
+      <ul class="o-secondary-navigation_list
                  o-secondary-navigation_list__parents
                  o-report-sidenav__appendix">
        {%- for item in report_appendices %}
           <li class="m-list_item">
             {{ nav_link.render(item.numbering + item.title, "#" + item.id, true) }}
           {%- if item.children -%}
-              <ul class="m-list
-                         m-list__unstyled
-                         o-secondary-navigation_list
+              <ul class="o-secondary-navigation_list
                          o-secondary-navigation_list__children">
               {%- for child in item.children -%}
-                  <li class="m-list_item">
+                  <li>
                       {{ nav_link.render(child.title, "#" + child.id, false) }}
                   </li>
               {%- endfor %}
@@ -73,5 +75,6 @@
           </li>
       {%- endfor %}
       </ul>
+      {% endcall %}
 </nav>
 {% endmacro %}

--- a/cfgov/unprocessed/apps/research-reports/js/index.js
+++ b/cfgov/unprocessed/apps/research-reports/js/index.js
@@ -2,6 +2,8 @@
 /* ==========================================================================
    Scripts for Report Sidenav organism
    ========================================================================== */
+import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
+Expandable.init();
 
 const sidenav = document.querySelector( '.o-report-sidenav' );
 const tocHeaders = document.querySelectorAll( '.o-report-sidenav .m-nav-link' );


### PR DESCRIPTION
Take two on #5797 

MVP table of contents for small screens on Reports pages

---

GHE/CFPB/super-regular/issues/74
this is based on the reports-as-webpages branch

## Additions

- add expandable js to Reports js


## Removals

- extraneous css & list classes in the table of contents markup


## Changes

- add expandable to table of contents template


## How to test this PR

1.


## Screenshots


## Notes and todos

- not sure if anything broke JS-wise so let me know


## Checklist

_[Feel free to delete any checkboxes that are not applicable to this PR.]_

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing with the feature/section you're addressing, e.g., "Mega Menu: fix layout bug" or "Paying for College: Update content on Repay tool"
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentialy one or more of:
  - [This repo’s docs](https://cfpb.github.io/cfgov-refresh/) (edit the files in the `/docs` folder) – for basic, close-to-the-code documentation on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

_[When new or significantly modified front-end functionality is present, the following things should be tested. Feel free to delete this section if not applicable to this PR.]_

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

[Further guidance on browser support](https://github.com/cfpb/development/blob/master/guides/browser-support.md)

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
