### PR TITLE
Stop importing from local settings in test settings

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,5 +1,29 @@
-from .local import *
+from .base import *
 
+
+SECRET_KEY = "not-secret-key-for-testing"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {"level": "DEBUG", "class": "logging.StreamHandler",}
+    },
+    "loggers": {
+        "": {"handlers": ["console"], "level": "INFO", "propagate": True,}
+    },
+}
+
+# Disable caching for testing
+CACHES = {
+    k: {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "TIMEOUT": 0,
+    }
+    for k in ("default", "post_preview")
+}
+
+ALLOW_ADMIN_URL = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 


### PR DESCRIPTION
This is causing a problem over on #5984 by activating the placeholders in tests, and it may have been hiding other problems.

Felt worthy of its own PR, so it didn't go unnoticed in #5984. 


## Changes

- `settings/test.py` now imports from `base.py`, not `local.py`, and a few necessary settings from `local.py` have been copied over


## How to test this PR

1. `tox`


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
