### PR TITLE
Change default filterable list results to 25

### DIFF
--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -13,7 +13,7 @@ from v1.util.util import get_secondary_nav_items
 class FilterableListMixin(RoutablePageMixin):
     """Wagtail Page mixin that allows for filtering of other pages."""
 
-    filterable_per_page_limit = 10
+    filterable_per_page_limit = 25
     """Number of results to return per page."""
 
     do_not_index = False


### PR DESCRIPTION
This commit alters the default pagination size for filterable lists from 10 to 25.

## How to test this PR

1. Visit http://localhost:8000/about-us/blog/ and see that 25 results are shown, as opposed to https://www.consumerfinance.gov/about-us/blog/ where only 10 are shown.

## TODOs

Assessment of backend performance / database queries associated with this change.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets