### PR TITLE
Add Elasticsearch 7 tests

### DIFF
--- a/cfgov/ask_cfpb/documents.py
+++ b/cfgov/ask_cfpb/documents.py
@@ -1,42 +1,84 @@
 from django import forms
 from django.db import models
 from django.utils.html import strip_tags
+from django.utils.text import Truncator
+
+from wagtail.admin.edit_handlers import (
+    FieldPanel, MultiFieldPanel, ObjectList, StreamFieldPanel, TabbedInterface
+)
+from wagtail.core.fields import RichTextField, StreamField
+from wagtail.core.models import Page
+from wagtail.search import index
+from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
-
-from elasticsearch_dsl import analyzer, tokenizer, token_filter
-
+from elasticsearch_dsl import analyzer, token_filter, tokenizer
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
-
-from wagtail.core.fields import RichTextField, StreamField
-from wagtail.admin.edit_handlers import (
-    FieldPanel, InlinePanel, MultiFieldPanel, ObjectList, StreamFieldPanel,
-    TabbedInterface
-)
-from wagtail.core.models import Orderable, Page
-from wagtail.search import index
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtailautocomplete.edit_handlers import AutocompletePanel
 
 from ask_cfpb.models import blocks as ask_blocks
-from ask_cfpb.search_indexes import extract_raw_text, truncatissimo as truncate
-
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager, PortalCategory, PortalTopic
 from v1.models.snippets import RelatedResource, ReusableText
 
+
+UNSAFE_CHARACTERS = [
+    '#', '%', ';', '^', '~', '`', '|',
+    '<', '>', '[', ']', '{', '}', '\\'
+]
+
+
+def make_safe(term):
+    for char in UNSAFE_CHARACTERS:
+        term = term.replace(char, '')
+    return term
+
+
+def truncate_preview(text):
+    """Limit preview text to 40 words AND to 255 characters."""
+    word_limit = 40
+    while word_limit:
+        test = Truncator(text).words(word_limit, truncate=' ...')
+        if len(test) <= 255:
+            return test
+        else:
+            word_limit -= 1
+
+
+def extract_raw_text(stream_data):
+    # Extract text from stream_data, starting with the answer text.
+    text_chunks = [
+        block.get('value').get('content')
+        for block in stream_data
+        if block.get('type') == 'text'
+    ]
+    extra_chunks = [
+        block.get('value').get('content')
+        for block in stream_data
+        if block.get('type') in ['tip', 'table']
+    ]
+    chunks = text_chunks + extra_chunks
+    return " ".join(chunks)
+
+
 label_autocomplete = analyzer(
     'label_autocomplete',
-    tokenizer=tokenizer('trigram', 'edge_ngram', min_gram=2, max_gram=25, token_chars=["letter", "digit"]),
+    tokenizer=tokenizer(
+        'trigram',
+        'edge_ngram',
+        min_gram=2,
+        max_gram=25,
+        token_chars=["letter", "digit"]
+    ),
     filter=['lowercase', token_filter('ascii_fold', 'asciifolding')]
 )
 
 synonynm_filter = token_filter(
     'synonym_filter_en',
     'synonym',
-    synonyms_path = '/usr/share/elasticsearch/config/synonyms/synonyms_en.txt'
+    synonyms_path='/usr/share/elasticsearch/config/synonyms/synonyms_en.txt'
 )
 
 synonym_analyzer = analyzer(
@@ -48,8 +90,9 @@ synonym_analyzer = analyzer(
         'lowercase'
     ])
 
+
 def get_ask_breadcrumbs(language='en', portal_topic=None):
-    DEFAULT_CRUMBS = {
+    default_crumbs = {
         'es': [{
             'title': 'Obtener respuestas', 'href': '/es/obtener-respuestas/',
         }],
@@ -65,7 +108,8 @@ def get_ask_breadcrumbs(language='en', portal_topic=None):
             'href': page.url
         }]
         return crumbs
-    return DEFAULT_CRUMBS[language]
+    return default_crumbs[language]
+
 
 def get_portal_or_portal_search_page(portal_topic, language='en'):
     if portal_topic:
@@ -79,6 +123,7 @@ def get_portal_or_portal_search_page(portal_topic, language='en'):
             return portal_search_page
     return None
 
+
 REUSABLE_TEXT_TITLES = {
     'about_us': {
         'en': 'About us (For consumers)',
@@ -90,6 +135,7 @@ REUSABLE_TEXT_TITLES = {
     }
 }
 
+
 def get_reusable_text_snippet(snippet_title):
     try:
         return ReusableText.objects.get(
@@ -97,14 +143,17 @@ def get_reusable_text_snippet(snippet_title):
     except ReusableText.DoesNotExist:
         pass
 
+
 def get_standard_text(language, text_type):
     return get_reusable_text_snippet(
         REUSABLE_TEXT_TITLES[text_type][language]
     )
 
+
 class AnswerPage(CFGOVPage):
     """Page type for Ask CFPB answers."""
-    from ask_cfpb.models import Answer
+
+    from ask_cfpb.models.django import Answer
     last_edited = models.DateField(
         blank=True,
         null=True,
@@ -272,7 +321,7 @@ class AnswerPage(CFGOVPage):
         context['related_questions'] = self.related_questions.all()
         context['description'] = (
             self.short_answer if self.short_answer
-            else Truncator(self.answer_content).words(40, truncate=' ...'))
+            else truncate_preview(self.answer_content))
         context['last_edited'] = self.last_edited
         context['portal_page'] = get_portal_or_portal_search_page(
             portal_topic, language=self.language)
@@ -290,20 +339,21 @@ class AnswerPage(CFGOVPage):
         return strip_tags(" ".join([self.short_answer, raw_text]))
 
     def answer_content_data(self):
-        return truncate(self.answer_content_text())
+        return truncate_preview(self.answer_content_text())
 
     def short_answer_data(self):
-        return ' '.join(RichTextField.get_searchable_content(self, self.short_answer))
+        return ' '.join(
+            RichTextField.get_searchable_content(self, self.short_answer))
 
     def text(self):
         short_answer = self.short_answer_data()
         answer_text = self.answer_content_text()
-        full_text = short_answer + "\n\n" + answer_text + "\n\n" + self.question
+        full_text = f"{short_answer}\n\n{answer_text}\n\n{self.question}"
         return full_text
 
     def __str__(self):
         if self.answer_base:
-            return '{}: {}'.format(self.answer_base.id, self.title)
+            return f"{self.answer_base.id}: {self.title}"
         else:
             return self.title
 
@@ -311,7 +361,7 @@ class AnswerPage(CFGOVPage):
     def clean_search_tags(self):
         return [
             tag.strip()
-            for tag in self.search_tags.split(',')
+            for tag in self.search_tags.split(",")
         ]
 
     @property
@@ -341,6 +391,7 @@ class AnswerPage(CFGOVPage):
     def split_test_id(self):
         return self.answer_base.id
 
+
 @registry.register_document
 class AnswerPageDocument(Document):
 
@@ -351,7 +402,6 @@ class AnswerPageDocument(Document):
     url = fields.TextField()
     suggestions = fields.TextField(attr="text")
     preview = fields.TextField(attr="answer_content_data")
-
 
     def get_queryset(self):
         query_set = super().get_queryset()
@@ -376,7 +426,7 @@ class AnswerPageDocument(Document):
         name = 'ask-cfpb'
         settings = {'number_of_shards': 1,
                     'number_of_replicas': 0}
-        
+
     class Django:
         model = AnswerPage
 
@@ -385,25 +435,17 @@ class AnswerPageDocument(Document):
             'language',
         ]
 
-UNSAFE_CHARACTERS = [
-    '#', '%', ';', '^', '~', '`', '|',
-    '<', '>', '[', ']', '{', '}', '\\'
-]
-
-
-def make_safe(term):
-    for char in UNSAFE_CHARACTERS:
-        term = term.replace(char, '')
-    return term  
 
 def get_suggestion_for_search(search_term):
-    s = AnswerPageDocument.search().suggest('text_suggestion', search_term, term={'field': 'text'})
+    s = AnswerPageDocument.search().suggest(
+        'text_suggestion', search_term, term={'field': 'text'})
     response = s.execute()
     try:
         suggested_term = response.suggest.text_suggestion[0].options[0].text
         return suggested_term
     except IndexError:
         return search_term
+
 
 class AnswerPageSearch:
     def __init__(self, search_term, language='en', base_query=None):
@@ -412,16 +454,21 @@ class AnswerPageSearch:
         self.base_query = base_query
 
     def autocomplete(self):
-        s = AnswerPageDocument.search().query('match', autocomplete=self.search_term)
-        results = [{'question': result.autocomplete, 'url': result.url } for result in s[:20]]
+        s = AnswerPageDocument.search().query(
+            'match', autocomplete=self.search_term)
+        results = [
+            {'question': result.autocomplete, 'url': result.url}
+            for result in s[:20]
+        ]
         return results
 
     def search(self):
         if not self.base_query:
-            search = AnswerPageDocument.search().filter("match", language=self.language)
+            search = AnswerPageDocument.search().filter(
+                "match", language=self.language)
         else:
             search = self.base_query.filter("match", language=self.language)
-        
+
         if self.search_term != '':
             search.query("match", text=self.search_term)
         total_results = search.count()
@@ -441,7 +488,9 @@ class AnswerPageSearch:
                 search = AnswerPageDocument.search()
             else:
                 search = self.base_query
-            suggested_results = search.query("match", text=suggested_term).filter("term", language=self.language)
+            suggested_results = search.query(
+                "match", text=suggested_term).filter(
+                "term", language=self.language)
             total = suggested_results.count()
             suggested_results = suggested_results[0:total]
             suggested_response = suggested_results.execute()
@@ -452,7 +501,8 @@ class AnswerPageSearch:
                 'results': results
             }
         else:
-            # We know there are no results for the original term, so return an empty results list with no suggestion.
+            # We know there are no results for the original term,
+            # so return an empty results list with no suggestion.
             return {
                 'search_term': self.search_term,
                 'suggestion': None,

--- a/cfgov/ask_cfpb/models/__init__.py
+++ b/cfgov/ask_cfpb/models/__init__.py
@@ -1,12 +1,11 @@
 # flake8: noqa F401
+from ask_cfpb.documents import AnswerPage, AnswerPageDocument, AnswerPageSearch
 from ask_cfpb.models.django import (
     ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG, Answer, NextStep
 )
 from ask_cfpb.models.pages import (
-    AnswerLandingPage, AnswerResultsPage, PortalSearchPage,
+    AnswerLandingPage, AnswerPage, AnswerResultsPage, PortalSearchPage,
     SecondaryNavigationJSMixin, TagResultsPage, get_ask_breadcrumbs,
     get_reusable_text_snippet, get_standard_text, validate_page_number
 )
-from ask_cfpb.models.search import AskSearch
 from ask_cfpb.models.snippets import GlossaryTerm
-from ask_cfpb.documents import AnswerPageSearch, AnswerPageDocument, AnswerPage

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -1,5 +1,29 @@
-from .local import *
+from .base import *
 
+
+SECRET_KEY = "not-secret-key-for-testing"
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {"level": "DEBUG", "class": "logging.StreamHandler",}
+    },
+    "loggers": {
+        "": {"handlers": ["console"], "level": "INFO", "propagate": True,}
+    },
+}
+
+# Disable caching for testing
+CACHES = {
+    k: {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        "TIMEOUT": 0,
+    }
+    for k in ("default", "post_preview")
+}
+
+ALLOW_ADMIN_URL = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -19,7 +19,7 @@ from wagtailautocomplete.urls.admin import (
 )
 
 from ask_cfpb.views import (
-    ask_autocomplete_es7, ask_search, ask_search_es7, redirect_ask_search, view_answer
+    ask_autocomplete_es7, ask_search_es7, redirect_ask_search, view_answer
 )
 from core.views import (
     ExternalURLNoticeView, govdelivery_subscribe, regsgov_comment

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from django.views.generic import TemplateView
 
-# from complaint_search import views
+from complaint_search import views
 from flags.state import flag_enabled
 from rest_framework.test import APIRequestFactory
 
@@ -44,7 +44,7 @@ class ComplaintLandingView(TemplateView):
             args = {'field': 'all', 'size': '1', 'no_aggs': 'true'}
             factory = APIRequestFactory()
             request = factory.get('/search/', args, format='json')
-            # response = views.search(request)
+            response = views.search(request)
 
             if response.status == 200:
                 res_json = response.data

--- a/cfgov/search/backends.py
+++ b/cfgov/search/backends.py
@@ -1,12 +1,13 @@
 # Based on https://wellfire.co/learn/custom-haystack-elasticsearch-backend/
 
+import haystack.backends.elasticsearch2_backend
 from django.conf import settings
 from haystack.backends.elasticsearch2_backend import (
     Elasticsearch2SearchBackend, Elasticsearch2SearchEngine
 )
 
-import haystack.backends.elasticsearch2_backend
 import elasticsearch2
+
 
 haystack.backends.elasticsearch2_backend.elasticsearch = elasticsearch2
 
@@ -14,7 +15,6 @@ haystack.backends.elasticsearch2_backend.elasticsearch = elasticsearch2
 class CFGOVElasticsearch2SearchBackend(Elasticsearch2SearchBackend):
 
     def __init__(self, connection_alias, **connection_options):
-        print(haystack.backends.elasticsearch2_backend.elasticsearch.VERSION)
         super(CFGOVElasticsearch2SearchBackend, self).__init__(
             connection_alias, **connection_options)
 


### PR DESCRIPTION
This adjusts ask_cfpb unit tests to run using configuration
for the django-elasticsearch-dsl package.

## Additions
- A strip-tags helper to prevent the "mortgageA" problem, wherein some headings
can get mashed together with following text after tags are stripped
for indexing.
- Some linting and debugging

## To do
There were some bugs around the json api that have been fixed, but there are still three related tests commented out because of a mocking issue.  