### PR TITLE
Add missing `key-terms` slug to DefinedTerm URL tag

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -213,6 +213,7 @@ class PortalSearchPage(
     portal_category = None
     query_base = None
     glossary_terms = None
+    category_slug = None
     overview = models.TextField(blank=True)
     content_panels = CFGOVPage.content_panels + [
         FieldPanel('portal_topic'),
@@ -376,10 +377,10 @@ class PortalSearchPage(
 
     @route(r'^(?P<category>[^/]+)/$')
     def portal_category_page(self, request, **kwargs):
-        category_slug = kwargs.get('category')
-        if category_slug not in self.category_map:
+        self.category_slug = kwargs.get('category')
+        if self.category_slug not in self.category_map:
             raise Http404
-        self.portal_category = self.category_map.get(category_slug)
+        self.portal_category = self.category_map.get(self.category_slug)
         self.title = "{} {}".format(
             self.portal_topic.title(self.language),
             self.portal_category.title(self.language).lower())

--- a/cfgov/jinja2/v1/ask-cfpb/see-all.html
+++ b/cfgov/jinja2/v1/ask-cfpb/see-all.html
@@ -8,7 +8,7 @@
 
 {% block content_main %}
     <h1>
-      {{ page.title }}
+      {{ page.title }} -- {{ page.category_slug }}
     </h1>
     {% if page.glossary_terms %}
         <dl class="terms" itemscope itemtype="http://schema.org/DefinedTermSet">

--- a/cfgov/jinja2/v1/ask-cfpb/see-all.html
+++ b/cfgov/jinja2/v1/ask-cfpb/see-all.html
@@ -8,7 +8,7 @@
 
 {% block content_main %}
     <h1>
-      {{ page.title }} -- {{ page.category_slug }}
+      {{ page.title }}
     </h1>
     {% if page.glossary_terms %}
         <dl class="terms" itemscope itemtype="http://schema.org/DefinedTermSet">
@@ -19,7 +19,7 @@
                  itemtype="http://schema.org/DefinedTerm">
                 <dt class="term_name" itemprop="name">
                     {{ term.name(page.language) }}
-                    <link itemprop="url" href="{{ page.full_url }}key-terms/#{{ term.anchor(page.language) }}">
+                    <link itemprop="url" href="{{ page.full_url }}{{ page.category_slug }}/#{{ term.anchor(page.language) }}">
                 </dt>
                 <dd class="term_definition" itemprop="description">
                     {{ term.definition(page.language) | richtext }}

--- a/cfgov/jinja2/v1/ask-cfpb/see-all.html
+++ b/cfgov/jinja2/v1/ask-cfpb/see-all.html
@@ -19,7 +19,7 @@
                  itemtype="http://schema.org/DefinedTerm">
                 <dt class="term_name" itemprop="name">
                     {{ term.name(page.language) }}
-                    <link itemprop="url" href="{{ page.full_url }}#{{ term.anchor(page.language) }}">
+                    <link itemprop="url" href="{{ page.full_url }}key-terms/#{{ term.anchor(page.language) }}">
                 </dt>
                 <dd class="term_definition" itemprop="description">
                     {{ term.definition(page.language) | richtext }}


### PR DESCRIPTION
Our contacts at Google alerted us to an oversight of mine when I implemented our DefinedTerm markup: the URL for each term that goes in the `<link itemprop="url" href="{URL}">` tag was missing the `key-terms/` part of the URL. Turns out, our use of RoutablePageMixin to generate the Key Terms pages meant that the `page.full_url` tag was not including that `key-terms/` part of the URL.

~~I tried using the `routablepageurl` template tag, but that only returns a root-relative URL, whereas we need an absolute URL, and it required hardcoding a `category='key-terms'` kwarg, anyway, so we might as well just hardcode it this way.~~

/cc @kelleyholden 


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/auto-loans/answers/key-terms/, inspect the markup for a term, and see that the `<link itemprop="url" …>` tag's `href` attribute does not include the `key-terms/` path segment
1. Pull branch
1. Reload the page and see that the `key-terms/` is now included


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
