### PR TITLE
Add about us and events to footer; remove newsroom

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -51,18 +51,23 @@
                     </li>
                 {% else %}
                     <li class="m-list_item">
+                        <a class="m-list_link" href="/about-us/">
+                            About Us
+                        </a>
+                    </li>
+                    <li class="m-list_item">
                         <a class="m-list_link" href="/about-us/contact-us/">
                             Contact Us
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/about-us/newsroom/">
-                            Newsroom
+                        <a class="m-list_link" href="/about-us/careers/">
+                            Careers
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/about-us/careers/">
-                            Careers
+                        <a class="m-list_link" href="/about-us/events/">
+                            Events 
                         </a>
                     </li>
                     <li class="m-list_item">


### PR DESCRIPTION
HOLD until IA launch

Adds "About Us" and "Events" to the global footer & removes "Newsroom"

<img width="1102" alt="Screen Shot 2020-09-14 at 3 15 52 PM" src="https://user-images.githubusercontent.com/1558033/93143732-5aaff200-f69d-11ea-9714-792debd9e5d1.png">
