### PR TITLE
Filters: Remove colons from form date input labels

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -109,7 +109,7 @@
                                         <div class="m-form-field">
                                             <label class="a-label a-label__heading"
                                                    for="{{ form.from_date.id_for_label }}">
-                                                From:
+                                                From
                                             </label>
                                             {{ form.from_date }}
                                         </div>
@@ -119,7 +119,7 @@
                                         <div class="m-form-field">
                                             <label class="a-label a-label__heading"
                                                    for="{{ form.to_date.id_for_label }}">
-                                                To:
+                                                To
                                             </label>
                                             {{ form.to_date }}
                                         </div>


### PR DESCRIPTION

## Removals

- Remove colons from form date input labels for consistency with other filter labels.


## How to test this PR

1. /blog date inputs labels should not have colons any longer.
