### PR TITLE
Improve mega menu submenu highlighting

### DIFF
--- a/cfgov/mega_menu/frontend_conversion.py
+++ b/cfgov/mega_menu/frontend_conversion.py
@@ -1,4 +1,8 @@
+import re
 from itertools import chain
+
+
+REGEX_REMOVE_QUERY_STRING = re.compile(r'\?.*$')
 
 
 class FrontendConverter:
@@ -15,7 +19,7 @@ class FrontendConverter:
         # Normally we want to mark menu links as selected if the current
         # request is either on that link or one of its children; this lets us
         # properly highlight the menu if on the child of a menu link. But we
-        # don't want to do this for overview links, which are always the parent
+        # don't want to do this for overview links, which may be the parent
         # of all links beneath them.
         overview_link = self.make_link(
             {
@@ -48,9 +52,12 @@ class FrontendConverter:
             *chain(column['nav_items'] for column in columns)
         ):
             url = link.get('url')
-            if url and self.request.path.startswith(url):
-                menu_item['selected'] = True
-                break
+            if url:
+                url_no_query_string = REGEX_REMOVE_QUERY_STRING.sub('', url)
+
+                if self.request.path.startswith(url_no_query_string):
+                    menu_item['selected'] = True
+                    break
 
         return menu_item
 

--- a/cfgov/mega_menu/tests/test_frontend_conversion.py
+++ b/cfgov/mega_menu/tests/test_frontend_conversion.py
@@ -13,7 +13,7 @@ class FrontendConverterTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.root_page = Site.objects.get(is_default_site=True).root_page
-        cls.request = RequestFactory().get('/consumer-tools/')
+        cls.request = RequestFactory().get('/foo/bar/')
         Site.find_for_request(cls.request)
 
         consumer_tools_page = cls.make_test_page('Consumer Tools')
@@ -39,7 +39,7 @@ class FrontendConverterTests(TestCase):
                                     'text': 'Wagtail page with other text',
                                 },
                                 {
-                                    'url': '/foo/bar/',
+                                    'url': '/foo/bar/?baz=1',
                                     'text': 'Non-Wagtail page',
                                 },
                             ],
@@ -124,7 +124,6 @@ class FrontendConverterTests(TestCase):
                 'overview': {
                     'url': '/consumer-tools/',
                     'text': 'Consumer Tools',
-                    'selected': True,
                 },
                 'nav_groups': [
                     {
@@ -140,7 +139,7 @@ class FrontendConverterTests(TestCase):
                                 'text': 'Wagtail page with other text',
                             },
                             {
-                                'url': '/foo/bar/',
+                                'url': '/foo/bar/?baz=1',
                                 'text': 'Non-Wagtail page',
                             },
                         ],


### PR DESCRIPTION
We want a mega menu submenu to be highlighted (i.e. appear visually selected) when users are on a child page of that submenu.

The current logic assumes that we can determine this by comparing URL paths; for example, if a submenu contains a link to /foo/, and the user is on /foo/bar/, then we should highlight the submenu.

For increased flexibility, we also want to support the case when menu items point to links with query strings, for example /foo/?something. In this case, we want a page like /foo/bar/ to also mark the submenu as selected. This commit alters the logic so that we strip off the menu link query string before comparing it to the request path.

Note that this logic only applies to the top-level highlighting of submenus (for example Consumer Tools on the current site). This doesn't alter how the specific menu links themselves are highlighted.

## How to test this PR

1. Run locally and confirm that menu highlighting works properly with the current menus.
   - For example, [the Press Resources page](http://localhost:8000/about-us/newsroom/press-resources/) should highlight both the About Us submenu as well as its parent Newsroom link.
2. Change a menu link so that it points to a URL with a query string (see #6011 for one way to do this), and then confirm that its menu continues to be highlighted if you visit the URL without the query string.
   - Note that the link itself will _not_ be highlighted; this is unfortunate but deliberate to avoid duplicate highlighting in cases where multiple links differ only by their query string.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)