### PR TITLE
Replaces the ElasticSearch 2.3 and 2.4 images with a single 2.3.5 image

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -4,8 +4,7 @@ version: "3.7"
 
 services:
   elasticsearch:
-    image: elasticsearch:2.4-alpine
-    user: elasticsearch
+    image: ${CFGOV_ES_IMAGE}
     deploy:
       placement:
         constraints:

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -11,7 +11,9 @@ services:
           - node.role!=manager
       restart_policy:
         condition: any
+        delay: 10s
         max_attempts: 3
+        window: 120s
     networks:
       - app
 

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -10,7 +10,8 @@ services:
         constraints:
           - node.role!=manager
       restart_policy:
-        condition: none
+        condition: any
+        max_attempts: 3
     networks:
       - app
 

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,4 +1,31 @@
-FROM elasticsearch:2.3
-RUN plugin install org.codelibs/elasticsearch-dataformat/2.3.0
+FROM centos:7
+
+# Update and install OS dependencies
+RUN yum update -y && \
+    yum install -y java-1.8.0-openjdk && \
+    yum clean all && rm -rf /var/cache/yum
+
+# Install ElasticSearch
+RUN adduser -s /bin/false elasticsearch
+RUN curl https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz -o /opt/elasticsearch.tar.gz
+
+RUN cd /opt && \
+    tar -xvf elasticsearch.tar.gz && \
+    rm -rf elasticsearch.tar.gz && \
+    mv elasticsearch-2.3.5 elasticsearch 
+
+WORKDIR /opt/elasticsearch
 COPY cfgov/search/resources/synonyms_en.txt config/analysis/synonyms_en.txt
 COPY cfgov/search/resources/synonyms_es.txt config/analysis/synonyms_es.txt
+# is this still needed?
+RUN bin/plugin install org.codelibs/elasticsearch-dataformat/2.3.0
+
+RUN chown -R elasticsearch:elasticsearch ./
+
+
+
+EXPOSE 9200
+USER elasticsearch
+
+CMD [ "/opt/elasticsearch/bin/elasticsearch", "-Des.network.host=0.0.0.0" ]
+


### PR DESCRIPTION
This replaces the 2 separate ES 2.3 / 2.4 images, used in docker-compose.yml and docker-stack.yml, with a single image.

This image is based on CentOS7 and downloads and installs ES 2.3.5 from Elastic. It ensures the same image is used in both local development and in a docker cluster. We hypothesize this _may_ help with ES flakiness in the docker cluster, though that is admittedly a long shot.

Addresses APPOPS-1201

<!-- Enter an explanation of what the pull request does and why. -->

We have had success with an identical approach to older ElasticSearch images, in a different stack. It's _possible_ that this approach will be more stable in the docker cluster. It also has the benefit of using the exact same image for both local development and in the cluster.


## How to test this PR

1. Follow the documented procedures for creating a local docker development environment for consumerfinance.gov
1. `docker-compose up --build`
1. Ensure database is loaded
1. `docker-compose exec python bash`
1. `cd cfgov`
1. `manage.py rebuild_index`

This will build all configured indexes. After a few minutes, the Ask CFPB content will be loaded and be searchable. It's then testable with http://localhost:8000/ask-cfpb/search/?q=mortgage


## Screenshots

<img width="791" alt="Screen Shot 2020-09-16 at 11 42 18 PM" src="https://user-images.githubusercontent.com/127017/93417472-4a06a400-f876-11ea-8cfb-7543d39764d9.png">

