### PR TITLE
Bump the django-college-costs-comparison version to 1.17.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -51,5 +51,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.15.1/comparisontool-1.15.1-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.0/comparisontool-1.17.0-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl


### PR DESCRIPTION
This change removes comparisontool code and haystack indexing code,
so that indexing no longer hits the comparisontool tables.
This will allow us to archive and drop the comparisontool tables from our
production database.

There are only 3 static pages left that are served from the satellite repo.
- https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/
- https://www.consumerfinance.gov/paying-for-college/manage-your-college-money/
- https://www.consumerfinance.gov/paying-for-college/repay-student-debt/

