### PR TITLE
Add script for mega menu link checking

### DIFF
--- a/cfgov/scripts/validate_mega_menu.py
+++ b/cfgov/scripts/validate_mega_menu.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+import argparse
+import re
+import sys
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def validate_mega_menu(base):
+    failures = []
+
+    print(f'Retrieving mega menu from {base}')
+    response = requests.get(base, allow_redirects=True)
+    response.raise_for_status()
+
+    html = response.content
+    soup = BeautifulSoup(html, 'html.parser')
+
+    links = soup.findAll('a', {'class': 'o-mega-menu_content-link'})
+    for link in links:
+        if 'o-mega-menu_content-link__has-children' in link['class']:
+            continue
+
+        text = link.text.strip()
+        href = link['href']
+
+        print(f'Checking "{text}" ({href})...', end='')
+        if not re.search(r'^https?://', href):
+            href = base + href
+
+        response = requests.get(href)
+
+        if response.ok:
+            print('ok')
+        else:
+            print('error!', response.status_code)
+            failures.append((text, href))
+
+    if failures:
+        print('\nFailures:')
+
+        for text, href in failures:
+            print(f'- "{text}" ({href})"')
+
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'base',
+        help='Base URL, defaults to %(default)s',
+        default='https://www.consumerfinance.gov',
+        nargs='?'
+    )
+
+    args = parser.parse_args()
+    validate_mega_menu(**vars(args))


### PR DESCRIPTION
This new command line script allows for checking of mega menu links on a running cf.gov server. To run against www.consumerfinance.gov:

```
cfgov/scripts/validate_mega_menu.py
```

or to run against an alternate server:

```
cfgov/scripts/validate_mega_menu.py http://localhost:8000
```

The script checks each link in the mega menu (as it appears on the homepage) and validates that the link can be fetched with a 200.

## How to test this PR

To test, run a local server, edit the English menu (http://localhost:8000/admin/mega_menu/menu/edit/en/) and add a broken link. Run this script against localhost and it will fail.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)