### PR TITLE
Add script for validating redirects

### DIFF
--- a/cfgov/scripts/validate_redirects.py
+++ b/cfgov/scripts/validate_redirects.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+
+import requests
+from tablib import Dataset
+
+
+def load_redirects(redirects_filename):
+    csv = redirects_filename.endswith('.csv')
+    mode = 'rt' if csv else 'rb'
+
+    with open(redirects_filename, mode) as f:
+        dataset = Dataset().load(f, format='csv' if csv else None)
+
+    return [tuple(row[i].rstrip('*') for i in (5, 6)) for row in dataset]
+
+
+def validate_redirects(redirects_filename, baseurl):
+    failures = []
+
+    for from_path, to_path in load_redirects(redirects_filename):
+        print(f'Checking {from_path} -> {to_path}...', end='')
+        response = requests.get(baseurl + from_path, allow_redirects=False)
+
+        redirected = response.status_code in (301, 302)
+
+        if not redirected:
+            print('error!', response.status_code)
+            failures.append((from_path, to_path))
+            continue
+
+        location = response.headers.get('location')
+
+        if location != to_path:
+            print('error! location:', location)
+            failures.append((from_path, to_path))
+            continue
+
+        print('ok')
+
+    if failures:
+        print('\nFailures:')
+
+        for from_path, to_path in failures:
+            print(f'- {from_path} -> {to_path}')
+
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'redirects_filename',
+        help='Redirects filename (XLSX format)'
+    )
+    parser.add_argument(
+        'baseurl',
+        help='Base URL, defaults to %(default)s',
+        default='https://www.consumerfinance.gov',
+        nargs='?'
+    )
+
+    args = parser.parse_args()
+    validate_redirects(**vars(args))


### PR DESCRIPTION
This new script allows for validation of a set of redirects as defined in a CSV or XLSX file. The first line of the file will be ignored as headers. The "from" and "to" paths default to being read from the 6th and 7th column of the input file, respectively.

To run against www.consumerfinance.gov, using an input XLSX:

```
cfgov/scripts/validate_redirects.py redirects.xlsx
```

To run against localhost, using an input CSV:

```
cfgov/scripts/validate_redirects.py redirects.csv http://localhost:8000
```

To specify alternate CSV columns for the "from" and "to" paths:

```
cfgov/scripts/validate_redirects.py redirects.xlsx --from-index=1 --to-index=2
```

## How to test this PR

To test, run without one of the redirects and observe that the check fails. Now add the redirect and note that the check passes as long as it redirects to the correct path.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)