### PR TITLE
IA Migration day: Update Apache redirects, URLs, and site footer

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -52,24 +52,39 @@ equal-credit-opportunity-act-valuation-rule/|\
 rural-and-underserved-counties-list/|\
 secure-fair-enforcement-for-mortgage-licensing-act/.*|\
 mortserv/.*\
-) /policy-compliance/guidance/mortgage-resources/$1
+) /compliance/compliance-resources/mortgage-resources/$1
 
 RedirectMatch permanent ^/policy-compliance/guidance/(\
 fair-credit-reporting-act/.*|\
 equal-credit-opportunity-act/.*\
-) /policy-compliance/guidance/other-applicable-requirements/$1
+) /compliance/compliance-resources/other-applicable-requirements/$1
 
-Redirect permanent /policy-compliance/guidance/hmda-implementation/ /policy-compliance/guidance/mortgage-resources/hmda-reporting-requirements/
-Redirect permanent /policy-compliance/guidance/home-ownership-and-equity-protection-act-rule/ /policy-compliance/guidance/mortgage-resources/high-cost-mortgages/
-Redirect permanent /policy-compliance/guidance/loan-originator-rule/ /policy-compliance/guidance/mortgage-resources/loan-origination-rule/
-Redirect permanent /policy-compliance/guidance/tila-respa-disclosure-rule/ /policy-compliance/guidance/mortgage-resources/tila-respa-integrated-disclosures/
-Redirect permanent /policy-compliance/guidance/tila-higher-priced-mortgage-loans-appraisal-rule/ /policy-compliance/guidance/mortgage-resources/higher-priced-mortgage-loans-appraisal-rule/
-Redirect permanent /policy-compliance/guidance/tila-higher-priced-mortgage-loan-escrow-rule/ /policy-compliance/guidance/mortgage-resources/higher-priced-mortgage-loan-escrow-rule/
-Redirect permanent /policy-compliance/guidance/payday-lending-rule/ /policy-compliance/guidance/consumer-lending-resources/payday-lending-rule/
-Redirect permanent /policy-compliance/guidance/prepaid-rule/ /policy-compliance/guidance/consumer-cards-resources/prepaid-cards/
-Redirect permanent /policy-compliance/guidance/truth-lending-annual-threshold-adjustments/ /policy-compliance/guidance/consumer-cards-resources/truth-lending-annual-threshold-adjustments/
-Redirect permanent /policy-compliance/guidance/remittance-transfer-rule/ /policy-compliance/guidance/deposit-accounts-resources/remittance-transfer-rule/
-Redirect permanent /policy-compliance/guidance/gramm-leach-bliley-act/ /policy-compliance/guidance/other-applicable-requirements/privacy-notices/
+Redirect permanent /policy-compliance/guidance/hmda-implementation/ /compliance/compliance-resources/mortgage-resources/hmda-reporting-requirements/
+Redirect permanent /policy-compliance/guidance/home-ownership-and-equity-protection-act-rule/ /compliance/compliance-resources/mortgage-resources/high-cost-mortgages/
+Redirect permanent /policy-compliance/guidance/loan-originator-rule/ /compliance/compliance-resources/mortgage-resources/loan-origination-rule/
+Redirect permanent /policy-compliance/guidance/tila-respa-disclosure-rule/ /compliance/compliance-resources/mortgage-resources/tila-respa-integrated-disclosures/
+Redirect permanent /policy-compliance/guidance/tila-higher-priced-mortgage-loans-appraisal-rule/ /compliance/compliance-resources/mortgage-resources/higher-priced-mortgage-loans-appraisal-rule/
+Redirect permanent /policy-compliance/guidance/tila-higher-priced-mortgage-loan-escrow-rule/ /compliance/compliance-resources/mortgage-resources/higher-priced-mortgage-loan-escrow-rule/
+Redirect permanent /policy-compliance/guidance/payday-lending-rule/ /compliance/compliance-resources/consumer-lending-resources/payday-lending-rule/
+Redirect permanent /policy-compliance/guidance/prepaid-rule/ /compliance/compliance-resources/consumer-cards-resources/prepaid-cards/
+Redirect permanent /policy-compliance/guidance/truth-lending-annual-threshold-adjustments/ /compliance/compliance-resources/consumer-cards-resources/truth-lending-annual-threshold-adjustments/
+Redirect permanent /policy-compliance/guidance/remittance-transfer-rule/ /compliance/compliance-resources/deposit-accounts-resources/remittance-transfer-rule/
+Redirect permanent /policy-compliance/guidance/gramm-leach-bliley-act/ /compliance/compliance-resources/other-applicable-requirements/privacy-notices/
+
+# 9/30/20 IA work, policy and compliance changes
+RedirectMatch permanent ^/policy-compliance/guidance/(\
+other-applicable-requirements/.*|\
+consumer-lending-resources/.*|\
+consumer-cards-resources/.*|\
+deposit-accounts-resources/.*|\
+mortgage-resources/.*\
+) /compliance/compliance-resources/$1
+
+Redirect permanent /policy-compliance/notice-opportunities-comment/ /rules-policy/notice-opportunities-comment/
+Redirect permanent /policy-compliance/amicus/ /compliance/amicus/
+Redirect permanent /policy-compliance/enforcement/ /enforcement/
+Redirect permanent /policy-compliance/rulemaking/ /rules-policy/
+Redirect permanent /policy-compliance/guidance/ /compliance/
 
 RedirectMatch permanent  ^/the-cfpb-wants-you-to-blow-the-whistle-on-lawbreakers/[/]?$ /blog/the-cfpb-wants-you-to-blow-the-whistle-on-lawbreakers/
 RedirectMatch permanent  ^/financial-education-for-moms-and-all-women([/]?)  /blog/financial-education-for-moms-and-all-women/
@@ -483,18 +498,15 @@ Redirect permanent /budget/cfo-q4-2011/	/about-us/budget-strategy/financial-repo
 Redirect permanent /budget/cfo-q3-2011/	/about-us/budget-strategy/financial-reports/cfo-q3-2011/
 Redirect permanent /budget/cfo-q2-2011/	/about-us/budget-strategy/financial-reports/cfo-q2-2011/
 Redirect permanent /budget/cfo-q1-2011/	/about-us/budget-strategy/financial-reports/cfo-q1-2011/
-Redirect permanent /budget/civil-penalty-fund    /about-us/payments-harmed-consumers/payments-by-case
+Redirect permanent /budget/civil-penalty-fund    /enforcement/payments-harmed-consumers/payments-by-case
 Redirect permanent /budget/	/about-us/budget-strategy/
 
 RedirectMatch permanent ^\/leadership-calendar\/(?!cfpb-leadership.json)   /about-us/the-bureau/leadership-calendar/
 Redirect permanent /the-bureau/about-rich-cordray/   /about-us/the-bureau/about-director/
-Redirect permanent /administrativeadjudication/2015-cfpb-0029/	/policy-compliance/enforcement/actions/integrity-advance/
-Redirect permanent /administrativeadjudication/2014-cfpb-0002/	/policy-compliance/enforcement/actions/phh-corporation/
-Redirect permanent /administrativeadjudication/2013-cfpb-0002/	/policy-compliance/enforcement/actions/3d-resorts-bluegrass/
-Redirect permanent /administrativeadjudication/	/policy-compliance/enforcement/actions/?form-id=0&filter0_categories=admin-filing&filter0_from_date=&filter0_to_date=
-
-Redirect permanent /amicus/amicus-faqs/	/policy-compliance/amicus/suggest/
-Redirect permanent /amicus/	/policy-compliance/amicus/
+Redirect permanent /administrativeadjudication/2015-cfpb-0029/	/enforcement/actions/integrity-advance/
+Redirect permanent /administrativeadjudication/2014-cfpb-0002/	/enforcement/actions/phh-corporation/
+Redirect permanent /administrativeadjudication/2013-cfpb-0002/	/enforcement/actions/3d-resorts-bluegrass/
+Redirect permanent /administrativeadjudication/	/enforcement/actions/?form-id=0&filter0_categories=admin-filing&filter0_from_date=&filter0_to_date=
 
 
 Redirect permanent /jobs/title     /careers/current-openings/
@@ -503,14 +515,16 @@ RedirectMatch permanent ^\/jobs\/detail\/.*  /careers/current-openings/
 RedirectMatch permanent ^\/jobs\/(?!supervision)(?!technology-innovation-fellows)(?!jobs.json).* /about-us/careers/
 
 
-Redirect permanent /advisory-groups/advisory-groups-meeting-details/ /about-us/advisory-groups/
-Redirect permanent /advisory-groups/ /about-us/advisory-groups/
+Redirect permanent /advisory-groups/advisory-groups-meeting-details/ /rules-policy/advisory-committees/
+Redirect permanent /advisory-groups/ /rules-policy/advisory-committees/
+Redirect permanent /about-us/advisory-groups/ /rules-policy/advisory-committees/
+Redirect permanent /hmda/  /data-research/hmda/
 Redirect permanent /data-research/mortgage-data-hmda/  /data-research/hmda/
 
 Redirect permanent /complaintdatabase/ /data-research/consumer-complaints/
 
-Redirect permanent /remittances-transfer-rule-amendment-to-regulation-e/  /policy-compliance/rulemaking/final-rules/electronic-fund-transfers-regulation-e/
-Redirect permanent /regulations/integrated-mortgage-disclosures-under-the-real-estate-settlement-procedures-act-regulation-x-and-the-truth-in-lending-act-regulation-z/ /policy-compliance/rulemaking/final-rules/2013-integrated-mortgage-disclosure-rule-under-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z/
+Redirect permanent /remittances-transfer-rule-amendment-to-regulation-e/  /rules-policy/final-rules/electronic-fund-transfers-regulation-e/
+Redirect permanent /regulations/integrated-mortgage-disclosures-under-the-real-estate-settlement-procedures-act-regulation-x-and-the-truth-in-lending-act-regulation-z/ /rules-policy/final-rules/2013-integrated-mortgage-disclosure-rule-under-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z/
 
 RedirectMatch permanent ^\/retirement[\/]?$  /retirement/before-you-claim
 
@@ -527,44 +541,42 @@ RedirectMatch permanent ^\/credit-cards\/credit-card-act\/feb2011-factsheet[\/]?
 Redirect permanent /credit-cards/college-agreements/   /data-research/credit-card-data/college-credit-card-agreement/
 
 # regulatory-implementation
-RedirectMatch permanent ^\/regulatory\-implementation\/?$ /policy-compliance/guidance/implementation-guidance/
-Redirect permanent /regulatory-implementation/title-xiv	/policy-compliance/guidance/implementation-guidance/title-xiv-mortgage-rules/
-Redirect permanent /regulatory-implementation/tila-respa	/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/
-Redirect permanent /remittances-transfer-rule-amendment-to-regulation-e	/policy-compliance/guidance/implementation-guidance/remittance-transfer-rule/
-Redirect permanent /regulatory-implementation/hmda	/policy-compliance/guidance/implementation-guidance/hmda-implementation/
+RedirectMatch permanent ^\/regulatory\-implementation\/?$ /compliance/implementation-guidance/
+Redirect permanent /regulatory-implementation/title-xiv	/compliance/implementation-guidance/title-xiv-mortgage-rules/
+Redirect permanent /regulatory-implementation/tila-respa	/compliance/implementation-guidance/tila-respa-disclosure-rule/
+Redirect permanent /remittances-transfer-rule-amendment-to-regulation-e	/compliance/implementation-guidance/remittance-transfer-rule/
+Redirect permanent /regulatory-implementation/hmda	/compliance/implementation-guidance/hmda-implementation/
 
 # legacy regulations URL's
-Redirect permanent /regulations/integrated-mortgage-disclosures-under-the-real-estate-settlement-procedures-act-regulation-x-and-the-truth-in-lending-act-regulation-z/	/policy-compliance/rulemaking/final-rules/2013-integrated-mortgage-disclosure-rule-under-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z/
-Redirect permanent /regulations/consumer-financial-civil-penalty-fund-rule/	/policy-compliance/rulemaking/final-rules/consumer-financial-civil-penalty-fund-rule/
-Redirect permanent /regulations/loan-originator-compensation-requirements-under-the-truth-in-lending-act-regulation-z/	/policy-compliance/rulemaking/final-rules/loan-originator-compensation-requirements-under-truth-lending-act-regulation-z/
-Redirect permanent /regulations/disclosure-and-delivery-requirements-for-copies-of-appraisals-and-other-written-valuations-under-the-equal-credit-opportunity-act-regulation-b/	/policy-compliance/rulemaking/final-rules/disclosure-and-delivery-requirements-copies-appraisals-and-other-written-valuations-under-equal-credit-opportunity-act-regulation-b/
-Redirect permanent /regulations/appraisals-for-higher-priced-mortgage-loans/	/policy-compliance/rulemaking/final-rules/appraisals-higher-priced-mortgage-loans/
-Redirect permanent /regulations/2013-real-estate-settlement-procedures-act-regulation-x-and-truth-in-lending-act-regulation-z-mortgage-servicing-final-rules/	/policy-compliance/rulemaking/final-rules/2013-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z-mortgage-servicing-final-rules/
-Redirect permanent /regulations/escrow-requirements-under-the-truth-in-lending-act-regulation-z/	/policy-compliance/rulemaking/final-rules/escrow-requirements-under-truth-lending-act-regulation-z/
-Redirect permanent /regulations/high-cost-mortgage-and-homeownership-counseling-amendments-to-regulation-z-and-homeownership-counseling-amendments-to-regulation-x/	/policy-compliance/rulemaking/final-rules/high-cost-mortgage-and-homeownership-counseling-amendments-truth-lending-act-regulation-z-and-homeownership-counseling-amendments-real-estate-settlement-procedures-act-regulation-x/
-Redirect permanent /regulations/ability-to-repay-and-qualified-mortgage-standards-under-the-truth-in-lending-act-regulation-z/	/policy-compliance/rulemaking/final-rules/ability-repay-and-qualified-mortgage-standards-under-truth-lending-act-regulation-z/
+Redirect permanent /regulations/integrated-mortgage-disclosures-under-the-real-estate-settlement-procedures-act-regulation-x-and-the-truth-in-lending-act-regulation-z/	/rules-policy/final-rules/2013-integrated-mortgage-disclosure-rule-under-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z/
+Redirect permanent /regulations/consumer-financial-civil-penalty-fund-rule/	/rules-policy/final-rules/consumer-financial-civil-penalty-fund-rule/
+Redirect permanent /regulations/loan-originator-compensation-requirements-under-the-truth-in-lending-act-regulation-z/	/rules-policy/final-rules/loan-originator-compensation-requirements-under-truth-lending-act-regulation-z/
+Redirect permanent /regulations/disclosure-and-delivery-requirements-for-copies-of-appraisals-and-other-written-valuations-under-the-equal-credit-opportunity-act-regulation-b/	/rules-policy/final-rules/disclosure-and-delivery-requirements-copies-appraisals-and-other-written-valuations-under-equal-credit-opportunity-act-regulation-b/
+Redirect permanent /regulations/appraisals-for-higher-priced-mortgage-loans/	/rules-policy/final-rules/appraisals-higher-priced-mortgage-loans/
+Redirect permanent /regulations/2013-real-estate-settlement-procedures-act-regulation-x-and-truth-in-lending-act-regulation-z-mortgage-servicing-final-rules/	/rules-policy/final-rules/2013-real-estate-settlement-procedures-act-regulation-x-and-truth-lending-act-regulation-z-mortgage-servicing-final-rules/
+Redirect permanent /regulations/escrow-requirements-under-the-truth-in-lending-act-regulation-z/	/rules-policy/final-rules/escrow-requirements-under-truth-lending-act-regulation-z/
+Redirect permanent /regulations/high-cost-mortgage-and-homeownership-counseling-amendments-to-regulation-z-and-homeownership-counseling-amendments-to-regulation-x/	/rules-policy/final-rules/high-cost-mortgage-and-homeownership-counseling-amendments-truth-lending-act-regulation-z-and-homeownership-counseling-amendments-real-estate-settlement-procedures-act-regulation-x/
+Redirect permanent /regulations/ability-to-repay-and-qualified-mortgage-standards-under-the-truth-in-lending-act-regulation-z/	/rules-policy/final-rules/ability-repay-and-qualified-mortgage-standards-under-truth-lending-act-regulation-z/
 
 # misc redirects
-Redirect permanent /regulatory-agenda-archive/	/policy-compliance/rulemaking/regulatory-agenda/
-Redirect permanent /fall-2011-semiannual-regulatory-agenda-and-regulatory-plan/	/policy-compliance/rulemaking/regulatory-agenda/fall-2011-semiannual-regulatory-agenda-and-regulatory-plan/
-Redirect permanent /fall-2011-statement-of-regulatory-priorities/	/policy-compliance/rulemaking/regulatory-agenda/fall-2011-statement-regulatory-priorities/
+Redirect permanent /regulatory-agenda-archive/	/rules-policy/regulatory-agenda/
+Redirect permanent /fall-2011-semiannual-regulatory-agenda-and-regulatory-plan/	/rules-policy/regulatory-agenda/fall-2011-semiannual-regulatory-agenda-and-regulatory-plan/
+Redirect permanent /fall-2011-statement-of-regulatory-priorities/	/rules-policy/regulatory-agenda/fall-2011-statement-regulatory-priorities/
 
-RedirectMatch permanent ^/guidance/supervision/manual/$  /policy-compliance/guidance/supervision-examinations/
-Redirect permanent /guidance/supervision/	/policy-compliance/guidance/supervision-examinations/
-Redirect permanent /guidance/petitions-to-modify-or-set-aside/	/policy-compliance/enforcement/petitions/
+RedirectMatch permanent ^/guidance/supervision/manual/$  /compliance/supervision-examinations/
+Redirect permanent /guidance/supervision/	/compliance/supervision-examinations/
+Redirect permanent /guidance/petitions-to-modify-or-set-aside/	/enforcement/petitions/
 
-Redirect permanent /guidance/	/policy-compliance/guidance/
+Redirect permanent /guidance/	/compliance/
 
-Redirect permanent /mortgage-rules-at-a-glance/   /policy-compliance/rulemaking/final-rules/?form-id=1&filter1_title=&filter1_topics=Mortgages
+Redirect permanent /mortgage-rules-at-a-glance/   /rules-policy/final-rules/?form-id=1&filter1_title=&filter1_topics=Mortgages
 Redirect permanent /students-and-recent-graduates/  /careers/students-and-graduates/
 
-Redirect permanent /notice-and-comment/	/policy-compliance/notice-opportunities-comment/
-Redirect permanent /amicus/	/policy-compliance/amicus-program/
-Redirect permanent /amicus/amicus-faqs/	/policy-compliance/amicus/suggest/
-Redirect permanent /small-financial-services-providers/	/policy-compliance/community-banks-credit-unions/
+Redirect permanent /notice-and-comment/	 /rules-policy/notice-opportunities-comment/
+Redirect permanent /amicus/	/compliance/amicus/
+Redirect permanent /amicus/amicus-faqs/	/compliance/amicus/suggest/
+Redirect permanent /small-financial-services-providers/	/rules-policy/community-banks-credit-unions/
 Redirect permanent /doing-business-with-us/	/about-us/doing-business-with-us/
-Redirect permanent /advisory-groups/	/about-us/advisory-groups/
-Redirect permanent /advisory-groups/advisory-groups-meeting-details/	/about-us/advisory-groups/
 Redirect permanent /projectcatalyst/ 	/about-us/project-catalyst/
 Redirect permanent /ProjectCatalyst/ 	/about-us/project-catalyst/
 Redirect permanent /contact-us/	/about-us/contact-us/
@@ -818,11 +830,11 @@ RedirectMatch permanent \/blog\/category\/equal-treatment\/.*$ /about-us/blog/?f
 
 # Redirect old FinEd Resources downloads to their new Wagtail sublanding pages
 RedirectMatch permanent ^/money-as-you-grow/(.*)\.pdf$ /consumer-tools/money-as-you-grow/
-RedirectMatch permanent ^/library-resources/(.*)\.(docx|pdf|png|txt|zip)$ /practitioner-resources/library-resources/
-RedirectMatch permanent ^/tax-preparer-resources/(.*)\.(docx|pdf|png|txt|zip)$ /practitioner-resources/resources-for-tax-preparers/
+RedirectMatch permanent ^/library-resources/(.*)\.(docx|pdf|png|txt|zip)$ /consumer-tools/educator-tools/library-resources/
+RedirectMatch permanent ^/tax-preparer-resources/(.*)\.(docx|pdf|png|txt|zip)$ /consumer-tools/educator-tools/resources-for-tax-preparers/
 
 # ILSA vanity URL
-RedirectMatch permanent (?i)^/ILSA([/]?)$ /policy-compliance/guidance/interstate-land-sales-registration/
+RedirectMatch permanent (?i)^/ILSA([/]?)$ /compliance/interstate-land-sales-registration/
 
 # Link from payday lending disclosures
 RedirectMatch permanent (?i)^/payday([/]?)$ /askcfpb/search/?selected_facets=category_exact:payday-loans
@@ -890,17 +902,19 @@ Redirect permanent /askcfpb/535 /askcfpb/381
 RedirectMatch permanent (?i)^/CreditReportingDisputeLetter([/]?)$ https://files.consumerfinance.gov/f/documents/092016_cfpb_CreditReportingDisputeLetter.docx
 
 
-# Educational Resources redirects, updated 12/13/16 with move to Wagtail
+# Educational Resources
+Redirect permanent /educational-resources/ /consumer-tools/educator-tools/
 
 ## Money as You Grow
 RedirectMatch permanent (?i)^/parent([s]?)([/]?)$ /consumer-tools/money-as-you-grow/
 RedirectMatch permanent (?i)^/money([\-]?)as([\-]?)you([\-]?)grow(.*) /consumer-tools/money-as-you-grow$4
+Redirect permanent /practitioner-resources/money-as-you-grow/ /consumer-tools/money-as-you-grow/
 
 ## Youth Financial Education
-RedirectMatch permanent (?i)^/youth-financial-education([/]?)$ /practitioner-resources/youth-financial-education/
+RedirectMatch permanent (?i)^/youth-financial-education([/]?)$ /consumer-tools/educator-tools/youth-financial-education/
 
 ## Adult Financial Education
-RedirectMatch permanent (?i)^/adult-financial-education([/]?)$ /practitioner-resources/adult-financial-education/
+RedirectMatch permanent (?i)^/adult-financial-education([/]?)$ /consumer-tools/educator-tools/adult-financial-education/
 
 ## MAYG Spanish, redirecting from the "just add /es" model to the real address
 RedirectMatch permanent (?i)/money-as-you-grow/es([/]?)$ /es/el-dinero-mientras-creces/
@@ -949,16 +963,17 @@ RedirectMatch permanent (?i)^/es/guia-asesor-financiero https://pueblo.gpo.gov/C
 # Redirects associated with moving Older Americans and MSEM to Wagtail
 
 ## This one specific page got moved to another specific page
-RedirectMatch permanent (?i)^/older-americans/protecting-whats-yours([/]?)$ /practitioner-resources/resources-for-older-adults/protecting-whats-yours/
+RedirectMatch permanent (?i)^/older-americans/protecting-whats-yours([/]?)$ /consumer-tools/educator-tools/resources-for-older-adults/protecting-whats-yours/
 
 ## Send everything else beginning with /older-americans to the new main Resources for Older Adults page
-RedirectMatch permanent (?i)^/older-americans/ /practitioner-resources/resources-for-older-adults/
+RedirectMatch permanent (?i)^/older-americans/ /consumer-tools/educator-tools/resources-for-older-adults/
 
 ## MSEM moved under Resources for Older Adults
 RedirectMatch permanent (?i)^/managing-someone-elses-money([/]?)$ /consumer-tools/managing-someone-elses-money/
+Redirect permanent /practitioner-resources/resources-for-older-adults/managing-someone-elses-money/ /consumer-tools/managing-someone-elses-money/
 
 # Redirect old Tax Preparers URL to its new Wagtail home
-RedirectMatch permanent (?i)^/tax-preparer-resources([/]?)$ /practitioner-resources/resources-for-tax-preparers/
+RedirectMatch permanent (?i)^/tax-preparer-resources([/]?)$ /consumer-tools/educator-tools/resources-for-tax-preparers/
 
 # Redirect FY13-17 Strategic Plan page to PDF to move out of WordPress
 # See discussion here: https://GHE/CFGOV/platform/issues/710
@@ -968,22 +983,25 @@ RedirectMatch (?i)^/strategic-plan/$ https://files.consumerfinance.gov/f/strateg
 # Redirects associated with moving Library Resources to Wagtail
 
 ## Specific redirects for changed pages
-RedirectMatch permanent (?i)^/library-resources/marketing-materials([/]?)$ /practitioner-resources/library-resources/outreach-materials-to-use-in-the-library/
-RedirectMatch permanent (?i)^/library-resources/websites-videos-courses([/]?)$ /practitioner-resources/library-resources/online-resources/
+RedirectMatch permanent (?i)^/library-resources/marketing-materials([/]?)$ /consumer-tools/educator-tools/library-resources/outreach-materials-to-use-in-the-library/
+RedirectMatch permanent (?i)^/library-resources/websites-videos-courses([/]?)$ /consumer-tools/educator-tools/library-resources/online-resources/
 
 ## Redirect main sublanding page, Librarian Training, and Program Ideas, which all have the same slug
-RedirectMatch permanent (?i)^/library-resources(.*) /practitioner-resources/library-resources$1
+RedirectMatch permanent (?i)^/library-resources(.*) /consumer-tools/educator-tools/library-resources$1
 
 ## Sending-money moved under Consumer Tools, along with all children whose slug has not changed
 RedirectMatch permanent (?i)^/sending-money(.*) /consumer-tools/sending-money$1
 
 ## Servicemembers redirects
-RedirectMatch permanent (?i)^/servicemembers/on-demand-forums-and-tools/?$ /practitioner-resources/servicemembers/webinars/
-RedirectMatch permanent (?i)^/servicemembers/(.*) /practitioner-resources/servicemembers/$1
+RedirectMatch permanent (?i)^/servicemembers/on-demand-forums-and-tools/?$ /consumer-tools/educator-tools/servicemembers/webinars/
+RedirectMatch permanent (?i)^/servicemembers/(.*) /consumer-tools/educator-tools/servicemembers/$1
 RedirectMatch permanent (?i)^/practitioner-resources/servicemembers/additionalresources/?$ /consumer-tools/military-financial-lifecycle/
 RedirectMatch permanent (?i)^/practitioner-resources/servicemembers/planning/?$ /consumer-tools/military-financial-lifecycle/
 RedirectMatch permanent (?i)^/practitioner-resources/servicemembers/planning/creativesavingsstrategies/?$ /consumer-tools/military-financial-lifecycle/
 RedirectMatch permanent (?i)^/practitioner-resources/servicemembers/protecting/?$ /consumer-tools/military-financial-lifecycle/
+
+# 9/30/20 IA work, practitioner-resources line moved here to allow the above redirects to maintain effect
+Redirect permanent /practitioner-resources/ /consumer-tools/educator-tools/
 
 # Common misspellings
 RedirectMatch (?i)(.*)morgage(.*) $1mortgage$2
@@ -992,7 +1010,7 @@ Redirect /assets https://files.consumerfinance.gov/a/assets
 
 # Redirects, requested by Rachael Keeler in July 2019
 # https://GHE/CFGOV/platform/issues/3484
-RedirectMatch permanent (?i)^/about-us/advisory-groups/(.*) /about-us/advisory-committees/$1
+RedirectMatch permanent (?i)^/about-us/advisory-groups/(.*) /rules-policy/advisory-committees/$1
 RedirectMatch permanent (?i)^/askcfpb/search/(.*) /ask-cfpb/search/$1
 RedirectMatch permanent (?i)^/how-to-prepare-your-finances-for-buying-a-home/(.*) /owning-a-home/process/prepare/
 Redirect /owning-a-home/help-us-improve/ /owning-a-home/feedback/

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -152,13 +152,13 @@ urlpatterns = [
         name='fair-lending'),
 
     re_path(
-        r'^practitioner-resources/students/knowbeforeyouowe/$',
+        r'^consumer-tools/educator-tools/students/knowbeforeyouowe/$',
         TemplateView.as_view(
             template_name='students/knowbeforeyouowe/index.html'),
         name='students-knowbeforeyouowe'
     ),
     re_path(
-        r'^practitioner-resources/students/'
+        r'^consumer-tools/educator-tools/students/'
         'helping-borrowers-find-ways-to-stay-afloat/$',
         TemplateView.as_view(
             template_name='students/helping-borrowers-find-'
@@ -370,22 +370,8 @@ urlpatterns = [
     ),
 
     # educational resources
-    re_path(r'^educational-resources/(?P<path>.*)$', RedirectView.as_view(
-        url='/practitioner-resources/%(path)s', permanent=True)),
     re_path(
-        r'^practitioner-resources/resources-for-older-adults/managing-someone-elses-money/(?P<path>.*)$',  # noqa: E501
-        RedirectView.as_view(
-            url='/consumer-tools/managing-someone-elses-money/%(path)s',  # noqa: E501
-            permanent=True)
-    ),
-    re_path(
-        r'^practitioner-resources/money-as-you-grow/(?P<path>.*)$',
-        RedirectView.as_view(
-            url='/consumer-tools/money-as-you-grow/%(path)s',
-            permanent=True)
-    ),
-    re_path(
-        r'^practitioner-resources/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
+        r'^consumer-tools/educator-tools/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
         FlaggedTemplateView.as_view(
             flag_name='YOUTH_EMPLOYMENT_SUCCESS',
             template_name='youth_employment_success/index.html'
@@ -400,12 +386,12 @@ urlpatterns = [
 
     # empowerment redirects
     re_path(r'^empowerment/$', RedirectView.as_view(
-            url='/practitioner-resources/economically-vulnerable/',
+            url='/consumer-tools/educator-tools/economically-vulnerable/',
             permanent=True)),
 
     # students redirects
     re_path(r'^students/(?P<path>.*)$', RedirectView.as_view(
-            url='/practitioner-resources/students/%(path)s',
+            url='/consumer-tools/educator-tools/students/%(path)s',
             permanent=True)),
 
     # ask-cfpb
@@ -509,12 +495,12 @@ urlpatterns = [
         'SEARCH_DOTGOV_API', r'^search/', include('search.urls')),
 
     re_path(
-        r'^practitioner-resources/youth-financial-education/',
+        r'^consumer-tools/educator-tools/youth-financial-education/',
         include('teachers_digital_platform.urls')
     ),
 
     re_path(
-        r'^practitioner-resources/youth-financial-education/curriculum-review/',  # noqa: E501
+        r'^consumer-tools/educator-tools/youth-financial-education/curriculum-review/',  # noqa: E501
         include('crtool.urls')
     ),
 

--- a/cfgov/jinja2/v1/_includes/organisms/footer.html
+++ b/cfgov/jinja2/v1/_includes/organisms/footer.html
@@ -51,13 +51,13 @@
                     </li>
                 {% else %}
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/about-us/contact-us/">
-                            Contact Us
+                        <a class="m-list_link" href="/about-us/">
+                            About Us
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/about-us/newsroom/">
-                            Newsroom
+                        <a class="m-list_link" href="/about-us/contact-us/">
+                            Contact Us
                         </a>
                     </li>
                     <li class="m-list_item">
@@ -66,7 +66,12 @@
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/policy-compliance/enforcement/information-industry-whistleblowers/">
+                        <a class="m-list_link" href="/about-us/events/">
+                            Events
+                        </a>
+                    </li>
+                    <li class="m-list_item">
+                        <a class="m-list_link" href="/enforcement/information-industry-whistleblowers/">
                             Industry Whistleblowers
                         </a>
                     </li>


### PR DESCRIPTION
Addresses:
- https://github.local/CFPB/super-regular/issues/150
- https://github.local/CFPB/super-regular/issues/149
- https://github.local/CFPB/super-regular/issues/167
- https://github.local/CFPB/super-regular/issues/157

1. Add all necessary Apache redirects for the IA Refresh migration
2. Update any existing redirects that are affected by the IA Refresh migration, to ensure we aren't creating redirect chains
3. Update URLs that are defined in Django's `urls.py` to move them to their new URLs.
4. Move some redirects that are defined in Django to Apache's `redirects.conf` instead, to start to reduce the number of places we're managing redirects.
5. Update the global footer to reflect the new IA

We'll be merging and deploying this PR as part of the IA Refresh migration on Wednesday, September 30.