### PR TITLE
IA Refresh: Scripts to add redirects and move Wagtail pages

### DIFF
--- a/cfgov/scripts/add_wagtail_redirects.py
+++ b/cfgov/scripts/add_wagtail_redirects.py
@@ -8,6 +8,8 @@ from wagtail.core.models import Page
 logger = logging.getLogger(__name__)
 
 
+# This script is for use on September 30, 2020, when we'll be migrating
+# cf.gov to a new IA. Delete this script after the migration is done.
 # Run this from the command line with this:
 #   cfgov/manage.py runscript add_wagtail_redirects --script-args [PATH]
 def run(*args):
@@ -23,7 +25,6 @@ def run(*args):
 
         with open(redirects_file, "r") as csv_file:
             redirect_list = csv.reader(csv_file, delimiter=',')
-            next(redirect_list)  # skip the header row
             for [from_url, to_id] in redirect_list:
                 # If conflicting redirects exist for this from_url, delete them
                 existing_redirects = Redirect.objects.filter(

--- a/cfgov/scripts/add_wagtail_redirects.py
+++ b/cfgov/scripts/add_wagtail_redirects.py
@@ -8,13 +8,6 @@ from wagtail.core.models import Page
 logger = logging.getLogger(__name__)
 
 
-# If the pages haven't been migrated yet, 'url' parameter should be the "from"
-# url. If the pages have migrated, 'url' parameter should be the "to" url.
-def existing_page_for_url(url):
-    url_path = f"/cfgov{url}"
-    return Page.objects.get(url_path=url_path)
-
-
 # Run this from the command line with this:
 #   cfgov/manage.py runscript add_wagtail_redirects --script-args [PATH]
 def run(*args):
@@ -31,7 +24,7 @@ def run(*args):
         with open(redirects_file, "r") as csv_file:
             redirect_list = csv.reader(csv_file, delimiter=',')
             next(redirect_list)  # skip the header row
-            for [from_url, to_url] in redirect_list:
+            for [from_url, to_id] in redirect_list:
                 # If conflicting redirects exist for this from_url, delete them
                 existing_redirects = Redirect.objects.filter(
                         old_path__iexact=Redirect.normalise_path(from_url))
@@ -41,7 +34,7 @@ def run(*args):
                     deletes += num
 
                 # Add the desired redirect
-                page = existing_page_for_url(from_url)
+                page = Page.objects.get(id=to_id)
                 Redirect.add_redirect(from_url, redirect_to=page, is_permanent=True)
                 successes += 1
 

--- a/cfgov/scripts/add_wagtail_redirects.py
+++ b/cfgov/scripts/add_wagtail_redirects.py
@@ -28,7 +28,7 @@ def run(*args):
             for [from_url, to_id] in redirect_list:
                 # If conflicting redirects exist for this from_url, delete them
                 existing_redirects = Redirect.objects.filter(
-                        old_path__iexact=Redirect.normalise_path(from_url))
+                    old_path__iexact=Redirect.normalise_path(from_url))
                 if len(existing_redirects) > 0:
                     dupes.append(from_url)
                     num, _ = existing_redirects.delete()
@@ -36,10 +36,11 @@ def run(*args):
 
                 # Add the desired redirect
                 page = Page.objects.get(id=to_id)
-                Redirect.add_redirect(from_url, redirect_to=page, is_permanent=True)
+                Redirect.add_redirect(from_url, redirect_to=page,
+                                      is_permanent=True)
                 successes += 1
 
         logger.info(f"Done! Added {successes} redirects")
         if len(dupes) > 0:
-            logger.debug(f"Redirects already existed for the following urls: {dupes}")
-            logger.info(f"Deleted {deletes} redirects and replaced with updated ones.")
+            logger.debug(f"Redirects already existed for these urls: {dupes}")
+            logger.info(f"Replaced {deletes} redirects with updated ones")

--- a/cfgov/scripts/move_wagtail_pages.py
+++ b/cfgov/scripts/move_wagtail_pages.py
@@ -21,12 +21,12 @@ def run(*args):
         successes = 0
 
         with open(page_moves_file, "r") as csv_file:
-            page_list = csv.reader(csv_file, delimiter=',')
-            next(page_list)  # skip the header row
+            pages = csv.reader(csv_file, delimiter=',')
+            next(pages)  # skip the header row
 
             # Edit this list to match the headers of the input file, just
             # make sure page_id, destination_id, new_slug are included
-            for [_, _, new_slug, page_id, _, _, _, destination_id, _] in page_list:
+            for [_, _, new_slug, page_id, _, _, _, destination_id, _] in pages:
                 page = Page.objects.get(id=page_id)
                 if new_slug:
                     page.slug = new_slug

--- a/cfgov/scripts/move_wagtail_pages.py
+++ b/cfgov/scripts/move_wagtail_pages.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 
-from wagtail.contrib.redirects.models import Redirect
 from wagtail.core.models import Page
 
 
@@ -22,7 +21,10 @@ def run(*args):
         with open(page_moves_file, "r") as csv_file:
             page_list = csv.reader(csv_file, delimiter=',')
             next(page_list)  # skip the header row
-            for [page_id, destination_id, new_slug] in page_list:
+
+            # Edit this list to match the headers of the input file, just
+            # make sure page_id, destination_id, new_slug are included
+            for [_, _, new_slug, page_id, _, _, _, destination_id, _] in page_list:
                 page = Page.objects.get(id=page_id)
                 if new_slug:
                     page.slug = new_slug

--- a/cfgov/scripts/move_wagtail_pages.py
+++ b/cfgov/scripts/move_wagtail_pages.py
@@ -7,6 +7,8 @@ from wagtail.core.models import Page
 logger = logging.getLogger(__name__)
 
 
+# This script is for use on September 30, 2020, when we'll be migrating
+# cf.gov to a new IA. Delete this script after the migration is done.
 # Run this from the command line with this:
 #   cfgov/manage.py runscript move_wagtail_pages --script-args [PATH]
 def run(*args):

--- a/cfgov/scripts/move_wagtail_pages.py
+++ b/cfgov/scripts/move_wagtail_pages.py
@@ -1,0 +1,34 @@
+import csv
+import logging
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Page
+
+
+logger = logging.getLogger(__name__)
+
+
+# Run this from the command line with this:
+#   cfgov/manage.py runscript move_wagtail_pages --script-args [PATH]
+def run(*args):
+    if not args:
+        logger.error("error. Use --script-args [PATH] to specify the " +
+                     "location of the csv.")
+    else:
+        page_moves_file = args[0]
+
+        successes = 0
+
+        with open(page_moves_file, "r") as csv_file:
+            page_list = csv.reader(csv_file, delimiter=',')
+            next(page_list)  # skip the header row
+            for [page_id, destination_id, new_slug] in page_list:
+                page = Page.objects.get(id=page_id)
+                if new_slug:
+                    page.slug = new_slug
+                    page.save()
+                new_parent = Page.objects.get(id=destination_id)
+                page.move(new_parent, pos='first-child')
+                successes += 1
+
+        logger.info(f"Done! Moved {successes} top-level pages")

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -20,7 +20,6 @@ def run(*args):
         redirects_file = 'redirects_list.csv'
 
         pages_to_move = set()
-        total = 0
 
         with open(page_moves_file, "r") as csv_file:
             page_list = csv.reader(csv_file, delimiter=',')
@@ -28,11 +27,12 @@ def run(*args):
 
             # Edit this list to match the headers of the input file, just
             # make sure page_id and redirect are included
-            for [redirect, _, _, page_id, _, _, _, _, _]in page_list:
+            for [redirect, _, _, page_id, _, _, _, _, _] in page_list:
                 # Get the set of pages that will need wagtail redirects
                 if redirect == 'TRUE':
                     page = Page.objects.get(id=page_id)
-                    live_descendants = page.get_descendants(True).filter(live=True)
+                    live_descendants = \
+                        page.get_descendants(True).filter(live=True)
                     pages_to_move = pages_to_move.union(live_descendants)
 
             ids = [pg.id for pg in pages_to_move]

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -1,7 +1,6 @@
 import csv
 import logging
 
-from wagtail.contrib.redirects.models import Redirect
 from wagtail.core.models import Page
 
 
@@ -21,15 +20,13 @@ def run(*args):
         pages_to_move = set()
         total = 0
 
-        # Edit this list to match the headers of the input file, just
-        # make sure page_id and redirect are included
-        headers = [page_id, destination_id, xlug, redirect]
-
-
         with open(page_moves_file, "r") as csv_file:
             page_list = csv.reader(csv_file, delimiter=',')
             next(page_list)  # skip the header row
-            for headers in page_list:
+
+            # Edit this list to match the headers of the input file, just
+            # make sure page_id and redirect are included
+            for [redirect, _, _, page_id, _, _, _, _, _]in page_list:
                 # Get the set of pages that will need wagtail redirects
                 if redirect == 'TRUE':
                     page = Page.objects.get(id=page_id)
@@ -37,11 +34,11 @@ def run(*args):
                     pages_to_move = pages_to_move.union(live_descendants)
 
             ids = [pg.id for pg in pages_to_move]
-            logger.info("IDs of pages to move: ", ids)
-            logger.info("Total pages: ", len(pages_to_move))
+            logger.info(f"IDs of pages to move: {ids}")
+            logger.info(f"Total pages: {len(ids)}")
 
         with open(redirects_file, "w") as output_file:
             redirects_list = csv.writer(output_file)
             for page in pages_to_move:
-                row = [page.url, page.i]
+                row = [page.url, page.id]
                 redirects_list.writerow(row)

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -7,6 +7,8 @@ from wagtail.core.models import Page
 logger = logging.getLogger(__name__)
 
 
+# This script is for use on September 30, 2020, when we'll be migrating
+# cf.gov to a new IA. Delete this script after the migration is done.
 # Run this from the command line with this:
 #   cfgov/manage.py runscript pages_to_redirect --script-args [PATH]
 def run(*args):

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -1,0 +1,47 @@
+import csv
+import logging
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Page
+
+
+logger = logging.getLogger(__name__)
+
+
+# Run this from the command line with this:
+#   cfgov/manage.py runscript pages_to_redirect --script-args [PATH]
+def run(*args):
+    if not args:
+        logger.error("error. Use --script-args [PATH] to specify the " +
+                     "location of the csv.")
+    else:
+        page_moves_file = args[0]
+        redirects_file = 'redirects_list.csv'
+
+        pages_to_move = set()
+        total = 0
+
+        # Edit this list to match the headers of the input file, just
+        # make sure page_id and redirect are included
+        headers = [page_id, destination_id, xlug, redirect]
+
+
+        with open(page_moves_file, "r") as csv_file:
+            page_list = csv.reader(csv_file, delimiter=',')
+            next(page_list)  # skip the header row
+            for headers in page_list:
+                # Get the set of pages that will need wagtail redirects
+                if redirect == 'TRUE':
+                    page = Page.objects.get(id=page_id)
+                    live_descendants = page.get_descendants(True).filter(live=True)
+                    pages_to_move = pages_to_move.union(live_descendants)
+
+            ids = [pg.id for pg in pages_to_move]
+            logger.info("IDs of pages to move: ", ids)
+            logger.info("Total pages: ", len(pages_to_move))
+
+        with open(redirects_file, "w") as output_file:
+            redirects_list = csv.writer(output_file)
+            for page in pages_to_move:
+                row = [page.url, page.i]
+                redirects_list.writerow(row)

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -35,8 +35,9 @@ def run(*args):
                         page.get_descendants(True).filter(live=True)
                     pages_to_move = pages_to_move.union(live_descendants)
 
+            pages_to_move = sorted(pages_to_move, key=lambda pg: pg.id)
             ids = [pg.id for pg in pages_to_move]
-            logger.info(f"IDs of pages to move: {ids}")
+            logger.info(f"IDs of pages to redirect: {ids}")
             logger.info(f"Total pages: {len(ids)}")
 
         with open(redirects_file, "w") as output_file:
@@ -44,3 +45,5 @@ def run(*args):
             for page in pages_to_move:
                 row = [page.url, page.id]
                 redirects_list.writerow(row)
+
+        logger.info(f"Generated redirects CSV at: {redirects_file}")

--- a/cfgov/scripts/pages_to_redirect.py
+++ b/cfgov/scripts/pages_to_redirect.py
@@ -35,7 +35,7 @@ def run(*args):
                         page.get_descendants(True).filter(live=True)
                     pages_to_move = pages_to_move.union(live_descendants)
 
-            pages_to_move = sorted(pages_to_move, key=lambda pg: pg.id)
+            pages_to_move = sorted(pages_to_move, key=lambda pg: pg.url)
             ids = [pg.id for pg in pages_to_move]
             logger.info(f"IDs of pages to redirect: {ids}")
             logger.info(f"Total pages: {len(ids)}")


### PR DESCRIPTION
Add three scripts that we will use to update consumerfinance.gov to its new IA next week.

1. `pages_to_redirect`, which takes a CSV of top-level pages that will move along with their children. Generates a full list of all URLs that will require Wagtail redirects.
2. `add_wagtail_redirects`, which takes the output of `pages_to_redirect` and uses it to add all necessary Wagtail redirects
3. `move_wagtail_pages`, which takes the same CSV as `pages_to_redirect` and moves all Wagtail pages to their new URLs.


## How to test this PR

1. Get a copy of our latest "Current redirects" spreadsheet and convert the first tab to CSV. There's a link to it in GHE/CFPB/super-regular/issues/148.
2. Get a recent Production database dump.
3. On this branch, from the project root, run the following: `cfgov/manage.py runscript pages_to_redirect --script-args [redirects_spreadsheet.csv]`
    - This will generate a file called `redirects_list.csv` with ~38 rows.
4. `cfgov/manage.py runscript add_wagtail_redirects --script-args redirects_list.csv`
    - This will create a Wagtail redirect for each row in the `redirects_list.csv` file. If you run it again, it will delete the redirects and create new ones. It won't cause duplication.
5. `cfgov/manage.py runscript move_wagtail_pages --script-args [redirects_spreadsheet.csv]`
    - This will move each of the page trees listed in the redirects spreadsheet. When a page moves, it brings all of its child pages with it, so there will be a total of >1300 pages moved. 
6. Run the server, log into the Wagtail admin, and see that the pages have moved and redirects have been added.


## Checklist

- [x] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets