### PR TITLE
Remove unused FINANCIAL_WELLBEING_HUB feature flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -696,8 +696,6 @@ FLAGS = {
     # SPLIT TESTING FLAGS
     # Ask CFPB page titles as H1s instead of H2s
     "ASK_CFPB_H1": [("in split testing cluster", "ASK_CFPB_H1")],
-    # Test financial well-being hub pages on Beta
-    "FINANCIAL_WELLBEING_HUB": [("environment is", "beta")],
     # Publish new HMDA Explore page
     # Delete after HMDA API is deprecated (hopefully Summer 2019)
     "HMDA_LEGACY_PUBLISH": [],

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -522,13 +522,6 @@ urlpatterns = [
         r'^beta_external_testing/',
         empty_200_response),
 
-    # put financial well-being pages behind feature flag for testing
-    flagged_wagtail_only_view(
-        'FINANCIAL_WELLBEING_HUB',
-        r'^practitioner-resources/financial-well-being-resources/',
-        'financial-well-being-resources'
-    ),
-
     # Temporary: HMDA Legacy pages
     # Will be deleted when HMDA API is retired (hopefully Summer 2019)
     re_path(


### PR DESCRIPTION
The `FINANCIAL_WELLBEING_HUB` is out of Beta testing and is now a permanent feature in Wagtail. We won't need to turn off the pages via a feature flag, so we may as well remove it.

This will simplify the IA refresh migration.

## Removals

- `FINANCIAL_WELLBEING_HUB` flag and flagged url


## How to test this PR

1. Run this branch, see that the "Financial well-being" pages still work


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets