### PR TITLE
Move certain Django redirects to Apache

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -896,11 +896,13 @@ Redirect permanent /askcfpb/535 /askcfpb/381
 RedirectMatch permanent (?i)^/CreditReportingDisputeLetter([/]?)$ https://files.consumerfinance.gov/f/documents/092016_cfpb_CreditReportingDisputeLetter.docx
 
 
-# Educational Resources redirects, updated 12/13/16 with move to Wagtail
+# Educational Resources
+RedirectMatch permanent (?i)^/educational-resources/(.*) /consumer-tools/educator-tools/$1
 
 ## Money as You Grow
 RedirectMatch permanent (?i)^/parent([s]?)([/]?)$ /consumer-tools/money-as-you-grow/
 RedirectMatch permanent (?i)^/money([\-]?)as([\-]?)you([\-]?)grow(.*) /consumer-tools/money-as-you-grow$4
+RedirectMatch permanent (?i)^/practitioner-resources/money-as-you-grow/(.*) /consumer-tools/money-as-you-grow/$1
 
 ## Youth Financial Education
 RedirectMatch permanent (?i)^/youth-financial-education([/]?)$ /consumer-tools/educator-tools/youth-financial-education/
@@ -962,6 +964,7 @@ RedirectMatch permanent (?i)^/older-americans/ /consumer-tools/educator-tools/re
 
 ## MSEM moved under Resources for Older Adults
 RedirectMatch permanent (?i)^/managing-someone-elses-money([/]?)$ /consumer-tools/managing-someone-elses-money/
+RedirectMatch permanent (?i)^/practitioner-resources/resources-for-older-adults/managing-someone-elses-money/(.*) /consumer-tools/managing-someone-elses-money/$1
 
 # Redirect old Tax Preparers URL to its new Wagtail home
 RedirectMatch permanent (?i)^/tax-preparer-resources([/]?)$ /consumer-tools/educator-tools/resources-for-tax-preparers/

--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -897,12 +897,12 @@ RedirectMatch permanent (?i)^/CreditReportingDisputeLetter([/]?)$ https://files.
 
 
 # Educational Resources
-RedirectMatch permanent (?i)^/educational-resources/(.*) /consumer-tools/educator-tools/$1
+Redirect permanent /educational-resources/ /consumer-tools/educator-tools/
 
 ## Money as You Grow
 RedirectMatch permanent (?i)^/parent([s]?)([/]?)$ /consumer-tools/money-as-you-grow/
 RedirectMatch permanent (?i)^/money([\-]?)as([\-]?)you([\-]?)grow(.*) /consumer-tools/money-as-you-grow$4
-RedirectMatch permanent (?i)^/practitioner-resources/money-as-you-grow/(.*) /consumer-tools/money-as-you-grow/$1
+Redirect permanent /practitioner-resources/money-as-you-grow/ /consumer-tools/money-as-you-grow/
 
 ## Youth Financial Education
 RedirectMatch permanent (?i)^/youth-financial-education([/]?)$ /consumer-tools/educator-tools/youth-financial-education/
@@ -964,7 +964,7 @@ RedirectMatch permanent (?i)^/older-americans/ /consumer-tools/educator-tools/re
 
 ## MSEM moved under Resources for Older Adults
 RedirectMatch permanent (?i)^/managing-someone-elses-money([/]?)$ /consumer-tools/managing-someone-elses-money/
-RedirectMatch permanent (?i)^/practitioner-resources/resources-for-older-adults/managing-someone-elses-money/(.*) /consumer-tools/managing-someone-elses-money/$1
+Redirect permanent /practitioner-resources/resources-for-older-adults/managing-someone-elses-money/ /consumer-tools/managing-someone-elses-money/
 
 # Redirect old Tax Preparers URL to its new Wagtail home
 RedirectMatch permanent (?i)^/tax-preparer-resources([/]?)$ /consumer-tools/educator-tools/resources-for-tax-preparers/

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -370,20 +370,6 @@ urlpatterns = [
     ),
 
     # educational resources
-    re_path(r'^educational-resources/(?P<path>.*)$', RedirectView.as_view(
-        url='/practitioner-resources/%(path)s', permanent=True)),
-    re_path(
-        r'^practitioner-resources/resources-for-older-adults/managing-someone-elses-money/(?P<path>.*)$',  # noqa: E501
-        RedirectView.as_view(
-            url='/consumer-tools/managing-someone-elses-money/%(path)s',  # noqa: E501
-            permanent=True)
-    ),
-    re_path(
-        r'^practitioner-resources/money-as-you-grow/(?P<path>.*)$',
-        RedirectView.as_view(
-            url='/consumer-tools/money-as-you-grow/%(path)s',
-            permanent=True)
-    ),
     re_path(
         r'^practitioner-resources/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
         FlaggedTemplateView.as_view(


### PR DESCRIPTION
(This PR is to the ia-direct-apache-redirects branch, not main!)

This commit moves three redirects from Django to Apache:

1. (required due to IA changes)

   From: /educational-resources/*
   To (before): /practitioner-resources/*
   To (after): /consumer-tools/educator-tools/*

2. (not needed due to IA changes, still belongs in Apache)

   From: /practitioner-resources/money-as-you-grow/*
   To: /consumer-tools/money-as-you-grow/*

3. (not needed due to IA changes, still belongs in Apache)

   From: /practitioner-resources/resources-for-older-adults/managing-someone-elses-money/*
   To: /consumer-tools/managing-someone-elses-money/*

## How to test this PR

Run using the local [production-like Docker setup](https://cfpb.github.io/consumerfinance.gov/running-docker/#production-like-docker-image), and test these redirects, using for example:

```sh
$ curl -I http://localhost:8000/educational-resources/foo
HTTP/1.1 301 Moved Permanently
Location: http://localhost:8000/consumer-tools/educator-tools/foo
$ curl -I http://localhost:8000/practitioner-resources/money-as-you-grow/foo
HTTP/1.1 301 Moved Permanently
Location: http://localhost:8000/consumer-tools/money-as-you-grow/foo
$ curl -I http://localhost:8000/practitioner-resources/resources-for-older-adults/managing-someone-elses-money/foo
HTTP/1.1 301 Moved Permanently
Location: http://localhost:8000/consumer-tools/managing-someone-elses-money/foo
```

Compare this with the behavior on the main branch:

```sh
$ curl -I http://localhost:8000/educational-resources/foo
HTTP/1.1 301 Moved Permanently
Location: /practitioner-resources/foo
$ curl -I http://localhost:8000/practitioner-resources/money-as-you-grow/foo
HTTP/1.1 301 Moved Permanently
Location: http://localhost:8000/consumer-tools/money-as-you-grow/foo
$ curl -I /practitioner-resources/resources-for-older-adults/managing-someone-elses-money/foo
HTTP/1.1 301 Moved Permanently
Location: /consumer-tools/managing-someone-elses-money/foo
```

As expected, only the first redirect exhibits significantly different behavior (note that Apache's redirects use absolute location by default whereas Django can return relative ones).

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)