### PR TITLE
Replace app_modal with page_js

### DIFF
--- a/cfgov/legacy/templates/front/base_nonresponsive.html
+++ b/cfgov/legacy/templates/front/base_nonresponsive.html
@@ -115,7 +115,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endblock %}
 
-        {% include_header %}
+    {% include_header %}
     <div id="page">
         {% block app_notification %}
         {% endblock %}
@@ -135,10 +135,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 
     </div><!-- /#page -->
-        {% include_footer %}
+    {% include_footer %}
 
-    {% block app_modal %}
-    {% endblock %}
+{% block page_js %}
+{% endblock %}
 
 <!-- for search.usa.gov indexing -->
 <script>


### PR DESCRIPTION
`page_js` is used by the supervision page http://localhost:8000/jobs/supervision/ 

`app_modal` is unused.

## Changes

- Re-add erroneously deleted `app_js` block.
- Remove unused `app_modal` block.


## How to test this PR

1. Buttons should scroll page on http://localhost:8000/jobs/supervision/ 
