### PR TITLE
Fix validate_redirects.py to handle absolute paths

### DIFF
--- a/cfgov/scripts/validate_redirects.py
+++ b/cfgov/scripts/validate_redirects.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import re
 import sys
 
 import requests
@@ -23,6 +24,9 @@ def load_redirects(redirects_filename, from_index, to_index):
 def validate_redirects(redirects, baseurl):
     failures = []
 
+    base_url_http_or_https = re.sub(r'^https?', 'https?', baseurl)
+    strip_baseurl_re = re.compile(r'^' + base_url_http_or_https)
+
     for from_path, to_path in redirects:
         print(f'Checking {from_path} -> {to_path}...', end='')
         response = requests.get(baseurl + from_path, allow_redirects=False)
@@ -36,8 +40,10 @@ def validate_redirects(redirects, baseurl):
 
         location = response.headers.get('location')
 
-        if location != to_path:
-            print('error! location:', location)
+        relative_location = strip_baseurl_re.sub('', location)
+
+        if relative_location != to_path:
+            print('error! location:', relative_location)
             failures.append((from_path, to_path))
             continue
 


### PR DESCRIPTION
The current redirects validation script (validate_redirects.py) assumes  that the server responds with redirects pointing to relative paths, like Django returns. Apache instead returns absolute paths, which fails the script. This change makes it so that the script properly handles either case.

## How to test this PR

You can test this using an input spreadsheet that includes an Apache-served redirect; internally this can be demonstrated now on UCP stack 6024.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)