### PR TITLE
Make mega-menu content-2 flyout width content-independent

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -1131,6 +1131,15 @@ body {
         }
 
     } );
+
+    // Normalize second level width between 901px and 1260px
+    .respond-to-range( @bp-med-min, @bp-lg-max + @grid_gutter-width, {
+
+        &_content-2 {
+            width: 100%;
+        }
+
+    } );
 }
 
 .o-mega-menu {


### PR DESCRIPTION
Closes https://github.local/CFPB/super-regular/issues/162

Previously, between 901px and 1260px, the width of the mega menu flyout could change based on the content. This was somewhat hard to reproduce  and resolved around `display: table-cell` weirdness of the child columns.

This now sets an explicit `width: 100%;` between those dimensions, which keeps the flyout a constant width, not matter the number of columns/presence of an overview link, etc.

Before:
<img width="1120" alt="Screen Shot 2020-09-25 at 5 04 29 PM" src="https://user-images.githubusercontent.com/1558033/94325143-d6d5ef80-ff51-11ea-953c-1a76f390fda7.png">

After:
<img width="1120" alt="Screen Shot 2020-09-25 at 5 05 07 PM" src="https://user-images.githubusercontent.com/1558033/94325146-dc333a00-ff51-11ea-8ebe-07709d83b76e.png">
