### PR TITLE
[CRTOOL] increase to version 2.1.0 to store review sessions on server

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -28,7 +28,7 @@ lxml==4.2.5
 Markdown==3.2.1
 ntplib==0.3.4
 openpyxl==3.0.3
-psycopg2==2.7.3.2
+psycopg2>=2.8.4
 pyelasticsearch==0.6.1
 python-dateutil==2.7.3
 regdown==1.0.2

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -52,4 +52,4 @@ https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
 https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.0/comparisontool-1.17.0-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.0/crtool-2.1.0-py3-none-any.whl


### PR DESCRIPTION
Bump Curriculum Review Tool to version [2.1.0](https://github.com/cfpb/curriculum-review-tool/compare/2.0.3...2.1.0)

Please create a feature branch environment for this, so we can get Product Owner approval before it is merged into the main branch.