### PR TITLE
Update django-college-costs-comparison to 1.17.1 to fix missing jQuery

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -51,5 +51,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.0/comparisontool-1.17.0-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.1/comparisontool-1.17.1-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl


### PR DESCRIPTION
This hotfix is needed to fix legacy PFC pages' references to the now-deleted jQuery 1.9.1.

See: https://github.com/cfpb/django-college-costs-comparison/pull/38

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
