### PR TITLE
Add functional tests for Ask CFPB search features

### DIFF
--- a/test/cypress/integration/pages/ask-cfpb.js
+++ b/test/cypress/integration/pages/ask-cfpb.js
@@ -4,10 +4,25 @@ const search = new AskCfpbSearch();
 
 describe( 'Ask CFPB', () => {
   describe( 'Search', () => {
+    it( 'should autocomplete results', () => {
+      search.open();
+      search.enter( 'security' );
+      search.autocomplete().should( 'be.visible' );
+    } );
+
     it( 'should return results', () => {
       search.open();
-      search.search( 'security' );
+      search.enter( 'security' );
+      search.search();
       search.resultsSection().should( 'be.visible' );
+    } );
+
+    it( 'should correct spelling', () => {
+      search.open();
+      search.enter( 'vehile' );
+      search.search();
+      search.resultsHeader().contains( 'results for “vehicle”' );
+      search.resultsHeader().siblings('p').first().contains( 'Search instead for' );
     } );
   } );
 } );

--- a/test/cypress/pages/ask-cfpb/search.js
+++ b/test/cypress/pages/ask-cfpb/search.js
@@ -1,11 +1,18 @@
 export class AskCfpbSearch {
 
   open() {
-    cy.visit( '/ask-cfpb/search/' );
+    cy.visit( '/ask-cfpb/' );
   }
 
-  search( term ) {
+  enter( term ) {
     cy.get( '#o-search-bar_query' ).type( term );
+  }
+
+  autocomplete() {
+    return cy.get( '.m-autocomplete_results');
+  }
+
+  search() {
     cy.get( 'form[action="/ask-cfpb/search/"]' ).first().within( () => {
       cy.get( '.a-btn' ).click();
     } );
@@ -15,4 +22,7 @@ export class AskCfpbSearch {
     return cy.get( '.search-results' );
   }
 
+  resultsHeader() {
+    return cy.get( '.results-header' );
+  }
 }


### PR DESCRIPTION
This change adds integration tests that test for the Ask CFPB autocomplete and spelling suggestion search features.

## How to test this PR

Run `yarn run cypress open` and then select `ask-cfpb.js` under `pages` in the Cypress dialog. Observe that it tests autocomplete, that there are search results, and that a misspelled search is corrected.

![image](https://user-images.githubusercontent.com/10562538/94709657-ec616580-0313-11eb-889c-7a250644df7b.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
