### PR TITLE
Replaces old postgres:10.3 with postgres:10-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,8 @@ services:
         ports:
             - "5601:5601"
     postgres:
-        image: postgres:10.3
+        image: postgres:10-alpine
+        user: postgres
         restart: always
         volumes:
             - postgres_data:/var/lib/postgresql/data/


### PR DESCRIPTION
postgres:10.3 is old and not updated. postgres:10-alpine is frequently updated.

We're already using postgres:10-alpine in docker-stack.yml, so this change creates consistency in the local and dev stack use cases

APPOPS-1192

