### PR TITLE
Add libraries for django-elasticsearch-dsl and deploy configuration

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -7,10 +7,9 @@ from django.utils.translation import ugettext_lazy as _
 import wagtail
 
 import dj_database_url
-from unipath import DIRS, Path
-
-from requests_aws4auth import AWS4Auth
 from elasticsearch7 import RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+from unipath import DIRS, Path
 
 from cfgov.util import admin_emails
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -666,6 +666,9 @@ FLAGS = {
     # When enabled, spelling suggestions will appear in Ask CFPB search and
     # will be used when the given search term provides no results
     "ASK_SEARCH_TYPOS": [],
+    # Ask CFPB date label	
+    # When enabled, date label will be changed from 'updated' to 'last reviewed'	
+    "ASK_UPDATED_DATE_LABEL": [],
     # Beta banner, seen on beta.consumerfinance.gov
     # When enabled, a banner appears across the top of the site proclaiming
     # "This beta site is a work in progress."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         stdin_open: true
         tty: true
         environment:
-            # ES7_HOST: http://elasticsearch:9200
+            ES7_HOST: http://elasticsearch:9200
             ES_HOST: http://elasticsearch2
 
     docs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
         stdin_open: true
         tty: true
         environment:
-            ES7_HOST: http://elasticsearch:9200
+            # ES7_HOST: http://elasticsearch:9200
             ES_HOST: http://elasticsearch2
 
     docs:

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -49,7 +49,7 @@ wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
 
-https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.1.1/elasticsearch_dsl-7.2.1.1-py2.py3-none-any.whl
+https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.2/elasticsearch_dsl-7.2.2-py2.py3-none-any.whl
 https://github.com/cfpb/wagtail-autocomplete/releases/download/0.7/wagtail_autocomplete-0.6-py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home_api-0.16.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -11,6 +11,7 @@ cryptography==2.9.2
 dj-database-url==0.5.0
 djangorestframework==3.11.1
 django-csp==3.4
+django-elasticsearch-dsl==7.1.4
 django-extensions==2.1.3
 django-flags==4.2.4
 django-haystack==2.8.1
@@ -21,6 +22,7 @@ django-storages==1.7.1
 django-treebeard==4.2.0
 django-watchman==0.15.0
 edgegrid-python==1.0.10
+elasticsearch7==7.9.1
 elasticsearch==2.4.1
 govdelivery==1.3
 Jinja2==2.11.2
@@ -29,10 +31,10 @@ Markdown==3.2.1
 ntplib==0.3.4
 openpyxl==3.0.3
 psycopg2==2.7.3.2
-pyelasticsearch==0.6.1
 python-dateutil==2.7.3
 regdown==1.0.2
 requests==2.22.0
+requests_aws4auth==0.8.0
 requests_toolbelt==0.8.0
 sha3==0.2.1
 unipath>=1.1,<=2.0
@@ -46,10 +48,12 @@ wagtail-treemodeladmin==1.2.1
 wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
+
+https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.1.1/elasticsearch_dsl-7.2.1.1-py2.py3-none-any.whl
 https://github.com/cfpb/wagtail-autocomplete/releases/download/0.7/wagtail_autocomplete-0.6-py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home_api-0.16.0-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.1/comparisontool-1.17.1-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.0/comparisontool-1.17.0-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -55,5 +55,5 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.16.0/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.15.0/retirement-0.15.0-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.1/ccdb5_api-1.5.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
-https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.0/comparisontool-1.17.0-py3-none-any.whl
+https://github.com/cfpb/django-college-costs-comparison/releases/download/1.17.1/comparisontool-1.17.1-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.0.3/crtool-2.0.3-py3-none-any.whl


### PR DESCRIPTION
Decomposes more of the Ask-CFPB work we've been doing into smaller PRs. This builds onto #6052 which now involves deploying ES7 as part of our docker stack. We've setup a flag in our ansible configuration to determine if we should configure connections to an AWS ES Cluster, or if we should default back to our standard configuration and default to an empty connection string if there is no configured ES7 Host.



---


## Additions

- Configure and include django-elasticsearch-dsl connection in `base.py` including working configuration with an AWS ES Cluster if provided.
- Forked elasticsearch-dsl dependency where we reference elasticsearch as elasticsearch7
- requests_4awsauth to connect with AWS ES.


## How to test this PR

1. App should be able to run locally, on docker enterprise, and on a DEV server even if configuration is missing such as `ES7_HOST`


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
