### PR TITLE
Remove last vestiges of the six library

### DIFF
--- a/cfgov/v1/tests/management/commands/test_add_images.py
+++ b/cfgov/v1/tests/management/commands/test_add_images.py
@@ -1,11 +1,11 @@
 import os
+from io import BytesIO
 
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, RequestFactory, TestCase
-from django.utils.six import BytesIO
 
 from PIL import Image
 
@@ -37,7 +37,7 @@ class TestAddImages(TestCase):
         self.factory = RequestFactory()
         self.request = self.factory.get('/')
         self.user = User.objects.get(pk=1)
- 
+
     def test_add_image(self):
         filename_only = os.path.split(self.filename)[-1]
         logo = create_image(None, filename_only)

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,6 +1,5 @@
 coverage==4.5.1
 diff_cover==2.6.0
-six==1.14.0
 pluggy==0.13.1
 tox==3.19.0
 tox-pip-extensions==1.6.0


### PR DESCRIPTION
Must've missed this a while back when we ditched Python 2.

## How to test this PR

1. See that the tests continue to pass


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
