### PR TITLE
Remove option to export page metadata as an .xlsx file

### DIFF
--- a/cfgov/templates/wagtailadmin/reports/site_history.html
+++ b/cfgov/templates/wagtailadmin/reports/site_history.html
@@ -1,0 +1,62 @@
+{% extends 'wagtailadmin/reports/base_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block actions %}
+    {% if view.list_export %}
+        <div class="actionbutton">
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block results %}
+    {% if object_list %}
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th class="title">
+                        {% trans 'Page' %}
+                    </th>
+                    <th>
+                        {% trans 'Action' %}
+                    </th>
+                    <th>
+                        {% trans 'User' %}
+                    </th>
+                    <th class="updated">
+                        {% trans 'Date / Time' %}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in object_list %}
+                    <tr>
+                        <td class="title">
+                            {% if entry.page %}
+                                {% page_permissions entry.page as page_perms %}
+                                {% if page_perms.can_edit %}
+                                    <a href="{% url 'wagtailadmin_pages:edit' entry.page_id %}" title="{% trans 'Edit this page' %}">{{ entry.label }}</a>
+                                {% else %}
+                                    {{ entry.label }}
+                                {% endif %}
+                            {% else %}
+                                {{ entry.label }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ entry|format_action_log_message }}
+                        </td>
+                        <td>
+                            {% include "wagtailadmin/shared/user_avatar.html" with user=entry.user username=entry.user_display_name %}
+                        </td>
+                        <td class="updated">
+                            <div class="human-readable-date" title="{{ entry.timestamp|date:"d M Y H:i" }}">{% blocktrans with time_period=entry.timestamp|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>{% trans "No log entries found." %}</p>
+    {% endif %}
+{% endblock %}

--- a/cfgov/v1/templates/v1/page_metadata_report.html
+++ b/cfgov/v1/templates/v1/page_metadata_report.html
@@ -1,4 +1,13 @@
 {% extends 'wagtailadmin/reports/base_page_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block actions %}
+    {% if view.list_export %}
+        <div class="button match-width">
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+        </div>
+    {% endif %}
+{% endblock %}
 
 {% block listing %}
     {% include 'v1/_list_page_metadata.html' %}

--- a/cfgov/v1/templates/v1/page_metadata_report.html
+++ b/cfgov/v1/templates/v1/page_metadata_report.html
@@ -3,7 +3,7 @@
 
 {% block actions %}
     {% if view.list_export %}
-        <div class="button match-width">
+        <div class="actionbutton">
             <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
         </div>
     {% endif %}


### PR DESCRIPTION
The XLSX download option was error-prone for page metadata reports,
possibly because of their size. The XLSX option required that the data be
held in memory before output, whereas the CSV option allows
for a more efficient streaming process.

In any case, not much is lost by removing the option, because the CSV can be
opened in Excel, which then saves the result as an .xlsx file by default.

## Update
The XLSX option was also removed from the site-history report.

## Testing
There should be no change in the CSV download option, which takes a bit of time to download.  
But the icon at the top right of the report page at `Reports -> Page Metadata` should change to a single choice:

Before:

<img width="263" alt="csv_and_xlsx_download" src="https://user-images.githubusercontent.com/515885/94868728-bf937800-0411-11eb-941d-58d91a9070f2.png">

Using this branch:

<img width="241" alt="download_csv" src="https://user-images.githubusercontent.com/515885/95081794-1508a700-06e8-11eb-81d3-5f1609fff718.png">

