### PR TITLE
Keep duplicated filterable list params when paginating

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/pagination.html
+++ b/cfgov/jinja2/v1/_includes/molecules/pagination.html
@@ -72,12 +72,14 @@
                     {{ current_page }} out of {{ total_pages }} total pages
                 </span>
             </label>
-            {% for (key, value) in request.GET.items() %}
-                {% if value != '' %}
-                    <input type="hidden"
-                           name="{{ key }}"
-                           value="{{ value }}">
-                {% endif %}
+            {% for (key, value_as_list) in request.GET.lists() %}
+                {% for list_item in value_as_list %}
+                    {% if list_item != '' and key != 'page' %}
+                        <input type="hidden"
+                               name="{{ key }}"
+                               value="{{ list_item }}">
+                    {% endif %}
+                {% endfor %}
             {% endfor %}
             <input id="m-pagination_current-page-{{ index | string }}"
                    class="m-pagination_current-page"


### PR DESCRIPTION
Closes #2199 from over 4 years ago!

The problem here stemmed from the use of `request.GET.items()`, which returns only the last value when multiple params have the same key, by design.

See https://docs.djangoproject.com/en/3.1/ref/request-response/#django.http.QueryDict.items

Changing to `.lists()` and updating the logic a bit to handle the resulting lists stops params from being dropped.
Also, filtering out the 'page' param prevents the other bug here which was repeated page params in the querystring.