### PR TITLE
Update Credit Card Agreements with Q2-2020 data

### DIFF
--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -51,16 +51,24 @@
                 <ul class="m-list m-list__links u-mt15 cc-links">
                     <li class="m-list m-list__links">
                       <span>
+                          Q2-2020 agreements may include omissions due to the Bureau’s COVID-19
+                          <a href=" https://files.consumerfinance.gov/f/documents/cfpb_data-collection-statement_covid-19_2020-03.pdf">
+                              regulatory flexibility statement
+                          </a>.
+                      </span><br/>
+                          <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2020_Q2.zip">
+                              Download all most recent agreements (Q2-2020)
+                          </a>
+                    </li>
+                    <li class="m-list m-list__links">
+                      <span>
                           Q1-2020 agreements may include omissions due to the Bureau’s COVID-19
                           <a href=" https://files.consumerfinance.gov/f/documents/cfpb_data-collection-statement_covid-19_2020-03.pdf">
                               regulatory flexibility statement
                           </a>.
                       </span><br/>
-                    </li>
-                    <li class="m-list m-list__links">
-                      <span>
                         <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2020_Q1.zip">
-                            Download all most recent agreements (Q1-2020)
+                            Archived Q1-2020 agreements
                         </a>
                     </li>
                     <li class="m-list m-list__links">


### PR DESCRIPTION
Add Q2-2020 data to the Credit Card Agreements database. Also adds a statement about possible omissions in the data set, as requested by the stakeholder.

## How to test this PR

1. Visit http://localhost:8000/credit-cards/agreements/
2. Ensure the links to Q1-2020 and Q2-2020 data work, as well as the links to the Regulatory Flexibility Statement.

## Screenshots

![Screen Shot 2020-10-02 at 10 40 25 AM](https://user-images.githubusercontent.com/4295388/94936547-63296a80-049c-11eb-8946-e322de48bf3a.png)


## Notes and todos

- The dropdown on the Credit Card Agreements page still contains Q1-2020 data. Updating that doesn't require a PR, and will happen soon.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of: