### PR TITLE
Fixes bug introduced by #5984

### DIFF
--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -38,7 +38,7 @@ def image_alt_value(image):
         return image.alt
 
     # Otherwise, if it is a block
-    if image:
+    if image and hasattr(image, 'get'):
         block_alt = image.get('alt')
         upload = image.get('upload')
 


### PR DESCRIPTION
The image placeholder library, introduced in #5984, will sometimes replace the `image` object, expected by `alt_text`
handling logic in our `jinja2tags/__init__.py`, with a `Placeholder` object with a different interface. This PR slightly extends that logic to exit gracefully when the image interface is not as expected.

## Testing

 - On main visit http://localhost:8000/about-us/blog/?categories=at-the-cfpb&categories=directors-notebook&page=3
 - Should 500
 - Pull branch
 - Visit the same page, should see a bunch of blog posts (some with kitten images) and no 500.