### PR TITLE
Fix the nmdb CSV export by calling getvalue()

### DIFF
--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -46,7 +46,7 @@ def bake_csv_to_s3(slug, csv_file_obj, sub_bucket=None):
         Key='{}/{}.csv'.format(sub_bucket, slug),
         ACL='public-read',
         ContentType='text/csv',
-        Body=csv_file_obj,
+        Body=csv_file_obj.getvalue(),
         CacheControl='max-age=2592000,public',
         Expires=expires
     )


### PR DESCRIPTION
Not sure why this cropped up now, but along the way we lost the ability
to feed a file object to boto3 for uploading to S3. Boto creates a
hash of the content and expects bytes in making the hash, and
our previous routine delivered unicode.

The solution is to pass the bytes instead of the file object to boto,
by calling `getvalue()` on the file object.

## Testing
I ran the zusa prep job `cf.gov-nmdb-data-prep` against this branch, and it succeeded. The charts on DEV5 and CSV downloads on S3 look good.
