### PR TITLE
Break meta-description ranking into function

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -264,7 +264,7 @@ class CFGOVPage(Page):
                 self.header, 'text_introduction', 'intro')
             candidates['header_item_intro'] = self.get_streamfield_content(
                 self.header, 'item_introduction', 'paragraph')
-        if hasattr(self, 'preview_description'):
+        if self.preview_description:
             candidates['preview_description'] = self.preview_description
         if hasattr(self, 'content'):
             candidates['content_text_intro'] = self.get_streamfield_content(

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -247,6 +247,33 @@ class CFGOVPage(Page):
                 return self.remove_html_tags(item.value[value].source)
         return
 
+    def get_meta_description(self):
+        """Deliver a meta_description, following a preference order."""
+        preference_order = [
+            'header_hero_body',
+            'preview_description',
+            'header_text_intro',
+            'content_text_intro',
+            'header_item_intro',
+        ]
+        candidates = {item: None for item in preference_order}
+        if hasattr(self, 'header'):
+            candidates['header_hero_body'] = self.get_streamfield_content(
+                self.header, 'hero', 'body')
+            candidates['header_text_intro'] = self.get_streamfield_content(
+                self.header, 'text_introduction', 'intro')
+            candidates['header_item_intro'] = self.get_streamfield_content(
+                self.header, 'item_introduction', 'paragraph')
+        if hasattr(self, 'preview_description'):
+            candidates['preview_description'] = self.preview_description
+        if hasattr(self, 'content'):
+            candidates['content_text_intro'] = self.get_streamfield_content(
+                self.content, 'text_introduction', 'intro')
+        for entry in preference_order:
+            if candidates.get(entry):
+                return candidates[entry]
+        return ''
+
     def get_context(self, request, *args, **kwargs):
         context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
 
@@ -267,37 +294,10 @@ class CFGOVPage(Page):
         if self.schema_json:
             context['schema_json'] = self.schema_json
 
-        context['meta_description'] = ''
         if self.search_description:
             context['meta_description'] = self.search_description
-        if hasattr(self, 'header') and not context['meta_description']:
-            context['meta_description'] = self.get_streamfield_content(
-                self.header,
-                'hero',
-                'body')
-        if (
-            hasattr(self, 'preview_description')
-            and not context['meta_description']
-        ):
-            context['meta_description'] = self.preview_description
-        if hasattr(self, 'header') and not context['meta_description']:
-            context['meta_description'] = self.get_streamfield_content(
-                self.header,
-                'text_introduction',
-                'intro')
-        if hasattr(self, 'content') and not context['meta_description']:
-            context['meta_description'] = self.get_streamfield_content(
-                self.content,
-                'text_introduction',
-                'intro')
-        if hasattr(self, 'header') and not context['meta_description']:
-            context['meta_description'] = self.get_streamfield_content(
-                self.header,
-                'item_introduction',
-                'paragraph')
-        if not context['meta_description']:
-            context['meta_description'] = ''
-
+        else:
+            context['meta_description'] = self.get_meta_description()
         return context
 
     def serve(self, request, *args, **kwargs):

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -256,7 +256,7 @@ class CFGOVPage(Page):
             'content_text_intro',
             'header_item_intro',
         ]
-        candidates = {item: None for item in preference_order}
+        candidates = {}
         if hasattr(self, 'header'):
             candidates['header_hero_body'] = self.get_streamfield_content(
                 self.header, 'hero', 'body')

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -309,13 +309,13 @@ class TestCFGOVPageContext(TestCase):
         }
         test_context = self.page.get_context(self.request)
         self.assertIn('schema_json', test_context)
-    
+
     def test_get_context_sets_meta_description_from_search_description(self):
         result = 'Correct Meta Description'
         self.page = LandingPage(
-            title='test', 
-            search_description = result, 
-                        header=json.dumps(
+            title='test',
+            search_description=result,
+            header=json.dumps(
                 [
                     {
                         "type": "hero",
@@ -327,11 +327,11 @@ class TestCFGOVPageContext(TestCase):
             ),)
         test_context = self.page.get_context(self.request)
         self.assertEqual(test_context['meta_description'], result)
-    
+
     def test_get_context_sets_meta_description_from_hero(self):
         expected = 'Correct Meta Description'
         self.page = LandingPage(
-            title='test',             
+            title='test',
             header=json.dumps(
                 [
                     {
@@ -383,10 +383,10 @@ class TestCFGOVPageContext(TestCase):
         result = test_context['meta_description']
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_from_header_text_introduction_intro(self):
+    def test_get_context_sets_meta_description_from_header_text_introduction_intro(self):  # noqa
         expected = 'Correct Meta Description'
         self.page = LandingPage(
-            title='test',             
+            title='test',
             header=json.dumps(
                 [
                     {
@@ -418,7 +418,7 @@ class TestCFGOVPageContext(TestCase):
         result = test_context['meta_description']
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_from_content_text_introduction_intro(self):
+    def test_get_context_sets_meta_description_from_content_text_introduction_intro(self):  # noqa
         expected = 'Correct Meta Description'
         self.page = SublandingPage(
             title='test',
@@ -431,7 +431,7 @@ class TestCFGOVPageContext(TestCase):
                         }
                     },
                 ]
-            ),            
+            ),
             content=json.dumps(
                 [
                     {
@@ -447,7 +447,7 @@ class TestCFGOVPageContext(TestCase):
         result = test_context['meta_description']
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_from_header_item_introduction_paragraph(self):
+    def test_get_context_sets_meta_description_from_header_item_introduction_paragraph(self):  # noqa
         expected = 'Correct Meta Description'
         self.page = AbstractFilterPage(
             title='test',
@@ -466,10 +466,10 @@ class TestCFGOVPageContext(TestCase):
         result = test_context['meta_description']
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_to_blank_if_no_other_data_to_set(self):
+    def test_get_context_sets_meta_description_to_blank_if_no_other_data_to_set(self):  # noqa
         expected = ''
         self.page = SublandingPage(
-            title='test',             
+            title='test',
             content=json.dumps(
                 [
                     {
@@ -488,7 +488,7 @@ class TestCFGOVPageContext(TestCase):
     def test_get_context_sets_meta_description_strips_html_tags(self):
         expected = 'Correct Meta Description'
         self.page = SublandingPage(
-            title='test',             
+            title='test',
             header=json.dumps(
                 [
                     {


### PR DESCRIPTION
This may not be much more efficient or elegant, but the order of preference seems clearer.

We don't lint v1 tests, but I also cleaned up some trailing-space issues in the tests.