### PR TITLE
Add Elasticsearch 7 support to regulations search behind a flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -769,6 +769,8 @@ FLAGS = {
     # Used to enable use of django-elasticsearch-dsl and disable use of Haystack
     # This will be used in the ask_cfpb and regulations applications
     "ELASTIC_SEARCH_DSL": [("boolean", False)],
+    # Used to enable django-elasticsearch-dsl and disable haystack within the regulations app.
+    "ELASTICSEARCH_DSL_REGULATIONS": [("boolean", False)],
 }
 
 

--- a/cfgov/regulations3k/documents.py
+++ b/cfgov/regulations3k/documents.py
@@ -13,6 +13,7 @@ class SectionParagraphDocument(Document):
     date = fields.DateField()
     section_order = fields.TextField()
     section_label = fields.TextField()
+    short_name = fields.TextField()
 
     def prepare_date(self, instance):
         return instance.section.subpart.version.effective_date
@@ -25,6 +26,9 @@ class SectionParagraphDocument(Document):
 
     def prepare_section_order(self, instance):
         return instance.section.sortable_label
+
+    def prepare_short_name(self, instance):
+        return instance.section.subpart.version.part.short_name
 
     def prepare_title(self, instance):
         return instance.section.title

--- a/cfgov/regulations3k/documents.py
+++ b/cfgov/regulations3k/documents.py
@@ -7,11 +7,11 @@ from regulations3k.models import SectionParagraph
 @registry.register_document
 class SectionParagraphDocument(Document):
 
-    text = fields.TextField(attr='paragraph')
+    text = fields.TextField(attr='paragraph', boost=10)
     title = fields.TextField()
     part = fields.KeywordField()
     date = fields.DateField()
-    section_order = fields.TextField()
+    section_order = fields.KeywordField()
     section_label = fields.TextField()
     short_name = fields.TextField()
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -76,7 +76,8 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 request,
                 self.get_template(request),
                 self.get_context(request))
-        search = SectionParagraphDocument.search().query('match', text=search_query).highlight('text', pre_tags="<strong>", post_tags="</strong>")
+        search = SectionParagraphDocument.search().query('match', text=search_query)
+        search = search.highlight('text', pre_tags="<strong>", post_tags="</strong>")
         total_results = search.count()
         all_regs = [{
                         'short_name': reg.short_name,
@@ -103,7 +104,6 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                     "Query string {} produced a TypeError: {}".format(
                         search_query, e))
                 continue
-
             hit_payload = {
                 'id': hit.paragraph_id,
                 'part': hit.part,
@@ -143,7 +143,6 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
     @route(r'^results/')
     def regulation_results_page(self, request):
         if flag_enabled('ELASTICSEARCH_DSL_REGULATIONS'):
-            print("Calling ES7 Functions!")
             return self.regulation_results_page_es7(request)
         all_regs = Part.objects.order_by('part_number')
         regs = validate_regs_list(request)

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -28,9 +28,9 @@ from regdown import regdown
 
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin
 from regulations3k.blocks import RegulationsListingFullWidthText
+from regulations3k.documents import SectionParagraphDocument
 from regulations3k.models import Part, Section, SectionParagraph, label_re_str
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
-from regulations3k.documents import SectionParagraphDocument
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager
 
@@ -76,15 +76,18 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 request,
                 self.get_template(request),
                 self.get_context(request))
-        search = SectionParagraphDocument.search().query('match', text=search_query)
-        search = search.highlight('text', pre_tags="<strong>", post_tags="</strong>")
+        search = SectionParagraphDocument.search().query(
+            'match', text=search_query)
+        search = search.highlight(
+            'text', pre_tags="<strong>", post_tags="</strong>")
         total_results = search.count()
         all_regs = [{
-                        'short_name': reg.short_name,
-                        'id': reg.part_number,
-                        'num_results': search.filter('term', part=reg.part_number).count(),
-                        'selected': reg.part_number in regs }
-                        for reg in all_regs
+                    'short_name': reg.short_name,
+                    'id': reg.part_number,
+                    'num_results': search.filter(
+                        'term', part=reg.part_number).count(),
+                    'selected': reg.part_number in regs}
+                    for reg in all_regs
                     ]
         payload.update({
             'all_regs': all_regs,
@@ -138,7 +141,6 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
             request,
             self.get_template(request),
             context)
-
 
     @route(r'^results/')
     def regulation_results_page(self, request):

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -22,6 +22,7 @@ from wagtail.core.fields import StreamField
 from wagtail.core.models import PageManager
 
 import requests
+from flags.state import flag_enabled
 from jinja2 import Markup
 from regdown import regdown
 
@@ -29,6 +30,7 @@ from ask_cfpb.models.pages import SecondaryNavigationJSMixin
 from regulations3k.blocks import RegulationsListingFullWidthText
 from regulations3k.models import Part, Section, SectionParagraph, label_re_str
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
+from regulations3k.documents import SectionParagraphDocument
 from v1.atomic_elements import molecules, organisms
 from v1.models import CFGOVPage, CFGOVPageManager
 
@@ -56,8 +58,93 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
             template = 'regulations3k/search-regulations-results.html'
         return template
 
+    def regulation_results_page_es7(self, request):
+        all_regs = Part.objects.order_by('part_number')
+        regs = validate_regs_list(request)
+        order = validate_order(request)
+        search_query = request.GET.get('q', '').strip()
+        payload = {
+            'search_query': search_query,
+            'results': [],
+            'total_results': 0,
+            'regs': regs,
+            'all_regs': [],
+        }
+        if not search_query or len(urllib.parse.unquote(search_query)) == 1:
+            self.results = payload
+            return TemplateResponse(
+                request,
+                self.get_template(request),
+                self.get_context(request))
+        search = SectionParagraphDocument.search().query('match', text=search_query).highlight('text', pre_tags="<strong>", post_tags="</strong>")
+        total_results = search.count()
+        all_regs = [{
+                        'short_name': reg.short_name,
+                        'id': reg.part_number,
+                        'num_results': search.filter('term', part=reg.part_number).count(),
+                        'selected': reg.part_number in regs }
+                        for reg in all_regs
+                    ]
+        payload.update({
+            'all_regs': all_regs,
+            'total_count': total_results
+        })
+        if regs:
+            search = search.filter('terms', part=regs)
+        if order == 'regulation':
+            search = search.sort('part', 'section_order')
+        search = search[0:total_results]
+        response = search.execute()
+        for hit in response[0:total_results]:
+            try:
+                snippet = Markup("".join(hit.meta.highlight.text[0]))
+            except TypeError as e:
+                logger.warning(
+                    "Query string {} produced a TypeError: {}".format(
+                        search_query, e))
+                continue
+
+            hit_payload = {
+                'id': hit.paragraph_id,
+                'part': hit.part,
+                'reg': hit.short_name,
+                'label': hit.title,
+                'snippet': snippet,
+                'url': "{}{}/{}/#{}".format(
+                    self.parent().url, hit.part,
+                    hit.section_label, hit.paragraph_id),
+            }
+            payload['results'].append(hit_payload)
+
+        payload.update({'current_count': search.count()})
+        self.results = payload
+        context = self.get_context(request)
+        num_results = validate_num_results(request)
+        paginator = Paginator(payload['results'], num_results)
+        page_number = validate_page_number(request, paginator)
+        paginated_page = paginator.page(page_number)
+        context.update({
+            'current_count': payload['current_count'],
+            'total_count': payload['total_count'],
+            'paginator': paginator,
+            'current_page': page_number,
+            'num_results': num_results,
+            'order': order,
+            'results': paginated_page,
+            'show_filters': any(
+                reg['selected'] is True for reg in payload['all_regs'])
+        })
+        return TemplateResponse(
+            request,
+            self.get_template(request),
+            context)
+
+
     @route(r'^results/')
     def regulation_results_page(self, request):
+        if flag_enabled('ELASTICSEARCH_DSL_REGULATIONS'):
+            print("Calling ES7 Functions!")
+            return self.regulation_results_page_es7(request)
         all_regs = Part.objects.order_by('part_number')
         regs = validate_regs_list(request)
         order = validate_order(request)

--- a/cfgov/regulations3k/tests/test_documents.py
+++ b/cfgov/regulations3k/tests/test_documents.py
@@ -38,5 +38,6 @@ class SectionParagraphDocumentTest(TestCase):
             'date': version.effective_date,
             'section_order': section.sortable_label,
             'section_label': section.label,
+            'short_name': part.short_name,
             'paragraph_id': section_paragraph.paragraph_id
         })

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -15,6 +15,7 @@ import mock
 from model_bakery import baker
 
 from core.testutils.mock_cache_backend import CACHE_PURGED_URLS
+from regulations3k.documents import SectionParagraphDocument
 from regulations3k.models.django import (
     EffectiveVersion, Part, Section, SectionParagraph, Subpart,
     effective_version_saved, section_saved, sortable_label, validate_label
@@ -25,9 +26,6 @@ from regulations3k.models.pages import (
     get_section_url, validate_num_results, validate_order,
     validate_page_number, validate_regs_list
 )
-from regulations3k.documents import SectionParagraphDocument
-
-from elasticsearch_dsl.response import Response
 
 
 class RegModelTests(DjangoTestCase):
@@ -420,11 +418,14 @@ class RegModelTests(DjangoTestCase):
         self.assertEqual(response2.status_code, 200)
         self.assertEqual(mock_sqs.call_count, 6)
 
-    @override_settings(FLAGS={"ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
+    @override_settings(FLAGS={
+        "ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
     @mock.patch.object(SectionParagraphDocument, 'search')
     def test_routable_search_page_calls_elasticsearch7(self, mock_search):
         mock_hit = mock.Mock()
-        mock_hit.text = 'i. Mortgage escrow accounts for collecting taxes and property insurance premiums.'
+        mock_hit.text = (
+            'i. Mortgage escrow accounts for collecting taxes',
+            'and property insurance premiums.')
         mock_hit.title = 'Comment for 1030.2 - Definitions'
         mock_hit.part = '1030'
         mock_hit.date = datetime.datetime(2011, 12, 30, 0, 0)
@@ -432,24 +433,33 @@ class RegModelTests(DjangoTestCase):
         mock_hit.section_label = 'Interp-2'
         mock_hit.short_name = 'Regulation DD'
         mock_hit.paragraph_id = '2-a-Interp-2-i'
-        mock_hit.meta.highlight.text = ["<strong>Mortgage</strong> highlighted"]
-        
-        mock_search().query().highlight().filter().sort().__getitem__().execute.return_value = [mock_hit]
+        mock_hit.meta.highlight.text = ["<strong>Mortgage</strong> highlight"]
+        mock_search().query() \
+            .highlight().filter().sort() \
+            .__getitem__().execute.return_value = [mock_hit]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
+        mock_search().query() \
+            .highlight().filter().sort() \
+            .__getitem__().count = mock_count
         response = self.client.get(
             self.reg_search_page.url + self.reg_search_page.reverse_subpage(
                 'regulation_results_page'),
-            {'q': 'mortgage', 'regs': '1030', 'order': 'regulation', 'results': '50'})
+            {'q': 'mortgage',
+             'regs': '1030',
+             'order': 'regulation',
+             'results': '50'})
         self.assertEqual(mock_search.call_count, 4)
         self.assertEqual(response.status_code, 200)
 
-    @override_settings(FLAGS={"ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
+    @override_settings(FLAGS={
+        "ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
     @mock.patch.object(SectionParagraphDocument, 'search')
-    def test_routable_search_page_handles_null_highlights_elasticsearch7(self, mock_search):
+    def test_routable_search_page_handles_null_highlights_es7(self, mock_search):  # noqa: E501
         mock_hit = mock.Mock()
-        mock_hit.text = 'i. Mortgage escrow accounts for collecting taxes and property insurance premiums.'
+        mock_hit.text = (
+            'i. Mortgage escrow accounts for collecting',
+            ' taxes and property insurance premiums.')
         mock_hit.title = 'Comment for 1030.2 - Definitions'
         mock_hit.part = '1030'
         mock_hit.date = datetime.datetime(2011, 12, 30, 0, 0)
@@ -457,28 +467,36 @@ class RegModelTests(DjangoTestCase):
         mock_hit.section_label = 'Interp-2'
         mock_hit.short_name = 'Regulation DD'
         mock_hit.paragraph_id = '2-a-Interp-2-i'
-        
-        mock_search().query().highlight().filter().sort().__getitem__().execute.return_value = [mock_hit]
+        mock_search().query() \
+            .highlight().filter().sort() \
+            .__getitem__().execute.return_value = [mock_hit]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
+        mock_search().query() \
+            .highlight().filter().sort() \
+            .__getitem__().count = mock_count
         response = self.client.get(
-            self.reg_search_page.url + self.reg_search_page.reverse_subpage(
+            self.reg_search_page.url +
+            self.reg_search_page.reverse_subpage(
                 'regulation_results_page'),
-            {'q': 'mortgage', 'regs': '1030', 'order': 'regulation', 'results': '50'})
+            {'q': 'mortgage',
+             'regs': '1030',
+             'order': 'regulation',
+             'results': '50'})
         self.assertEqual(mock_search.call_count, 4)
         self.assertEqual(response.status_code, 200)
 
-    @override_settings(FLAGS={"ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
+    @override_settings(FLAGS={
+        "ELASTICSEARCH_DSL_REGULATIONS": [("boolean", True)]})
     @mock.patch.object(SectionParagraphDocument, 'search')
-    def test_search_page_refuses_single_character_search_elasticsearch7(self, mock_search):
+    def test_search_page_refuses_single_character_search_elasticsearch7(self, mock_search):  # noqa: E501
         response = self.client.get(
-            self.reg_search_page.url + self.reg_search_page.reverse_subpage(
+            self.reg_search_page.url +
+            self.reg_search_page.reverse_subpage(
                 'regulation_results_page'),
             {'q': '%21', 'regs': '1002', 'order': 'regulation'})
         self.assertEqual(mock_search.call_count, 0)
         self.assertEqual(response.status_code, 200)
-
 
     @mock.patch('regulations3k.models.pages.SearchQuerySet.models')
     def test_routable_search_page_handles_null_highlights(self, mock_sqs):


### PR DESCRIPTION
Places ES7 search functionality behind a toggle.


---



## Additions

- Moving search code to work with ES7 behind flag.
- Add short_name to index to reduce need to query DB for data needed.
- configure boost for text field to improve results
- swap section_order to Keyword Field so we can sort by it.

## How to test this PR

1. Enable `ELASTICSEARCH_DSL_REGULATIONS` flag
2. Load up ES7 index `cfgov/manage.py search_index --rebuild -f --parallel`
3. Search regulations


## Screenshots


## Notes and todos

- Seeing a large discrepancy in search result counts. "mortgage" is off by nearly 300 records.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
