### PR TITLE
Isolate ES2.3.5 image creation to be singular vs every PR/Build/etc.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
         )
         booleanParam(
             name: 'BUILD_ES2',
-            defaultValue: true,
+            defaultValue: false,
             description: 'Build the elasticsearch 2.3 image?'
         )
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     parameters {
         booleanParam(
             name: 'DEPLOY',
-            defaultValue: false,
+            defaultValue: true,
             description: 'Deploy the stack?'
         )
         booleanParam(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,7 +134,7 @@ pipeline {
         }
         stage('Build ElasticSearch') {
             when {
-                  expression { return params.BUILD_ES }
+                  expression { return params.BUILD_ES2 }
             }
             environment {
                 DOCKER_BUILDKIT = '1'


### PR DESCRIPTION
Isolate the regular creation of ElasticSearch images, to prevent unnecessary re-indexing.




