### PR TITLE
Moved analyzers and filters from ask_cfpb to elasticsearch_helpers.py

### DIFF
--- a/cfgov/ask_cfpb/documents.py
+++ b/cfgov/ask_cfpb/documents.py
@@ -1,36 +1,8 @@
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
-from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
 from ask_cfpb.models.answer_page import AnswerPage
-
-
-label_autocomplete = analyzer(
-    'label_autocomplete',
-    tokenizer=tokenizer(
-        'trigram',
-        'edge_ngram',
-        min_gram=2,
-        max_gram=25,
-        token_chars=["letter", "digit"]
-    ),
-    filter=['lowercase', token_filter('ascii_fold', 'asciifolding')]
-)
-
-synonynm_filter = token_filter(
-    'synonym_filter_en',
-    'synonym',
-    synonyms_path='/usr/share/elasticsearch/config/synonyms/synonyms_en.txt'
-)
-
-synonym_analyzer = analyzer(
-    'synonym_analyzer_en',
-    type='custom',
-    tokenizer='standard',
-    filter=[
-        synonynm_filter,
-        'lowercase'
-    ])
+from search.elasticsearch_helpers import label_autocomplete, synonym_analyzer
 
 
 @registry.register_document

--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -1,0 +1,29 @@
+from elasticsearch_dsl import analyzer, token_filter, tokenizer
+
+
+label_autocomplete = analyzer(
+    'label_autocomplete',
+    tokenizer=tokenizer(
+        'trigram',
+        'edge_ngram',
+        min_gram=2,
+        max_gram=25,
+        token_chars=["letter", "digit"]
+    ),
+    filter=['lowercase', token_filter('ascii_fold', 'asciifolding')]
+)
+
+synonynm_filter = token_filter(
+    'synonym_filter_en',
+    'synonym',
+    synonyms_path='/usr/share/elasticsearch/config/synonyms/synonyms_en.txt'
+)
+
+synonym_analyzer = analyzer(
+    'synonym_analyzer_en',
+    type='custom',
+    tokenizer='standard',
+    filter=[
+        synonynm_filter,
+        'lowercase'
+    ])


### PR DESCRIPTION
The analyzers and filters are generic and can be used by both ask_cfpb and paying_for_college


## Additions

- Add analyzers and filters in search `elasticsearch_helpers.py`


## Removals

- Delete analyzers and filters from ask_cfpb `documents.py`


## Changes

- Moved analyzers and filters from ask_cfpb `documents.py` to search `elasticsearch_helpers.py`


## How to test this PR

1. tox -e unittest-current ask_cfpb.tests.test_documents


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
