### PR TITLE
Bump New Relic Python agent version to 5.20.1.150

### DIFF
--- a/docs/debugging-monitoring.md
+++ b/docs/debugging-monitoring.md
@@ -89,18 +89,13 @@ file contains placeholder entries for these two variables.
 Once you've set these two variables, start or restart your local web server.
 
 When you make your first web request, you'll see messages in the console
-indicating that the New Relic Python agent has been activated. You should see
-a message indicating your select application name:
+indicating that the New Relic Python agent has been activated. You should also
+see a message containing a link to the New Relic console:
 
 ```txt
-Successfully registered New Relic Python agent where app_name='cf.gov myname python'...
+Reporting to: https://rpm.newrelic.com/accounts/XXXXXXXX/applications/XXXXXXXX
 ```
 
-as well as a message indicating the use of high security mode:
-
-```txt        
-High Security Mode is being applied to all communications between the agent and the data collector for this session.
-```
-
-You should now be able to navigate to the New Relic console and, after a few
-seconds, see your web server traffic in New Relic APM and New Relic Browser.
+You should now be able to use that link to navigate to the New Relic console
+and, after a few seconds, see your web server traffic in New Relic APM and
+New Relic Browser.

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,2 +1,2 @@
 -r base.txt
-newrelic==4.18.0.118
+newrelic==5.20.1.150


### PR DESCRIPTION
This change bumps the version of the New Relic Python agent from 4.18.0.118 to [5.20.1.150](https://github.com/newrelic/newrelic-python-agent/releases/tag/v5.20.1.150). Release notes for the agent are [here](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes).

A couple of notable improvements that stand out:

- Real-time event streaming (5.2.0.127): data is now sent to New Relic every five seconds, instead of every minute.
- Support for Python 3.8 (5.2.3.131) and 3.9 (5.20.1.150)

## How to test this PR

To test this locally, see [here](https://cfpb.github.io/consumerfinance.gov/debugging-monitoring/#monitoring-using-new-relic).

## Screenshots

Updated docs:

![image](https://user-images.githubusercontent.com/654645/96310138-be974480-0fd4-11eb-8a37-4c1f105e9f15.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Project documentation has been updated