### PR TITLE
Fix the ELASTICSEARCH_DSL settings

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -428,9 +428,14 @@ ELASTICSEARCH_DSL_AUTO_REFRESH = False
 ELASTICSEARCH_DSL_AUTOSYNC = False
 
 if os.environ.get('USE_AWS_ES', False):
-    awsauth = AWS4Auth(os.environ.get('AWS_ES_ACCESS_KEY'), os.environ.get('AWS_ES_SECRET_KEY'), 'us-east-1', 'es')
+    awsauth = AWS4Auth(
+        os.environ.get('AWS_ES_ACCESS_KEY'),
+        os.environ.get('AWS_ES_SECRET_KEY'),
+        'us-east-1',
+        'es'
+    )
     host = os.environ.get('ES7_HOST', '')
-    ELASTICSEARCH_DSL={
+    ELASTICSEARCH_DSL = {
         'default': {
             'hosts': [{'host': host, 'port': 443}],
             'http_auth': awsauth,
@@ -439,12 +444,10 @@ if os.environ.get('USE_AWS_ES', False):
         },
     }
 else:
-    ELASTICSEARCH_DSL={
-        'default': {
-            'hosts': os.path.join("http://",
-                os.environ.get("ES7_HOST", "localhost"), ":",
-                os.environ.get("ES_PORT", "9200"))
-        },
+    host = os.environ.get("ES7_HOST", "localhost")
+    port = os.environ.get("ES_PORT", "9200")
+    ELASTICSEARCH_DSL = {
+        "default": {"hosts": f"http://{host}:{port}"}
     }
 
 # S3 Configuration

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -25,15 +25,6 @@ INSTALLED_APPS += (
     "wagtail.contrib.styleguide",
 )
 
-ELASTICSEARCH_DSL={
-    'default': {
-        'hosts': os.path.join("http://",
-            os.environ.get("ES7_HOST", "localhost"), ":",
-            os.environ.get("ES_PORT", "9200"))
-    },
-}
-
-
 STATIC_ROOT = REPOSITORY_ROOT.child("collectstatic")
 
 ALLOW_ADMIN_URL = DEBUG or os.environ.get("ALLOW_ADMIN_URL", False)


### PR DESCRIPTION
The current use of `os.path.join` in base and local settings results in a malformed host
value (below), in which the port signifier ':' is surrounded by slashes:

```python
{
    'ELASTICSEARCH_DSL': {'default': {'hosts': 'http://localhost/:/9200'}}
}
```

Elasticsearch then reads the ':' as an index name and raises a naming error:

```bash
"Invalid index name [:], must not contain ':'")
```

The error was repeated in the `local.py` settings, but I don't think we need the setting there, because it will get picked up from  from `base.py`. So I removed it.


## Testing
- On main, enable one of the DSL flags and try running `./cfgov/manage.py search_index --rebuild`
Currently you should get an error.
- Running an ES7 index job on this branch should succeed.



