### PR TITLE
Upgrade local Elasticsearch from 7.4 to 7.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     environment {
         IMAGE_REPO = 'cfpb/cfgov-python'
         IMAGE_ES2_REPO = 'cfpb/cfgov-elasticsearch-23'
-        IMAGE_ES_REPO = 'cfpb/cfgov-elasticsearch-74'
+        IMAGE_ES_REPO = 'cfpb/cfgov-elasticsearch-77'
         IMAGE_TAG = "${JOB_BASE_NAME}-${BUILD_NUMBER}"
         STACK_PREFIX = 'cfgov'
         NOTIFICATION_CHANNEL = 'cfgov-deployments'
@@ -75,7 +75,7 @@ pipeline {
                     LAST_STAGE = env.STAGE_NAME
                     docker.build(env.IMAGE_NAME_LOCAL, '--build-arg scl_python_version=rh-python36 --target cfgov-prod .')
                     docker.build(env.IMAGE_NAME_ES2_LOCAL, '-f ./docker/elasticsearch/Dockerfile .')
-                    docker.build(env.IMAGE_NAME_ES_LOCAL, '-f ./docker/elasticsearch/7.4/Dockerfile .')
+                    docker.build(env.IMAGE_NAME_ES_LOCAL, '-f ./docker/elasticsearch/7.7/Dockerfile .')
                 }
             }
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     elasticsearch:
         build:
             context: ./
-            dockerfile: ./docker/elasticsearch/7.4/Dockerfile
+            dockerfile: ./docker/elasticsearch/7.7/Dockerfile
         ports: 
             - "9200:9200"
             - "9300:9300"
@@ -23,7 +23,7 @@ services:
         volumes:
             - ./cfgov/search/resources/:/usr/share/elasticsearch/config/synonyms
     kibana:
-        image: blacktop/kibana:7.4
+        image: blacktop/kibana:7.7
         depends_on:
             - elasticsearch
         ports:

--- a/docker/elasticsearch/7.7/Dockerfile
+++ b/docker/elasticsearch/7.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM blacktop/elasticsearch:7.4
+FROM blacktop/elasticsearch:7.7
 
 # Copy Synonyms files into ElasticSearch
 COPY ./cfgov/search/resources/ /usr/share/elasticsearch/config/synonyms


### PR DESCRIPTION
Upgrades our local Elasticsearch version from 7.4 to 7.7 to reduce the number of twistlock vulnerabilities being reported.


---

<!-- Feel free to delete any sections that are not applicable to this PR. -->

## Changes

- Alpine Elasticsearch base image from 7.4 -> 7.7
- Alpine Kibana image from 7.4 -> 7.7


## How to test this PR

1. Run the stack locally


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

