### PR TITLE
Add archive options to Filterable List Controls

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -1,6 +1,6 @@
 {% macro _filter_selectable(type, label_text, id, name, value, required=None, group=None) %}
-    <li class="m-form-field m-form-field__checkbox">
-        <input class="{{ 'a-checkbox' if type == 'checkbox' else 'a-radio' }}"
+    <li class="m-form-field m-form-field__{{ type }}">
+        <input class="a-{{ type }}"
                type="{{ type }}"
                value="{{ value }}"
                id="filter_{{ id }}"
@@ -14,7 +14,7 @@
     </li>
 {% endmacro %}
 
-{% macro _render_filter_fields(value, form) -%}
+{% macro _render_filter_fields(value, form, show_archive_filter=False) -%}
     {% if value.title %}
         <div class="content-l_col
                     content-l_col-1">
@@ -132,12 +132,35 @@
             </div>
         </div>
     {% endif %}
+    {% if show_archive_filter %}
+        <div class="content-l_col
+                    content-l_col-1-3">
+            <div class="o-form_group">
+                <fieldset class="o-form_fieldset">
+                    <legend class="a-legend">
+                        Archived items
+                    </legend>
+                    <ul class="m-list m-list__unstyled" role="group">
+                    {%- for radio in form.archived %}
+                        {{ _filter_selectable(
+                            'radio',
+                            radio.choice_label,
+                            'archived_'+radio.data.value,
+                            'archived',
+                            radio.data.value
+                        ) }}
+                    {% endfor -%}
+                    </ul>
+                </fieldset>
+            </div>
+        </div>
+    {% endif %}
 {% endmacro %}
 
 {% macro _filters_form(value, form) %}
     <form method="get" action=".">
         <div class="content-l">
-            {{ _render_filter_fields(value, form) }}
+            {{ _render_filter_fields(value, form, has_archived_posts) }}
             <div class="content-l_col
                         content-l_col-1
                         m-btn-group">

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -134,7 +134,7 @@
     {% endif %}
     {% if show_archive_filter %}
         <div class="content-l_col
-                    content-l_col-1-3">
+                    content-l_col-1-2">
             <div class="o-form_group">
                 <fieldset class="o-form_fieldset">
                     <legend class="a-legend">

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -247,15 +247,15 @@ class FilterableListForm(forms.Form):
     # Returns a list of query strings to associate for each field, ordered by
     # the field declaration for the form. Note: THEY MUST BE ORDERED IN THE
     # SAME WAY AS THEY ARE DECLARED IN THE FORM DEFINITION.
-    def get_query_strings(self):  # pragma: no cover
+    def get_query_strings(self):
         return [
-            'title__icontains',       # title
-            'date_published__gte',    # from_date
-            'date_published__lte',    # to_date
-            'categories__name__in',   # categories
-            'tags__slug__in',         # topics
-            'authors__slug__in',      # authors
-            'is_archived',            # archived
+            'title__icontains',      # title
+            'date_published__gte',   # from_date
+            'date_published__lte',   # to_date
+            'categories__name__in',  # categories
+            'tags__slug__in',        # topics
+            'authors__slug__in',     # authors
+            'is_archived',           # archived
         ]
 
     def clean_archived(self):

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -105,7 +105,7 @@ class FilterableListForm(forms.Form):
 
     archived = forms.ChoiceField(
         choices=[
-            ('exclude', 'Exclude archived items'),
+            ('exclude', 'Exclude archived items (default)'),
             ('only', 'Show only archived items'),
             ('include', 'Show all items'),
         ]

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -103,6 +103,14 @@ class FilterableListForm(forms.Form):
         })
     )
 
+    archived = forms.ChoiceField(
+        choices=[
+            ('exclude', 'Exclude archived items'),
+            ('only', 'Show only archived items'),
+            ('include', 'Show all items'),
+        ]
+    )
+
     preferred_datetime_format = '%Y-%m-%d'
 
     def __init__(self, *args, **kwargs):
@@ -229,23 +237,35 @@ class FilterableListForm(forms.Form):
                 self.get_query_strings(),
                 self.declared_fields
             ):
-                if self.cleaned_data.get(field_name):
-                    final_query &= \
-                        Q((query, self.cleaned_data.get(field_name)))
+                if self.cleaned_data.get(field_name) not in (None, [], ''):
+                    final_query &= Q(
+                        (query, self.cleaned_data.get(field_name))
+                    )
+
         return final_query
 
     # Returns a list of query strings to associate for each field, ordered by
     # the field declaration for the form. Note: THEY MUST BE ORDERED IN THE
     # SAME WAY AS THEY ARE DECLARED IN THE FORM DEFINITION.
-    def get_query_strings(self):
+    def get_query_strings(self):  # pragma: no cover
         return [
-            'title__icontains',      # title
-            'date_published__gte',   # from_date
-            'date_published__lte',   # to_date
-            'categories__name__in',  # categories
-            'tags__slug__in',        # topics
-            'authors__slug__in',     # authors
+            'title__icontains',       # title
+            'date_published__gte',    # from_date
+            'date_published__lte',    # to_date
+            'categories__name__in',   # categories
+            'tags__slug__in',         # topics
+            'authors__slug__in',      # authors
+            'is_archived',            # archived
         ]
+
+    def clean_archived(self):
+        data = self.cleaned_data['archived']
+        if data == 'exclude':
+            return False
+        elif data == 'only':
+            return True
+
+        return None
 
 
 class EnforcementActionsFilterForm(FilterableListForm):

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -51,6 +51,12 @@ def image_alt_value(image):
 
 
 def is_filter_selected(context, fieldname, value):
+    """Check URL query parameters to see if a filter option should be selected
+
+    Returns True if fieldname=value is found in the GET data in order to output
+    the `checked` attribute on a checkbox or radio button in the
+    _filter_selectable macro (see: filterable-list-controls.html).
+    """
     request_get = context['request'].GET
 
     query_string_values = [
@@ -59,6 +65,10 @@ def is_filter_selected(context, fieldname, value):
         request_get.getlist('filter_' + fieldname)
         if k
     ]
+
+    # Dirty hack to check the default option for the `archived` filter
+    if fieldname == 'archived' and value == 'exclude':
+        return True
 
     return value in query_string_values
 

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -89,3 +89,9 @@ class TestIsFilterSelected(TestCase):
     def test_query_parameter_also_works_with_filter_prefix(self):
         request = self.factory.get('/?filter_foo=bar')
         self.assertEqual(self._render_template_with_request(request), 'True')
+
+    def test_query_parameter_archived_selected(self):
+        request = self.factory.get('/')
+        s = '{{ is_filter_selected("archived", "exclude") }}'
+        template = self.jinja_engine.from_string(s)
+        self.assertEqual(template.render({'request': request}), 'True')

--- a/cfgov/v1/tests/models/test_filterable_list_mixins.py
+++ b/cfgov/v1/tests/models/test_filterable_list_mixins.py
@@ -158,7 +158,7 @@ class FilterableListRelationsTestCase(TestCase):
         self.set_filterable_controls(self.filter_controls)
 
         qs = self.filterable_page.get_filterable_queryset()
-        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.count(), 2)
         self.assertEqual(qs[0].pk, self.sibling_page.pk)
 
     def test_get_filterable_archived_pages(self):

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -156,6 +156,11 @@ class TestFilterableListForm(TestCase):
         page_set = form.get_page_set()
         self.assertEqual(len(page_set), 2)
 
+        form.data = {'archived': 'include'}
+        form.full_clean()
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 2)
+
         form.data = {'archived': 'exclude'}
         form.full_clean()
         page_set = form.get_page_set()

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -102,7 +102,7 @@ class TestFilterableListForm(TestCase):
 
     def test_validate_date_after_1900_can_pass(self):
         form = self.setUpFilterableForm()
-        form.data = {'from_date': '1/1/1900'}
+        form.data = {'from_date': '1/1/1900', 'archived': 'exclude'}
         self.assertTrue(form.is_valid())
 
     def test_validate_date_after_1900_can_fail(self):
@@ -143,3 +143,27 @@ class TestFilterableListForm(TestCase):
                 'to-congress',
             ]
         )
+
+    def test_filter_by_archived(self):
+        page1 = BlogPage(title='test page', is_archived=True)
+        page2 = BlogPage(title='another test page')
+        publish_page(page1)
+        publish_page(page2)
+        form = self.setUpFilterableForm()
+
+        form.data = {}
+        form.full_clean()
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 2)
+
+        form.data = {'archived': 'exclude'}
+        form.full_clean()
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, page2)
+
+        form.data = {'archived': 'only'}
+        form.full_clean()
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, page1)


### PR DESCRIPTION
This PR adds the ability to filter based on the archive status of pages to our filterable list controls.

![image](https://user-images.githubusercontent.com/10562538/96464625-08ab4080-11f6-11eb-9786-07c122061823.png)

If the filterable pages in the filterable list contains archived pages, the option to either exclude, include, or only filter archived pages will be presented to users (defaulting to exclude).

## How to test this PR

1. Visit a filterable list page, i.e. http://localhost:8000/data-research/research-reports
2. Observe that the option to filter based on archived items does not appear
3. Archive a page that is within that filterable list page and publish the change
4. Observe that the option to filter based on archived items does appear
5. Observe that the newly archived page is excluded from the results by default

## Notes and todos

This PR intentionally preserves for now the ability to set filterable pages to include archived pages *only* that was introduced in #6039, although the functionality this PR introduces makes that unnecessary. Depending on how archiving ends up implemented in practice, one of these approaches will need some cleanup.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)

