### PR TITLE
Tweak multiselect background color to prevent browser bug

### DIFF
--- a/cfgov/unprocessed/css/molecules/multiselect.less
+++ b/cfgov/unprocessed/css/molecules/multiselect.less
@@ -36,7 +36,6 @@ select.o-multiselect {
         margin-top: -1px;
         width: 100%;
 
-        background-color: @white;
         transition: max-height 0.25s ease-out;
     }
 
@@ -52,6 +51,7 @@ select.o-multiselect {
     }
 
     &_options {
+        background-color: @white;
         padding: unit( 10px / @base-font-size-px, em );
 
         li:last-child {


### PR DESCRIPTION
Chrome barfs when the multiselect fieldset has a background color and
its child unordered list doesn't. I haven't been able to figure out *why*
it barfs but moving the bg color fixes it.

Demo: https://codepen.io/contolini/pen/KKMoPEY

| before | after |
|--------|-------|
| ![multi-before](https://user-images.githubusercontent.com/1060248/97896961-ce689580-1d03-11eb-9e68-fbdae0d5cb87.gif)   | ![multi-after](https://user-images.githubusercontent.com/1060248/97896973-d294b300-1d03-11eb-8ee4-e7365a6884be.gif)  |

## Changes

- Move `background-color` from multiselect fieldset to unordered list.

## How to test this PR

1. Visit the [blog](https://www.consumerfinance.gov/about-us/blog/) in Chrome (I'm on v86).
1. Open the Topic multiselect and scroll through the long list. Notice how Chrome struggles to paint the list of options.
1. Pull down this branch, `./frontend.sh`, and verify the bug doesn't occur [locally](http://0.0.0.0:8000/about-us/blog/).

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
