### PR TITLE
P4C: Fix URL map

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/url-parameter-utils.js
@@ -29,7 +29,7 @@ const urlParameters = {
   'book': 'financialModel.indiCost_books',
   'indo': 'financialModel.indiCost_other',
   'tran': 'financialModel.indiCost_transportation',
-  'nda': 'financialModel.indiCost_added',
+  'nda': 'financialModel.otherCost_additional',
 
   'pelg': 'financialModel.grant_pell',
   'seog': 'financialModel.grant_seog',
@@ -38,9 +38,9 @@ const urlParameters = {
   'schg': 'financialModel.grant_school',
   'othg': 'financialModel.grant_other',
 
-  'mta': 'financialModel.mil_milTuitAssist',
-  'gi': 'financialModel.mil_GIBill',
-  'othm': 'financialModel.mil_other',
+  'mta': 'financialModel.grant_mta',
+  'gi': 'financialModel.grant_gibill',
+  'othm': 'financialModel.grant_servicememberOther',
 
   'stas': 'financialModel.scholarship_state',
   'schs': 'financialModel.scholarship_school',
@@ -71,7 +71,7 @@ const urlParameters = {
   'offj': 'financialModel.income_jobOffCampus',
   'onj': 'financialModel.income_jobOnCampus',
   'eta': 'financialModel.income_employerAssist',
-  'othf': 'financialModel.income_other',
+  'othf': 'financialModel.income_otherFunding',
 
   'pvl1': 'financialModel.privLoan_privLoan1',
   'pvr1': 'financialModel.privloan_privLoanRate1',


### PR DESCRIPTION
Currently a few of the college costs app user-entered values are not being preserved in the URL. This PR updates the variable names in the URL map so the values will be correctly added to the query string.



## Changes

- Updates to URL map


## How to test this PR

1. Check out branch
2. Run `gulp scripts:apps`
3. Navigate to [college costs app](http://localhost:8000/paying-for-college/your-financial-path-to-graduation/?iped=131469&houp=onCampus&typp=bachelors&lenp=4&depp=dependent&cobs=n&tuit=55230&hous=13850&book=1325)
4. Enter values in the following fields
    - Costs page: Additional financial obligations
    - Grants & scholarships: Other federal grants, Military tuition assistance, GI Bill, Other (Yellow Ribbon, etc)
    - Other sources: Other funding
5. Copy the URL, open it in another tab, and verify that the values entered in the previous step persist in the new tab


