### PR TITLE
Paying for College - Fix Expenses Selection

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/dispatchers/update-models.js
@@ -139,6 +139,7 @@ const updateSchoolData = function( iped ) {
 
         // Update expenses by region
         document.querySelector( '#expenses__region' ).value = schoolModel.values.region;
+        updateRegion( schoolModel.values.region );
 
         updateSchoolView();
         updateUrlQueryString();


### PR DESCRIPTION
This PR fixes a bug occurring when user loads a school from the URL but the expenses region does not match the school's default region.

## Changes
- Add line to `updateSchoolData` that updates the expenses model with appropriate region data


## How to test this PR
1. Bring it down.
2. Choose a school in Texas, for instance.
3. Check that the Region on the "Can I afford my payment?" page is "South" (if you picked a school in Texas, for instance)
4. Copy the URL of your page and load it in a new window (or reload the page, that should work). Check again that the region on the "Can I afford my payment?" page is "South."

## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
