### PR TITLE
Consistent IDs for form inputs

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/checkbox.html
+++ b/cfgov/jinja2/v1/_includes/atoms/checkbox.html
@@ -30,7 +30,7 @@
 
 {% macro render(value) -%}
 
-{%- set id = value.id or get_unique_id('input_', '_') ~ slugify( value.label ) -%}
+{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ slugify( value.label ) -%}
 {%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
 {%- set val = value.value if value.value else id -%}
 {%- set name = value.name if value.name else id -%}

--- a/cfgov/jinja2/v1/_includes/atoms/radio-button.html
+++ b/cfgov/jinja2/v1/_includes/atoms/radio-button.html
@@ -28,7 +28,7 @@
 
 {% macro render(value) -%}
 
-{%- set id = value.id or get_unique_id('input_', '_') ~ slugify( value.label ) -%}
+{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ slugify( value.label ) -%}
 {%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
 {%- set val = value.value if value.value else id -%}
 {%- set name = value.name if value.name else id -%}

--- a/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-popup/base.html
@@ -18,7 +18,7 @@
 
    ========================================================================== #}
 
-{% set form_id = get_unique_id() %}
+{% set form_id = unique_id_in_context() %}
 
 <div class="o-email-popup"
      data-popup-label="{{ popup_label }}"

--- a/cfgov/jinja2/v1/_includes/organisms/email-signup.html
+++ b/cfgov/jinja2/v1/_includes/organisms/email-signup.html
@@ -20,7 +20,7 @@
 
    ========================================================================== #}
 
-{% set form_id = get_unique_id() %}
+{% set form_id = unique_id_in_context() %}
 
 {% set disclaimer_url = '/privacy/email-sign-privacy-act-statement/'
    if not value.disclaimer_url

--- a/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
+++ b/cfgov/jinja2/v1/_includes/organisms/full-width-text.html
@@ -35,7 +35,7 @@
             </div>
         {% elif block_type in ['email_signup'] %}
             <div class="m-inset__email">
-                {{ block | safe }}
+                {% include_block block %}
             </div>
         {% elif block_type in ['well', 'well_with_ask_search'] %}
             <div class="block">

--- a/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
@@ -44,7 +44,7 @@
                 'gd_code': 'USCFPB_127',
                 'disclaimer_url': '/owning-a-home/privacy-act-statement/'
             } %}
-            {% include '_includes/organisms/email-signup.html' %}
+            {% include '_includes/organisms/email-signup.html' with context %}
         </div>
     </div>
 </footer>

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -1,6 +1,6 @@
 {% extends 'layout-full.html' %}
 {% import 'atoms/checkbox.html' as checkbox %}
-{% import 'atoms/radio-button.html' as radio %}
+{% import 'atoms/radio-button.html' as radio with context %}
 {% import 'atoms/tag.html' as tag %}
 {% import 'regulations3k/regulations3k-search-bar.html' as search_bar %}
 {% import 'regulations3k/regulations3k-search-result-item.html' as search_item %}

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -98,6 +98,36 @@ def render_stream_child(context, stream_child):
     return Markup(unescaped)
 
 
+def unique_id_in_context(context):
+    """Return an ID that is unique within the given context
+
+    For a given request, return a unique ID each time this method is
+    called. The goal is to generate IDs to uniquely identify elements
+    in a template that are consistent between page loads.
+
+    If the context has a request object, the generated id will increment:
+
+    >>> context = {'request': request}
+    >>> unique_id_in_context(context)  # returns 1
+    >>> unique_id_in_context(context)  # returns 2
+    >>> unique_id_in_context(context)  # returns 3
+
+    If the context lacks a request, this function will return a 14-character
+    unique alphanumeric string.
+    """
+    request = context.get('request')
+    if request:
+        attribute_name = '__last_unique_id'
+        if not hasattr(request, attribute_name):
+            setattr(request, attribute_name, 0)
+        id = getattr(request, attribute_name) + 1
+        setattr(request, attribute_name, id)
+        return id
+
+    else:
+        return get_unique_id()
+
+
 class V1Extension(Extension):
     def __init__(self, environment):
         super(V1Extension, self).__init__(environment)
@@ -118,6 +148,7 @@ class V1Extension(Extension):
             'is_report': ref.is_report,
             'is_filter_selected': contextfunction(is_filter_selected),
             'render_stream_child': contextfunction(render_stream_child),
+            'unique_id_in_context': contextfunction(unique_id_in_context),
             'app_url': app_url,
             'app_page_url': app_page_url,
         })

--- a/cfgov/v1/templatetags/email_popup.py
+++ b/cfgov/v1/templatetags/email_popup.py
@@ -20,7 +20,7 @@ def email_popup(request):
             continue
 
         template = 'organisms/email-popup/{}.html'.format(label)
-        context = {'popup_label': label}
+        context = {'popup_label': label, 'request': request}
         return mark_safe(render_to_string(template, context=context))
 
     return ''

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -1,5 +1,7 @@
+import re
 from datetime import date
 
+from django.http import HttpRequest
 from django.template import engines
 from django.test import RequestFactory, TestCase, override_settings
 
@@ -95,3 +97,58 @@ class TestIsFilterSelected(TestCase):
         s = '{{ is_filter_selected("archived", "exclude") }}'
         template = self.jinja_engine.from_string(s)
         self.assertEqual(template.render({'request': request}), 'True')
+
+
+class TestUniqueIdInContext(TestCase):
+
+    def setUp(self):
+        self.engine = engines['wagtail-env']
+        self.template = '{{ unique_id_in_context() }}'
+        self.random_id_pattern = re.compile('[a-z0-9]{14}')
+
+    def render(self, template, context=None):
+        return self.engine.from_string(template).render(context=context)
+
+    def assert_is_random_id(self, input):
+        match = self.random_id_pattern.match(input)
+        self.assertIsNotNone(match)
+
+    def assert_is_not_random_id(self, input):
+        match = self.random_id_pattern.match(input)
+        self.assertIsNone(match)
+
+    def test_no_context_returns_random_string(self):
+        rendered = self.render(self.template)
+        self.assert_is_random_id(rendered)
+
+    def test_no_request_in_context_returns_random_string(self):
+        rendered = self.render(self.template, {})
+        self.assert_is_random_id(rendered)
+
+    def test_render_with_request_in_context(self):
+        rendered = self.render(self.template, {'request': HttpRequest()})
+        self.assertEqual(rendered, '1')
+        self.assert_is_not_random_id(rendered)
+
+    def test_render_uses_request_to_make_multiple_unique_ids(self):
+        request = HttpRequest()
+        template = ' and '.join([self.template, self.template])
+        self.assertEqual(
+            self.render(template, {'request': request}),
+            '1 and 2'
+        )
+
+    def test_multiple_renders_multiple_unique_ids(self):
+        request = HttpRequest()
+        rendered = [
+            self.render(self.template, {'request': request})
+            for _ in range(5)
+        ]
+        self.assertEqual(rendered, ['1', '2', '3', '4', '5'])
+
+    def test_different_requests_allow_repeats(self):
+        for i in range(5):
+            self.assertEqual(
+                self.render(self.template, {'request': HttpRequest()}),
+                '1'
+            )


### PR DESCRIPTION
The new `unique_id_in_context` method will replace the use of `get_unique_id` method to generate unique identifiers for form inputs. `get_unique_id` would generate a random sequence of characters on each page load, meaning the input id would always change. This caused an issue for our web archive, since it caused unnecessary diffs on pages that didn't have substantive changes.

With `unique_id_in_context`, the markup for input forms should remain consistent between page loads, which will allow the web archive to be more useful and not contain superfluous diffs.


## Additions

- `unique_id_in_context()` method and jinja tag


## Changes

- Update several templates to use `unique_id_in_context()` instead of `get_unique_id()`


## How to test this PR

1. Run this branch
2. Visit a page that contains an email sign-up form, such as http://localhost:8000/owning-a-home/
3. Use the inspector to verify that the `label` and `input` in the HTML of the email sign-up form use single-digit identifiers, like in the screenshot below. This should also be true in the email pop-up form.

![Screen Shot 2020-11-13 at 12 01 13 PM](https://user-images.githubusercontent.com/4295388/99099302-3c387b00-25a8-11eb-9bfa-cd6773035e04.png)


## Notes and todos

- Some templates still use the `get_unique_id()` method. We will replace those with `unique_id_for_context()` in an upcoming PR, then remove `get_unique_id` as a jinja tag.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing
No visual changes.