### PR TITLE
Increase docker start period to improve deployments.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,7 @@ RUN ln -s ${SCL_HTTPD_ROOT}/etc/httpd/modules ${APACHE_SERVER_ROOT}/modules && \
     mkdir -p cfgov/f /tmp/eregs_cache
 
 # Healthcheck retry set high since database loads take a while
-HEALTHCHECK --start-period=15s --interval=30s --retries=30 \
+HEALTHCHECK --start-period=300s --interval=30s --retries=30 \
             CMD curl -sf -A docker-healthcheck -o /dev/null http://localhost:8000
 
 CMD ["httpd", "-d", "cfgov/apache", "-D", "FOREGROUND"]


### PR DESCRIPTION
I'm noticing our docker deployments are failing to spin up healthy python containers. It looks like it could be due to indexing all our elasticsearch servers is taking longer than the currently allocated 15 minutes and 15 seconds. While unclear why this is taking additional time recently, this seems like an opportunity to add some additional resiliency.


---

## Changes

- Start Period 15s -> 300s


## How to test this PR

1. Changes to docker deploy, will be done via monitoring deployments.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
