### PR TITLE
Exclude Haystack search_indexes.py file from coverage

### DIFF
--- a/cfgov/.coveragerc
+++ b/cfgov/.coveragerc
@@ -10,6 +10,7 @@ omit =
     */ask_cfpb/scripts/*
     */ask_cfpb/search_indexes*
     */paying_for_college/data_sources/bls_processing.py
+    */paying_for_college/search_indexes*
 data_file = ../.coverage
 
 [report]


### PR DESCRIPTION
I don't think the remaining uncovered Haystack lines are worth pursuing, since we will be abandoning that code, and they may have never been covered. For this, I have excluded the untested Haystack search_indexes.py file from code coverage.