### PR TITLE
Prepaid search: Handle product deletions when writing CSV files

### DIFF
--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import csv
 
 from prepaid_agreements.models import PrepaidAgreement
@@ -55,42 +52,44 @@ def write_agreements_data(path=''):
 
     for agreement in agreements:
         product = agreement.product
-        most_recent = 'Yes' if agreement.is_most_recent else 'No'
-        created_time = agreement.created_time.strftime('%Y-%m-%d %H:%M:%S')
+        # CSV should only includes data that has not been marked for deletion
+        if product.deleted_at is None:
+            most_recent = 'Yes' if agreement.is_most_recent else 'No'
+            created_time = agreement.created_time.strftime('%Y-%m-%d %H:%M:%S')
 
-        other_relevant_parties = product.other_relevant_parties
-        if other_relevant_parties:
-            other_relevant_parties = other_relevant_parties.replace(
-                '\n', '; '
-            )
-        else:
-            other_relevant_parties = 'No information provided'
+            other_relevant_parties = product.other_relevant_parties
+            if other_relevant_parties:
+                other_relevant_parties = other_relevant_parties.replace(
+                    '\n', '; '
+                )
+            else:
+                other_relevant_parties = 'No information provided'
 
-        data = {
-            'issuer_name': product.issuer_name,
-            'product_name': product.name,
-            'product_id': product.pk,
-            'agreement_effective_date': agreement.effective_date,
-            'created_date': created_time,
-            'withdrawal_date': product.withdrawal_date,
-            'current_status': product.status,
-            'prepaid_product_type': product.prepaid_type,
-            'program_manager_exists': product.program_manager_exists,
-            'program_manager': product.program_manager,
-            'other_relevant_parties': other_relevant_parties,
-            'path': agreement.bulk_download_path,
-            'direct_download': agreement.compressed_files_url,
-            'agreement_id': agreement.pk
-        }
+            data = {
+                'issuer_name': product.issuer_name,
+                'product_name': product.name,
+                'product_id': product.pk,
+                'agreement_effective_date': agreement.effective_date,
+                'created_date': created_time,
+                'withdrawal_date': product.withdrawal_date,
+                'current_status': product.status,
+                'prepaid_product_type': product.prepaid_type,
+                'program_manager_exists': product.program_manager_exists,
+                'program_manager': product.program_manager,
+                'other_relevant_parties': other_relevant_parties,
+                'path': agreement.bulk_download_path,
+                'direct_download': agreement.compressed_files_url,
+                'agreement_id': agreement.pk
+            }
 
-        # Product-level CSV only includes data
-        # for a product's most recent agreement,
-        # such that there is one row per product ID
-        if agreement.is_most_recent:
-            products_writer.writerow(data)
+            # Product-level CSV only includes data
+            # for a product's most recent agreement,
+            # such that there is one row per product ID
+            if agreement.is_most_recent:
+                products_writer.writerow(data)
 
-        data['most_recent_agreement'] = most_recent
-        agreements_writer.writerow(data)
+            data['most_recent_agreement'] = most_recent
+            agreements_writer.writerow(data)
 
     agreements_file.close()
     products_file.close()


### PR DESCRIPTION
This change will catch the exclusion that was not happening in the CSV files creation

## Additions

Added a check for the product's `deleted_at` status in the `write_prepaid_agreements_data_to_csv` and not write agreements whose products have been deleted to the CSV files

## How to test this PR

1. git checkout fix-3913
1. cd cfgov
1. ./manage.py runscript write_prepaid_agreements_data_to_csv

Use the following url to search for agreements matched for a specific product:
https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/?search_field=all&issuer_name=Sunrise+Banks%2C+National+Association

Verify the number of matches are identical to that in the CSV file using grep as follows:
```
$ grep "Sunrise Banks, National Association" prepaid_metadata_recent_agreements.csv|wc -l
      92
```

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
