### PR TITLE
Update EFIP notification endpoints for test-runner

### DIFF
--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -6,10 +6,6 @@ from paying_for_college.models import Contact
 
 
 # urls
-EDMC_DEV = "https://dev.exml.edmc.edu/cfpb"
-EDMC_BETA = "https://beta.exml.edmc.edu/cfpb"
-EDMC_PROD = 'edmc'
-BPI_PROD = 'bpi'
 BIN = "https://httpbin.org/"
 BINPOST = "https://httpbin.org/post"
 BINGET = "https://httpbin.org/get"
@@ -33,8 +29,10 @@ def send_test_notifications(url=None, oid=OID, errors=ERRORS):
     - print(send_test_notifications(url=BINPOST))
     """
     prod_endpoints = {
-        'edmc': Contact.objects.get(name='EDMC').endpoint,
-        'bpi': Contact.objects.get(name='Bridgepoint Education').endpoint
+        # 'edmc': Contact.objects.get(name='EDMC').endpoint,
+        'bpi': Contact.objects.get(name='Bridgepoint Education').endpoint,
+        'su': Contact.objects.get(name='South University').endpoint,
+        'ai': Contact.objects.get(name='Art Institutes').endpoint,
     }
     if not url:
         urls = list(prod_endpoints.values())

--- a/cfgov/paying_for_college/fixtures/test_contacts.json
+++ b/cfgov/paying_for_college/fixtures/test_contacts.json
@@ -5,7 +5,8 @@
     "fields": {
         "contacts": "contact1@example.com",
         "endpoint": "https://example.com",
-        "name": "EDMC"
+        "name": "EDMC",
+        "internal_note": ""
     }
 },
 {
@@ -14,7 +15,28 @@
     "fields": {
         "contacts": "contact2@example.com",
         "endpoint": "https://example.com",
-        "name": "Bridgepoint Education"
+        "name": "Bridgepoint Education",
+        "internal_note": ""
+    }
+},
+{
+    "model": "paying_for_college.contact",
+    "pk": 4,
+    "fields": {
+        "contacts": "contact3@example.com",
+        "endpoint": "https://example.com",
+        "name": "South University",
+        "internal_note": ""
+    }
+},
+{
+    "model": "paying_for_college.contact",
+    "pk": 5,
+    "fields": {
+        "contacts": "contact4@example.com",
+        "endpoint": "https://example.com",
+        "name": "Art Institutes",
+        "internal_note": ""
     }
 }
 ]

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -655,11 +655,11 @@ class TestScripts(django.test.TestCase):
         mock_post.return_value = mock_return
         resp1 = send_test_notifications()
         self.assertTrue('OK' in resp1)
-        self.assertTrue(mock_post.call_count == 2)
+        self.assertEqual(mock_post.call_count, 3)
         mock_post.side_effect = requests.exceptions.ConnectTimeout
         resp2 = send_test_notifications(url='example.com')
         self.assertTrue('timed out' in resp2)
-        self.assertTrue(mock_post.call_count == 3)
+        self.assertEqual(mock_post.call_count, 4)
 
     def test_calculate_percent(self):
         percent = api_utils.calculate_group_percent(100, 900)


### PR DESCRIPTION
We have sporadically needed to change EFIP endpoints, and having
the notification_tester script up to date helps in testing and
troubleshooting new endpoints.

In the latest round of changes, new endpoints were added for 2 school systems:
- South University
- Art Institutes

These two new endpoints fully replace the original edmc endpoint, so it can be retired.

Running the script's `send_test_notificaions` function with no arguments
will now send tests to the two new endpoints, as well as to the third
remaining endpoint, BPI.

Testing
The script can be tested locally, but requests may time out,
because the school systems may block them if they don't come from one
of our production servers.

To test locally, open a Django shell with `./cfgov/manage.py shell` and run the following:

```python
from paying_for_college.disclosures.scripts.notification_tester import *
print(send_test_notifications())
```

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Project documentation has been updated
