### PR TITLE
Expose undergraduate programs in the paying-for-college API

### DIFF
--- a/cfgov/paying_for_college/tests/test_models.py
+++ b/cfgov/paying_for_college/tests/test_models.py
@@ -196,7 +196,6 @@ class SchoolModelsTest(TestCase):
         self.assertTrue(isinstance(p, Program))
         self.assertIn(p.program_name, p.__str__())
         self.assertIn(p.program_name, p.as_json())
-        self.assertIn('Bachelor', p.get_level())
         noti = self.create_notification(s)
         self.assertTrue(isinstance(noti, Notification))
         self.assertIn(noti.oid, noti.__str__())
@@ -441,7 +440,7 @@ class ProgramCodesTest(TestCase):
 
     def test_program_codes_deliver_no_undergrad(self):
         programs = self.school.program_codes
-        self.assertEqual(len(programs.get('undergrad')), 0)
+        self.assertEqual(len(programs.get('undergrad')), 1)
 
     def test_grad_program_codes(self):
         programs = self.school.program_codes


### PR DESCRIPTION
The newish [financial-path tool](https://www.consumerfinance.gov/paying-for-college/your-financial-path-to-graduation/) is ready to start helping undergraduate users. The initial launch was aimed solely at
graduate programs, so undergrad programs were left out of the API.

This just opens the gate for the `undergrad` portion of the schools' `programCodes` endpoint.

## Testing
It helps to have a json viewing extension installed in your browser.

- Visit the current school endpoint for Texas Tech (ID 229115), and note that programCodes[undergrad] is an empty list.  
<https://www.consumerfinance.gov/paying-for-college2/understanding-your-financial-aid-offer/api/school/229115/>
- Check out the branch and visit the local endpoint for Texas Tech (ID 229115):  
<http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/api/school/229115/>
Note that the programCodes endpoint lists both graduate and undergrad programs.
