### PR TITLE
Add explicit 127.0.0.1 IP addresses to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,15 @@ services:
             context: ./
             dockerfile: ./docker/elasticsearch/Dockerfile
         ports:
-            - "9000:9200"
-            - "9100:9300"
+            - 127.0.0.1:9000:9200
+            - 127.0.0.1:9100:9300
     elasticsearch:
         build:
             context: ./
             dockerfile: ./docker/elasticsearch/7.7/Dockerfile
-        ports: 
-            - "9200:9200"
-            - "9300:9300"
+        ports:
+            - 127.0.0.1:9200:9200
+            - 127.0.0.1:9300:9300
         environment:
             discovery.type: single-node
         volumes:
@@ -27,7 +27,7 @@ services:
         depends_on:
             - elasticsearch
         ports:
-            - "5601:5601"
+            - 127.0.0.1:5601:5601
     postgres:
         image: postgres:10-alpine
         user: postgres
@@ -39,7 +39,7 @@ services:
             POSTGRES_PASSWORD: cfpb
             POSTGRES_DB: cfgov
         ports:
-            - "5432:5432"
+            - 127.0.0.1:5432:5432
 
     python:
         build:
@@ -63,7 +63,7 @@ services:
             context: ./
             dockerfile: ./docker/docs/Dockerfile
         ports:
-            - "8888:8888"
+            - 127.0.0.1:8888:8888
         environment:
             LANG: en_US.utf8
             LC_ALL: en_US.utf8


### PR DESCRIPTION
This prevents your running Docker containers from being hit by network-wide security scans.

## How to test this PR

1. Pull branch
1. Ensure `docker-compose up` continues working as expected

## Notes and todos

- I believe this causes a conflict between the Postgres container and a running local Postgres service, if you happen to have both. As far as I can tell, the best workaround is simply to stop the local service when firing up the container.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)