### PR TITLE
Paying for College: Migrate feedback script off jquery

### DIFF
--- a/cfgov/paying_for_college/static/paying_for_college/feedback/js/feedback.js
+++ b/cfgov/paying_for_college/static/paying_for_college/feedback/js/feedback.js
@@ -4,6 +4,10 @@ const feedbackTextarea = feedbackContainer.querySelector( 'textarea' );
 feedbackButton.setAttribute( 'disabled', 'disabled' );
 feedbackTextarea.addEventListener( 'keyup' , feedbackTextareaKeyUp );
 
+/**
+ * Disable the submit button if there is no content in the textarea input.
+ * @param {KeyboardEvent} event - The keyup event object from the textarea.
+ */
 function feedbackTextareaKeyUp( event ) {
     if ( event.target.value === '' ) {
         feedbackButton.setAttribute( 'disabled', 'disabled' );

--- a/cfgov/paying_for_college/static/paying_for_college/feedback/js/feedback.js
+++ b/cfgov/paying_for_college/static/paying_for_college/feedback/js/feedback.js
@@ -1,15 +1,13 @@
-var CFPBComparisonFeedback = (function() {
-    $('#feedback-container button').attr('disabled', true);
+const feedbackContainer = document.querySelector( '#feedback-container' );
+const feedbackButton = feedbackContainer.querySelector( 'button' );
+const feedbackTextarea = feedbackContainer.querySelector( 'textarea' );
+feedbackButton.setAttribute( 'disabled', 'disabled' );
+feedbackTextarea.addEventListener( 'keyup' , feedbackTextareaKeyUp );
 
-    $(document).ready(function() {
-        $('#feedback-container').on('keyup', 'textarea', function() {
-            if ( $(this).val() != "" ) {
-                $('#feedback-container button').removeAttr('disabled');            
-            }
-            else {
-                $('#feedback-container button').attr('disabled', true);
-            }
-        });
-    });
-
-})(jQuery); 
+function feedbackTextareaKeyUp( event ) {
+    if ( event.target.value === '' ) {
+        feedbackButton.setAttribute( 'disabled', 'disabled' );
+    } else {
+        feedbackButton.removeAttribute( 'disabled' );
+    }
+}


### PR DESCRIPTION
https://www.consumerfinance.gov/paying-for-college2/understanding-your-financial-aid-offer/feedback/ has the error `Uncaught ReferenceError: jQuery is not defined`. The jquery script disables the submit button till something is typed into the textarea input. This PR migrates that script off jquery.

## Changes

- Migrate Paying for College feedback script off jQuery.


## How to test this PR

1. Visit https://www.consumerfinance.gov/paying-for-college2/understanding-your-financial-aid-offer/feedback/ and see an error in dev console for jquery and the submit button is not disabled.
2. Pull branch and run locally and visit http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/feedback/ and see that submit button is disabled till typing into the textarea input, and there should be no dev console error.
