### PR TITLE
IA Migration: Script to update outdated Wagtail redirects

### DIFF
--- a/cfgov/scripts/update_existing_redirects.py
+++ b/cfgov/scripts/update_existing_redirects.py
@@ -31,6 +31,6 @@ def run(*args):
         if dry_run:
             print(f'\n\nSummary: Would update {total} redirects matching {old_pattern}')
             print('run the following command to update them:')
-            print('  ./cfgov/manage.py runscript update_existing_redirects --script-args')
+            print('  ./cfgov/manage.py runscript update_existing_redirects --script-args update')
         else:
             print(f'\n\nSummary: Updated {total} redirects')

--- a/cfgov/scripts/update_existing_redirects.py
+++ b/cfgov/scripts/update_existing_redirects.py
@@ -1,0 +1,36 @@
+from wagtail.contrib.redirects.models import Redirect
+
+
+outdated_patterns = [ ('/policy-compliance/guidance', '/compliance') ]
+
+# This script is for use on November 25, 2020, when we'll be migrating
+# cf.gov to a new IA. Delete this script after the migration is done.
+# Run this from the command line with this:
+#   cfgov/manage.py runscript update_existing_redirects
+#   cfgov/manage.py runscript update_existing_redirects --script-args update
+def run(*args):
+    if 'update' in args:
+        dry_run = False
+    else:
+        dry_run = True
+
+    for (old_pattern, new_pattern) in outdated_patterns:
+        matching_redirects = Redirect.objects.filter(old_path__startswith=old_pattern)
+        total = len(matching_redirects)
+
+        for redirect in matching_redirects:
+            old_path = redirect.old_path
+            updated_path = old_path.replace(old_pattern, new_pattern)
+            if dry_run:
+                print(f'{old_path} -> {updated_path}')
+            else:
+                print(f"updating {old_path} -> {updated_path}")
+                redirect.old_path = updated_path
+                redirect.save()
+
+        if dry_run:
+            print(f'\n\nSummary: Would update {total} redirects matching {old_pattern}')
+            print('run the following command to update them:')
+            print('  ./cfgov/manage.py runscript update_existing_redirects --script-args')
+        else:
+            print(f'\n\nSummary: Updated {total} redirects')

--- a/cfgov/scripts/update_existing_redirects.py
+++ b/cfgov/scripts/update_existing_redirects.py
@@ -1,7 +1,8 @@
 from wagtail.contrib.redirects.models import Redirect
 
 
-outdated_patterns = [ ('/policy-compliance/guidance', '/compliance') ]
+outdated_patterns = [('/policy-compliance/guidance', '/compliance')]
+
 
 # This script is for use on November 25, 2020, when we'll be migrating
 # cf.gov to a new IA. Delete this script after the migration is done.
@@ -15,7 +16,9 @@ def run(*args):
         dry_run = True
 
     for (old_pattern, new_pattern) in outdated_patterns:
-        matching_redirects = Redirect.objects.filter(old_path__startswith=old_pattern)
+        matching_redirects = Redirect.objects.filter(
+            old_path__startswith=old_pattern
+        )
         total = len(matching_redirects)
 
         for redirect in matching_redirects:
@@ -29,8 +32,8 @@ def run(*args):
                 redirect.save()
 
         if dry_run:
-            print(f'\n\nSummary: Would update {total} redirects matching {old_pattern}')
+            print(f'\n\nSummary: Would update {total} redirects matching {old_pattern}')  # noqa E501
             print('run the following command to update them:')
-            print('  ./cfgov/manage.py runscript update_existing_redirects --script-args update')
+            print('  ./cfgov/manage.py runscript update_existing_redirects --script-args update')  # noqa E501
         else:
             print(f'\n\nSummary: Updated {total} redirects')


### PR DESCRIPTION
The IA migration adds new redirects to Apache's redirects.conf. These make some existing Wagtail redirects outdated. This script fixes the ones we know about immediately. After the migration, we can do a more complete accounting of which redirects are still legitimate.

## Additions

- `update_existing_redirects` script to correct the set of outdated redirects that causes smoke test failures

## Notes and todos

- This is a hotfix to get the IA Migration out the door. Once that deadline has passed, we will take more time to create a more effective system around managing redirects and ensuring that all of them are effective.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated
