### PR TITLE
Fix incorrect webpack exclude regex

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -29,8 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -30,7 +30,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -29,9 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/webpack-config.js
@@ -28,7 +28,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
@@ -34,9 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
@@ -34,8 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
@@ -35,7 +35,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/webpack-config.js
@@ -33,7 +33,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -29,8 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -30,7 +30,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -29,9 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/webpack-config.js
@@ -28,7 +28,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/form-explainer/webpack-config.js
+++ b/cfgov/unprocessed/apps/form-explainer/webpack-config.js
@@ -29,8 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/form-explainer/webpack-config.js
+++ b/cfgov/unprocessed/apps/form-explainer/webpack-config.js
@@ -30,7 +30,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/form-explainer/webpack-config.js
+++ b/cfgov/unprocessed/apps/form-explainer/webpack-config.js
@@ -29,9 +29,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/form-explainer/webpack-config.js
+++ b/cfgov/unprocessed/apps/form-explainer/webpack-config.js
@@ -28,7 +28,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -34,9 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -34,8 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -35,7 +35,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
+++ b/cfgov/unprocessed/apps/owning-a-home/webpack-config.js
@@ -33,7 +33,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/paying-for-college/webpack-config.js
+++ b/cfgov/unprocessed/apps/paying-for-college/webpack-config.js
@@ -33,7 +33,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
 
     /* The below regex will capture all node modules
-       that start with `cf-` or `cfpb-`.
+       that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/5 */
     exclude : [
         /node_modules\/(?:cf\-.+|cfpb\-.+)/,

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
@@ -34,9 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
@@ -34,8 +34,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
@@ -35,7 +35,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/webpack-config.js
@@ -33,7 +33,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
@@ -30,9 +30,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
@@ -30,8 +30,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
@@ -31,7 +31,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/webpack-config.js
@@ -29,7 +29,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
@@ -32,7 +32,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
@@ -34,7 +34,8 @@ const COMMON_MODULE_CONFIG = {
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/9 */
-    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
@@ -33,9 +33,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
-    use: {
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,    use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {
         presets: [ [ '@babel/preset-env', {

--- a/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
+++ b/cfgov/unprocessed/apps/youth-employment-success/webpack-config.js
@@ -33,8 +33,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -22,7 +22,7 @@ const COMMON_MODULE_CONFIG = {
     test: /\.js$/,
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
-       except those that start with `cf-` or `cfpb-`.
+       except those that start with `@cfpb/` or `cfpb-`.
        Regex test: https://regex101.com/r/zizz3V/8 */
     exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -23,8 +23,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `cf-` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/7 */
-    exclude: /node_modules\/(?!(?:cf\-.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/8 */
+    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {

--- a/config/webpack-config.js
+++ b/config/webpack-config.js
@@ -23,8 +23,8 @@ const COMMON_MODULE_CONFIG = {
     /* Exclude modules from transpiling.
        The below regex will match and exclude all node modules
        except those that start with `@cfpb/` or `cfpb-`.
-       Regex test: https://regex101.com/r/zizz3V/8 */
-    exclude: /^.*node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
+       Regex test: https://regex101.com/r/zizz3V/9 */
+    exclude: /node_modules\/(?!(?:@cfpb\/.+|cfpb\-.+)).+/,
     use: {
       loader: 'babel-loader?cacheDirectory=true',
       options: {


### PR DESCRIPTION
Webpack was not transpiling `@cfpb` node modules coming from the design system.

## Changes

- Fix incorrect webpack exclude regex to properly include `@cfpb` node modules in webpack transpiling.


## How to test this PR

1. Pull branch and `gulp clean && gulp build`.
2. Built files in `cfgov/static_built/js/` should not contain `const`.
