### PR TITLE
Add AND operator to regulations search for Elasticsearch 7

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -77,7 +77,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 self.get_template(request),
                 self.get_context(request))
         search = SectionParagraphDocument.search().query(
-            'match', text=search_query)
+            'match', text={"query": search_query, "operator": "AND"})
         search = search.highlight(
             'text', pre_tags="<strong>", post_tags="</strong>")
         total_results = search.count()


### PR DESCRIPTION
Implements the AND operator logic for iregs searches to improve the number of results returned for multi word queries. 


---

## Changes

- Replaced default OR operator with AND for iregs ES7 search.


## How to test this PR

1. Search phrases instead of single words on iregs with ES7 search enabled. You should see only results all words present be returned.


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/16838497/100754681-5c927300-33b9-11eb-86b4-78da11c4d3d9.png)
### After
![image](https://user-images.githubusercontent.com/16838497/100754749-6ddb7f80-33b9-11eb-808c-801db75458bd.png)


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
