### PR TITLE
Remove redundant ArticlePage search field

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -18,8 +18,7 @@ from wagtail.admin.edit_handlers import (
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import Orderable, Page
-from wagtail.search import index
+from wagtail.core.models import Orderable
 
 from flags.state import flag_enabled
 from modelcluster.fields import ParentalKey
@@ -638,10 +637,6 @@ class ArticlePage(CFGOVPage):
     ], blank=True)
 
     sidebar_panels = [StreamFieldPanel('sidebar'), ]
-
-    search_fields = Page.search_fields + [
-        index.SearchField('title'),
-    ]
 
     edit_handler = TabbedInterface([
         ObjectList(content_panels, heading='Content'),


### PR DESCRIPTION
The ask_cfpb.ArticlePage model defines a custom search field for the 'title' field, but this field is already included [in the base
Page.search_fields](https://github.com/wagtail/wagtail/blob/cc13aecd7d25163a5deac60c9aea6df3e0a45e1b/wagtail/core/models.py#L494).

Redefining the field like this causes problems when trying to use Wagtail search with an Elasticsearch backend, because it's not possible to change a mapping once it has been created. See [this related Wagtail issue](https://github.com/wagtail/wagtail/issues/4717).

## Notes and todos

I do note that the base Page definition of the index is slightly different:

`index.SearchField('title', partial_match=True, boost=2)`

as opposed to the simpler form used here:

`index.SearchField('title')`

The git blame doesn't indicate that this change was deliberate in [the PR that created this page type](https://github.com/cfpb/consumerfinance.gov/pull/5009).

The only place this might impact the live site is in our "external linksearch", as Ask CFPB uses its own, separate Elasticsearch logic. Thus I am inclined to make this change unless there is a specific reason for this redefinition.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)