### PR TITLE
Only install gettext as needed for GitHub Actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -34,9 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # Make sure we have gettext installed for the translation validation
-      - run: |
-          sudo apt-get install gettext
+      - name: Install gettext for translation validation
+        if: matrix.toxenv == 'validate-translations'
+        run: sudo apt-get install gettext
 
       - name: Set up Python
         uses: actions/setup-python@v1


### PR DESCRIPTION
Currently we install gettext on all of our backend GitHub Actions runs, even though it is only needed for the 'validate-translations' matrix run. This change modifies the configuration to only install gettext as needed, which should speed up the other matrix runs.

## Notes and todos

This logic was added in https://github.com/cfpb/consumerfinance.gov/pull/5939.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)