### PR TITLE
Mega Menu: Convert unordered list label from aria-label to title

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -67,7 +67,7 @@
                 {% if aria_group_title %}
                 aria-labelledby="{{ aria_group_title | slugify ~ '-menu' }}"
                 {% elif nav_title %}
-                aria-label="{{ nav_title | safe }}"
+                title="{{ nav_title | safe }}"
                 {% endif %}>
                 {% if nav_depth == 1 -%}
                     {% set complaint_url = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}


### PR DESCRIPTION
HTML validator says the aria-label on `ul` element in the mega menu may be an error:

![Screen Shot 2020-12-02 at 10 03 15 AM](https://user-images.githubusercontent.com/704760/101060680-acaa3a80-355d-11eb-98bd-e429b2398237.png)


https://fae.disability.illinois.edu/rulesets/LIST_2/ says 

> The title attribute can also be used to add a label to a list container element to provide an explicit text description of its contents.

So this PR turns the `aria-label` into `title` attributes.

## Changes

- Change mega menu `ul` `aria-label` into `title` attributes.

## How to test this PR

1. Run voiceover on the menu and see that the list has a title

![Screen Shot 2020-12-02 at 11 56 53 AM](https://user-images.githubusercontent.com/704760/101060933-f430c680-355d-11eb-9af6-0eefbdec2c03.png)
