### PR TITLE
Fix title on YES transportation tool page

### DIFF
--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -5,10 +5,9 @@
   <link rel="stylesheet" href="{{ static('apps/youth-employment-success/css/main.css') }}">
 {%- endblock css %}
 
-{% block title %}
-  {{ super() }}
+{% block title -%}
   Planning how you’ll get to work | {{ _('Consumer Financial Protection Bureau') }}
-{% endblock %}
+{%- endblock %}
 
 {%- block desc -%}
   This tool helps youth plan how to get to work, budget for transportation costs, and identify a backup plan. 


### PR DESCRIPTION
The title on [the YES transportation tool page](https://www.consumerfinance.gov/consumer-tools/educator-tools/resources-youth-employment-programs/transportation-tool/) is wrong. It says:

> Consumer Financial Protection Bureau Planning how you’ll get to work | Consumer Financial Protection Bureau

but should just be

> Planning how you’ll get to work | Consumer Financial Protection Bureau

![image](https://user-images.githubusercontent.com/654645/101097602-784f7200-358f-11eb-9fba-15b964dad6a7.png)