### PR TITLE
Use canonical URLs in smoke tests

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -43,6 +43,8 @@ BASE = 'https://www.consumerfinance.gov'
 S3_URI = 'https://files.consumerfinance.gov/build/smoketests/smoketest_urls.json'  # noqa: E501
 
 # Fall-back list of top 25 URLs, as of July 2, 2020, from hubcap/wiki
+# All URLs in the list should be canonical locations of the given pages,
+# not redirects.
 TOP = [
     '/',  # home page
     '/about-us/blog/guide-covid-19-economic-stimulus-checks/',
@@ -67,28 +69,30 @@ TOP = [
     '/about-us/blog/guide-coronavirus-mortgage-relief-options/#relief-options/',  # noqa: E501
     '/coronavirus/managing-your-finances/economic-impact-payment-prepaid-debit-cards/',  # noqa: E501
     '/ask-cfpb/how-can-i-tell-who-owns-my-mortgage-en-214/',
-    '/policy-compliance/rulemaking/regulations/',
+    '/rules-policy/regulations/',
     '/ask-cfpb/what-is-a-debt-to-income-ratio-why-is-the-43-debt-to-income-ratio-important-en-1791/',  # noqa: E501
 ]
 
 # URLs for cfgov sub-apps that are expected to be present
+# All URLs in the list should be canonical locations of the given pages,
+# not redirects.
 APPS = [
     '/about-us/budget-strategy/',
-    '/about-us/payments-harmed-consumers/',
+    '/enforcement/payments-harmed-consumers/',
     '/about-us/blog/',
     '/about-us/newsroom/',
     '/about-us/events/',
     '/about-us/careers/',
     '/about-us/careers/current-openings/',
     '/about-us/doing-business-with-us/',
-    '/about-us/innovation/',
+    '/rules-policy/innovation/',
     '/activity-log/',
-    '/ask-cfpb/'
+    '/ask-cfpb/',
     '/your-story/',
     '/es/',
     '/es/obtener-respuestas/',
     '/students/',
-    '/practitioner-resources/servicemembers/',
+    '/consumer-tools/educator-tools/servicemembers/',
     '/know-before-you-owe/',
     '/fair-lending/',
     '/paying-for-college/',
@@ -101,15 +105,15 @@ APPS = [
     '/consumer-tools/prepaid-cards/',
     '/consumer-tools/sending-money/',
     '/mortgagehelp/',
-    '/practitioner-resources/your-money-your-goals/',
-    '/adult-financial-education/',
-    '/practitioner-resources/youth-financial-education/',
-    '/practitioner-resources/library-resources/',
-    '/practitioner-resources/resources-for-tax-preparers/',
+    '/consumer-tools/educator-tools/your-money-your-goals/',
+    '/consumer-tools/educator-tools/adult-financial-education/',
+    '/consumer-tools/educator-tools/youth-financial-education/',
+    '/consumer-tools/educator-tools/library-resources/',
+    '/consumer-tools/educator-tools/resources-for-tax-preparers/',
     '/consumer-tools/money-as-you-grow/',
     '/empowerment/',
-    '/practitioner-resources/resources-for-older-adults/',
-    '/practitioner-resources/youth-financial-education/',  # TDP
+    '/consumer-tools/educator-tools/resources-for-older-adults/',
+    '/consumer-tools/educator-tools/youth-financial-education/',  # TDP
     '/data-research/',
     '/data-research/research-reports/',
     '/data-research/cfpb-research-conference/',
@@ -121,15 +125,15 @@ APPS = [
     '/data-research/cfpb-researchers/',
     '/data-research/mortgage-performance-trends/',
     '/policy-compliance/',
-    '/policy-compliance/rulemaking/',
-    '/policy-compliance/guidance/',
-    '/policy-compliance/guidance/implementation-guidance/',
-    '/policy-compliance/enforcement/',
-    '/policy-compliance/notice-opportunities-comment/',
-    '/policy-compliance/amicus/',
-    '/policy-compliance/guidance/implementation-guidance/hmda-implementation/',
-    '/policy-compliance/guidance/implementation-guidance/mortserv/',
-    '/policy-compliance/guidance/implementation-guidance/tila-respa-disclosure-rule/',  # noqa: E501
+    '/rules-policy/',
+    '/compliance/',
+    '/compliance/implementation-guidance/',
+    '/enforcement/',
+    '/rules-policy/notice-opportunities-comment/',
+    '/compliance/amicus/',
+    '/compliance/implementation-guidance/hmda-implementation/',
+    '/compliance/implementation-guidance/mortserv/',
+    '/compliance/implementation-guidance/tila-respa-disclosure-rule/'
 ]
 
 # call `set` on the combined list to weed out dupes


### PR DESCRIPTION
Previously, the smoke test list contained several URLs that are redirected as a result of the Nov 25 IA migration. As of #6145, individual servers (which we target in smoke tests) can no longer serve URLs that redirect in Apache, so smoke tests were failing. This PR updates these URLs to their new locations. I also updated the s3 list of URLs that the smoke test job uses by default. Smoke tests are now passing on Beta.

Our smoke tests ensure that the most important pages on cf.gov return a 200. Validating redirects is out of scope for the smoke test job. We're planning to find another way to validate redirects, outside of the smoke test job.

## Changes

- Update smoke test URLs to use their new locations as of the IA migration of November 25.


## How to test this PR

1. `cfgov/scripts/http_smoke_test.py --base http://[BetaServerName] -v`


## Notes and todos

- With #6145, it's now important to only use canonical URLs in smoke tests, not URLs that redirect. We'll need to keep this list up-to-date to prevent smoke test failures.
- I've also updated the list of URLs in the S3 bucket that the smoke test job uses by default.


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance