### PR TITLE
Have Jenkins report PR build/functional test status to GitHub

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,14 @@
 // This pipeline uses Jenkins Shared Libraries for several
 // pipeline steps. For details on how those work, see
 // GHE repo: app-ops/app-ops-jenkins-shared-libraries
+
+def postGitHubStatus(String context, String status, String message, String url) {
+    masked_url = url.replace(env.JENKINS_URL, "http://dev-jenkins/")
+    withCredentials([string(credentialsId: 'cfpbot-github-api-token', variable: 'GITHUB_TOKEN')]) {
+        sh "curl https://api.github.com/repos/cfpb/consumerfinance.gov/statuses/\${GIT_COMMIT} -H \"Authorization: token \${GITHUB_TOKEN}\" -H 'Content-Type: application/json' -X POST -d '{\"state\": \"$status\", \"context\": \"$context\", \"description\": \"$message\", \"target_url\": \"$masked_url\"}'"
+    }
+}
+
 pipeline {
     agent {
         label 'docker'
@@ -63,6 +71,9 @@ pipeline {
                         git ghe.getRepoUrl('CFGOV/cfgov-fonts')
                     }
                 }
+                script {
+                    env.GIT_COMMIT = sh(returnStdout: true, script: "git rev-parse HEAD | cut -c1-7").trim()
+                }
             }
         }
 
@@ -71,6 +82,9 @@ pipeline {
                 DOCKER_BUILDKIT = '1'
             }
             steps {
+                postGitHubStatus("jenkins/deploy", "pending", "Building", env.JOB_URL)
+                postGitHubStatus("jenkins/functional-tests", "pending", "Waiting", env.JOB_URL)
+
                 script {
                     LAST_STAGE = env.STAGE_NAME
                     docker.build(env.IMAGE_NAME_LOCAL, '--build-arg scl_python_version=rh-python36 --target cfgov-prod .')
@@ -82,6 +96,8 @@ pipeline {
 
         stage('Scan Image') {
             steps {
+                postGitHubStatus("jenkins/deploy", "pending", "Scanning", env.JOB_URL)
+
                 script {
                     LAST_STAGE = env.STAGE_NAME
                 }
@@ -130,6 +146,7 @@ pipeline {
                 }
             }
             steps {
+                postGitHubStatus("jenkins/deploy", "pending", "Deploying", env.JOB_URL)
                 script {
                     LAST_STAGE = env.STAGE_NAME
                     timeout(time: 30, unit: 'MINUTES') {
@@ -137,7 +154,10 @@ pipeline {
                     }
                     DEPLOY_SUCCESS = true
                 }
+
                 echo "Site available at: https://${CFGOV_HOSTNAME}"
+
+                postGitHubStatus("jenkins/deploy", "success", "Deployed", env.JOB_URL)
             }
         }
 
@@ -149,6 +169,8 @@ pipeline {
                 }
             }
             steps {
+                postGitHubStatus("jenkins/functional-tests", "pending", "Started", env.JOB_URL)
+
                 script {
                     LAST_STAGE = env.STAGE_NAME
                     timeout(time: 15, unit: 'MINUTES') {
@@ -156,6 +178,8 @@ pipeline {
                         sh "docker run -v ${WORKSPACE}/test/cypress:/app/test/cypress -v ${WORKSPACE}/cypress.json:/app/cypress.json -w /app -e CYPRESS_baseUrl=https://${CFGOV_HOSTNAME} -e CI=1 cypress/included:4.10.0 npx cypress run -b chrome --headless"
                     }
                 }
+
+                postGitHubStatus("jenkins/functional-tests", "success", "Passed", env.JOB_URL)
             }
         }
     }
@@ -179,6 +203,13 @@ pipeline {
                 notify("${NOTIFICATION_CHANNEL}", 
                     """:x: **${STACK_PREFIX} [${env.GIT_BRANCH}]($changeUrl)** $author $deployText at stage **${LAST_STAGE}** 
                     \n:jenkins-devil: [Details](${env.RUN_DISPLAY_URL})    :mantelpiece_clock: [Pipeline History](${env.JOB_URL})    :docker-dance: [Stack URL](${env.STACK_URL}) """)
+
+                if (env.DEPLOY_SUCCESS == false) {
+                    postGitHubStatus("jenkins/deploy", "failure", "Failed", env.RUN_DISPLAY_URL)
+                    postGitHubStatus("jenkins/functional-tests", "error", "Cancelled", env.JOB_URL)
+                } else {
+                    postGitHubStatus("jenkins/functional-tests", "failure", "Failed", env.RUN_DISPLAY_URL)
+                }
             }
         }
     }


### PR DESCRIPTION
This changes adds GitHub status API calls for our internal Jenkins deploy and functional test runs. This should allow us to see in GitHub PRs when our internal deploys fail and when our automated functional test runs that depend on those deploys fail.

This is imperfect right now because it depends on our Jenkins polling GitHub, but it gets the information into the PR where it's most relevant.

This will require editing our `/etc/hosts` files to ensure the "Details" link works.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
