### PR TITLE
Use Python pathlib instead of third-party Unipath

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from django.conf import global_settings
 from django.utils.translation import ugettext_lazy as _
@@ -6,17 +7,16 @@ from django.utils.translation import ugettext_lazy as _
 import dj_database_url
 from elasticsearch7 import RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
-from unipath import DIRS, Path
 
 from cfgov.util import admin_emails
 
 
 # Repository root is 4 levels above this file
-REPOSITORY_ROOT = Path(__file__).ancestor(4)
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 # This is the root of the Django project, 'cfgov'
-PROJECT_ROOT = REPOSITORY_ROOT.child("cfgov")
-V1_TEMPLATE_ROOT = PROJECT_ROOT.child("jinja2", "v1")
+PROJECT_ROOT = REPOSITORY_ROOT.joinpath("cfgov")
+V1_TEMPLATE_ROOT = PROJECT_ROOT.joinpath("jinja2", "v1")
 
 SECRET_KEY = os.environ.get("SECRET_KEY", os.urandom(32))
 
@@ -173,7 +173,7 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # Look for Django templates in these directories
-        "DIRS": [PROJECT_ROOT.child("templates")],
+        "DIRS": [PROJECT_ROOT.joinpath("templates")],
         # Look for Django templates in each app under a templates subdirectory
         "APP_DIRS": True,
         "OPTIONS": {
@@ -192,9 +192,9 @@ TEMPLATES = [
         # Look for Jinja2 templates in these directories
         "DIRS": [
             V1_TEMPLATE_ROOT,
-            V1_TEMPLATE_ROOT.child("_includes"),
-            V1_TEMPLATE_ROOT.child("_layouts"),
-            PROJECT_ROOT.child("static_built"),
+            V1_TEMPLATE_ROOT.joinpath("_includes"),
+            V1_TEMPLATE_ROOT.joinpath("_layouts"),
+            PROJECT_ROOT.joinpath("static_built"),
         ],
         # Look for Jinja2 templates in each app under a jinja2 subdirectory
         "APP_DIRS": True,
@@ -275,12 +275,14 @@ STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 # Used to include directories not traditionally found,
 # app-specific 'static' directories.
 STATICFILES_DIRS = [
-    PROJECT_ROOT.child("static_built"),
-    PROJECT_ROOT.child("templates", "wagtailadmin"),
+    PROJECT_ROOT.joinpath("static_built"),
+    PROJECT_ROOT.joinpath("templates", "wagtailadmin"),
 ]
 
 # Also include any directories under static.in
-STATICFILES_DIRS += REPOSITORY_ROOT.child("static.in").listdir(filter=DIRS)
+STATICFILES_DIRS += [
+    d for d in REPOSITORY_ROOT.joinpath("static.in").iterdir() if d.is_dir()
+]
 
 ALLOWED_HOSTS = ["*"]
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -3,8 +3,6 @@ import warnings
 
 import django
 
-from unipath import DIRS
-
 from .base import *
 
 
@@ -25,7 +23,7 @@ INSTALLED_APPS += (
     "wagtail.contrib.styleguide",
 )
 
-STATIC_ROOT = REPOSITORY_ROOT.child("collectstatic")
+STATIC_ROOT = REPOSITORY_ROOT.joinpath("collectstatic")
 
 ALLOW_ADMIN_URL = DEBUG or os.environ.get("ALLOW_ADMIN_URL", False)
 

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -72,7 +72,7 @@ STATICFILES_FINDERS += [
 ]
 
 STATICFILES_DIRS += [
-    PROJECT_ROOT.child('core', 'testutils', 'staticfiles'),
+    PROJECT_ROOT.joinpath('core', 'testutils', 'staticfiles'),
 ]
 
 MOCK_STATICFILES_PATTERNS = {

--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -34,8 +34,8 @@ class TestRunner(DiscoverRunner):
         )
 
         for p in PLACEHOLDER_FILES:
-            filename = settings.PROJECT_ROOT.child(*p.split(os.sep))
-            filename.parent.mkdir(parents=True)
+            filename = settings.PROJECT_ROOT.joinpath(*p.split(os.sep))
+            filename.parent.mkdir(parents=True, exist_ok=True)
 
             if not filename.exists():
                 with open(filename, 'w') as f:

--- a/cfgov/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/cfgov/paying_for_college/disclosures/scripts/nat_stats.py
@@ -1,10 +1,9 @@
 import json
 from collections import OrderedDict
+from pathlib import Path
 
-from unipath import Path
 
-
-FIXTURES_DIR = Path(__file__).ancestor(3)
+FIXTURES_DIR = Path(__file__).resolve().parents[2]
 NAT_DATA_FILE = '{0}/fixtures/national_stats.json'.format(FIXTURES_DIR)
 BACKUP_FILE = '{0}/fixtures/national_stats_backup.json'.format(FIXTURES_DIR)
 # source for BLS_FILE: http://www.bls.gov/cex/#tables_long

--- a/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -4,19 +4,19 @@ import os
 import zipfile
 from collections import OrderedDict
 from csv import DictReader as cdr, writer as csw
+from pathlib import Path
 from subprocess import call
 
 from django.contrib.humanize.templatetags.humanize import intcomma
 
 import requests
-from unipath import Path
 
 from paying_for_college.models import Alias, School
 from paying_for_college.views import get_school
 
 
 SCRIPT = os.path.basename(__file__).partition('.')[0]
-PFC_ROOT = Path(__file__).ancestor(3)
+PFC_ROOT = Path(__file__).resolve().parents[2]
 
 # DATA_YEAR specifies first year of an academic-year pair.
 # Normally we'd run this script early in a calendar year, which will be

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -31,7 +31,6 @@ requests==2.22.0
 requests_aws4auth==0.8.0
 requests_toolbelt==0.8.0
 sha3==0.2.1
-unipath>=1.1,<=2.0
 urllib3==1.25.2
 # wagtail-autocomplete==0.6 TODO: Restore when wagtail-autocomplete #77 is merged
 wagtail-flags==4.2.2


### PR DESCRIPTION
This commit deprecates use of the third-party Unipath package and instead uses the built-in Python pathlib package.

Unipath [is now in maintenance mode](https://github.com/mikeorr/Unipath). We used it previously with Python 2. Python 3.4 introduced [pathlib](https://docs.python.org/3/library/pathlib.html) which has the same functionality for our purposes.

We currently use Unipath for path-handling logic, but `pathlib.Path` can do the same thing. The default Django project settings file [uses pathlib in this way](https://github.com/django/django/blob/45f4282149e13a2c1548a579f60d098e397a33d7/django/conf/project_template/project_name/settings.py-tpl#L13-L16).

There are [no other uses](https://github.com/search?q=user%3Acfpb+unipath&type=code) of pathlib in any of the cf.gov satellite apps.

## Notes and todos

Because this removes a dependency on a third-party package, this will (very incrementally) reduce the size of cf.gov builds and speed up the deploy process.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)