### PR TITLE
IA migration cleanup: Script to update links within Regs3k

### DIFF
--- a/cfgov/scripts/update_internal_regs3k_links.py
+++ b/cfgov/scripts/update_internal_regs3k_links.py
@@ -1,0 +1,35 @@
+import logging
+
+from regulations3k.models.django import Section
+
+
+logger = logging.getLogger(__name__)
+
+
+# This is a one-time script to update internal links within the Regs3k tool
+# that were outdated when the regulations tool moved to a new URL,
+# /policy-compliance/rulemaking/regulations/ to /rules-policy/regulations/.
+# Delete this script after running it in Production, December 2020.
+# Run it with the following command:
+# cfgov/manage.py runscript update_internal_regs3k_links
+def run():
+    count = 0
+    url_base = "/policy-compliance/rulemaking/regulations/"
+    for section in Section.objects.all():
+        # First, update any links to this reg section
+        # /policy-compliance/rulemaking/regulations/[part]/[section]/#[pg]
+        # to ../[section]/#[pg]
+        part = section.subpart.label
+        this_section = url_base + part + "/"
+        update1 = section.contents.replace(this_section, "../")
+
+        # Next, update any links to other reg sections
+        # /policy-compliance/rulemaking/regulations/[part]/[section]/#[pg]
+        # to ../../[part]/[section]/#[pg]
+        update2 = update1.replace(url_base, "../../")
+
+        section.contents = update2
+        section.save()
+        count += 1
+
+    logger.info(f"Updated {count} regulation sections")


### PR DESCRIPTION
Links within the Interactive Bureau Regulations tool are stored in the reg markdown as literal `a` tags, like this: `<a href="/policy-compliance/rulemaking/regulations/1002/2/#l" data-linktag="0">1002.2(l),</a>`. All of those pages moved as part of the IA migration on Nov 25 from `/policy-compliance/rulemaking/regulations/` to `/rules-policy/regulations/`, so we need to update the links to their new destinations.

This PR updates those links to use relative paths, to prevent this issue in the future. Example:

`<a href="/policy-compliance/rulemaking/regulations/1002/2/#l" data-linktag="0">1002.2(l),</a>`
Within reg 1002, changes to: `<a href="../2/#l" data-linktag="0">1002.2(l),</a>`
Within another reg, changes to: `<a href="../../1002/2/#l" data-linktag="0">1002.2(l),</a>`

See https://github.local/CFPB/super-regular/issues/215 for more information.

## Additions

- One-time script to update links within regulations


## How to test this PR

1. `cfgov/manage.py runscript update_internal_regs3k_links`
2. Visit a reg page such as http://localhost:8000/rules-policy/regulations/1002/5/
3. Check that all links lead to the intended destinations and use the new URL pattern, `/rules-policy/regulations/`

I'm also planning to run this change on DEV4. I can let y'all know when I do that.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
