### PR TITLE
CCDB: Update highcharts to 7.2.2 to fix security warning

### DIFF
--- a/cfgov/unprocessed/apps/ccdb-landing-map/package.json
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/package.json
@@ -19,7 +19,7 @@
     "core-js": "3.8.1",
     "d3": "6.3.1",
     "debounce": "1.2.0",
-    "highcharts": "7.2.1",
+    "highcharts": "7.2.2",
     "moment": "2.29.1",
     "sinon": "9.2.2",
     "whatwg-fetch": "3.5.0"

--- a/cfgov/unprocessed/apps/ccdb-landing-map/yarn.lock
+++ b/cfgov/unprocessed/apps/ccdb-landing-map/yarn.lock
@@ -308,10 +308,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-highcharts@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.2.1.tgz#313c434bbfd4525a72b76c6bfbd9c39dfe2d1993"
-  integrity sha512-/fSUZiONmM+x49IQJNf8XwZGiNGOPRmxEOcd0xdJP9Xc3OlG46ZiUWgSLfhYQ9Oyhmzc3V3SKYCLud8+rKLi+w==
+highcharts@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.2.2.tgz#94d6bae545d7f0fbf49615b28640f5fdbf99d11e"
+  integrity sha512-jRKujQuPKHLgGQd2sByBI9K5m56CInm2augVZnBYqdmyoU88hcI62uuAXHvxC3FW8YY0FJ74A1uw6sxrcmcmvg==
 
 iconv-lite@0.4:
   version "0.4.24"


### PR DESCRIPTION

<img width="986" alt="Screen Shot 2020-12-14 at 12 18 46 PM" src="https://user-images.githubusercontent.com/704760/102113032-89597800-3e06-11eb-8df2-061ade4c901d.png">

## Changes

- Updates highcharts from 7.2.1 to 7.2.2 to fix security warning.


## How to test this PR

1. Pull branch, run `./frontend.sh`, and visit http://localhost:8000/data-research/consumer-complaints/ and all should be as it was.
