### PR TITLE
Fix: Don't render empty info unit heading blocks

### DIFF
--- a/cfgov/jinja2/v1/_includes/blocks/heading.html
+++ b/cfgov/jinja2/v1/_includes/blocks/heading.html
@@ -1,6 +1,42 @@
-<{{ value.level }}>
-    {%- if value.icon %}
-        {{ svg_icon(value.icon) }}
-    {% endif -%}
-    {{ value.text | safe }}
-</{{ value.level }}>
+{# ==========================================================================
+
+   Heading
+
+   ==========================================================================
+
+   Description:
+
+   Create a heading when given:
+
+   value.text:          Heading text.
+
+   value.level:         The heading level (h2, h3, h4). Default: h3.
+
+   value.level_class:   (Optional) Alternate heading class, used for tags like:
+                        <h2 class="h3">
+
+   value.icon:          (Optional) Name of icon to insert before the heading
+                        text. See list of available icon names at:
+                        https://cfpb.github.io/design-system/foundation/iconography
+
+   ========================================================================== #}
+{%- macro heading( value ) -%}
+
+{%- set _default_level = 'h3' -%}
+
+{# Don't render anything if the heading text is empty. #}
+{% if value.text -%}
+
+<{{ value.level | default( _default_level ) }}
+{%- if value.level_class %} class="{{ value.level_class }}"{% endif -%}
+>
+    {%- if value.icon %}{{ svg_icon( value.icon ) }} {% endif %}
+    {{- value.text | safe -}}
+</{{ value.level | default( _default_level ) }}>
+
+{%- endif %}
+
+{%- endmacro -%}
+
+{# Allows this template to be rendered directly without using a macro. #}
+{% if value %}{{ heading( value ) }}{% endif %}

--- a/cfgov/jinja2/v1/_includes/blocks/heading.html
+++ b/cfgov/jinja2/v1/_includes/blocks/heading.html
@@ -10,7 +10,7 @@
 
    value.text:          Heading text.
 
-   value.level:         The heading level (h2, h3, h4). Default: h3.
+   value.level:         The heading level (h2, h3, h4).
 
    value.level_class:   (Optional) Alternate heading class, used for tags like:
                         <h2 class="h3">
@@ -22,17 +22,15 @@
    ========================================================================== #}
 {%- macro heading( value ) -%}
 
-{%- set _default_level = 'h3' -%}
-
 {# Don't render anything if the heading text is empty. #}
 {% if value.text -%}
 
-<{{ value.level | default( _default_level ) }}
+<{{ value.level }}
 {%- if value.level_class %} class="{{ value.level_class }}"{% endif -%}
 >
     {%- if value.icon %}{{ svg_icon( value.icon ) }} {% endif %}
     {{- value.text | safe -}}
-</{{ value.level | default( _default_level ) }}>
+</{{ value.level }}>
 
 {%- endif %}
 

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -16,15 +16,8 @@
 
    value.image.alt:              String for image alt text.
 
-   value.heading:                (Optional) An object containing:
-
-   value.heading.text            The text of a heading.
-
-   value.heading.level:          The heading level (H2, H3, H4). Default: H3
-
-   value.heading.icon:           (Optional) A string containing cf-icon name
-                                 that triggers the insertion of an icon before
-                                 the heading.
+   value.heading:                (Optional) A heading object.
+                                 See _includes/blocks/heading.html.
 
    value.body:                   (Optional) A string containing the content
                                  to display below the heading (typically a
@@ -46,6 +39,8 @@
 
    ========================================================================== #}
 
+{%- from 'blocks/heading.html' import heading without context %}
+
 {%- macro info_unit(value, format, link_image_and_heading) -%}
 
 {# Confirm that not only is link_image_and_heading set, but that this
@@ -55,7 +50,7 @@
                                  and value.links
                                  and value.links[0]
                                  and value.links[0].url
-                                 and (value.image.upload or value.heading) %}
+                                 and (value.image.upload or value.heading.text) %}
 
 <div class="m-info-unit
             {{- ' m-info-unit__inline' if format == '25-75' else '' }}">
@@ -84,9 +79,9 @@
                 {% endif %}
         {%- endif %}
 
-        {%- if value.heading.text %}
+        {%- if value.heading and value.heading.text %}
             <div class="m-info-unit_heading-text">
-                {% include_block value.heading %}
+                {{ heading( value.heading ) }}
             </div>
         {%- endif %}
 

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -46,11 +46,12 @@
 {# Confirm that not only is link_image_and_heading set, but that this
    particular info unit has a link in its list and there's either an
    image or heading to wrap in a link. #}
+{%- set has_heading = value.heading and value.heading.text %}
+{%- set has_image = value.image and value.image.upload %}
+{%- set has_link = value.links and value.links[0] and value.links[0].url %}
 {%- set link_image_and_heading = link_image_and_heading
-                                 and value.links
-                                 and value.links[0]
-                                 and value.links[0].url
-                                 and (value.image.upload or value.heading.text) %}
+                                 and has_link
+                                 and ( has_heading or has_image ) %}
 
 <div class="m-info-unit
             {{- ' m-info-unit__inline' if format == '25-75' else '' }}">
@@ -60,29 +61,32 @@
            href="{{ value.links[0].url | safe }}">
     {% endif %}
 
-        {%- if value.image.upload %}
-            {%- set img = image(value.image.upload, 'original') %}
-            {# Empty alt attribute if header text is present to prevent screen reader repetition #}
-            {%- set img_alt_text = '' if value.heading.text else image_alt_value(value.image) %}
-            <img class="m-info-unit_image
-                        {{- ' m-info-unit_image__square' if img.is_square else '' }}"
-                src="{{ img.url }}"
-                alt="{{ img_alt_text }}">
-        {%- endif %}
+    {%- if has_image %}
+        {%- set img = image( value.image.upload, 'original' ) %}
 
-        {%- if value.heading and value.heading.text %}
-            <div class="m-info-unit_heading-text">
-                {{ heading( value.heading ) }}
-            </div>
-        {%- endif %}
+        {# Don't include image alt text if the image is being linked and
+           there's also heading text in the link. #}
+        {%- set img_alt_text = ''
+            if ( link_image_and_heading and has_heading )
+            else image_alt_value( value.image ) %}
+        <img class="m-info-unit_image
+                    {{- ' m-info-unit_image__square' if img.is_square else '' }}"
+            src="{{ img.url }}"
+            alt="{{ img_alt_text }}">
+    {%- endif %}
+
+    {%- if has_heading %}
+        <div class="m-info-unit_heading-text">
+            {{ heading( value.heading ) }}
+        </div>
+    {%- endif %}
 
     {%- if link_image_and_heading %}
         </a>
     {%- endif -%}
 
-        <div class="m-info-unit_content">
-
-            {{ value.body | safe }}
+    <div class="m-info-unit_content">
+        {{ value.body | safe }}
 
         {% if value.links %}
             <ul class="m-list m-list__links u-mt15">
@@ -104,9 +108,6 @@
             {%- endfor %}
             </ul>
         {%- endif %}
-
-        </div>
-
+    </div>
 </div>
-
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -88,10 +88,6 @@
             <div class="m-info-unit_heading-text">
                 {% include_block value.heading %}
             </div>
-        {%- elif value.heading %}
-            <div class="m-info-unit_heading-text">
-                {{ value.heading|safe }}
-            </div>
         {%- endif %}
 
     {%- if link_image_and_heading %}

--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -64,19 +64,10 @@
             {%- set img = image(value.image.upload, 'original') %}
             {# Empty alt attribute if header text is present to prevent screen reader repetition #}
             {%- set img_alt_text = '' if value.heading.text else image_alt_value(value.image) %}
-                {%- if image_alt_value(value.image) %}
-                    <img class="m-info-unit_image
-                                {{- ' m-info-unit_image__square' if img.is_square else '' }}"
-                        src="{{ img.url }}"
-                        alt="{{ img_alt_text }}">
-                {%- else %}
-                    <div class="m-info-unit_image
-                                {{- ' m-info-unit_image__square' if img.is_square else '' }}"
-                        style="background-image: url( '{{ img.url }}' );
-                                {{- ' padding-bottom: ' ~ ( img.height / img.width * 100 ) ~ '%;'
-                                    if not img.is_square else '' }}">
-                    </div>
-                {% endif %}
+            <img class="m-info-unit_image
+                        {{- ' m-info-unit_image__square' if img.is_square else '' }}"
+                src="{{ img.url }}"
+                alt="{{ img_alt_text }}">
         {%- endif %}
 
         {%- if value.heading and value.heading.text %}

--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -150,10 +150,6 @@
                             <div class="content-l_col
                                         content-l_col-1-2">
                                 {% set post_url = pageurl(post) %}
-                                {% set heading = '<h2 class="h3">' ~
-                                                 post.preview_title ~
-                                                 '</h2>'
-                                if post.preview_title else null %}
                                 {% if post.secondary_link_url and post.secondary_link_text %}
                                     {% set links = [
                                         {
@@ -166,10 +162,14 @@
                                 {{ info_unit( 
                                     {
                                         'image': {
-                                        'upload': post.preview_image,
-                                        'alt': post.preview_image.alt if post.preview_image.alt else '',
+                                            'upload': post.preview_image,
+                                            'alt': post.preview_image.alt if post.preview_image.alt else ''
                                         } if post.preview_image else {},
-                                        'heading': heading,
+                                        'heading': {
+                                            'text': post.preview_title,
+                                            'level': 'h2',
+                                            'level_class': 'h3'
+                                        } if post.preview_title else null,
                                         'body': post.preview_description,
                                         'links': links or null,
                                     },

--- a/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
+++ b/cfgov/jinja2/v1/_includes/organisms/info-unit-group-2.html
@@ -17,15 +17,8 @@
                                   'render_block.html' to modify classes on
                                   wrapper '.block' div.
 
-   value.heading:                 (Optional) An object containing:
-
-   value.heading.text             The text of a heading.
-
-   value.heading.level:           The heading level (H2, H3, H4). Default: H3
-
-   value.heading.icon:            (Optional) A string containing cf-icon name
-                                  that triggers the insertion of an icon before
-                                  the heading.
+   value.heading:                (Optional) A heading object.
+                                 See _includes/blocks/heading.html.
 
    value.intro:                   An introduction for the info unit group.
                                   If not empty, a heading is required.
@@ -44,18 +37,14 @@
 
    ========================================================================== #}
 
+{%- from 'blocks/heading.html' import heading without context %}
 {%- from 'molecules/info-unit-2.html' import info_unit with context %}
 
 <div class="o-info-unit-group"
      {{- ' id="' ~ value.heading.text|slugify ~ '" ' if value.heading and value.heading.text else ' ' -}}>
 
 {% if value.heading and value.heading.text %}
-    <{{ value.heading.level }}>
-        {%- if value.heading.icon %}
-            {{ svg_icon(value.heading.icon) }}
-        {% endif -%}
-        {{ value.heading.text | safe }}
-    </{{ value.heading.level }}>
+    {{ heading( value.heading ) }}
 {% endif -%}
 
 {%- if value.intro and not ( value.intro | richtext_isempty ) %}

--- a/cfgov/v1/template_debug/__init__.py
+++ b/cfgov/v1/template_debug/__init__.py
@@ -3,6 +3,7 @@ from wagtail.core import hooks
 from v1.views.template_debug import TemplateDebugView
 
 from .featured_content import featured_content_test_cases  # noqa 401
+from .heading import heading_test_cases  # noqa 401
 from .notification import notification_test_cases  # noqa 401
 from .video_player import video_player_test_cases  # noqa 401
 

--- a/cfgov/v1/template_debug/heading.py
+++ b/cfgov/v1/template_debug/heading.py
@@ -1,0 +1,29 @@
+heading_defaults = {
+    'text': 'This is a heading.',
+}
+
+
+heading_test_cases = {
+    'Text only': {},
+
+    'No text (should render nothing)': {
+        'text': None,
+    },
+
+    'Different heading level (H2)': {
+        'level': 'h2',
+    },
+
+    'Different heading class (H3 rendered as H2)': {
+        'level_class': 'h2',
+    },
+
+    'Icon': {
+        'icon': 'pencil',
+    },
+}
+
+
+for test_case in heading_test_cases.values():
+    for k, v in heading_defaults.items():
+        test_case.setdefault(k, v)

--- a/cfgov/v1/template_debug/heading.py
+++ b/cfgov/v1/template_debug/heading.py
@@ -1,24 +1,25 @@
 heading_defaults = {
     'text': 'This is a heading.',
+    'level': 'h3',
 }
 
 
 heading_test_cases = {
-    'Text only': {},
+    'H3': {},
 
-    'No text (should render nothing)': {
+    'H3, no text (should render nothing)': {
         'text': None,
     },
 
-    'Different heading level (H2)': {
+    'H2': {
         'level': 'h2',
     },
 
-    'Different heading class (H3 rendered as H2)': {
+    'H3 rendered as H2': {
         'level_class': 'h2',
     },
 
-    'Icon': {
+    'H3 with icon': {
         'icon': 'pencil',
     },
 }

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -27,7 +27,7 @@ from v1.models.portal_topics import PortalCategory, PortalTopic
 from v1.models.resources import Resource
 from v1.models.snippets import Contact, RelatedResource, ReusableText
 from v1.template_debug import (
-    featured_content_test_cases, notification_test_cases,
+    featured_content_test_cases, heading_test_cases, notification_test_cases,
     register_template_debug, video_player_test_cases
 )
 from v1.util import util
@@ -441,6 +441,14 @@ register_template_debug(
     '_includes/organisms/featured-content.html',
     featured_content_test_cases,
     extra_js=['featured-content-module.js']
+)
+
+
+register_template_debug(
+    'v1',
+    'heading',
+    '_includes/blocks/heading.html',
+    heading_test_cases
 )
 
 


### PR DESCRIPTION
Currently if an info unit contains an empty heading block (meaning empty text), an empty `<div class="m-info-unit_heading-text"><h3></h3></div>` gets rendered on the page:

![image](https://user-images.githubusercontent.com/654645/102130716-29230000-3e1f-11eb-81ae-0b108dbbb35f.png)

If a heading has empty text, it should not be rendered as part of an info unit. This commit removes the branch of logic that does this.

## How to test this PR

To test, visit a page with an empty heading, for example in production:

http://localhost:8000/consumer-tools/educator-tools/adult-financial-education/

Alternatively, create a new e.g. Sublanding page with an info unit group, then add an info unit with an empty heading.

## Notes and todos

Fixes internal platform#3854.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)