### PR TITLE
Only expose django on localhost

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,7 @@ services:
         build:
             target: cfgov-dev
         ports:
-            - "8000:8000" # Django
+            - "127.0.0.1:8000:8000" # Django
         volumes: &python_volumes
             - ./:/src/consumerfinance.gov/
             - ./.env:/etc/profile.d/dev-env.sh


### PR DESCRIPTION
Follow-up to https://github.com/cfpb/consumerfinance.gov/pull/6121

This prevents django from being opened across the network on 8000, which was missing in the previous PR.
