### PR TITLE
Add mapbox token for docker stacks

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -81,6 +81,7 @@ services:
       - GOVDELIVERY_PASSWORD
       - PGPASSWORD
       - SECRET_KEY
+      - MABOX_ACCESS_TOKEN
     deploy:
       placement:
         constraints:
@@ -135,4 +136,7 @@ secrets:
     external: True
   GOVDELIVERY_PASSWORD:
     name: staging_govdelivery_password
+    external: True
+  MABOX_ACCESS_TOKEN:
+    name: mabox_access_token
     external: True


### PR DESCRIPTION
The MAPBOX_ACCESS_TOKEN env var is missing on UCP stacks, causing functional test
failures on /find-a-housing-counselor/

This should add the missing var, which is available in the cluster.