### PR TITLE
Move language macro from main container to blocks

### DIFF
--- a/cfgov/jinja2/v1/_includes/macros/accessible-languages.html
+++ b/cfgov/jinja2/v1/_includes/macros/accessible-languages.html
@@ -11,10 +11,8 @@
    ========================================================================== #}
 
 {% macro render() %}
-    {%- if page -%}
-        lang="{{ page.language if page.language else 'en' }}"
-              {%- if page.language in ['ar'] -%}
-                  dir="rtl"
-              {%- endif -%}
+    {%- set rtl_languages = ['ar'] -%}
+    {%- if page and page.language in rtl_languages -%}
+        lang="{{ page.language }}" dir="rtl"
     {%- endif -%}
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -1,4 +1,5 @@
 {% macro render(block, index) %}
+    {%- import 'macros/accessible-languages.html' as accessible_languages with context -%}
     <div class="block
                 {{ 'block__flush-top' if index == 1
                    and not (block.value.has_top_border or block.value.has_top_rule_line) else '' }}
@@ -9,7 +10,8 @@
                 {{ 'block__padded-bottom block__border-bottom'
                    if block.value.has_rule or block.value.has_bottom_border else '' }}
 
-                {{ block.block.meta.classname if block.block.meta.classname else '' -}}">
+                {{ block.block.meta.classname if block.block.meta.classname else '' -}}"
+         {{ accessible_languages.render() }}>
         {{ render_stream_child(block) | safe }}
     </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/templates/render_block.html
+++ b/cfgov/jinja2/v1/_includes/templates/render_block.html
@@ -11,7 +11,7 @@
                    if block.value.has_rule or block.value.has_bottom_border else '' }}
 
                 {{ block.block.meta.classname if block.block.meta.classname else '' -}}"
-         {{ accessible_languages.render() }}>
+        {{ accessible_languages.render() }}>
         {{ render_stream_child(block) | safe }}
     </div>
 {% endmacro %}

--- a/cfgov/jinja2/v1/_layouts/content-base.html
+++ b/cfgov/jinja2/v1/_layouts/content-base.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %}
 
 {% block content scoped %}
-    {%- import 'macros/accessible-languages.html' as accessible_languages with context-%}
     <main class="content {% block content_modifiers -%}{%- endblock %}"
-          id="main"
-          {{ accessible_languages.render() }}>
+          id="main">
         {% block hero -%}{%- endblock %}
         {% block pre_content scoped -%}
             {% if breadcrumb_items | length > 0 %}


### PR DESCRIPTION
We have a [macro](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/macros/accessible-languages.html) that swaps the language direction for Arabic. We currently use it on a page's container element which causes all children inline elements to flow from right to left, breaking our inline-block layout and making the site unusable for Arabic speakers. Adding it to individual children blocks preserves the layout while still reversing text flow.

## How to test this PR

1. `./refresh-data.sh`
1. Compare the [new Arabic content](http://content.localhost:8000/language/ar/coronavirus/mortgage-and-housing-assistance/) before and after this PR.


## Screenshots

| before | after |
|--------|-------|
| <img width="1156" alt="before" src="https://user-images.githubusercontent.com/1060248/102388275-8776ec80-3f9f-11eb-9129-b7a3823f9536.png"> | <img width="1156" alt="after" src="https://user-images.githubusercontent.com/1060248/102388286-8b0a7380-3f9f-11eb-97ff-d6efd8ec7721.png">  |

## Notes

- In the above screenshot the English content is also RTL'ed -- this is bad. We're deciding if we should either remove English content from Arabic pages or find another solution.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
