### PR TITLE
Override the TreeModelAdmin URL Helper for Regs breadcrumbs

### DIFF
--- a/cfgov/regulations3k/tests/test_hooks.py
+++ b/cfgov/regulations3k/tests/test_hooks.py
@@ -10,6 +10,7 @@ from regulations3k.models.django import (
     EffectiveVersion, Part, Section, Subpart
 )
 from regulations3k.models.pages import RegulationLandingPage, RegulationPage
+from regulations3k.wagtail_hooks import RegsURLHelper
 
 
 class TestRegs3kHooks(TestCase, WagtailTestUtils):
@@ -105,3 +106,22 @@ class TestRegs3kHooks(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'View live', response.content)
         self.assertIn(b'View draft', response.content)
+
+    def test_regs_url_helper(self):
+        helper = RegsURLHelper(Section)
+
+        self.assertNotIn(
+            self.subpart.__str__(),
+            helper.crumb(
+                parent_field="subpart",
+                parent_instance=self.subpart,
+                specific_instance=self.section_num4,
+            )[1],
+        )
+
+        self.assertEqual(
+            self.section_num4.__str__(),
+            helper.crumb(
+                specific_instance=self.section_num4,
+            )[1],
+        )

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -1,12 +1,43 @@
 from datetime import date
 
+from django.utils.encoding import force_text
+
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
+from treemodeladmin.helpers import TreeAdminURLHelper
 from treemodeladmin.options import TreeModelAdmin
 from treemodeladmin.views import TreeIndexView
 
 from regulations3k.copyable_modeladmin import CopyableModelAdmin
 from regulations3k.models import EffectiveVersion, Part, Section, Subpart
+
+
+class RegsURLHelper(TreeAdminURLHelper):
+
+    def crumb(
+        self, parent_field=None, parent_instance=None, specific_instance=None
+    ):
+        """ Override the URL helper's crumb method to shorten reg model crumbs.
+
+        The regulation models include their "parent" model's string
+        representation within their own string representation. This is useful
+        when referencing a model without context, but not so useful in
+        breadcrumbs. This method will remove the "[Parent], " from the string
+        if the specific_instance and parent_instance are provided.
+        """
+        index_url, crumb_text = super().crumb(
+            parent_field=parent_field,
+            parent_instance=parent_instance,
+            specific_instance=specific_instance
+        )
+
+        if specific_instance is not None and parent_instance is not None:
+            crumb_text = force_text(specific_instance).replace(
+                force_text(parent_instance) + ", ",
+                ""
+            )
+
+        return (index_url, crumb_text)
 
 
 class SectionPreviewIndexView(TreeIndexView):
@@ -52,6 +83,7 @@ class SectionModelAdmin(TreeModelAdmin):
         'label', 'title')
     parent_field = 'subpart'
     index_view_class = SectionPreviewIndexView
+    url_helper_class = RegsURLHelper
 
 
 class SubpartModelAdmin(TreeModelAdmin):
@@ -66,6 +98,7 @@ class SubpartModelAdmin(TreeModelAdmin):
     child_model_admin = SectionModelAdmin
     parent_field = 'version'
     ordering = ['subpart_type', 'title']
+    url_helper_class = RegsURLHelper
 
 
 class EffectiveVersionModelAdmin(CopyableModelAdmin):
@@ -79,6 +112,7 @@ class EffectiveVersionModelAdmin(CopyableModelAdmin):
     child_field = 'subparts'
     child_model_admin = SubpartModelAdmin
     parent_field = 'part'
+    url_helper_class = RegsURLHelper
 
     def copy(self, instance):
         subparts = instance.subparts.all()
@@ -121,3 +155,4 @@ class PartModelAdmin(TreeModelAdmin):
     )
     child_field = 'versions'
     child_model_admin = EffectiveVersionModelAdmin
+    url_helper_class = RegsURLHelper


### PR DESCRIPTION
This change overrides the TreeModelAdmin URL Helper for Regulations breadcrumbs. in #5703 we ensured that the regs models' `__str__` methods included their parents, so that one could see what regulation and version a particular section object belongs to in the model drop-downs and anywhere else Django renders the model to string.

Unfortunately the `__str__` is the same mechanism TreeModelAdmin uses to generate the breadcrumbs at the top. This seems reasonable, which is why I don't want to change it there.

So to eliminate the duplicity in the breadcrumbs, this change overrides the TreeModelAdmin URL helper class to remove the parent's string if the URL helper is generating a breadcrumb for a specific model and a parent instance is given.

Before:

![image](https://user-images.githubusercontent.com/10562538/102397847-7680a800-3fac-11eb-81f8-b8b8af0f2a54.png)


After:

![image](https://user-images.githubusercontent.com/10562538/102397805-65379b80-3fac-11eb-8980-e6c06d4c492a.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
