### PR TITLE
CCDB: Add consumer-complaints functional tests

### DIFF
--- a/test/cypress/integration/pages/consumer-complaints.js
+++ b/test/cypress/integration/pages/consumer-complaints.js
@@ -1,0 +1,75 @@
+import { ConsumerComplaints } from '../../pages/data-research/consumer-complaints';
+
+const page = new ConsumerComplaints();
+const states = ['AK', 'AL', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+  'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN',
+  'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK',
+  'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'];
+
+describe( 'Consumer Complaint Database', () => {
+  beforeEach( () => {
+    cy.visit( '/data-research/consumer-complaints/' );
+  } );
+
+  it( 'should display chart with complaints for all 50 states', () => {
+    page.clickButton( 'Complaints' );
+    page.checkLegend( 'description' ).should( 'contain', 'Complaints' );
+    page.chartSize( 580, 940 );
+    page.clickTile( 'DC' );
+    cy.url().should( 'include', 'state=DC' );
+    states.forEach(name => {
+      page.checkChart( name ).should( 'be.visible' );
+    });
+    page.clickButton( 'Complaints per 1,000' );
+    page.checkLegend( 'description' ).should( 'contain', 'Complaints per 1,000' );
+    page.checkLegend( 'dates' ).should( 'be.visible' );
+    states.forEach(name => {
+      page.checkState( name ).should( 'be.visible' );
+    });
+  } );
+
+  it( 'should limit results by a date range', () => {
+    page.click( 'View complaint data' );
+    page.clickDateRange( '3m' );
+    cy.url().should( 'include', 'dateRange=3m' );
+    page.clickDateRange( '6m' );
+    cy.url().should( 'include', 'dateRange=6m' );
+    page.clickDateRange( '1y' );
+    cy.url().should( 'include', 'dateRange=1y' );
+    page.clickDateRange( '3y' );
+    cy.url().should( 'include', 'dateRange=3y' );
+    page.clickDateRange( 'All' );
+    cy.url().should( 'include', 'dateRange=All' );
+  } );
+
+  it( 'should limit results by search query', () => {
+    page.click( 'View complaint data' );
+    page.clickTab( 'trends' );
+    cy.url().should( 'include', 'tab=Trends' );
+    page.enter( 'money' );
+    page.search();
+    page.searchSummary().should( 'be.visible' );
+    cy.url().should( 'include', 'searchField' );
+  } );
+
+  it( 'should search based on multiple terms', () => {
+    page.click( 'View complaint data' );
+    page.clickTab( 'list' );
+    cy.url().should( 'include', 'tab=List' );
+    page.enter( 'loan sold' );
+    page.search();
+    page.searchSummary().should( 'be.visible' );
+    cy.url().should( 'include', 'searchText=loan' );
+  } );
+
+  it( 'should display Download the data', () => {
+    page.click( 'Download options and API' );
+    cy.url().should( 'include', 'download-the-data' );
+  } );
+
+  it( 'should display Consumer Response annual report', () => {
+    page.click( 'Read our annual report' );
+    cy.url().should( 'include', 'consumer-response-annual-report' );
+  } );
+
+} );

--- a/test/cypress/integration/pages/consumer-complaints.js
+++ b/test/cypress/integration/pages/consumer-complaints.js
@@ -14,9 +14,7 @@ describe( 'Consumer Complaint Database', () => {
   it( 'should display chart with complaints for all 50 states', () => {
     page.clickButton( 'Complaints' );
     page.checkLegend( 'description' ).should( 'contain', 'Complaints' );
-    page.chartSize( 580, 940 );
-    page.clickTile( 'DC' );
-    cy.url().should( 'include', 'state=DC' );
+    cy.get( '.cfpb-chart' ).should( 'be.visible' );
     states.forEach(name => {
       page.checkChart( name ).should( 'be.visible' );
     });
@@ -26,6 +24,8 @@ describe( 'Consumer Complaint Database', () => {
     states.forEach(name => {
       page.checkState( name ).should( 'be.visible' );
     });
+    page.clickTile( 'DC' );
+    cy.url().should( 'include', 'state=DC' );
   } );
 
   it( 'should limit results by a date range', () => {

--- a/test/cypress/pages/data-research/consumer-complaints.js
+++ b/test/cypress/pages/data-research/consumer-complaints.js
@@ -16,14 +16,6 @@ export class ConsumerComplaints {
     cy.get( '.a-btn' ).contains( name ).click();
   }
 
-  chartSize( height, width) {
-    cy.get( '.cfpb-chart' ).should( 'be.visible' )
-      .and(chart => {
-        expect(chart.height()).to.be.equal(height);
-        expect(chart.width()).to.be.equal(width);
-    });
-  }
-
   clickTile( name ) {
     const tile = name.toUpperCase();
     return cy.get( `.tile-${tile}` ).click();

--- a/test/cypress/pages/data-research/consumer-complaints.js
+++ b/test/cypress/pages/data-research/consumer-complaints.js
@@ -1,0 +1,56 @@
+export class ConsumerComplaints {
+
+  click( name ) {
+    cy.get( '.btn' ).contains( name ).click();
+  }
+
+  clickTab( name ) {
+    cy.get( `.${name}` ).click();
+  }
+
+  clickDateRange( name ) {
+    cy.get( `.range-${name}` ).click();
+  }
+
+  clickButton( name ) {
+    cy.get( '.a-btn' ).contains( name ).click();
+  }
+
+  chartSize( height, width) {
+    cy.get( '.cfpb-chart' ).should( 'be.visible' )
+      .and(chart => {
+        expect(chart.height()).to.be.equal(height);
+        expect(chart.width()).to.be.equal(width);
+    });
+  }
+
+  clickTile( name ) {
+    const tile = name.toUpperCase();
+    return cy.get( `.tile-${tile}` ).click();
+  }
+
+  checkState( name ) {
+    return cy.get( `.highcharts-name-${name}`.toLowerCase() );
+  }
+
+  checkChart( name ) {
+    return cy.get( '.highcharts-tracker' ).should( 'contain', name );
+  }
+
+  checkLegend( name ) {
+    return cy.get( `.highcharts-legend-${name}` );
+  }
+
+  enter( term ) {
+    cy.get( '#searchText.a-text-input' ).type( term );
+  }
+
+  search() {
+    cy.get( '.a-btn.flex-fixed' ).click();
+  }
+
+  searchSummary() {
+    return cy.get( '#search-summary' );
+  }
+
+}


### PR DESCRIPTION
Add Cypress tests to CCDB landing page (/data-research/consumer-complaints/) to test dynamic parts

## How to test this PR

Run `yarn run cypress open` and select the cypress integration test `consumer-complaints.js`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
