### PR TITLE
Prefer date_filed from final_dispostion for enforcement actions

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/enforcement-action-metadata.html
+++ b/cfgov/jinja2/v1/_includes/molecules/enforcement-action-metadata.html
@@ -145,8 +145,12 @@
         <h3 class="h4">
           Initial filing date
         </h3>
-        {% if page.date_filed %}
-            {{_date(page.date_filed)}}
+        {% if dispositions|length > 0 %}
+            {{_date(dispositions[0].date_filed)}}
+        {% else %}
+            {% if page.date_filed %}
+                {{_date(page.date_filed)}}
+            {% endif %}
         {% endif %}
     </div>
     <div class="m-related-metadata_item-container m-related-metadata_status">


### PR DESCRIPTION
EnforcementActionPages are currently structured to allow the date_filed to be updated in the final_disposition section in Wagtail. This updates the template to match that expected behavior.