### PR TITLE
Fix the Docker attach line in docs

### DIFF
--- a/docs/running-docker.md
+++ b/docs/running-docker.md
@@ -80,10 +80,16 @@ and need to interact with the running Django process when the breakpoint is reac
 you can run [`docker attach`](https://docs.docker.com/engine/reference/commandline/attach/):
 
 ```bash
-docker attach consumerfinance.gov_python_1
+docker attach consumerfinancegov_python_1
 ```
 
 When you're done, you can detach with `Ctrl+P Ctrl+Q`.
+
+!!! note
+    `docker attach` takes the specific container name or ID. 
+    Yours may or may not be `consumerfinancegov_python_1`. 
+    To verify, use `docker container ls` 
+    to get the Python container's full name or ID.
 
 
 ## Useful Docker commands


### PR DESCRIPTION
This change fixes the line in our docs for the `docker attach` command when you need to interact with a `pdb` session. I think when we renamed this repo from `cfgov-refresh` to `consumerfinance.gov`, we mistakenly broke this command. It should not have the dot in the container name; it should be `consumerfinancegov_python_1`.


## Checklist


- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
