### PR TITLE
Fix capitalization in regulations service worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ local-storage.json
 # Auto-generated service workers #
 ##################################
 cfgov/regulations3k/jinja2/regulations3k/regulations3k-service-worker.js
+cfgov/regulations3k/jinja2/regulations3k/regulations3k-service-worker.js.map
+cfgov/regulations3k/jinja2/regulations3k/workbox-*.js
+cfgov/regulations3k/jinja2/regulations3k/workbox-*.js.map
 
 # Apache #
 ##########

--- a/cfgov/unprocessed/apps/regulations3k/webpack-config.js
+++ b/cfgov/unprocessed/apps/regulations3k/webpack-config.js
@@ -69,13 +69,13 @@ const SERVICE_WORKER_CONFIG = {
     `apps/${ APP_NAME }/css/main.css`,
     `apps/${ APP_NAME }/js/index.js`
   ],
-  modifyUrlPrefix: {
+  modifyURLPrefix: {
     'apps/': '/static/apps/'
   },
   runtimeCaching: [
     {
       urlPattern: new RegExp( `/${ APP_PATH }/` ),
-      handler: 'staleWhileRevalidate',
+      handler: 'StaleWhileRevalidate',
       options: {
         cacheName: `${ APP_NAME }-content`,
         expiration: {
@@ -85,7 +85,7 @@ const SERVICE_WORKER_CONFIG = {
     },
     {
       urlPattern: new RegExp( `/static/apps/${ APP_NAME }` ),
-      handler: 'staleWhileRevalidate',
+      handler: 'StaleWhileRevalidate',
       options: {
         cacheName: `${ APP_NAME }-assets`,
         expiration: {
@@ -95,7 +95,7 @@ const SERVICE_WORKER_CONFIG = {
     },
     {
       urlPattern: new RegExp( '/static/(css|js|fonts|img)' ),
-      handler: 'staleWhileRevalidate',
+      handler: 'StaleWhileRevalidate',
       options: {
         cacheName: 'cfpb-assets',
         expiration: {


### PR DESCRIPTION
This change fixes the capitalization of `StaleWhileRevalidate` and `modifyURLPrefix` in our regulations service worker. This seems like a recent change upstream that started requiring specific capitalization.

I've also gitignore'd additional files that it has started generating.

This should fix a `TemplateDoesNotExist` error we're seeing because the service worker was no longer building.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
