### PR TITLE
Update sorting for enforcement actions filter page to match publishing date

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -279,7 +279,7 @@ class EnforcementActionsFilterForm(FilterableListForm):
     def get_page_set(self):
         query = self.generate_query()
         return self.filterable_pages.filter(query).distinct().order_by(
-            '-date_filed'
+            '-date_published'
         )
 
     def get_query_strings(self):


### PR DESCRIPTION
Fixes an issue where the currently inconsistent `date_filed` field was causing enforcement actions to appear out of order