### PR TITLE
Fix draft regulation landing pages not being shareable

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -73,10 +73,6 @@
 
 {# BODY items #}
 
-{% block body_classes %}
-    {{ super() }}
-{% endblock body_classes %}
-
 {% block content_modifiers -%}
     {{ super() }} content__hide-horizontal-overflow
 {%- endblock %}

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -24,10 +24,6 @@
 
 {# BODY items #}
 
-{% block body_classes %}
-    {{ super() }}
-{% endblock body_classes %}
-
 {% block hero -%}
     {% for block in page.header -%}
         {{ render_block.render(block, loop.index) }}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -49,10 +49,6 @@
 
 {# BODY items #}
 
-{% block body_classes %}
-    {{ super() }}
-{% endblock body_classes %}
-
 {% block content_main_modifiers -%}
     content__1-3
 {%- endblock %}

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -19,6 +19,7 @@ from wagtail.admin.edit_handlers import (
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.core.fields import StreamField
 from wagtail.core.models import PageManager
+from wagtailsharing.models import ShareableRoutablePageMixin
 
 import requests
 from jinja2 import Markup
@@ -142,7 +143,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
             context)
 
 
-class RegulationLandingPage(RoutablePageMixin, CFGOVPage):
+class RegulationLandingPage(ShareableRoutablePageMixin, CFGOVPage):
     """Landing page for eregs."""
 
     header = StreamField([
@@ -171,7 +172,7 @@ class RegulationLandingPage(RoutablePageMixin, CFGOVPage):
     template = 'regulations3k/landing-page.html'
 
     def get_context(self, request, *args, **kwargs):
-        context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
+        context = super().get_context(request, *args, **kwargs)
         context.update({
             'get_secondary_nav_items': get_secondary_nav_items,
         })
@@ -197,7 +198,9 @@ class RegulationLandingPage(RoutablePageMixin, CFGOVPage):
         return JsonResponse(response.json())
 
 
-class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
+class RegulationPage(
+    ShareableRoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage
+):
     """A routable page for serving an eregulations page by Section ID."""
 
     objects = PageManager()
@@ -290,9 +293,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         )
 
     def get_context(self, request, *args, **kwargs):
-        context = super(RegulationPage, self).get_context(
-            request, *args, **kwargs
-        )
+        context = super().get_context(request, *args, **kwargs)
         context.update({
             'regulation': self.regulation,
             'current_version': self.get_effective_version(request),
@@ -307,7 +308,7 @@ class RegulationPage(RoutablePageMixin, SecondaryNavigationJSMixin, CFGOVPage):
         return context
 
     def get_breadcrumbs(self, request, section=None, **kwargs):
-        crumbs = super(RegulationPage, self).get_breadcrumbs(request)
+        crumbs = super().get_breadcrumbs(request)
 
         if section is not None:
             crumbs = crumbs + [

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -12,9 +12,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from v1.models.base import CFGOVPage
 from v1.models.resources import Resource
-from v1.wagtail_hooks import (
-    form_module_handlers, get_resource_tags, set_served_by_wagtail_sharing
-)
+from v1.wagtail_hooks import form_module_handlers, get_resource_tags
 
 
 class TestFormModuleHandlers(TestCase):
@@ -214,14 +212,3 @@ class TestAllowlistOverride(SimpleTestCase):
         input_html = '<scan class="id">Consumer <embed>Finance</embed></scan>'
         output_html = self.allowlister.clean(input_html)
         self.assertHTMLEqual(output_html, 'Consumer Finance')
-
-
-class TestSetServedByWagtailSharing(TestCase):
-
-    def setUp(self):
-        self.factory = RequestFactory()
-
-    def test_set_served_by_wagtail_sharing(self):
-        request = self.factory.get('/an-url')
-        set_served_by_wagtail_sharing(None, request, [], {})
-        self.assertTrue(request.served_by_wagtail_sharing)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -422,11 +422,6 @@ def register_span_feature(features):
     features.default_features.append('span')
 
 
-@hooks.register('before_serve_shared_page')
-def set_served_by_wagtail_sharing(page, request, args, kwargs):
-    setattr(request, 'served_by_wagtail_sharing', True)
-
-
 @hooks.register('register_permissions')
 def add_export_feedback_permission_to_wagtail_admin_group_view():
     return Permission.objects.filter(

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -35,7 +35,7 @@ urllib3==1.25.2
 wagtail-flags==5.1.0
 wagtail-inventory==1.2.0
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.4.0
+wagtail-sharing==2.5.1
 wagtail-treemodeladmin==1.4.0
 wagtailmedia==0.6.0
 


### PR DESCRIPTION
Draft content on regulation pages that have been previous published is not shared by wagtail-sharing because of how `RoutablePageMixin` resolves page routes before rendering. This is fixed in https://github.com/cfpb/wagtail-sharing/pull/43 with the introduction of `ShareableRoutablePageMixin`. 

This change uses that class in place of `RoutablePageMixin` in regulations.

~~This PR must wait on https://github.com/cfpb/wagtail-sharing/pull/43 to be merged and a new release of wagtail-sharing before it can be merged.~~ (This has happened).

To test this:

- Log into your local running cf.gov. 
- Make a change to a regulation landing page and save it as draft, for example, http://localhost:8000/rules-policy/regulations/1002/
- Observe that the change does not show when viewing the page at http://localhost:8000/rules-policy/regulations/1002/
- Observe that the change *does* show when viewing the page the sharing site, default is http://content.localhost:8000/rules-policy/regulations/1002/

## Notes
Login to http://localhost:8000/admin
Navigate to reg B, i.e. http://localhost:8000/rules-policy/regulations/1002/
Click the Wagtail bird in the bottom right hand corner
Then click the edit button to get to the landing page
Finally click on SAVE DRAFT button after editing the page

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
