### PR TITLE
Improve Info Unit image alt text logic

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
+++ b/cfgov/jinja2/v1/_includes/molecules/info-unit-2.html
@@ -64,11 +64,19 @@
     {%- if has_image %}
         {%- set img = image( value.image.upload, 'original' ) %}
 
-        {# Don't include image alt text if the image is being linked and
-           there's also heading text in the link. #}
-        {%- set img_alt_text = ''
-            if ( link_image_and_heading and has_heading )
-            else image_alt_value( value.image ) %}
+        {%- if not link_image_and_heading %}
+            {# If the image isn't being linked, include its alt text. #}
+            {% set img_alt_text = image_alt_value( value.image ) %}
+        {% elif has_heading %}
+            {# If the image is being linked, and there's a heading, set
+               empty alt text to avoid having duplicate text in the link. #}
+            {% set img_alt_text = '' %}
+        {% else %}
+            {# If the image is being linked, but there's no heading, use
+               the text from the link. #}
+            {% set img_alt_text = value.links[0].text %}
+        {% endif -%}
+
         <img class="m-info-unit_image
                     {{- ' m-info-unit_image__square' if img.is_square else '' }}"
             src="{{ img.url }}"


### PR DESCRIPTION
This commit modifies how Info Unit image alt text is set. With this change, the following logic is used:

- If the image is not a link, use its alt text. This might be the alt text configured on the Info Unit, or, as a fallback, the alt text set on the image when added to Wagtail.
- If the image is a link, and the Info Unit has a heading, don't set any alt text. The link will already include the heading text, and we don't want there to be duplicate text in the link.
- If the image is a link, and the Info Unit doesn't have a heading, make the alt text equal to the link text. If we used image-specific alt text here, then we'd have two links going to the same place, but with
different text. Using the link text means that both links are the same. This is consistent with how the carousel links work on the homepage mega menu.

This is followup work from #6168.

## How to test this PR

Run a local server.

- If the image is a link, and the Info Unit has a heading: http://localhost:8000/consumer-tools/everyone-has-a-story/. Note that images have empty alt text, because the link contains the heading.
- If the image is a link, and the Info Unit doesn't have a heading: http://localhost:8000/consumer-tools/educator-tools/adult-financial-education/. Note that the image alt text is set to the same text as the link text ("Explore resources").
- If the image is not a link: Edit the previous page (http://localhost:8000/admin/pages/10538/edit/) and uncheck "Link image and heading", and then enter some alt text for the Info Unit image. Hit preview, and note that the image alt text is set as expected.

## Notes and todos

This change suffers from an existing issue related to quotations in script tags, documented at platform#3839. A fix for that is outside of the scope of this PR, though.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets