### PR TITLE
Update ES7 Docker image to 7.10.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
                     LAST_STAGE = env.STAGE_NAME
                     docker.build(env.IMAGE_NAME_LOCAL, '--build-arg scl_python_version=rh-python36 --target cfgov-prod .')
                     docker.build(env.IMAGE_NAME_ES2_LOCAL, '-f ./docker/elasticsearch/Dockerfile .')
-                    docker.build(env.IMAGE_NAME_ES_LOCAL, '-f ./docker/elasticsearch/7.7/Dockerfile .')
+                    docker.build(env.IMAGE_NAME_ES_LOCAL, '-f ./docker/elasticsearch/7/Dockerfile .')
                 }
             }
         }
@@ -189,8 +189,8 @@ pipeline {
             script {
                 author = env.CHANGE_AUTHOR ? "by ${env.CHANGE_AUTHOR}" : "branch"
                 changeUrl = env.CHANGE_URL ? env.CHANGE_URL : env.GIT_URL
-                notify("${NOTIFICATION_CHANNEL}", 
-                    """:white_check_mark: **${STACK_PREFIX} [${env.GIT_BRANCH}]($changeUrl)** $author [deployed](https://${env.CFGOV_HOSTNAME}/)! 
+                notify("${NOTIFICATION_CHANNEL}",
+                    """:white_check_mark: **${STACK_PREFIX} [${env.GIT_BRANCH}]($changeUrl)** $author [deployed](https://${env.CFGOV_HOSTNAME}/)!
                     \n:jenkins: [Details](${env.RUN_DISPLAY_URL})    :mantelpiece_clock: [Pipeline History](${env.JOB_URL})    :docker-dance: [Stack URL](${env.STACK_URL}) """)
             }
         }
@@ -200,8 +200,8 @@ pipeline {
                 author = env.CHANGE_AUTHOR ? "by ${env.CHANGE_AUTHOR}" : "branch"
                 changeUrl = env.CHANGE_URL ? env.CHANGE_URL : env.GIT_URL
                 deployText = DEPLOY_SUCCESS ? "[deployed](https://${env.CFGOV_HOSTNAME}/) but failed" : "failed"
-                notify("${NOTIFICATION_CHANNEL}", 
-                    """:x: **${STACK_PREFIX} [${env.GIT_BRANCH}]($changeUrl)** $author $deployText at stage **${LAST_STAGE}** 
+                notify("${NOTIFICATION_CHANNEL}",
+                    """:x: **${STACK_PREFIX} [${env.GIT_BRANCH}]($changeUrl)** $author $deployText at stage **${LAST_STAGE}**
                     \n:jenkins-devil: [Details](${env.RUN_DISPLAY_URL})    :mantelpiece_clock: [Pipeline History](${env.JOB_URL})    :docker-dance: [Stack URL](${env.STACK_URL}) """)
 
                 if (env.DEPLOY_SUCCESS == false) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     elasticsearch:
         build:
             context: ./
-            dockerfile: ./docker/elasticsearch/7.7/Dockerfile
+            dockerfile: ./docker/elasticsearch/7/Dockerfile
         ports:
             - 127.0.0.1:9200:9200
             - 127.0.0.1:9300:9300
@@ -23,7 +23,7 @@ services:
         volumes:
             - ./cfgov/search/resources/:/usr/share/elasticsearch/config/synonyms
     kibana:
-        image: blacktop/kibana:7.7
+        image: blacktop/kibana:7.10.1
         depends_on:
             - elasticsearch
         ports:

--- a/docker/elasticsearch/7.7/Dockerfile
+++ b/docker/elasticsearch/7.7/Dockerfile
@@ -1,7 +1,0 @@
-FROM blacktop/elasticsearch:7.7
-
-# Copy Synonyms files into ElasticSearch
-COPY ./cfgov/search/resources/ /usr/share/elasticsearch/config/synonyms
-
-# Set User to Non Root
-USER elasticsearch

--- a/docker/elasticsearch/7/Dockerfile
+++ b/docker/elasticsearch/7/Dockerfile
@@ -1,0 +1,4 @@
+FROM blacktop/elasticsearch:7.10.1
+
+# Set User to Non Root
+USER elasticsearch


### PR DESCRIPTION
This clears out a few vulnerabilities in the 7.7 image. Tested and working in my local Docker environment.

Also renames the ES7 image folder to just `7` so we don't have to keep updating it if there are more minor version updates before we get rid of the ES2 image.


## How to test this PR

1. Pull branch
2. `docker-compose build elasticsearch`
3. `docker-compose up`
4. `docker-compose exec python bash`
5. `./cfgov/manage.py search_index --rebuild --parallel -f`
6. Visit the various ES-powered things and confirm that they still work


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
