### PR TITLE
Improve keyboard navigation of VideoPlayer

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/video-player.html
+++ b/cfgov/jinja2/v1/_includes/organisms/video-player.html
@@ -54,17 +54,6 @@
         <div class="o-video-player_video-container
                     {{- ' o-video-player_video-container__flexible' if not is_fcm else '' }}
                     u-show-on-video-playing">
-            <div class="o-video-player_iframe-container">
-                <iframe class="o-video-player_iframe"
-                    width="100%"
-                    src="{{ video_url }}"
-                    frameborder="0"
-                    allow="autoplay"
-                    allowfullscreen="true"
-                    scrolling="no"
-                    tabindex="-1">
-                </iframe>
-            </div>
             <div class="o-video-player_video-actions-container">
                 <div class="o-video-player_video-actions">
                     <button class="a-btn o-video-player_close-btn"
@@ -84,6 +73,17 @@
                         'email_title': page.title if page else 'Consumer Financial Protection Bureau'
                     } ) }}
                 {% endif %}
+            </div>
+            <div class="o-video-player_iframe-container">
+                <iframe class="o-video-player_iframe"
+                    width="100%"
+                    src="{{ video_url }}"
+                    frameborder="0"
+                    allow="autoplay"
+                    allowfullscreen="true"
+                    scrolling="no"
+                    tabindex="-1">
+                </iframe>
             </div>
         </div>
         <div class="o-video-player_image-container

--- a/cfgov/jinja2/v1/_includes/organisms/video-player.html
+++ b/cfgov/jinja2/v1/_includes/organisms/video-player.html
@@ -61,12 +61,16 @@
                     frameborder="0"
                     allow="autoplay"
                     allowfullscreen="true"
-                    scrolling="no">
+                    scrolling="no"
+                    tabindex="-1">
                 </iframe>
             </div>
             <div class="o-video-player_video-actions-container">
                 <div class="o-video-player_video-actions">
-                    <button class="a-btn o-video-player_close-btn" href="/">
+                    <button class="a-btn o-video-player_close-btn"
+                        href="/"
+                        aria-label="Close video"
+                        tabindex="-1">
                         Close {{ svg_icon('close-round') }}
                     </button>
                 </div>

--- a/cfgov/unprocessed/js/organisms/VideoPlayer.js
+++ b/cfgov/unprocessed/js/organisms/VideoPlayer.js
@@ -161,6 +161,16 @@ function VideoPlayer( element ) {
     if ( _player ) {
       _player.playVideo();
       _dom.classList.add( 'video-playing' );
+
+      /* Allow keyboard navigation of the close button and video iframe.
+       * Disallow keyboard navigation of the play button. */
+      _closeBtnDom.removeAttribute( 'tabindex' );
+      _iframeDom.removeAttribute( 'tabindex' );
+      _playBtnDom.setAttribute( 'tabindex', '-1' );
+
+      // Set the keyboard focus to the close button.
+      _closeBtnDom.focus();
+
       this.dispatchEvent( 'onPlay' );
     }
 
@@ -175,6 +185,16 @@ function VideoPlayer( element ) {
     if ( _player ) {
       _player.stopVideo();
       _dom.classList.remove( 'video-playing' );
+
+      /* Allow keyboard navigation of the play button.
+       * Disallow keyboard navigation of the close button and video iframe. */
+      _closeBtnDom.setAttribute( 'tabindex', '-1' );
+      _iframeDom.setAttribute( 'tabindex', '-1' );
+      _playBtnDom.removeAttribute( 'tabindex' );
+
+      // Set the keyboard focus to the play button.
+      _playBtnDom.focus();
+
       this.dispatchEvent( 'onStop' );
     }
 


### PR DESCRIPTION
This commit improves keyboard navigation of the VideoPlayer module by changing which elements are assigned tabstops.

This fixes https://github.com/cfpb/design-system/issues/1124 which reports that tabbing through the video player pauses on invisible elements. This is because currently both the close button and video iframe can be tabbed to even when they are invisible because the video is not playing. An example live page where this behavior can be seen is https://www.consumerfinance.gov/consumer-tools/managing-someone-elses-money/.

This commit adds `tabindex="-1"` to both the iframe and close button so that, in the initial page load state, neither of these invisible elements can be tabbed to.

The JS code is altered here so that, when the video is played, the `tabindex` attribute is removed, thus making these elements tabbable. The play button also then gets `tabindex="-1"`, as it gets hidden when the video is played. Additionally, the "Close video" now gets the focus when this happens (and also a new `aria-label`).

When the video is stopped, the JS code now reverses the process, and the focus is set to the play button.

## How to test this PR

To test, use VoiceOver on the Mac (for example as documented [here](https://www.imore.com/how-enable-voiceover-mac)) and tab through the page, noting that only appropriate elements can be selected. Use the space bar to open/close the video. Alternatively or additionally, you can also add a watch expression for `document.activeElement` in Chrome developer tools, and observe how it changes as you tab.

## Notes and todos

One potential followup to this work would be to consider the placement of the close button relative to the video controls. Currently the module HTML puts both the play and close buttons AFTER the video iframe. This means that someone using keyboard navigation would have to tab "in reverse" to get to the video controls, where they might expect these to come after play/close. Fixing this would require moving the buttons before the iframe, and I'm not sure what else this might impact.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

### Front-end testing

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
