### PR TITLE
Restore model method for EFIP program type

### DIFF
--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -718,6 +718,12 @@ class Program(models.Model):
     def __str__(self):
         return "{} ({})".format(self.program_name, self.institution)
 
+    def get_level(self):
+        level = ''
+        if self.level and str(self.level) in HIGHEST_DEGREES:
+            level = HIGHEST_DEGREES[str(self.level)]
+        return level
+
     def as_json(self):
         ordered_out = OrderedDict()
         dict_out = {


### PR DESCRIPTION
In refactoring paying-for-college data for the financial-path tool, we dropped
an outdated model method that returned a program level name. It appeared to be
unused, but it was in fact called from the legacy EFIP template for use as a label.

This restores the method so that we don't need to touch EFIP front-end code.

## Testing

Before pulling in the branch, go to a recent EFIP disclosure and note that the
**PROGRAM TYPE** field is blank on the opening page:

http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=475121&pid=5460&oid=D52A4D6A8D320E7C8E7CD6AFB3E483BF2508D54B&book=1503&gib=0&gpl=0&hous=7101&insi=0.0000&insl=0&inst=37&leng=0&mta=0&othg=0&othr=4338&parl=0&pelg=6345&perl=0&ppl=0&prvl=0&prvf=0.0000&prvi=0.0000&schg=0&stag=0&subl=3465&totl=65825&tran=2322&tuit=14580&unsl=5937&wkst=0%5C

Check out this branch and refresh the page above, and **PROGRAM TYPE** should read **Bachelor's degree**.
