### PR TITLE
Update wagtail-sharing to version 2.4.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -35,7 +35,7 @@ urllib3==1.25.2
 wagtail-flags==5.0.0
 wagtail-inventory==1.2.0
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.3.0
+wagtail-sharing==2.4.0
 wagtail-treemodeladmin==1.4.0
 wagtailmedia==0.6.0
 


### PR DESCRIPTION
This commit bumps the version of our wagtail-sharing package from version 2.3.0 to the new release 2.4.0. See the release notes for details on changes: https://github.com/cfpb/wagtail-sharing/releases/tag/2.4.0

## How to test this PR

Run a local server and verify that [sharing pages](http://content.localhost:8000/) continue to work, that sharing links are correct (see "View sharing link" under MORE under a page title in [a listing view](http://localhost:8000/admin/pages/319/)), and that the sharing banner now works properly [on interactive regulations pages](http://content.localhost:8000/rules-policy/regulations/1002/).

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)