### PR TITLE
Update regdown and remove dependency on sha3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -26,11 +26,10 @@ ntplib==0.3.4
 openpyxl==3.0.3
 psycopg2==2.7.3.2
 python-dateutil==2.7.3
-regdown==1.0.2
+regdown==1.0.3
 requests==2.22.0
 requests_aws4auth==0.8.0
 requests_toolbelt==0.8.0
-sha3==0.2.1
 urllib3==1.25.2
 # wagtail-autocomplete==0.6 TODO: Restore when wagtail-autocomplete #77 is merged
 wagtail-flags==5.0.0


### PR DESCRIPTION
**Hold until a new version of regdown has been released including https://github.com/cfpb/regdown/pull/4.**

This commit bumps the version of our external regdown package and also removes an unnecessary dependency on the sha3 package. This dependency is no longer needed on Python 3.6+.

## Notes and todos

Our inclusion of the external [sha3](https://pypi.org/project/sha3/) package can cause issues when trying to `pip install -e` on Macs using Python installed via pyenv. If sha3 is installed into a Python 3.6 virtual environment, in certain cases trying to `pip install -e` can result in errors like

> ...
> AttributeError: module '_hashlib' has no attribute 'openssl_sha3_224'
>
>  During handling of the above exception, another exception occurred:
> ...
> AttributeError: module '_sha3' has no attribute 'sha3_224'

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)