### PR TITLE
Enforcement actions API

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -36,6 +36,7 @@ from v1.views import (
     password_reset_confirm
 )
 from v1.views.documents import DocumentServeView
+from v1.views.enforcement_api import EnforcementAPIView
 
 
 try:
@@ -362,6 +363,12 @@ urlpatterns = [
     re_path(
         r'^data-research/mortgages/api/v1/',
         include('data_research.urls')
+    ),
+
+    re_path(
+        r'^api/enforcement_actions/v1/$',
+        EnforcementAPIView.as_view(),
+        name='enforcement_action_api'
     ),
 
     # educational resources

--- a/cfgov/v1/models/enforcement_action_page.py
+++ b/cfgov/v1/models/enforcement_action_page.py
@@ -281,6 +281,24 @@ class EnforcementActionPage(AbstractFilterPage):
         index.SearchField('content')
     ]
 
+    @classmethod
+    def all_actions(cls):
+        # Return the collection of all Enforcement Action Pages.
+        # Exclude any pages in the Trash or otherwise not a child of the
+        # EnforcementActionsFilterPage.
+        try:
+            # TODO: find a less hacky way to get only the pages in the
+            # correct part of the page tree
+            pg_id = 1327
+            parent_page = Page.objects.get(id=pg_id)
+            query = cls.objects.child_of(parent_page)
+        except(Page.DoesNotExist):
+            query = cls.objects
+
+        query = query.filter(initial_filing_date__isnull=False)
+        query = query.live().order_by('-initial_filing_date')
+        return query
+
     def get_context(self, request):
         context = super(EnforcementActionPage, self).get_context(request)
         dispositions = self.enforcement_dispositions.all()

--- a/cfgov/v1/tests/views/test_enforcement_api.py
+++ b/cfgov/v1/tests/views/test_enforcement_api.py
@@ -1,0 +1,125 @@
+import json
+from datetime import date
+
+from django.test import TestCase
+
+from wagtail.core.models import Site
+
+from model_bakery import baker
+
+from v1.models.enforcement_action_page import (
+    EnforcementActionAtRisk, EnforcementActionDefendantType,
+    EnforcementActionDisposition, EnforcementActionDocket,
+    EnforcementActionPage, EnforcementActionProduct, EnforcementActionStatus,
+    EnforcementActionStatute
+)
+from v1.views.enforcement_api import EnforcementActionSerializer
+
+
+class EnforcementAPITestCase(TestCase):
+    # Things to note in the expected JSON output:
+    # Lists of products, statuses, etc. are flattened to lists of strings, not
+    # JSON objects. ChoiceFields like statuses, statutes, etc. use their
+    # display values.
+    expected_json = json.loads('''
+    {
+        "public_enforcement_action": "Sample Enforcement Action",
+        "initial_filing_date": "2021-01-01",
+        "defendant_types": ["Bank", "Nonbank"],
+        "court": "CFPB Office of Administrative Adjudication",
+        "docket_numbers": ["2021-CFPB-0001"],
+        "settled_or_contested_at_filing": "Settled",
+        "products": ["Other Consumer Product (not lending)"],
+        "at_risk_groups": ["Students"],
+        "enforcement_dispositions": [
+            {
+                "final_disposition": "Sample Sample Action",
+                "final_disposition_type": "Final Order",
+                "final_order_date": "2021-02-02",
+                "dismissal_date": null,
+                "final_order_consumer_redress": "333.00",
+                "final_order_consumer_redress_suspended": "444.00",
+                "final_order_other_consumer_relief": "555.00",
+                "final_order_other_consumer_relief_suspended": "666.00",
+                "final_order_disgorgement": "777.00",
+                "final_order_disgorgement_suspended": "888.00",
+                "final_order_civil_money_penalty": "999.00",
+                "final_order_civil_money_penalty_suspended": "111.00",
+                "estimated_consumers_entitled_to_relief": "Zero"
+            }
+        ],
+        "statuses": ["Expired/Terminated/Dismissed"],
+        "statutes": ["Consumer Leasing Act/Regulation M"],
+        "url": "/enforcement/actions/sample-action/"
+    }
+    ''')
+
+    def setUp(self):
+        self.enforcement_page = baker.prepare(EnforcementActionPage)
+
+        self.enforcement_page.public_enforcement_action = 'Sample Enforcement Action'
+        self.enforcement_page.initial_filing_date = date(2021, 1, 1)
+        self.enforcement_page.defendant_types = [
+                EnforcementActionDefendantType(defendant_type='Bank'),
+                EnforcementActionDefendantType(defendant_type='Non-Bank'),
+                ]
+        self.enforcement_page.court = "CFPB Office of Administrative Adjudication"
+        self.enforcement_page.docket_numbers.add(
+                EnforcementActionDocket(docket_number='2021-CFPB-0001'))
+        self.enforcement_page.settled_or_contested_at_filing = 'Settled'
+        self.enforcement_page.products.add(
+            EnforcementActionProduct(product='Other Consumer Products (Not Lending)'))
+        self.enforcement_page.at_risk_groups.add(
+            EnforcementActionAtRisk(at_risk_group='Students'))
+        self.enforcement_page.enforcement_dispositions.add(
+                EnforcementActionDisposition(
+                final_disposition = "Sample Sample Action",
+                final_disposition_type = "Final Order",
+                final_order_date = "2021-02-02",
+                final_order_consumer_redress = "333.00",
+                final_order_consumer_redress_suspended = "444.00",
+                final_order_other_consumer_relief = "555.00",
+                final_order_other_consumer_relief_suspended = "666.00",
+                final_order_disgorgement = "777.00",
+                final_order_disgorgement_suspended = "888.00",
+                final_order_civil_money_penalty = "999.00",
+                final_order_civil_money_penalty_suspended = "111.00",
+                estimated_consumers_entitled_to_relief = "Zero"
+                    ))
+        self.enforcement_page.statuses.add(
+            EnforcementActionStatus(status='expired-terminated-dismissed'))
+        self.enforcement_page.statutes.add(
+                EnforcementActionStatute(statute='CLA'))
+
+
+    def test_serializes_correct_keys(self):
+        serializer = EnforcementActionSerializer(self.enforcement_page)
+        output_keys = serializer.data.keys()
+        expected_keys = self.expected_json.keys()
+        self.assertEqual(output_keys, expected_keys)
+
+    def test_uses_display_names(self):
+        serializer = EnforcementActionSerializer(self.enforcement_page)
+        self.assertEqual(
+                serializer.data['statuses'],
+                self.expected_json['statuses']
+                )
+        self.assertEqual(
+                serializer.data['products'],
+                self.expected_json['products']
+                )
+
+    def test_flattens_lists(self):
+        serializer = EnforcementActionSerializer(self.enforcement_page)
+        self.assertEqual(
+                serializer.data['defendant_types'],
+                self.expected_json['defendant_types']
+                )
+
+    def test_can_serialize_empty_metadata(self):
+        empty_page = baker.prepare(EnforcementActionPage)
+        serializer = EnforcementActionSerializer(empty_page)
+        output_keys = serializer.data.keys()
+        expected_keys = self.expected_json.keys()
+        self.assertEqual(output_keys, expected_keys)
+

--- a/cfgov/v1/tests/views/test_enforcement_api.py
+++ b/cfgov/v1/tests/views/test_enforcement_api.py
@@ -60,19 +60,19 @@ class EnforcementAPITestCase(TestCase):
         self.enforcement_page.public_enforcement_action = 'Sample Enforcement Action'
         self.enforcement_page.initial_filing_date = date(2021, 1, 1)
         self.enforcement_page.defendant_types = [
-                EnforcementActionDefendantType(defendant_type='Bank'),
-                EnforcementActionDefendantType(defendant_type='Non-Bank'),
-                ]
+            EnforcementActionDefendantType(defendant_type='Bank'),
+            EnforcementActionDefendantType(defendant_type='Non-Bank'),
+        ]
         self.enforcement_page.court = "CFPB Office of Administrative Adjudication"
         self.enforcement_page.docket_numbers.add(
-                EnforcementActionDocket(docket_number='2021-CFPB-0001'))
+            EnforcementActionDocket(docket_number='2021-CFPB-0001'))
         self.enforcement_page.settled_or_contested_at_filing = 'Settled'
         self.enforcement_page.products.add(
             EnforcementActionProduct(product='Other Consumer Products (Not Lending)'))
         self.enforcement_page.at_risk_groups.add(
             EnforcementActionAtRisk(at_risk_group='Students'))
         self.enforcement_page.enforcement_dispositions.add(
-                EnforcementActionDisposition(
+            EnforcementActionDisposition(
                 final_disposition = "Sample Sample Action",
                 final_disposition_type = "Final Order",
                 final_order_date = "2021-02-02",
@@ -85,11 +85,11 @@ class EnforcementAPITestCase(TestCase):
                 final_order_civil_money_penalty = "999.00",
                 final_order_civil_money_penalty_suspended = "111.00",
                 estimated_consumers_entitled_to_relief = "Zero"
-                    ))
+            ))
         self.enforcement_page.statuses.add(
             EnforcementActionStatus(status='expired-terminated-dismissed'))
         self.enforcement_page.statutes.add(
-                EnforcementActionStatute(statute='CLA'))
+            EnforcementActionStatute(statute='CLA'))
 
 
     def test_serializes_correct_keys(self):
@@ -103,18 +103,18 @@ class EnforcementAPITestCase(TestCase):
         self.assertEqual(
                 serializer.data['statuses'],
                 self.expected_json['statuses']
-                )
+        )
         self.assertEqual(
                 serializer.data['products'],
                 self.expected_json['products']
-                )
+        )
 
     def test_flattens_lists(self):
         serializer = EnforcementActionSerializer(self.enforcement_page)
         self.assertEqual(
                 serializer.data['defendant_types'],
                 self.expected_json['defendant_types']
-                )
+        )
 
     def test_can_serialize_empty_metadata(self):
         empty_page = baker.prepare(EnforcementActionPage)

--- a/cfgov/v1/views/enforcement_api.py
+++ b/cfgov/v1/views/enforcement_api.py
@@ -1,0 +1,90 @@
+from rest_framework import serializers
+from rest_framework.generics import ListAPIView
+
+from v1.models.enforcement_action_page import (
+    EnforcementActionDisposition, EnforcementActionPage
+)
+
+
+class EnforcementStatuteSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.get_statute_display()
+
+
+class EnforcementDefendantTypeSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.get_defendant_type_display()
+
+
+class EnforcementDocketSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.docket_number
+
+
+class EnforcementStatusSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.get_status_display()
+
+
+class EnforcementAtRiskSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.get_at_risk_group_display()
+
+
+class EnforcementProductSerializer(serializers.Serializer):
+    def to_representation(self, value):
+        return value.get_product_display()
+
+
+class EnforcementDispositionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = EnforcementActionDisposition
+        fields = [
+            'final_disposition',
+            'final_disposition_type',
+            'final_order_date',
+            'dismissal_date',
+            'final_order_consumer_redress',
+            'final_order_consumer_redress_suspended',
+            'final_order_other_consumer_relief',
+            'final_order_other_consumer_relief_suspended',
+            'final_order_disgorgement',
+            'final_order_disgorgement_suspended',
+            'final_order_civil_money_penalty',
+            'final_order_civil_money_penalty_suspended',
+            'estimated_consumers_entitled_to_relief',
+        ]
+
+
+class EnforcementActionSerializer(serializers.ModelSerializer):
+
+    products = EnforcementProductSerializer(many=True)
+    defendant_types = EnforcementDefendantTypeSerializer(many=True)
+    docket_numbers = EnforcementDocketSerializer(many=True)
+    statuses = EnforcementStatusSerializer(many=True)
+    enforcement_dispositions = EnforcementDispositionSerializer(many=True)
+    statutes = EnforcementStatuteSerializer(many=True)
+    at_risk_groups = EnforcementAtRiskSerializer(many=True)
+
+    class Meta:
+
+        model = EnforcementActionPage
+        fields = [
+            'public_enforcement_action',
+            'initial_filing_date',
+            'defendant_types',
+            'court',
+            'docket_numbers',
+            'settled_or_contested_at_filing',
+            'products',
+            'at_risk_groups',
+            'enforcement_dispositions',
+            'statuses',
+            'statutes',
+            'url',
+        ]
+
+
+class EnforcementAPIView(ListAPIView):
+    serializer_class = EnforcementActionSerializer
+    queryset = EnforcementActionPage.all_actions()

--- a/cfgov/v1/views/enforcement_api.py
+++ b/cfgov/v1/views/enforcement_api.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
-from rest_framework.generics import ListAPIView
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from v1.models.enforcement_action_page import (
     EnforcementActionDisposition, EnforcementActionPage
@@ -85,6 +86,8 @@ class EnforcementActionSerializer(serializers.ModelSerializer):
         ]
 
 
-class EnforcementAPIView(ListAPIView):
-    serializer_class = EnforcementActionSerializer
-    queryset = EnforcementActionPage.all_actions()
+class EnforcementAPIView(APIView):
+    def get(self, request):
+        queryset = EnforcementActionPage.all_actions()
+        serializer = EnforcementActionSerializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
New API endpoint at /api/enforcement_actions/v1/ returns a JSON serialization of all Enforcement Action Pages that are children of the `EnforcementActionFilterPage` in the page tree.

This will be used to power the charts displaying data about enforcement actions over time.

## How to test this PR

1. Run this branch
2. Visit this URL in the browser or in code: [http://localhost:8000/api/enforcement_actions/v1/](http://localhost:8000/api/enforcement_actions/v1/)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance


