### PR TITLE
Restrict EnforcementActionPages to one part of the page tree

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -77,6 +77,8 @@ class BrowseFilterablePage(FilterableListMixin, CFGOVPage):
 
 
 class EnforcementActionsFilterPage(BrowseFilterablePage):
+    subpage_types = ['v1.EnforcementActionPage', 'v1.LearnPage']
+
     template = 'browse-filterable/index.html'
     objects = PageManager()
 

--- a/cfgov/v1/models/enforcement_action_page.py
+++ b/cfgov/v1/models/enforcement_action_page.py
@@ -201,6 +201,10 @@ class EnforcementActionStatute(models.Model):
 
 
 class EnforcementActionPage(AbstractFilterPage):
+    # Only allow these pages in the Enforcement Actions filter or Trash
+    parent_page_types = ['v1.EnforcementActionsFilterPage', 'v1.HomePage']
+    subpage_types = []
+
     public_enforcement_action = models.CharField(max_length=150, blank=True)
     initial_filing_date = models.DateField(null=True, blank=True)
     settled_or_contested_at_filing = models.CharField(


### PR DESCRIPTION
Ensure all `EnforcementActionPage`s are children of `EnforcementActionFilterPage`. This helps ensure that when we use `EnforcementActionPage.objects.all()` (or similar), we're only getting Enforcement Actions that should be included in the list.

## Changes

- `EnforcementActionPage` can only be a child of `EnforcementActionFilterPage`.
- `EnforcementActionFilterPage` can only have two page types as children: `EnforcementActionPage` and `LearnPage` (the Enforcement Action Definitions page).
- `EnforcementActionPage` can't have child pages.


## How to test this PR

1. Check that you can create a new `EnforcementActionPage` as a child of the Enforcement Actions Filter page.
2. Check that you can't create one in other parts of the page tree.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated