### PR TITLE
Only add Watchman URL if WATCHMAN_TOKENS is defined

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -764,9 +764,11 @@ FLAGS = {
     "ASK_SURVEY_INTERCEPT": [],
 }
 
-
-# Watchman tokens, used to authenticate global status endpoint
-WATCHMAN_TOKENS = os.environ.get("WATCHMAN_TOKENS", secrets.token_hex())
+# Watchman tokens, a comma-separated string of tokens used to authenticate
+# global status endpoint. The Watchman status URL endpoint is only included if
+# WATCHMAN_TOKENS is defined as an environment variable. A blank value for
+# WATCHMAN_TOKENS will make the status endpoint accessible without a token.
+WATCHMAN_TOKENS = os.environ.get("WATCHMAN_TOKENS")
 
 # This specifies what checks Watchman should run and include in its output
 # https://github.com/mwarkentin/django-watchman#custom-checks

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -462,8 +462,6 @@ urlpatterns = [
         name='ask-autocomplete-es'
     ),
 
-    re_path(r'^_status/', include('watchman.urls')),
-
     re_path(
         r'^consumer-tools/financial-well-being/',
         include('wellbeing.urls')
@@ -705,6 +703,11 @@ if settings.ALLOW_ADMIN_URL:
     ]
 
     urlpatterns = patterns + urlpatterns
+
+if settings.WATCHMAN_TOKENS is not None:
+    urlpatterns.append(
+        re_path(r'^_status/', include('watchman.urls')),
+    )
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,


### PR DESCRIPTION
If `WATCHMAN_TOKENS` is not defined in the environment, the Django setting will default to `None` and the Watchman `_status/` URL will not added the URL patterns.



## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
