### PR TITLE
Add product and at risk group filters to enforcement action filter page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list-controls.html
@@ -46,7 +46,7 @@
             </div>
         </div>
     {% endif %}
-    {% if show_topic_filter or value.authors or value.statuses or value.date_range %}
+    {% if show_topic_filter or value.authors or value.statuses or value.products or value.at_risk_groups or value.date_range %}
         <div class="content-l_col
                     content-l_col-2-3">
             <div class="content-l">
@@ -64,6 +64,32 @@
                                 {% endfor %}
                                 </ul>
                             </fieldset>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if value.products %}
+                    <div class="content-l_col
+                                content-l_col-1-2">
+                        <div class="o-form_group">
+                            <div class="m-form-field">
+                                <label class="a-label a-label__heading">
+                                   Product
+                                </label>
+                                {{ form.products }}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+                {% if value.at_risk_groups %}
+                    <div class="content-l_col
+                                content-l_col-1-2">
+                        <div class="o-form_group">
+                            <div class="m-form-field">
+                                <label class="a-label a-label__heading">
+                                  At risk group
+                                </label>
+                                {{ form.at_risk_groups }}
+                            </div>
                         </div>
                     </div>
                 {% endif %}

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -824,6 +824,15 @@ class FilterableList(BaseExpandable):
 
     statuses = blocks.BooleanBlock(default=False, required=False,
                                    label='Filter Enforcement Statuses')
+
+    products = blocks.BooleanBlock(default=False, required=False,
+                                   label='Filter Enforcement Products')
+
+    at_risk_groups = blocks.BooleanBlock(
+        default=False, required=False,
+        label='Filter Enforcement At risk groups'
+    )
+
     authors = blocks.BooleanBlock(default=True, required=False,
                                   label='Filter Authors')
     date_range = blocks.BooleanBlock(default=True, required=False,

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -277,6 +277,28 @@ class EnforcementActionsFilterForm(FilterableListForm):
         widget=widgets.CheckboxSelectMultiple()
     )
 
+    products = forms.MultipleChoiceField(
+        required=False,
+        choices=enforcement_action_page.enforcement_products,
+        widget=widgets.SelectMultiple(attrs={
+            'id': 'o-filterable-list-controls_products',
+            'class': 'o-multiselect',
+            'data-placeholder': 'Search for products',
+            'multiple': 'multiple',
+        })
+    )
+
+    at_risk_groups = forms.MultipleChoiceField(
+        required=False,
+        choices=enforcement_action_page.enforcement_at_risk_groups,
+        widget=widgets.SelectMultiple(attrs={
+            'id': 'o-filterable-list-controls_at_risk_groups',
+            'class': 'o-multiselect',
+            'data-placeholder': 'Search for at risk groups',
+            'multiple': 'multiple',
+        })
+    )
+
     def get_page_set(self):
         query = self.generate_query()
         return self.filterable_pages.filter(query).distinct().order_by(
@@ -285,14 +307,16 @@ class EnforcementActionsFilterForm(FilterableListForm):
 
     def get_query_strings(self):
         return [
-            'title__icontains',          # title
-            'initial_filing_date__gte',  # from_date
-            'initial_filing_date__lte',  # to_date
-            'categories__name__in',      # categories
-            'tags__slug__in',            # topics
-            'authors__slug__in',         # authors
-            'is_archived__in',           # archived
-            'statuses__status__in',      # statuses
+            'title__icontains',                      # title
+            'initial_filing_date__gte',              # from_date
+            'initial_filing_date__lte',              # to_date
+            'categories__name__in',                  # categories
+            'tags__slug__in',                        # topics
+            'authors__slug__in',                     # authors
+            'is_archived__in',                       # archived
+            'statuses__status__in',                  # statuses
+            'products__product__in',                 # products
+            'at_risk_groups__at_risk_group__in',     # at_risk_groups
         ]
 
 

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -129,7 +129,10 @@ class FilterableListMixin(RoutablePageMixin):
         form_data = {'archived': 'include'}
         has_active_filters = False
         for field in self.get_form_class().declared_fields:
-            if field in ['categories', 'topics', 'authors', 'statuses']:
+            if field in [
+                'categories', 'topics', 'authors', 'statuses', 'products',
+                'at_risk_groups'
+            ]:
                 value = request_dict.getlist(field, [])
             else:
                 value = request_dict.get(field, '')


### PR DESCRIPTION
Testing:
 - Go to the enforcement filterable list page in wagtail and check the "filter enforcement products" and "filter enforcement at risk groups" check boxes
 - Filter by various combinations of these on the enforcement filterable page
 - Check that visiting the page by URL with selected params works
 - Check that other filterable list pages (blog, etc.) aren't affected

Wagtail checks:
<img width="354" alt="Screen Shot 2021-01-22 at 2 52 53 PM" src="https://user-images.githubusercontent.com/1558033/105538896-f0413b00-5ca8-11eb-84a7-4fa8f693e243.png">

Filterable List controls:
<img width="986" alt="Screen Shot 2021-01-22 at 2 52 07 PM" src="https://user-images.githubusercontent.com/1558033/105538897-f0413b00-5ca8-11eb-8728-b1f4ff7734df.png">
