### PR TITLE
Invalidate Akamai cache for EnforcementAPI endpoint

### DIFF
--- a/cfgov/v1/apps.py
+++ b/cfgov/v1/apps.py
@@ -3,7 +3,11 @@ from django.contrib.auth import get_user_model
 from django.contrib.staticfiles import storage
 from django.db.models.signals import post_save
 
-from .signals import user_save_callback
+from wagtail.core.signals import (
+    page_published, page_unpublished, post_page_move
+)
+
+from .signals import break_enforcement_cache, user_save_callback
 
 
 class V1AppConfig(AppConfig):
@@ -25,3 +29,11 @@ class V1AppConfig(AppConfig):
                 (r"""(@import\s*["']\s*(.*?)["'])""", """@import url("%s")"""),
             )),
         )
+
+        from v1.models.enforcement_action_page import EnforcementActionPage
+        page_published.connect(break_enforcement_cache,
+                               sender=EnforcementActionPage)
+        page_unpublished.connect(break_enforcement_cache,
+                                 sender=EnforcementActionPage)
+        post_page_move.connect(break_enforcement_cache,
+                               sender=EnforcementActionPage)

--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
 
 from django.core.cache import caches
+from django.urls import reverse
 from django.utils import timezone
 
+from wagtail.contrib.frontend_cache.utils import PurgeBatch
 from wagtail.core.signals import page_published
 
 
@@ -46,3 +48,12 @@ def invalidate_post_preview(sender, **kwargs):
 
 
 page_published.connect(invalidate_post_preview)
+
+
+def break_enforcement_cache(sender, instance, **kwargs):
+    base = instance.get_site().root_url
+    batch = PurgeBatch()
+    enf_api_url = base + reverse('enforcement_action_api')
+    enf_charts_url = base + '/enforcement/payments-harmed-consumers/enforcement-database/'  # noqa: E501
+    batch.add_urls([enf_api_url, enf_charts_url])
+    batch.purge()


### PR DESCRIPTION
Invalidate Akamai cache for EnforcementAPI endpoint when the collection of EnforcementActionPages changes.


## Additions

- A listener to the "publish" and "move" signals for the EnforcementActionPage now triggers a `purge_url_from_cache` action (the same action that the `cf.gov-flush-akamai-cache` job uses)


## Notes and todos

- To do: Add tests.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance