### PR TITLE
Enforcement API: Serialize DecimalFields as numerals

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -859,3 +859,8 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
         },
     },
 }
+
+# Serialize Decimal(3.14) as 3.14, not "3.14"
+REST_FRAMEWORK = {
+    "COERCE_DECIMAL_TO_STRING": False
+}

--- a/cfgov/v1/tests/views/test_enforcement_api.py
+++ b/cfgov/v1/tests/views/test_enforcement_api.py
@@ -37,14 +37,14 @@ class EnforcementAPITestCase(TestCase):
                 "final_disposition_type": "Final Order",
                 "final_order_date": "2021-02-02",
                 "dismissal_date": null,
-                "final_order_consumer_redress": "333.00",
-                "final_order_consumer_redress_suspended": "444.00",
-                "final_order_other_consumer_relief": "555.00",
-                "final_order_other_consumer_relief_suspended": "666.00",
-                "final_order_disgorgement": "777.00",
-                "final_order_disgorgement_suspended": "888.00",
-                "final_order_civil_money_penalty": "999.00",
-                "final_order_civil_money_penalty_suspended": "111.00",
+                "final_order_consumer_redress": 333.0,
+                "final_order_consumer_redress_suspended": 444.0,
+                "final_order_other_consumer_relief": 555.0,
+                "final_order_other_consumer_relief_suspended": 666.0,
+                "final_order_disgorgement": 777.0,
+                "final_order_disgorgement_suspended": 888.0,
+                "final_order_civil_money_penalty": 999.0,
+                "final_order_civil_money_penalty_suspended": 111.0,
                 "estimated_consumers_entitled_to_relief": "Zero"
             }
         ],
@@ -115,6 +115,18 @@ class EnforcementAPITestCase(TestCase):
                 serializer.data['defendant_types'],
                 self.expected_json['defendant_types']
         )
+
+    def test_serializes_disposition(self):
+        serializer = EnforcementActionSerializer(self.enforcement_page)
+        output_keys = serializer.data['enforcement_dispositions'][0].keys()
+        expected_keys = self.expected_json['enforcement_dispositions'][0].keys()  # noqa E501
+        self.assertEqual(output_keys, expected_keys)
+
+    def test_serializes_decimals_as_numbers(self):
+        serializer = EnforcementActionSerializer(self.enforcement_page)
+        output = serializer.data['enforcement_dispositions'][0]['final_order_disgorgement']  # noqa E501
+        expected = self.expected_json['enforcement_dispositions'][0]['final_order_disgorgement']   # noqa E501
+        self.assertEqual(output, expected)
 
     def test_can_serialize_empty_metadata(self):
         empty_page = baker.prepare(EnforcementActionPage)


### PR DESCRIPTION
Serialize DecimalFields as numerals. This will make conversion to a chart simpler on the front end.

## Changes

- Update django rest framework settings to serialize DecimalFields as numerals instead of strings.


## How to test this PR

1. Visit http://localhost:8000/api/enforcement_actions/v1/


## Example

```json
{
        "public_enforcement_action": "Sample Action, LLC.",
        "initial_filing_date": "2020-11-30",
        "defendant_types": [],
        "court": "",
        "docket_numbers": [
            "2020-BCFP-3333"
        ],
        "settled_or_contested_at_filing": "Settled",
        "products": [
            "Short Term, Small Dollar",
            "Other Consumer Lending"
        ],
        "at_risk_groups": [
            "Servicemembers"
        ],
        "enforcement_dispositions": [
            {
                "final_disposition": "Sample Sample, LLC.",
                "final_disposition_type": "Final Order",
                "final_order_date": "2020-11-30",
                "dismissal_date": null,
                "final_order_consumer_redress": 0.0,
                "final_order_consumer_redress_suspended": 0.0,
                "final_order_other_consumer_relief": 0.0,
                "final_order_other_consumer_relief_suspended": 0.0,
                "final_order_disgorgement": 0.0,
                "final_order_disgorgement_suspended": 0.0,
                "final_order_civil_money_penalty": 2995000.0,
                "final_order_civil_money_penalty_suspended": 0.0,
                "estimated_consumers_entitled_to_relief": ""
            }
        ],
        "statuses": [
            "Post Order/Post Judgment"
        ],
        "statutes": [
            "Consumer Financial Protection Act - Other",
            "Military Lending Act",
            "Electronic Fund Transfer Act/Regulation E"
        ],
        "url": "/enforcement/actions/sample-action-llc/"
    },
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
