### PR TITLE
Add support for previewing blog posts in list view

### DIFF
--- a/cfgov/v1/jinja2/v1/blog/blog_page_list_preview.html
+++ b/cfgov/v1/jinja2/v1/blog/blog_page_list_preview.html
@@ -5,7 +5,9 @@
 {% block content %}
 <div class="wrapper content_wrapper">
     <div class="content_main">
-        {{ preview.render( post ) }}
+        <div class="block block--sub">
+            {{ preview.render( post ) }}
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/cfgov/v1/jinja2/v1/blog/blog_page_list_preview.html
+++ b/cfgov/v1/jinja2/v1/blog/blog_page_list_preview.html
@@ -1,0 +1,11 @@
+{% extends "v1/layouts/base.html" %}
+
+{% import 'v1/includes/organisms/post-preview.html' as preview %}
+
+{% block content %}
+<div class="wrapper content_wrapper">
+    <div class="content_main">
+        {{ preview.render( post ) }}
+    </div>
+</div>
+{% endblock %}

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -1,3 +1,5 @@
+from django.template.response import TemplateResponse
+
 from wagtail import blocks
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import StreamField
@@ -38,6 +40,24 @@ class BlogPage(AbstractFilterPage):
         )
 
         return context
+
+    @property
+    def preview_modes(self):
+        return super().preview_modes + [
+            ("list_view", "List view"),
+        ]
+
+    def serve_preview(self, request, mode_name):
+        if mode_name != "list_view":
+            return super().serve_preview(request, mode_name)
+
+        return TemplateResponse(
+            request,
+            "v1/blog/blog_page_list_preview.html",
+            {
+                "post": self,
+            },
+        )
 
 
 class LegacyBlogContent(BlogContent):

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -51,11 +51,15 @@ class BlogPage(AbstractFilterPage):
         if mode_name != "list_view":
             return super().serve_preview(request, mode_name)
 
+        from v1.serializers import FilterPageSerializer
+
+        serializer = FilterPageSerializer(self, context={"request": request})
+
         return TemplateResponse(
             request,
             "v1/blog/blog_page_list_preview.html",
             {
-                "post": self,
+                "post": serializer.data,
             },
         )
 

--- a/cfgov/v1/tests/models/test_blog_page.py
+++ b/cfgov/v1/tests/models/test_blog_page.py
@@ -22,3 +22,18 @@ class BlogPageTests(TestCase):
 
         response = self.client.get("/test/test/")
         self.assertContains(response, 'href="/test/feed/')
+
+    def test_preview_modes(self):
+        page = BlogPage(title="test")
+        self.assertIn("list_view", dict(page.preview_modes))
+
+    def render_preview(self, mode_name=None):
+        page = BlogPage(title="test")
+        request = RequestFactory().get("/")
+        return page.serve_preview(request, mode_name=mode_name)
+
+    def test_render_preview(self):
+        self.assertNotContains(self.render_preview(), "o-post-preview")
+
+    def test_render_preview_list_view(self):
+        self.assertContains(self.render_preview("list_view"), "o-post-preview")


### PR DESCRIPTION
This change prototypes using Wagtail's page [preview modes](https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#wagtail.core.models.Page.preview_modes) to allow for previewing of blog posts in their list view, i.e. how they show up [on the blog page](https://www.consumerfinance.gov/about-us/blog/).

## How to test this PR

Run a local server and edit a blog page. Note that the Preview button is now a dropdown, and you can either preview as normal or preview the post in its "post preview" mode.

## Screenshots

<img width="408" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/bb28a4c6-847d-4b05-9f77-a22f6a60445b">

## Screenshots (OLD)

![image](https://user-images.githubusercontent.com/654645/106282235-4e709f80-620e-11eb-8850-b19e56399d04.png)

![image](https://user-images.githubusercontent.com/654645/106282261-592b3480-620e-11eb-9bc1-dc871313a0a6.png)

## Notes and todos

~~This can't be merged right now because the use of Django template caching [here](https://github.com/cfpb/consumerfinance.gov/blob/c85439f63dfd6c213be0c185bfbefee90f0c2d53/cfgov/jinja2/v1/_includes/organisms/post-preview.html#L116) means that previewing changes either won't work as expected or will incorrectly cache draft data. A solution to this might involve checking `request.is_preview` and somehow skipping the `{% cache %}` tag or (preferably) removing the need for that caching altogether.~~

This is no longer an issue after #8450.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets