### PR TITLE
Mega-menu: Reduce top-level padding further by 2px to accommodate long titles

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -902,11 +902,11 @@ body {
                     }
                 }
 
-                // Adjusts position by 2px to accommodate longer titles
                 &-icon-closed .cf-icon-svg,
                 &-icon-open .cf-icon-svg {
                     position: absolute;
-                    right: unit( ( 15px - 2px ) / @base-font-size-px, rem );
+                    // Adjusts position by 4px to accommodate longer titles.
+                    right: unit( ( 15px - 4px ) / @base-font-size-px, rem );
                     top: 19px;
                     font-size: unit( 10px / @base-font-size-px, em );
                 }
@@ -923,9 +923,10 @@ body {
                     display: none;
                 }
 
-                // Add padding to accommodate caret, removing 2px to accommodate longer titles.
+                // Add padding to accommodate caret.
                 &__has-children {
-                    padding-right: unit( ( @grid_gutter-width - 2px ) / @base-font-size-px, em );
+                    // Remove 4px to accommodate longer titles.
+                    padding-right: unit( ( @grid_gutter-width - 4px ) / @base-font-size-px, em );
                 }
 
                 &__current {


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/6005 reduced the padding on the top-level mega menu items. There exists a 10px window in window sizes where the top-level items wrap (https://[GHE]/CFGOV/platform/issues/3953). This PR increases the amount of padding reduction to handle that window. 

## Changes

- Mega-menu: Reduce item padding to 4px from 2px to accommodate long nav item titles.


## How to test this PR

1. `gulp clean && gulp build` and visit any page and resize the window and observe the mega menu appearance in the 901-911px window width. Compare to production. This PR will have 2px narrower top-level nav items in the desktop mega menu. 
