### PR TITLE
Optionally skip Django migrations during tests

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -95,3 +95,14 @@ HAYSTACK_CONNECTIONS["default"]["INDEX_NAME"] = (
 
 ELASTICSEARCH_DSL_AUTO_REFRESH = False
 ELASTICSEARCH_DSL_AUTOSYNC = False
+
+if os.getenv('SKIP_DJANGO_MIGRATIONS'):
+    class _NoMigrations:
+        def __contains__(self, item):
+            return True
+
+        def __getitem__(self, item):
+            return None
+
+
+    MIGRATION_MODULES = _NoMigrations()

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -77,9 +77,8 @@ In addition, we also have this environment:
   Python, Django, and Wagtail. We do not require this environment to pass in
   CI.
 
-By default this uses a local SQLite database for tests. To override this, you
-can set the `TEST_DATABASE_URL` environment variable to a database connection
-string as supported by [dj-database-url](https://github.com/kennethreitz/dj-database-url).
+Tests will run against the default Django database as configured in settings
+using the `DATABASE_URL` environment variable.
 
 If you would like to run only a specific test, or the tests for a specific app,
 you can provide a dotted path to the test as the final argument to any of the above calls to `tox`:
@@ -87,6 +86,9 @@ you can provide a dotted path to the test as the final argument to any of the ab
 ```sh
 tox -e unittest regulations3k.tests.test_regdown
 ```
+
+If you would like to skip running Django migrations when testing, set the
+`SKIP_DJANGO_MIGRATIONS` environment variable to any value before running `tox`.
 
 ### Linting
 

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    DATABASE_URL TEST_RUNNER
+    DATABASE_URL SKIP_DJANGO_MIGRATIONS TEST_RUNNER
 setenv=
     GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_ADMIN_USERNAME=admin


### PR DESCRIPTION
This commit restores the ability to optionally skip (most) Django migrations during Python tests. This repository used to have the ability to do this using `tox -e fast`, but this feature was removed some time ago.

With this commit, by setting the `SKIP_DJANGO_MIGRATIONS` environment variable, the Django [`settings.MIGRATION_MODULES`](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-MIGRATION_MODULES) will be set to a special object that skips all migrations. Our custom test runner will then run a few specific data migrations which create required test data, for example a single Wagtail Site object.

Running tests this way significant speeds up testing because you avoid the time required to run migrations. This is noticeable during the testing step:

"Creating test database for alias 'default'..."

An anecdotal timing comparison:

```
$ SKIP_DJANGO_MIGRATIONS= time tox -e unittest-current
233.62 real       187.74 user         5.94 sys

$ SKIP_DJANGO_MIGRATIONS=1 time tox -e unittest-current
183.44 real       141.04 user         5.41 sys
```

So we save about 40-50 seconds by not running migrations.

## Screenshots

Docs changes:

![image](https://user-images.githubusercontent.com/654645/106776293-efe26180-6611-11eb-9cf3-75f2d9118126.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo