### PR TITLE
Paying for College: Don't double-import design system packages

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/main.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/main.less
@@ -6,13 +6,13 @@
 // Project-specific Less rules go after the imports.
 
 // Import Capital Framework components.
-@import (less) "cfpb-core.less";
-@import (less) "cfpb-buttons.less";
-@import (less) "cfpb-forms.less";
-@import (less) "cfpb-grid.less";
-@import (less) "cfpb-icons.less";
-@import (less) "cfpb-layout.less";
-@import (less) "cfpb-typography.less";
+@import (reference) "cfpb-core.less";
+@import (reference) "cfpb-buttons.less";
+@import (reference) "cfpb-forms.less";
+@import (reference) "cfpb-grid.less";
+@import (reference) "cfpb-icons.less";
+@import (reference) "cfpb-layout.less";
+@import (reference) "cfpb-typography.less";
 
 // Import the brand color palette.
 @import (less) "brand-palette.less";

--- a/cfgov/unprocessed/apps/paying-for-college/css/main.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/main.less
@@ -5,7 +5,7 @@
 // This is your project's main Less file.
 // Project-specific Less rules go after the imports.
 
-// Import Capital Framework components.
+// Import Design System components.
 @import (reference) "cfpb-core.less";
 @import (reference) "cfpb-buttons.less";
 @import (reference) "cfpb-forms.less";
@@ -22,10 +22,10 @@
 // use this file as a template for adding web fonts.
 @import (less) 'licensed-fonts.css';
 
-// Override the Capital Framework theme variables with colors from the brand color palette.
+// Override the Design System theme variables with colors from the brand color palette.
 @import (less) "cf-theme-overrides.less";
 
-// Import the Capital Framework enhancements
+// Import the Design System enhancements
 @import (less) "cf-enhancements.less";
 
 // import CFPB nemo theme header and footer styles


### PR DESCRIPTION
Paying for college CSS is importing `cfpb-` less files, which is leading to strange behavior in the header and layout. Instead this PR changes those imports to references so that only the parts required elsewhere will be included.

## Changes

- Paying for College: change less imports to reference.


## How to test this PR

1. Pull branch and run `gulp clean && gulp build`
2. Visit http://localhost:8000/paying-for-college/your-financial-path-to-graduation/ and compare to https://www.consumerfinance.gov/paying-for-college/your-financial-path-to-graduation/


## Screenshots

Before:
<img width="1362" alt="Screen Shot 2021-02-09 at 9 27 45 AM" src="https://user-images.githubusercontent.com/704760/107378238-c4e88980-6ab9-11eb-95d9-a842e1ff5d21.png">

After:
<img width="1346" alt="Screen Shot 2021-02-09 at 9 27 55 AM" src="https://user-images.githubusercontent.com/704760/107378250-c6b24d00-6ab9-11eb-897f-1aa77eefbbfa.png">

Before:
<img width="935" alt="Screen Shot 2021-02-09 at 9 28 11 AM" src="https://user-images.githubusercontent.com/704760/107378256-c74ae380-6ab9-11eb-8bd7-a23f91d9063d.png">

After:
<img width="925" alt="Screen Shot 2021-02-09 at 9 28 19 AM" src="https://user-images.githubusercontent.com/704760/107378258-c7e37a00-6ab9-11eb-9641-78b286a9eb65.png">
