### PR TITLE
Clean up external links when printing

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -1,10 +1,21 @@
+import re
 import unittest
 
 from django.test import TestCase
 
 from core.utils import (
-    extract_answers_from_request, format_file_size, get_body_html,
-    get_link_tags
+    add_link_markup, extract_answers_from_request, format_file_size,
+    get_body_html, get_link_tags
+)
+
+
+VALID_LINK_MARKUP = re.compile(
+r'<a class="a-link a-link__icon" '  # noqa: E122
+   r'data-orig-href="https://example.com(/[\w\.]+)?" '  # noqa: E121
+   r'href="/external-site/\?ext_url=https%3A%2F%2Fexample.com(%2F[\w\.]+)?&amp;signature=\w+">'  # noqa: E501
+    r'<span class="a-link_text">foo</span> '  # noqa: E131
+    r'<svg class="cf-icon-svg".*>.+</svg>'  # noqa: E501
+r'\n?</a>'  # noqa: E122
 )
 
 
@@ -102,4 +113,44 @@ class LinkUtilsTests(TestCase):
         self.assertEqual(
             get_link_tags('outer <a  >inner</a>'),
             ['<a  >inner</a>', ]
+        )
+
+    def test_add_link_markup_invalid(self):
+        tag = 'not a valid tag'
+        path = '/about-us/blog/'
+        self.assertEqual(
+            add_link_markup(tag, path),
+            None
+        )
+
+    def test_add_link_markup_anchor(self):
+        tag = '<a href="/about-us/blog/#anchor">bar</a>'
+        path = '/about-us/blog/'
+        self.assertEqual(
+            add_link_markup(tag, path),
+            '<a class="" href="#anchor">bar</a>'
+        )
+
+    def test_add_link_markup_external(self):
+        tag = '<a href="/external-site/?ext_url=https%3A%2F%2Fexample.com">foo</a>'  # noqa: E501
+        path = '/about-us/blog/'
+        self.assertRegex(
+            add_link_markup(tag, path),
+            VALID_LINK_MARKUP
+        )
+
+    def test_add_link_markup_non_cfpb(self):
+        tag = '<a href="https://example.com">foo</a>'
+        path = '/about-us/blog/'
+        self.assertRegex(
+            add_link_markup(tag, path),
+            VALID_LINK_MARKUP
+        )
+
+    def test_add_link_markup_download(self):
+        tag = '<a href="https://example.com/file.pdf">foo</a>'
+        path = '/about-us/blog/'
+        self.assertRegex(
+            add_link_markup(tag, path),
+            VALID_LINK_MARKUP
         )

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -134,6 +134,8 @@ def add_link_markup(tag, request_path):
         arguments = parse_qs(components.query)
         if 'ext_url' in arguments:
             external_url = arguments['ext_url'][0]
+            # Add original URL for print styles
+            tag['data-orig-href'] = external_url
             # Add the redirect notice as well
             tag['href'] = signed_redirect(external_url)
 
@@ -141,6 +143,8 @@ def add_link_markup(tag, request_path):
         # Sets the icon to indicate you're leaving consumerfinance.gov
         icon = 'external-link'
         if NON_GOV_LINKS.match(tag['href']):
+            # Add original URL for print styles
+            tag['data-orig-href'] = tag['href']
             # Add the redirect notice as well
             tag['href'] = signed_redirect(tag['href'])
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -38,10 +38,20 @@
         content: " (" attr(href) ")";
     }
 
-    a[href^="/"]:not([href*="?authors"]):not([href="/"]):after {
-        // Output root-relative hrefs in parentheses with our domain prepended,
-        // as long as they are not author links or the logo homepage link.
-        content: " (https://www.consumerfinance.gov" attr(href) ")";
+    a[href^="/"]:after {
+        // Output root-relative hrefs in parentheses with our domain prepended.
+        content: " (https://www.cfpb.gov" attr(href) ")";
+    }
+
+    a[href^="/external-site"]:after {
+        // Output original href for links with external site interstitial.
+        content: " (" attr(data-orig-href) ")";
+    }
+
+    a[href="/"]:after,
+    a[href*="?authors"]:after {
+        // Don't append hrefs to the logo or author links.
+        content: none;
     }
 
     a[href^="#"],

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -29,6 +29,11 @@
 */
 
 .respond-to-print({
+    .a-link__icon .a-link_text {
+        border-bottom-style: solid;
+        font-weight: 500;
+    }
+
     a:after {
         word-break: break-all;
     }
@@ -40,7 +45,7 @@
 
     a[href^="/"]:after {
         // Output root-relative hrefs in parentheses with our domain prepended.
-        content: " (https://www.cfpb.gov" attr(href) ")";
+        content: " (cfpb.gov" attr(href) ")";
     }
 
     a[href^="/external-site"]:after {


### PR DESCRIPTION
To improve printed pages' usability, we append link URLs to link text in parentheses. Unfortunately, our external links point to an interstitial page that is long and ugly when printed.

This PR saves the original external URL as a data attribute on the anchor element for later retrieval by our print stylesheet.

See https://github.local/CFGOV/platform/issues/3812

## Additions

- `data-orig-href` attribute to keep track of original external URL.

## Changes

- Replaced `consumerfinance.gov` in relative URLs with the shorter `cfpb.gov`.
- The `:not()` pseudo-classes were increasing the specificity of their rule and overriding the latter `a[href^="/external-site"]` rule so I split them out.

## How to test this PR

1. [Emulate print media queries](https://developers.google.com/web/tools/chrome-devtools/css/print-preview) in Chrome.
1. Visit a page with a mix of different link types like our [coronavirus](http://0.0.0.0:8000/coronavirus/mortgage-and-housing-assistance/renter-protections/) [pages](http://0.0.0.0:8000/coronavirus/mortgage-and-housing-assistance/after-you-receive-relief/).
1. Verify that external links like LegalFAQ.org show `https://www.legalfaq.org` next to them and not `https://www.consumerfinance.gov/external-site/?ext_url=https%3A%2F%2Fwww.legalfaq.org&signature=XXXXXXXXXXXXXXXX`

## Screenshots

| before | after |
|--------|-------|
| <img width="796" alt="before" src="https://user-images.githubusercontent.com/1060248/107553407-bb871c00-6ba2-11eb-89ad-82fb3f8f8113.png">  | <img width="796" alt="after" src="https://user-images.githubusercontent.com/1060248/107553441-c5a91a80-6ba2-11eb-8bb4-932c0db6b40a.png">  |

## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
