### PR TITLE
Don't auto update Wagtail search indexes in tests

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -106,3 +106,6 @@ if os.getenv('SKIP_DJANGO_MIGRATIONS'):
 
 
     MIGRATION_MODULES = _NoMigrations()
+
+for search_backend_settings in WAGTAILSEARCH_BACKENDS.values():
+    search_backend_settings['AUTO_UPDATE'] = False


### PR DESCRIPTION
By default any configured Wagtail search indexes have `AUTO_UPDATE=True`, meaning that any changes to indexed model instances [get automatically re-indexed](https://docs.wagtail.io/en/stable/topics/search/backends.html#auto-update).

We currently have two Wagtail search indexes configured: a default one using the database backend (which doesn't actually use an index) and a "fulltext" one using the PostgreSQL backend (which does).

Because we have `AUTO_UPDATE` set to its default value of `True`, this latter index gets updated any time a Python test creates or updates a Page model instance. We don't need this functionality because we don't have any tests that rely on it.

Turning of auto update results in a non-trivial speedup to tests. Anecdotally before this change I can run `tox -e unittest-current` in around 3:30-3:40, and after it takes around 3:20-3:30, for a speedup of 10-15 seconds, or roughly 5%.

I've implemented this in a generic way for any backends defined in `settings.WAGTAILSEARCH_BACKENDS` should we add any additional backends in future, for example Elasticsearch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)