### PR TITLE
Add Mouseflow to valid image sources

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -611,6 +611,7 @@ CSP_IMG_SRC = (
     "www.facebook.com",
     "www.gravatar.com",
     "*.qualtrics.com",
+    "*.mouseflow.com",
 )
 
 # These specify what URL's we allow to appear in frames/iframes


### PR DESCRIPTION
In order to view heat maps for cf.gov pages, we need to allow images from Mouseflow's domains.

---

## Additions

- Mouseflow's domains to the list of valid image sources

## How to test this PR

This isn't really testable locally; you have to be logged into the Mouseflow admin to see the heat maps that need images.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)