### PR TITLE
Remove unnecessary use of FilterableListForm

### DIFF
--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -12,7 +12,6 @@ from wagtail.search import index
 from jobmanager.blocks import JobListingList
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
-from v1.forms import FilterableListForm
 from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
 
@@ -97,14 +96,14 @@ class SublandingPage(CFGOVPage):
                         and 'archive' not in p.title.lower()]
         posts_list = []
         for page in filter_pages:
-            eligible_children = AbstractFilterPage.objects.live().filter(
-                CFGOVPage.objects.child_of_q(page)
+            posts_list.extend(
+                AbstractFilterPage.objects.live().filter(
+                    CFGOVPage.objects.child_of_q(page)
+                )
             )
 
-            form = FilterableListForm(filterable_pages=eligible_children,
-                                      wagtail_block=None)
-            for post in form.get_page_set():
-                posts_list.append(post)
-        return sorted(posts_list,
-                      key=lambda p: p.date_published,
-                      reverse=True)[:limit]
+        return sorted(
+            posts_list,
+            key=lambda p: p.date_published,
+            reverse=True
+        )[:limit]


### PR DESCRIPTION
The SublandingPage class has a `get_browsefilterable_posts` method that is used to generate a list of posts to display if the page has a PostPreviewSnapshot module.

There are only two live pages on the site that use this functionality now:

https://www.consumerfinance.gov/compliance/amicus/
https://www.consumerfinance.gov/rules-policy/notice-opportunities-comment/

As part of broader work on filters, this commit removes the use of FilterableListForm here. Invoking the form does nothing because there are no form filters being specified. Removing this use of FLF will make it easier to make changes to that code.

## How to test this PR

You can visit these two pages and confirm that post order doesn't change.

Additionally, I wrote a simple Python script that dumps the list of all SublandingPages on the site (even those that don't have the PostPreviewSnapshot module) and their children as generated by this function. To test, save the following code to `cfgov/v1/management/commands/dump_sublanding_posts.py`, and run `cfgov/manage.py dump_sublanding_posts`. Compare the output on the main branch and on this one. There is only one slight difference caused by arbitrary ordering of posts published on the same day (see internal issue platform#3504 that discusses this).

```py
import sys
from operator import attrgetter

from django.core.management.base import BaseCommand

from wagtail.core.models import Page

from v1.models import SublandingPage


class Command(BaseCommand):
    def handle(self, *args, **kwargs):
        for page in SublandingPage.objects.order_by('pk'):
            print(f'{page.pk}:')

            posts = page.get_browsefilterable_posts(limit=sys.maxsize)
            for post in posts:
                print(f'\t{post.pk}, published {post.date_published}')
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)