### PR TITLE
Use unittest.mock instead of mock package

### DIFF
--- a/cfgov/agreements/tests/test_legacy.py
+++ b/cfgov/agreements/tests/test_legacy.py
@@ -1,11 +1,10 @@
 import random
+from unittest.mock import patch
 
 from django.core.paginator import Page
 from django.http import HttpResponse
 from django.test import TestCase
 from django.urls import reverse
-
-from mock import patch
 
 from agreements import models
 

--- a/cfgov/agreements/tests/test_management.py
+++ b/cfgov/agreements/tests/test_management.py
@@ -2,13 +2,12 @@ import io
 import os.path
 import unittest
 import zipfile
+from unittest import mock
 from zipfile import ZipFile
 
 from django.core import management
 from django.core.management.base import CommandError
 from django.test import TestCase
-
-import mock
 
 from agreements.management.commands import _util
 from agreements.management.commands.import_agreements import empty_folder_test

--- a/cfgov/alerts/tests/test_github_alert.py
+++ b/cfgov/alerts/tests/test_github_alert.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import patch
 
 from django.test import TestCase
 
 import github3
-from mock import patch
 
 from alerts.github_alert import GithubAlert
 

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -1,11 +1,10 @@
 import logging
 import os
+from unittest.mock import patch
 
 from django.conf import settings
 from django.http import QueryDict
 from django.test import RequestFactory, TestCase
-
-from mock import patch
 
 
 class ObjectThatCantBeRepresented(object):

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import patch
 
 from django.test import TestCase
-
-from mock import patch
 
 from alerts.mattermost_alert import MattermostAlert
 

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -1,8 +1,8 @@
 import datetime
 import time
 import unittest
+from unittest import mock
 
-import mock
 import requests
 
 from alerts.newrelic_alerts import NewRelicAlertViolations

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+from unittest.mock import patch
 
 from django.test import TestCase
 
 import github3
-from mock import patch
 
 from alerts.github_alert import GithubAlert
 from alerts.mattermost_alert import MattermostAlert

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -1,7 +1,6 @@
 import unittest
 from io import TextIOBase
-
-import mock
+from unittest import mock
 
 from alerts.send_new_relic_messages_to_sqs import (
     cache_known_violations, read_known_violations

--- a/cfgov/alerts/tests/test_sqs_queue.py
+++ b/cfgov/alerts/tests/test_sqs_queue.py
@@ -1,7 +1,7 @@
 import unittest
+from unittest import mock
 
 import boto3
-import mock
 
 from alerts.sqs_queue import SQSQueue
 

--- a/cfgov/ask_cfpb/tests/test_documents.py
+++ b/cfgov/ask_cfpb/tests/test_documents.py
@@ -1,4 +1,6 @@
 # Based on https://github.com/django-es/django-elasticsearch-dsl/blob/master/tests/test_documents.py  # noqa
+from unittest.mock import patch
+
 from django.apps import apps
 from django.db import models
 from django.test import TestCase
@@ -8,7 +10,6 @@ from wagtail.core.models import Site
 from django_elasticsearch_dsl import fields
 from django_elasticsearch_dsl.documents import DocType
 from django_elasticsearch_dsl.exceptions import ModelFieldNotMappedError
-from mock import patch
 from model_bakery import baker
 
 from ask_cfpb.documents import AnswerPageDocument

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -1,12 +1,11 @@
 import json
 import unittest
+from unittest import mock
 
 from django.apps import apps
 from django.http import Http404, HttpRequest, QueryDict
 from django.test import TestCase, override_settings
 from django.urls import reverse
-
-import mock
 
 from ask_cfpb.documents import AnswerPageDocument
 from ask_cfpb.models import ENGLISH_PARENT_SLUG, SPANISH_PARENT_SLUG

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.apps import apps
 from django.http import Http404, HttpRequest
 from django.test import TestCase
@@ -6,7 +8,6 @@ from django.utils import timezone
 from wagtail.core.models import Site
 from wagtailsharing.models import SharingSite
 
-import mock
 from model_bakery import baker
 
 from ask_cfpb.models import (

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -1,9 +1,8 @@
 from importlib import reload
+from unittest import mock
 
 import django
 from django.test import RequestFactory, TestCase, override_settings
-
-import mock
 
 from cfgov import urls
 

--- a/cfgov/core/tests/test_govdelivery.py
+++ b/cfgov/core/tests/test_govdelivery.py
@@ -1,9 +1,9 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
 
 import requests
-from mock import patch
 
 from core.govdelivery import (
     ExceptionMockGovDelivery, LoggingMockGovDelivery, MockGovDelivery,

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
 
 from django.http import HttpResponse
 from django.test import (
@@ -6,7 +7,6 @@ from django.test import (
 )
 from django.utils import translation
 
-import mock
 from bs4 import BeautifulSoup
 
 from core.middleware import (

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -1,12 +1,12 @@
 import json
 import re
+from unittest.mock import Mock, patch
 from urllib.parse import urlencode
 
 from django.http import Http404, QueryDict
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
-from mock import Mock, patch
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 from core.govdelivery import MockGovDelivery

--- a/cfgov/data_research/tests/test_mortgage_utilities.py
+++ b/cfgov/data_research/tests/test_mortgage_utilities.py
@@ -1,6 +1,6 @@
-import django
+from unittest import mock
 
-import mock
+import django
 
 from data_research.models import MortgageDataConstant
 from data_research.mortgage_utilities.fips_meta import load_constants

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -3,10 +3,10 @@ import datetime
 import tempfile
 import unittest
 from io import StringIO
+from unittest import mock
 
 import django
 
-import mock
 from dateutil import parser
 from model_bakery import baker
 

--- a/cfgov/deployable_zipfile/tests/test_create.py
+++ b/cfgov/deployable_zipfile/tests/test_create.py
@@ -2,10 +2,8 @@ import os
 import shutil
 import sys
 import tempfile
-from unittest import TestCase
+from unittest import TestCase, mock
 from zipfile import ZipFile
-
-import mock
 
 from deployable_zipfile.create import create_zipfile, save_wheels
 

--- a/cfgov/deployable_zipfile/tests/test_extract.py
+++ b/cfgov/deployable_zipfile/tests/test_extract.py
@@ -1,9 +1,7 @@
 import os
 import shutil
 import tempfile
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from deployable_zipfile.extract import (
     extract_zipfile, locate_virtualenv_site_packages

--- a/cfgov/deployable_zipfile/tests/test_install_wheels.py
+++ b/cfgov/deployable_zipfile/tests/test_install_wheels.py
@@ -1,9 +1,7 @@
 import os
 import shutil
 import tempfile
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from deployable_zipfile.install_wheels import install_wheels
 

--- a/cfgov/deployable_zipfile/tests/test_loadenv.py
+++ b/cfgov/deployable_zipfile/tests/test_loadenv.py
@@ -3,8 +3,7 @@ import os
 import shutil
 import tempfile
 import unittest
-
-import mock
+from unittest import mock
 
 from deployable_zipfile.loadenv import loadenv
 

--- a/cfgov/housing_counselor/tests/management/test_geocoder.py
+++ b/cfgov/housing_counselor/tests/management/test_geocoder.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
-
-from mock import patch
+from unittest.mock import patch
 
 from housing_counselor.geocoder import (
     BulkZipCodeGeocoder, ZipCodeBasedCounselorGeocoder, geocode_counselors

--- a/cfgov/housing_counselor/tests/test_views.py
+++ b/cfgov/housing_counselor/tests/test_views.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 from django.test import TestCase, override_settings
 
-import mock
 import requests
 
 from housing_counselor.views import (

--- a/cfgov/jobmanager/tests/models/test_panels.py
+++ b/cfgov/jobmanager/tests/models/test_panels.py
@@ -1,11 +1,11 @@
 import unittest
+from unittest.mock import Mock
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from wagtail.core.models import Locale, Page
 
-from mock import Mock
 from model_bakery import baker
 
 from jobmanager.models.django import ApplicantType, Grade

--- a/cfgov/jobmanager/tests/test_signals.py
+++ b/cfgov/jobmanager/tests/test_signals.py
@@ -1,8 +1,7 @@
 from datetime import date
+from unittest.mock import patch
 
 from django.test import TestCase
-
-from mock import patch
 
 from jobmanager.models.django import JobCategory
 from jobmanager.models.pages import JobListingPage

--- a/cfgov/legacy/tests/views/test_complaint.py
+++ b/cfgov/legacy/tests/views/test_complaint.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from django.test import RequestFactory, TestCase, override_settings
 
 from complaint_search import views as ComplaintViews
-from mock import patch
 from rest_framework.response import Response
 
 from legacy.views.complaint import ComplaintLandingView

--- a/cfgov/paying_for_college/tests/test_load_programs.py
+++ b/cfgov/paying_for_college/tests/test_load_programs.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
 from unittest.mock import mock_open, patch
 
 import django
-
-import mock
 
 from paying_for_college.disclosures.scripts.load_programs import (
     clean, clean_number_as_string, clean_string_as_string, get_school, load,

--- a/cfgov/paying_for_college/tests/test_search.py
+++ b/cfgov/paying_for_college/tests/test_search.py
@@ -1,9 +1,8 @@
 import json
+from unittest import mock
 
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
-
-import mock
 
 from paying_for_college.documents import SchoolDocument
 from paying_for_college.models import School

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -1,12 +1,11 @@
 import copy
 import json
 import unittest
+from unittest import mock
 
 import django
 from django.http import HttpRequest
 from django.urls import reverse
-
-import mock
 
 from paying_for_college.models import Program, School
 from paying_for_college.views import (

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -2,11 +2,11 @@
 import datetime
 import json
 import unittest
+from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase as DjangoTestCase
 
-import mock
 from bs4 import BeautifulSoup as bS
 from requests import Response
 

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -1,5 +1,6 @@
 import datetime
 import unittest
+from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ValidationError
@@ -11,7 +12,6 @@ from django.test import (
 
 from wagtail.core.models import Site
 
-import mock
 from model_bakery import baker
 
 from core.testutils.mock_cache_backend import CACHE_PURGED_URLS

--- a/cfgov/regulations3k/tests/test_scripts.py
+++ b/cfgov/regulations3k/tests/test_scripts.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
 
 from django.test import TestCase
-
-import mock
 
 from regulations3k.models import Section
 from regulations3k.scripts.insert_section_links import (

--- a/cfgov/regulations3k/tests/test_search_indexes.py
+++ b/cfgov/regulations3k/tests/test_search_indexes.py
@@ -1,7 +1,7 @@
+from unittest import mock
+
 from django.core.management import call_command
 from django.test import TestCase
-
-import mock
 
 from regulations3k.management.commands import update_regulation_index
 from regulations3k.models import Section, SectionParagraph

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -1,7 +1,7 @@
 """Test the deployment http and static resource smoke tests."""
 import unittest
+from unittest import mock
 
-import mock
 import requests
 
 from scripts import static_asset_smoke_test

--- a/cfgov/scripts/tests/test_unpublish_closed_jobs.py
+++ b/cfgov/scripts/tests/test_unpublish_closed_jobs.py
@@ -1,10 +1,10 @@
 import json
 from datetime import date
+from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
 import requests
-from mock import Mock, patch
 
 from jobmanager.models.django import ApplicantType, JobCategory
 from jobmanager.models.pages import JobListingPage

--- a/cfgov/search/tests/test_dotgov.py
+++ b/cfgov/search/tests/test_dotgov.py
@@ -1,6 +1,6 @@
-from django.test import TestCase
+from unittest import mock
 
-import mock
+from django.test import TestCase
 
 from search.dotgov import search, typeahead
 

--- a/cfgov/v1/tests/handlers/blocks/test_feedback.py
+++ b/cfgov/v1/tests/handlers/blocks/test_feedback.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
 
 from django.test import RequestFactory, TestCase
-
-import mock
 
 from v1.handlers.blocks.feedback import FeedbackHandler, get_feedback_type
 from v1.models import CFGOVPage, Feedback

--- a/cfgov/v1/tests/handlers/test_handler.py
+++ b/cfgov/v1/tests/handlers/test_handler.py
@@ -1,6 +1,4 @@
-from unittest import TestCase
-
-import mock
+from unittest import TestCase, mock
 
 from ...handlers import Handler
 

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -1,10 +1,10 @@
+from unittest.mock import patch
+
 from django.core.cache import cache, caches
 from django.template import engines
 from django.test import Client, TestCase, override_settings
 
 from wagtail.core.blocks import StreamValue
-
-from mock import patch
 
 from scripts import _atomic_helpers as atomic
 from v1.models.blog_page import BlogPage

--- a/cfgov/v1/tests/management/commands/test_delete_all_pages.py
+++ b/cfgov/v1/tests/management/commands/test_delete_all_pages.py
@@ -1,7 +1,7 @@
+from unittest import mock
+
 from django.core.management import call_command
 from django.test import TestCase, override_settings
-
-import mock
 
 
 @override_settings(

--- a/cfgov/v1/tests/management/commands/test_invalidate_all_pages.py
+++ b/cfgov/v1/tests/management/commands/test_invalidate_all_pages.py
@@ -1,7 +1,7 @@
+from unittest import mock
+
 from django.core.management import call_command
 from django.test import TestCase, override_settings
-
-import mock
 
 
 @override_settings(

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -1,6 +1,6 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-from mock import patch
+from django.test import TestCase
 
 from v1.models.base import CFGOVPage
 

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -1,4 +1,5 @@
 import json
+from unittest import mock
 
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -8,8 +9,6 @@ from django.test.client import RequestFactory
 
 from wagtail.core import blocks
 from wagtail.core.models import Site
-
-import mock
 
 from v1.models import (
     AbstractFilterPage, BrowsePage, CFGOVPage, LandingPage, SublandingPage

--- a/cfgov/v1/tests/models/test_filterable_list_mixins.py
+++ b/cfgov/v1/tests/models/test_filterable_list_mixins.py
@@ -1,9 +1,9 @@
+from unittest import mock
+
 from django.test import RequestFactory, TestCase
 
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Site
-
-import mock
 
 from scripts._atomic_helpers import filter_controls
 from v1.models import BlogPage

--- a/cfgov/v1/tests/models/test_images.py
+++ b/cfgov/v1/tests/models/test_images.py
@@ -1,10 +1,10 @@
+from unittest.mock import Mock, patch
+
 from django.db import IntegrityError
 from django.test import TestCase
 
 from wagtail.images.models import Filter
 from wagtail.images.tests.utils import get_test_image_file
-
-from mock import Mock, patch
 
 from v1.models.images import CFGOVImage, CFGOVRendition
 

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -1,9 +1,7 @@
 import datetime as dt
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from wagtail.core.blocks import StreamValue
-
-import mock
 
 from scripts import _atomic_helpers as atomic
 from v1.models import AbstractFilterPage, BrowseFilterablePage, SublandingPage

--- a/cfgov/v1/tests/test_admin_views.py
+++ b/cfgov/v1/tests/test_admin_views.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission, User
@@ -8,8 +9,6 @@ from django.urls import reverse
 
 from wagtail.core.models import Site
 from wagtail.tests.testapp.models import SimplePage
-
-import mock
 
 from v1.admin_views import ExportFeedbackView
 from v1.tests.wagtail_pages.helpers import save_new_page

--- a/cfgov/v1/tests/test_auth_forms.py
+++ b/cfgov/v1/tests/test_auth_forms.py
@@ -1,7 +1,7 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.test import TestCase
-
-from mock import patch
 
 from v1.auth_forms import UserCreationForm, UserEditForm
 

--- a/cfgov/v1/tests/test_blocks.py
+++ b/cfgov/v1/tests/test_blocks.py
@@ -1,8 +1,8 @@
+from unittest import mock
+
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.utils.safestring import SafeText
-
-import mock
 
 from v1.blocks import AbstractFormBlock, AnchorLink, PlaceholderCharBlock
 

--- a/cfgov/v1/tests/test_email.py
+++ b/cfgov/v1/tests/test_email.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import User
 from django.core import mail
 from django.http import HttpRequest
@@ -5,7 +7,6 @@ from django.test import TestCase
 
 from wagtail.core.models import Site
 
-from mock import patch
 from model_bakery import baker
 
 from v1.email import create_request_for_email, send_password_reset_email

--- a/cfgov/v1/tests/test_forms.py
+++ b/cfgov/v1/tests/test_forms.py
@@ -1,8 +1,7 @@
 import datetime
+from unittest import mock
 
 from django.test import TestCase
-
-import mock
 
 from v1.forms import FilterableDateField, FilterableListForm
 

--- a/cfgov/v1/tests/test_password_policy.py
+++ b/cfgov/v1/tests/test_password_policy.py
@@ -1,12 +1,11 @@
 from datetime import timedelta
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils import timezone
-
-from mock import Mock, patch
 
 from v1.models import PasswordHistoryItem
 from v1.util import password_policy

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 from django.test import (
     RequestFactory, SimpleTestCase, TestCase, override_settings
@@ -8,8 +9,6 @@ from wagtail.core.models import Site
 from wagtail.core.whitelist import Whitelister as Allowlister
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
-
-import mock
 
 from v1.models.base import CFGOVPage
 from v1.models.resources import Resource

--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
+
 from django.apps import apps
 from django.test import SimpleTestCase, TestCase
 
 from wagtail.core import blocks
 from wagtail.core.models import Page
 from wagtail.tests.testapp.models import StreamPage
-
-import mock
 
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.migrations import (

--- a/cfgov/v1/tests/util/test_util.py
+++ b/cfgov/v1/tests/util/test_util.py
@@ -1,8 +1,7 @@
 from datetime import date
+from unittest import mock
 
 from django.test import TestCase
-
-import mock
 
 from v1.models import BrowseFilterablePage, BrowsePage, CFGOVPage, HomePage
 from v1.tests.wagtail_pages import helpers

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@ coverage==4.5.1
 django-sslserver==0.20
 freezegun==0.3.12
 github3.py==0.9.6
-mock==2.0.0
 model-bakery==1.1.0
 moto==1.3.6
 pip==18.1


### PR DESCRIPTION
Currently we install the [mock](https://pypi.org/project/mock/) package as part of our test requirements. Starting in Python 3.3, this package is part of the standard library as [`unittest.mock`](https://docs.python.org/3/library/unittest.mock.html).

This commit replaces all uses of `mock` with `unittest.mock` and removes the test dependency on the external package.

## How to test this PR

All tests pass!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)