### PR TITLE
Elasticsearch-based filters suggestions

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -1,7 +1,9 @@
 import re
+import sys
 from unittest.mock import patch
 
 from django.conf import settings
+from django.core.management import call_command
 
 from elasticsearch_dsl import analyzer, token_filter, tokenizer
 
@@ -73,27 +75,37 @@ def environment_specific_index(base_name):
         return f'{settings.DEPLOY_ENVIRONMENT}-{base_name}'
 
 
-# https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-refresh.html
-class WaitForElasticsearchMixin:
-    """Test case mixin that makes Elasticsearch bulk updates blocking."""
-    @classmethod
-    def setUpClass(cls):
-        from elasticsearch.helpers import bulk as original_bulk
+def rebuild_elasticsearch_index(*models, stdout=sys.stdout):
+    """Rebuild an Elasticsearch index, waiting for its completion.
 
-        def bulk_wait_for_refresh(*args, **kwargs):
-            kwargs.setdefault('refresh', 'wait_for')
-            return original_bulk(*args, **kwargs)
+    This method is an alias for the built-in search_index Django management
+    command provided by django-elasticsearch-dsl.
 
-        cls.patched_es_bulk = patch(
-            'django_elasticsearch_dsl.documents.bulk',
-            new=bulk_wait_for_refresh
+    That command does not currently provide a way to make the indexing
+    blocking. This method patches the Elasticsearch bulk API call to ensure
+    that the reindex is immediately available in search results.
+
+    See the Elasticsearch documentation on refresh:
+    https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-refresh.html # noqa
+
+    See https://github.com/django-es/django-elasticsearch-dsl/pull/323 for
+    a proposed pull request to django-elasticsearch-dsl to support this
+    blocking behavior.
+    """
+    from elasticsearch.helpers import bulk as original_bulk
+
+    def bulk_wait_for_refresh(*args, **kwargs):
+        kwargs.setdefault('refresh', 'wait_for')
+        return original_bulk(*args, **kwargs)
+
+    with patch(
+        'django_elasticsearch_dsl.documents.bulk',
+        new=bulk_wait_for_refresh
+    ):
+        call_command(
+            'search_index',
+            action='rebuild',
+            force=True,
+            models=models,
+            stdout=stdout
         )
-        cls.patched_es_bulk.start()
-
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.patched_es_bulk.stop()
-
-        super().tearDownClass()

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -1,5 +1,3 @@
-from django.core.exceptions import FieldDoesNotExist
-
 from django_elasticsearch_dsl import Document, fields
 from django_elasticsearch_dsl.registries import registry
 
@@ -27,7 +25,6 @@ class FilterablePagesDocument(Document):
     })
     title = fields.TextField(attr='title')
     is_archived = fields.KeywordField(attr='is_archived')
-    content = fields.TextField()
     date_published = fields.DateField(attr='date_published')
     url = fields.KeywordField()
     start_dt = fields.DateField()
@@ -37,18 +34,6 @@ class FilterablePagesDocument(Document):
 
     def get_queryset(self):
         return AbstractFilterPage.objects.live().public()
-
-    def prepare_content(self, instance):
-        try:
-            content_field = instance._meta.get_field('content')
-            value = content_field.value_from_object(instance)
-            content = content_field.get_searchable_content(value)
-            content = content.pop()
-            return content
-        except FieldDoesNotExist:
-            return None
-        except IndexError:
-            return None
 
     def prepare_url(self, instance):
         return instance.url

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -33,29 +33,29 @@ class FilterablePagesDocument(Document):
     initial_filing_date = fields.DateField()
 
     def get_queryset(self):
-        return AbstractFilterPage.objects.live().public()
+        return AbstractFilterPage.objects.live().public().specific()
 
     def prepare_url(self, instance):
         return instance.url
 
     def prepare_start_dt(self, instance):
-        return getattr(instance.specific, 'start_dt', None)
+        return getattr(instance, 'start_dt', None)
 
     def prepare_end_dt(self, instance):
-        return getattr(instance.specific, 'end_dt', None)
+        return getattr(instance, 'end_dt', None)
 
     def prepare_statuses(self, instance):
-        statuses = getattr(instance.specific, 'statuses', None)
+        statuses = getattr(instance, 'statuses', None)
         if statuses is not None:
             return [status.status for status in statuses.all()]
         else:
             return None
 
     def prepare_initial_filing_date(self, instance):
-        return getattr(instance.specific, 'initial_filing_date', None)
+        return getattr(instance, 'initial_filing_date', None)
 
     def get_instances_from_related(self, related_instance):
-        # Related instances all inherit from AbstractFilerPage
+        # Related instances all inherit from AbstractFilterPage.
         return related_instance
 
     class Django:

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -1,8 +1,5 @@
-from io import StringIO
-
-from django.core import management
 from django.core.exceptions import ValidationError
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import SimpleTestCase, TestCase
 
 from wagtail.core.blocks import StreamValue
 
@@ -19,13 +16,7 @@ from v1.models.sublanding_page import SublandingPage
 from v1.tests.wagtail_pages.helpers import publish_page, save_new_page
 
 
-@override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
 class MoleculesTestCase(TestCase):
-
-    @classmethod
-    def setUpTestData(cls):
-        # Create a clean index for the test suite
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
 
     def test_text_intro(self):
         """Text introduction value correctly displays on a Browse Filterable Page"""

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -1,33 +1,26 @@
+import json
 from io import StringIO
+from unittest.mock import patch
 
-from django.core import management
 from django.core.cache import cache, caches
 from django.template import engines
 from django.test import Client, TestCase, override_settings
 
-from wagtail.core.blocks import StreamValue
-
-from mock import patch
-
 from scripts import _atomic_helpers as atomic
-from search.elasticsearch_helpers import WaitForElasticsearchMixin
+from search.elasticsearch_helpers import rebuild_elasticsearch_index
 from v1.models.blog_page import BlogPage
 from v1.models.browse_filterable_page import BrowseFilterablePage
 from v1.tests.wagtail_pages.helpers import publish_page
 
 
 @override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
-class TestFragmentCacheExtension(WaitForElasticsearchMixin, TestCase):
+class TestFragmentCacheExtension(TestCase):
     def test_cache_gets_called_when_visiting_filterable_page(self):
         # Create a filterable page
         page = BrowseFilterablePage(
             title='test browse filterable page',
-            slug='test-browse-filterable-page'
-        )
-        page.content = StreamValue(
-            page.content.stream_block,
-            [atomic.filter_controls],
-            True
+            slug='test-browse-filterable-page',
+            content=json.dumps([atomic.filter_controls])
         )
         publish_page(page)
 
@@ -38,8 +31,8 @@ class TestFragmentCacheExtension(WaitForElasticsearchMixin, TestCase):
             slug='test-blog-page'
         )
         page.add_child(instance=child_page)
-        # Index new page
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
+
+        rebuild_elasticsearch_index('v1', stdout=StringIO())
 
         cache = caches['post_preview']
         with patch.object(cache, 'add') as add_to_cache:

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -1,43 +1,46 @@
 import datetime as dt
+import json
 from io import StringIO
 
-from django.core import management
 from django.test import TestCase, override_settings
 
 from wagtail.core.blocks import StreamValue
 
-import mock
-
 from scripts import _atomic_helpers as atomic
-from search.elasticsearch_helpers import WaitForElasticsearchMixin
+from search.elasticsearch_helpers import rebuild_elasticsearch_index
 from v1.models import AbstractFilterPage, BrowseFilterablePage, SublandingPage
 from v1.tests.wagtail_pages import helpers
 
 
 @override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
-class SublandingPageTestCase(WaitForElasticsearchMixin, TestCase):
+class SublandingPageTestCase(TestCase):
     """
     This test case checks that the browse-filterable posts of a sublanding
     page are properly retrieved.
     """
     def setUp(self):
-        self.request = mock.MagicMock()
         self.limit = 10
         self.sublanding_page = SublandingPage(title='title')
 
         helpers.publish_page(child=self.sublanding_page)
-        self.post1 = BrowseFilterablePage(title='post 1')
-        self.post2 = BrowseFilterablePage(title='post 2')
-        # the content of this post has both a full_width_text
-        # and a filter_controls
-        self.post1.content = StreamValue(self.post1.content.stream_block,
-                                         [atomic.full_width_text, atomic.filter_controls],
-                                         True)
-        # this one only has a filter_controls
-        self.post2.content = StreamValue(self.post1.content.stream_block,
-                                         [atomic.filter_controls], True)
 
+        # This post has both a FullWidthText and a FilterableList.
+        self.post1 = BrowseFilterablePage(
+            title='post 1',
+            content=json.dumps([
+                atomic.full_width_text,
+                atomic.filter_controls
+            ])
+        )
         helpers.save_new_page(self.post1, self.sublanding_page)
+
+        # This one only has a FilterableList.
+        self.post2 = BrowseFilterablePage(
+            title='post 2',
+            content=json.dumps([
+                atomic.filter_controls
+            ])
+        )
         helpers.save_new_page(self.post2, self.sublanding_page)
 
         # manually set the publication date of the posts to ensure consistent
@@ -54,12 +57,7 @@ class SublandingPageTestCase(WaitForElasticsearchMixin, TestCase):
         helpers.save_new_page(self.child2_of_post1, self.post1)
         helpers.save_new_page(self.child1_of_post2, self.post2)
 
-        # Create a clean index for the test suite
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
-
-    def tearDown(self):
-
-        pass
+        rebuild_elasticsearch_index('v1', stdout=StringIO())
 
     def test_get_appropriate_descendants(self):
         """

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 from io import StringIO
 
-from django.core import management
 from django.test import TestCase
 
 from wagtail.core.models import Site
@@ -11,7 +10,7 @@ import dateutil.relativedelta
 from dateutil.relativedelta import relativedelta
 from pytz import timezone
 
-from search.elasticsearch_helpers import WaitForElasticsearchMixin
+from search.elasticsearch_helpers import rebuild_elasticsearch_index
 from v1.documents import (
     EnforcementActionFilterablePagesDocumentSearch,
     EventFilterablePagesDocumentSearch, FilterablePagesDocument,
@@ -108,7 +107,7 @@ class FilterablePagesDocumentTest(TestCase):
         self.assertEqual(prepared_data['statuses'], ['expired-terminated-dismissed'])
 
 
-class FilterablePagesDocumentSearchTest(WaitForElasticsearchMixin, TestCase):
+class FilterablePagesDocumentSearchTest(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -138,8 +137,7 @@ class FilterablePagesDocumentSearchTest(WaitForElasticsearchMixin, TestCase):
         cls.enforcement = enforcement
         cls.blog = blog
 
-        # Create a clean index for the test suite
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
+        rebuild_elasticsearch_index('v1', stdout=StringIO())
 
     def test_search_event_all_fields(self):
         to_date_dt = datetime(2021, 3, 16)

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -38,16 +38,13 @@ class FilterablePagesDocumentTest(TestCase):
 
     def test_fields_populated(self):
         mapping = FilterablePagesDocument._doc_type.mapping
-        self.assertEqual(
-            set(mapping.properties.properties.to_dict().keys()),
-            set(
-                [
-                    'tags', 'categories', 'authors',
-                    'title', 'url', 'is_archived',
-                    'content', 'date_published', 'start_dt',
-                    'end_dt', 'statuses', 'initial_filing_date'
-                ]
-            )
+        self.assertCountEqual(
+            mapping.properties.properties.to_dict().keys(),
+            [
+                'tags', 'categories', 'authors', 'title', 'url',
+                'is_archived', 'date_published', 'start_dt', 'end_dt',
+                'statuses', 'initial_filing_date'
+            ]
         )
 
     def test_get_queryset(self):
@@ -57,42 +54,6 @@ class FilterablePagesDocumentTest(TestCase):
         )
         qs = FilterablePagesDocument().get_queryset()
         self.assertFalse(qs.filter(title=test_event.title).exists())
-
-    def test_prepare_content_no_content_defined(self):
-        event = EventPage(
-            title='Event Test',
-            start_dt=datetime.now(timezone('UTC'))
-        )
-        doc = FilterablePagesDocument()
-        prepared_data = doc.prepare(event)
-        self.assertIsNone(prepared_data['content'])
-
-    def test_prepare_content_exists(self):
-        blog = BlogPage(
-            title='Test Blog',
-            content=json.dumps([
-                {
-                    'type': 'full_width_text',
-                    'value': [
-                        {
-                            'type':'content',
-                            'value': 'Blog Text'
-                    }]
-                }
-            ])
-        )
-        doc = FilterablePagesDocument()
-        prepared_data = doc.prepare(blog)
-        self.assertEqual(prepared_data['content'], 'Blog Text')
-
-    def test_prepare_content_empty(self):
-        blog = BlogPage(
-            title='Test Blog',
-            content=json.dumps([])
-        )
-        doc = FilterablePagesDocument()
-        prepared_data = doc.prepare(blog)
-        self.assertIsNone(prepared_data['content'])
 
     def test_prepare_statuses(self):
         enforcement = EnforcementActionPage(

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 from io import StringIO
 
-from django.core import management
 from django.test import TestCase, override_settings
 
 from pytz import timezone
 
-from search.elasticsearch_helpers import WaitForElasticsearchMixin
+from search.elasticsearch_helpers import rebuild_elasticsearch_index
 from v1.forms import FilterableListForm
 from v1.models import BlogPage
 from v1.models.base import CFGOVPageCategory
@@ -16,11 +15,10 @@ from v1.util.categories import clean_categories
 
 
 @override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
-class TestFilterableListForm(WaitForElasticsearchMixin, TestCase):
-    
+class TestFilterableListForm(TestCase):
+
     @classmethod
     def setUpTestData(cls):
-
         blog1 = BlogPage(title='test page')
         blog1.categories.add(CFGOVPageCategory(name='foo'))
         blog1.categories.add(CFGOVPageCategory(name='bar'))
@@ -55,8 +53,141 @@ class TestFilterableListForm(WaitForElasticsearchMixin, TestCase):
         cls.cool_event = cool_event
         cls.awesome_event = awesome_event
 
-        # Create a clean index for the test suite
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
+        rebuild_elasticsearch_index('v1', stdout=StringIO())
+
+    def setUpFilterableForm(self, data=None):
+        filterable_pages = AbstractFilterPage.objects.live()
+        form = FilterableListForm(
+            filterable_pages=filterable_pages,
+            wagtail_block=None,
+            filterable_root='/',
+            filterable_categories=None
+        )
+        form.is_bound = True
+        form.cleaned_data = data
+        return form
+
+    def test_filter_by_category(self):
+        form = self.setUpFilterableForm(data={'categories': ['foo']})
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, self.blog1)
+
+    def test_filter_by_nonexisting_category(self):
+        form = self.setUpFilterableForm(data={'categories': ['test filter']})
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 0)
+
+    def test_filter_by_tags(self):
+        form = self.setUpFilterableForm(data={'topics': ['foo', 'bar']})
+        page_set_pks = form.get_page_set().values_list('pk', flat=True)
+        self.assertEqual(len(page_set_pks), 2)
+        self.assertIn(self.blog1.pk, page_set_pks)
+        self.assertIn(self.event1.pk, page_set_pks)
+
+    def test_filter_doesnt_return_drafts(self):
+        page2 = BlogPage(title='test page 2')
+        page2.tags.add('foo')
+        # Don't publish new page
+        form = self.setUpFilterableForm(data={'topics': ['foo']})
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, self.blog1)
+
+    def test_filter_by_author_names(self):
+        form = self.setUpFilterableForm(data={'authors': ['sarah-simpson']})
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, self.blog1)
+
+    def test_filter_by_title(self):
+        form = self.setUpFilterableForm(data={'title': 'Cool'})
+        page_set = form.get_page_set()
+        self.assertEqual(len(page_set), 1)
+        self.assertEqual(page_set[0].specific, self.cool_event)
+
+    def test_validate_date_after_1900_can_pass(self):
+        form = self.setUpFilterableForm()
+        form.data = {'from_date': '1/1/1900', 'archived': 'exclude'}
+        self.assertTrue(form.is_valid())
+
+    def test_validate_date_after_1900_can_fail(self):
+        form = self.setUpFilterableForm()
+        form.data = {'from_date': '12/31/1899'}
+        self.assertFalse(form.is_valid())
+        self.assertIn('from_date', form._errors)
+
+    def test_clean_categories_converts_blog_subcategories_correctly(self):
+        form = self.setUpFilterableForm()
+        form.data = {'categories': ['blog']}
+        clean_categories(selected_categories=form.data.get('categories'))
+        self.assertEqual(
+            form.data['categories'],
+            [
+                'blog',
+                'at-the-cfpb',
+                'directors-notebook',
+                'policy_compliance',
+                'data-research-reports',
+                'info-for-consumers'
+            ]
+        )
+
+    def test_clean_categories_converts_reports_subcategories_correctly(self):
+        form = self.setUpFilterableForm()
+        form.data = {'categories': ['research-reports']}
+        clean_categories(selected_categories=form.data.get('categories'))
+        self.assertEqual(
+            form.data['categories'],
+            [
+                'research-reports',
+                'consumer-complaint',
+                'super-highlight',
+                'data-point',
+                'industry-markets',
+                'consumer-edu-empower',
+                'to-congress',
+            ]
+        )
+
+
+class TestFilterableListFormWithoutElasticsearch(TestCase):
+    
+    @classmethod
+    def setUpTestData(cls):
+        blog1 = BlogPage(title='test page')
+        blog1.categories.add(CFGOVPageCategory(name='foo'))
+        blog1.categories.add(CFGOVPageCategory(name='bar'))
+        blog1.tags.add('foo')
+        blog1.authors.add('richa-agarwal')
+        blog1.authors.add('sarah-simpson')
+        blog2 = BlogPage(title='another test page')
+        blog2.categories.add(CFGOVPageCategory(name='bar'))
+        blog2.tags.add('blah')
+        blog2.authors.add('richard-cordray')
+        event1 = EventPage(
+            title='test page 2',
+            start_dt=datetime.now(timezone('UTC'))
+        )
+        event1.tags.add('bar')
+        cool_event = EventPage(
+            title='Cool Event',
+            start_dt=datetime.now(timezone('UTC'))
+        )
+        awesome_event = EventPage(
+            title='Awesome Event',
+            start_dt=datetime.now(timezone('UTC'))
+        )
+        publish_page(blog1)
+        publish_page(blog2)
+        publish_page(event1)
+        publish_page(cool_event)
+        publish_page(awesome_event)
+        cls.blog1 = blog1
+        cls.blog2 = blog2
+        cls.event1 = event1
+        cls.cool_event = cool_event
+        cls.awesome_event = awesome_event
     
     def setUpFilterableForm(self, data=None):
         filterable_pages = AbstractFilterPage.objects.live()
@@ -153,143 +284,9 @@ class TestFilterableListForm(WaitForElasticsearchMixin, TestCase):
             ]
         )
 
-# @override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
-class TestFilterableListFormNoEs(WaitForElasticsearchMixin, TestCase):
-    
-    @classmethod
-    def setUpTestData(cls):
-
-        blog1 = BlogPage(title='test page')
-        blog1.categories.add(CFGOVPageCategory(name='foo'))
-        blog1.categories.add(CFGOVPageCategory(name='bar'))
-        blog1.tags.add('foo')
-        blog1.authors.add('richa-agarwal')
-        blog1.authors.add('sarah-simpson')
-        blog2 = BlogPage(title='another test page')
-        blog2.categories.add(CFGOVPageCategory(name='bar'))
-        blog2.tags.add('blah')
-        blog2.authors.add('richard-cordray')
-        event1 = EventPage(
-            title='test page 2',
-            start_dt=datetime.now(timezone('UTC'))
-        )
-        event1.tags.add('bar')
-        cool_event = EventPage(
-            title='Cool Event',
-            start_dt=datetime.now(timezone('UTC'))
-        )
-        awesome_event = EventPage(
-            title='Awesome Event',
-            start_dt=datetime.now(timezone('UTC'))
-        )
-        publish_page(blog1)
-        publish_page(blog2)
-        publish_page(event1)
-        publish_page(cool_event)
-        publish_page(awesome_event)
-        cls.blog1 = blog1
-        cls.blog2 = blog2
-        cls.event1 = event1
-        cls.cool_event = cool_event
-        cls.awesome_event = awesome_event
-    
-    def setUpFilterableForm(self, data=None):
-        filterable_pages = AbstractFilterPage.objects.live()
-        form = FilterableListForm(
-            filterable_pages=filterable_pages,
-            wagtail_block=None,
-            filterable_root='/',
-            filterable_categories=None
-        )
-        form.is_bound = True
-        form.cleaned_data = data
-        return form
-
-    def test_filter_by_category(self):
-        form = self.setUpFilterableForm(data={'categories': ['foo']})
-        page_set = form.get_page_set()
-        self.assertEqual(len(page_set), 1)
-        self.assertEqual(page_set[0].specific, self.blog1)
-
-    def test_filter_by_nonexisting_category(self):
-        form = self.setUpFilterableForm(data={'categories': ['test filter']})
-        page_set = form.get_page_set()
-        self.assertEqual(len(page_set), 0)
-
-    def test_filter_by_tags(self):
-        form = self.setUpFilterableForm(data={'topics': ['foo', 'bar']})
-        page_set_pks = form.get_page_set().values_list('pk', flat=True)
-        self.assertEqual(len(page_set_pks), 2)
-        self.assertIn(self.blog1.pk, page_set_pks)
-        self.assertIn(self.event1.pk, page_set_pks)
-
-    def test_filter_doesnt_return_drafts(self):
-        page2 = BlogPage(title='test page 2')
-        page2.tags.add('foo')
-        # Don't publish new page
-        form = self.setUpFilterableForm(data={'topics': ['foo']})
-        page_set = form.get_page_set()
-        self.assertEqual(len(page_set), 1)
-        self.assertEqual(page_set[0].specific, self.blog1)
-
-    def test_filter_by_author_names(self):
-        form = self.setUpFilterableForm(data={'authors': ['sarah-simpson']})
-        page_set = form.get_page_set()
-        self.assertEqual(len(page_set), 1)
-        self.assertEqual(page_set[0].specific, self.blog1)
-
-    def test_filter_by_title(self):
-        form = self.setUpFilterableForm(data={'title': 'Cool'})
-        page_set = form.get_page_set()
-        self.assertEqual(len(page_set), 1)
-        self.assertEqual(page_set[0].specific, self.cool_event)
-
-    def test_validate_date_after_1900_can_pass(self):
-        form = self.setUpFilterableForm()
-        form.data = {'from_date': '1/1/1900', 'archived': 'exclude'}
-        self.assertTrue(form.is_valid())
-
-    def test_validate_date_after_1900_can_fail(self):
-        form = self.setUpFilterableForm()
-        form.data = {'from_date': '12/31/1899'}
-        self.assertFalse(form.is_valid())
-        self.assertIn('from_date', form._errors)
-
-    def test_clean_categories_converts_blog_subcategories_correctly(self):
-        form = self.setUpFilterableForm()
-        form.data = {'categories': ['blog']}
-        clean_categories(selected_categories=form.data.get('categories'))
-        self.assertEqual(
-            form.data['categories'],
-            [
-                'blog',
-                'at-the-cfpb',
-                'directors-notebook',
-                'policy_compliance',
-                'data-research-reports',
-                'info-for-consumers'
-            ]
-        )
-
-    def test_clean_categories_converts_reports_subcategories_correctly(self):
-        form = self.setUpFilterableForm()
-        form.data = {'categories': ['research-reports']}
-        clean_categories(selected_categories=form.data.get('categories'))
-        self.assertEqual(
-            form.data['categories'],
-            [
-                'research-reports',
-                'consumer-complaint',
-                'super-highlight',
-                'data-point',
-                'industry-markets',
-                'consumer-edu-empower',
-                'to-congress',
-            ]
-        )
 
 @override_settings(FLAGS={"ELASTICSEARCH_FILTERABLE_LISTS": [("boolean", True)]})
-class TestFilterableListFormArchive(WaitForElasticsearchMixin, TestCase):
+class TestFilterableListFormArchive(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -300,14 +297,7 @@ class TestFilterableListFormArchive(WaitForElasticsearchMixin, TestCase):
         publish_page(cls.page2)
         publish_page(cls.page3)
 
-        # Create a clean index for the test suite
-        management.call_command(
-            'search_index',
-            action='rebuild',
-            force=True,
-            models=['v1'],
-            stdout=StringIO()
-        )
+        rebuild_elasticsearch_index('v1', stdout=StringIO())
 
     def get_filtered_pages(self, data):
         filterable_pages = AbstractFilterPage.objects.live()


### PR DESCRIPTION
Suggestions for #6262:

- Simplifying tests and removing some duplication.
- Removing indexing of content field since we're not using it yet and it'll require a more complicated implementation to handle different fields (the header) on different pages.
- Use [`PageQuerySet.specific()`](https://docs.wagtail.io/en/stable/reference/pages/queryset_reference.html#wagtail.core.query.PageQuerySet.specific) to optimize indexing.