### PR TITLE
Restore archive pages older than 2 years by default

### DIFF
--- a/cfgov/v1/management/commands/restore_archive_pages.py
+++ b/cfgov/v1/management/commands/restore_archive_pages.py
@@ -1,0 +1,123 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.db.models import Q
+from django.http import Http404
+from django.utils import timezone
+
+from wagtail.core.models import Site
+
+from dateutil.relativedelta import relativedelta
+
+
+def path_without_leading_trailing_slashes(path):
+    return path.lstrip("/").rstrip("/")
+
+
+class Command(BaseCommand):
+    help = "Mark archived pages within a filterable list as restored"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "url_path",
+            nargs="+",
+            type=path_without_leading_trailing_slashes,
+            help=(
+                "The URL path (without leading /) of a filterable list page "
+                "whose content should be restored if it was archived the "
+                "specified number of years, months, and days ago. "
+                "The filerable list page at the URL will not be restored."
+            ),
+        )
+        parser.add_argument(
+            "--years",
+            type=int,
+            default=2,
+            help=(
+                "Restore content archived this number of years ago. "
+                "Combines with --months --days. Default: 2"
+            ),
+        )
+        parser.add_argument(
+            "--months",
+            type=int,
+            default=0,
+            help=(
+                "Restore content archived this number of months ago. "
+                "Combines with --years --days. Default: 0"
+            ),
+        )
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=0,
+            help=(
+                "Restore content archived this number of days ago. "
+                "Combines with --years --months. Default: 0"
+            ),
+        )
+        parser.add_argument(
+            "--by-published-date",
+            choices=["first", "last"],
+            default="first",
+            help=(
+                "Restore based on either first or last published date. "
+                "Default: first"
+            ),
+        )
+
+    def handle(self, *args, **options):
+        url_paths = options["url_path"]
+
+        # Get the current date/time and then get our cutoff date for restoring
+        # based on it.
+        restored_at = timezone.now()
+        cutoff_date = restored_at - relativedelta(
+            years=options["years"],
+            months=options["months"],
+            days=options["days"],
+        )
+
+        # Construct a Q object to filter on based on this command-line
+        # argument.
+        if options["by_published_date"] == "last":
+            published_date_filter = Q(last_published_at__lt=cutoff_date)
+        else:
+            published_date_filter = Q(first_published_at__lt=cutoff_date)
+
+        # We'll use Wagtail's page routing to resolve the page at the given the
+        # URL paths.
+        default_site = Site.objects.get(is_default_site=True)
+        root_page = default_site.root_page
+
+        for path in url_paths:
+            path_components = path.split("/")
+
+            # Get the filterable list page we're interested in.
+            try:
+                filterable_page = root_page.route(None, path_components).page
+            except Http404:
+                raise CommandError(
+                    f"Unable to find a page at {path}. "
+                    "Ensure that the path is correct, and leave off any "
+                    "leading or trailing / characters."
+                )
+
+            # Get the filterable list QuerySet and filter it.
+            filtered_pages = filterable_page.get_filterable_queryset().filter(
+                published_date_filter,
+                is_archived="yes",
+            )
+
+            # Restore the content, letting the user know the title of the
+            # filterable list page, the cuttoff date and how many pages will be
+            # restored.
+            with transaction.atomic():
+                update_count = filtered_pages.select_for_update().update(
+                    is_archived="no",
+                    restored_at=restored_at
+                )
+            self.stdout.write(
+                f"Found and restored {update_count} pages within "
+                f"{filterable_page.title} older than "
+                f"{cutoff_date:%Y-%m-%d %H:%M %Z}. "
+            )

--- a/cfgov/v1/management/commands/restore_archive_pages.py
+++ b/cfgov/v1/management/commands/restore_archive_pages.py
@@ -70,8 +70,8 @@ class Command(BaseCommand):
 
         # Get the current date/time and then get our cutoff date for restoring
         # based on it.
-        restored_at = timezone.now()
-        cutoff_date = restored_at - relativedelta(
+        archived_at = timezone.now()
+        cutoff_date = archived_at - relativedelta(
             years=options["years"],
             months=options["months"],
             days=options["days"],
@@ -114,7 +114,7 @@ class Command(BaseCommand):
             with transaction.atomic():
                 update_count = filtered_pages.select_for_update().update(
                     is_archived="no",
-                    restored_at=restored_at
+                    archived_at=archived_at
                 )
             self.stdout.write(
                 f"Found and restored {update_count} pages within "

--- a/cfgov/v1/management/commands/restore_archive_pages.py
+++ b/cfgov/v1/management/commands/restore_archive_pages.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
                 "The URL path (without leading /) of a filterable list page "
                 "whose content should be restored if it was archived the "
                 "specified number of years, months, and days ago. "
-                "The filerable list page at the URL will not be restored."
+                "The filterable list page at the URL will not be restored."
             ),
         )
         parser.add_argument(

--- a/cfgov/v1/tests/management/commands/test_restore_archive_pages.py
+++ b/cfgov/v1/tests/management/commands/test_restore_archive_pages.py
@@ -1,0 +1,127 @@
+import datetime
+from io import StringIO
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from wagtail.core.models import Site
+
+import pytz
+from freezegun import freeze_time
+
+from v1.models import BlogPage
+from v1.models.browse_filterable_page import BrowseFilterablePage
+
+
+class TestRestoreArchivePages(TestCase):
+
+    def setUp(self):
+        self.filterable_page = BrowseFilterablePage(
+            title="Blog",
+            slug="test",
+            live=True
+        )
+        self.url_path = self.filterable_page.url
+
+        self.root = Site.objects.get(is_default_site=True).root_page
+        self.root.add_child(instance=self.filterable_page)
+
+        self.page1 = BlogPage(
+            title="Page archived in 2018",
+            live=True,
+            is_archived="yes",
+            first_published_at=datetime.datetime(2018, 1, 1, tzinfo=pytz.UTC),
+            last_published_at=datetime.datetime(2021, 1, 1, tzinfo=pytz.UTC)
+        )
+        self.page2 = BlogPage(
+            title="Page archived in 2019",
+            live=True,
+            is_archived="yes",
+            first_published_at=datetime.datetime(2019, 1, 1, tzinfo=pytz.UTC),
+            last_published_at=datetime.datetime(2019, 1, 1, tzinfo=pytz.UTC)
+        )
+        self.page3 = BlogPage(
+            title="Page archived in 2020",
+            live=True,
+            is_archived="yes",
+            first_published_at=datetime.datetime(2020, 1, 1, tzinfo=pytz.UTC),
+            last_published_at=datetime.datetime(2020, 1, 1, tzinfo=pytz.UTC)
+        )
+        self.page4 = BlogPage(
+            title="Page published in 2021",
+            live=True,
+            is_archived="no",
+            first_published_at=datetime.datetime(2021, 1, 1, tzinfo=pytz.UTC),
+            last_published_at=datetime.datetime(2021, 1, 1, tzinfo=pytz.UTC)
+        )
+
+        self.filterable_page.add_child(instance=self.page1)
+        self.filterable_page.add_child(instance=self.page2)
+        self.filterable_page.add_child(instance=self.page3)
+        self.filterable_page.add_child(instance=self.page4)
+
+        self.stdout = StringIO()
+
+    def test_restore_bad_path_errors(self):
+        with self.assertRaises(CommandError):
+            call_command("restore_archive_pages", "foo/bar")
+
+    @freeze_time("2021-1-1")
+    def test_restore_default_opts(self):
+        call_command(
+            "restore_archive_pages",
+            self.filterable_page.url,
+            stdout=self.stdout,
+        )
+
+        self.page1.refresh_from_db()
+        self.page2.refresh_from_db()
+        self.page3.refresh_from_db()
+        self.page4.refresh_from_db()
+
+        self.assertFalse(self.page1.archived)
+        self.assertTrue(self.page2.archived)
+        self.assertTrue(self.page3.archived)
+        self.assertFalse(self.page4.archived)
+
+    @freeze_time("2020-2-3")
+    def test_restore_months_days(self):
+        call_command(
+            "restore_archive_pages",
+            self.filterable_page.url,
+            years=1,
+            months=1,
+            days=1,
+            stdout=self.stdout,
+        )
+
+        self.page1.refresh_from_db()
+        self.page2.refresh_from_db()
+        self.page3.refresh_from_db()
+        self.page4.refresh_from_db()
+
+        self.assertFalse(self.page1.archived)
+        self.assertFalse(self.page2.archived)
+        self.assertTrue(self.page3.archived)
+        self.assertFalse(self.page4.archived)
+
+    @freeze_time("2021-1-2")
+    def test_restore_last_publish_date(self):
+        call_command(
+            "restore_archive_pages",
+            self.filterable_page.url,
+            years=1,
+            by_published_date="last",
+            stdout=self.stdout,
+        )
+
+        self.page1.refresh_from_db()
+        self.page2.refresh_from_db()
+        self.page3.refresh_from_db()
+        self.page4.refresh_from_db()
+
+        self.assertTrue(self.page1.archived)
+        self.assertFalse(self.page2.archived)
+        self.assertFalse(self.page3.archived)
+        self.assertFalse(self.page4.archived)


### PR DESCRIPTION
This change adds a management command `restore_archive_pages` that will take a filterable list page URL path as its argument and then restore the archived pages within that filterable list queryset if the page's `last_published_at` date is more than two years from when the command runs.

This is based on the archive_pages management command by @willbarton in #6041

This management command also support parameters for how far back in time you want to go.

```
# ./manage.py restore_archive_pages -h
usage: manage.py restore_archive_pages [-h] [--years YEARS] [--months MONTHS]
                                       [--days DAYS]
                                       [--by-published-date {first,last}]
                                       [--version] [-v {0,1,2,3}]
                                       [--settings SETTINGS]
                                       [--pythonpath PYTHONPATH] [--traceback]
                                       [--no-color] [--force-color]
                                       url_path [url_path ...]

Mark archived pages within a filterable list as restored

positional arguments:
  url_path              The URL path (without leading /) of a filterable list
                        page whose content should be restored if it was
                        archived the specified number of years, months, and
                        days ago. The filterable list page at the URL will not
                        be restored.

optional arguments:
  -h, --help            show this help message and exit
  --years YEARS         Restore content archived this number of years ago.
                        Combines with --months --days. Default: 2
  --months MONTHS       Restore content archived this number of months ago.
                        Combines with --years --days. Default: 0
  --days DAYS           Restore content archived this number of days ago.
                        Combines with --years --months. Default: 0
  --by-published-date {first,last}
                        Restore based on either first or last published date.
                        Default: first
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --force-color         Force colorization of the command output.
```

## How to test this PR

1. tox -e unittest-current v1.tests.management.commands.test_restore_archive_pages.TestRestoreArchivePages

This command can be run on the Newsroom, Blog, and Research and Reports, as follows:

```
./cfgov/manage.py restore_archive_pages about-us/blog
./cfgov/manage.py restore_archive_pages about-us/newsroom
./cfgov/manage.py restore_archive_pages data-research/research-reports
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [x] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
