### PR TITLE
Improve the homepage's jumbo hero layout

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -286,7 +286,7 @@
 } );
 
 
-// Jumbo hero for CampaignPages
+// Jumbo hero for CampaignPages and the HomePage
 .m-hero__jumbo {
     .m-hero_subhead {
         .lead-paragraph();
@@ -306,22 +306,17 @@
         }
 
         .m-hero_subhead {
-            .heading-2();
+            .heading-3();
         }
     } );
 
-    .respond-to-min( @bp-med-min, {
-        // .m-hero_text {
-        //     .grid_column( 6, 12 );
-        // }
-
+    .respond-to-min( @bp-lg-min, {
         .m-hero_heading {
             .superheading();
         }
-
-        // .m-hero_subhead {
-        //     .heading-2();
-        // }
+        .m-hero_subhead {
+            .heading-2();
+        }
     } );
 }
 

--- a/cfgov/v1/jinja2/v1/home_page.html
+++ b/cfgov/v1/jinja2/v1/home_page.html
@@ -10,11 +10,19 @@
 {% block css %}
     {{ super() }}
     <style>
+        /* TODO: remove inline styles when new homepage design is finalized in 2021. */
         .m-hero_wrapper {
             /* #b4b5b6 is @gray-40 */
             border-right: 1px solid #b4b5b6;
             border-bottom: 1px solid #b4b5b6;
             border-left: 1px solid #b4b5b6;
+        }
+        /* Swap the homepage hero's white text to black on small screens */
+        @media only all and (max-width: 37.5625em) {
+            .m-hero__knockout {
+                /* CFPB Black #101820 */
+                color: #101820;
+            }
         }
     </style>
 {% endblock css %}


### PR DESCRIPTION
The homepage's jumbo hero is unusual in that it doesn't have a background color yet still uses white text. This causes extra small screens to see white-on-white text.

It also has a long subhead that overflows the hero on smaller screens. Instead of writing a one-off fix for this, I modified the jumbo hero code to show a reduced heading and subhead on both small and medium screens.

## Changes

- One-off media query that turns the homepage hero text black on small screens.
- Reduced the size `.m-hero_heading` and `.m-hero_subhead` on small and medium screens.

## How to test this PR

1. Compare content's Spanish homepage to your [local homepage](http://0.0.0.0:8000/es/) at various widths. (Log into wagtail locally and publish the latest draft of the homepage to see the new hero).


## Screenshots

| before | after |
|--------|-------|
| <img width="791" alt="before" src="https://user-images.githubusercontent.com/1060248/108435720-098dc680-7218-11eb-97ca-19e90fc034e7.png"> | <img width="791" alt="after" src="https://user-images.githubusercontent.com/1060248/108435729-0db9e400-7218-11eb-8237-c6781ee24dd0.png"> |
| <img width="791" alt="after" src="https://user-images.githubusercontent.com/1060248/108435769-21654a80-7218-11eb-8c2f-70c39142952f.png">   | <img width="791" alt="after" src="https://user-images.githubusercontent.com/1060248/108428218-3805a480-720c-11eb-9cb5-c84c6833711e.png">  |

## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
