### PR TITLE
Restore mega menu and banners on Django pages

### DIFF
--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -33,7 +33,9 @@ class ComplaintLandingView(TemplateView):
 
         context.update({
             'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
-            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES')
+            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES'),
+            'show_banner': True,
+            'show_mega_menu': True,
         })
 
         return context

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -33,9 +33,7 @@ class ComplaintLandingView(TemplateView):
 
         context.update({
             'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
-            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES'),
-            'show_banner': True,
-            'show_mega_menu': True,
+            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES')
         })
 
         return context

--- a/cfgov/v1/jinja2/v1/header.html
+++ b/cfgov/v1/jinja2/v1/header.html
@@ -19,8 +19,8 @@
 
 {% import 'organisms/header.html' as header with context %}
 {{ header.render(
-    show_banner=show_banner,
-    show_mega_menu=show_mega_menu,
-    language=language
+    show_banner=show_banner | default( true ),
+    show_mega_menu=show_mega_menu | default( true ),
+    language=language | default( 'en' )
 ) }}
 <div id="after-nav"></div>


### PR DESCRIPTION
It disappeared due to the global header change in #6244.

This also restores the Beta banner for this page when on Beta.


## Additions

- Sets default values for `show_mega_menu`, `show_banner`, and `language` when Django pages call the `header.render()` macro


## How to test this PR

1. Load up http://localhost:8000/data-research/consumer-complaints/ and see no mega menu
1. Pull branch
1. Reload and see mega menu
1. Go to https://beta.consumerfinance.gov/data-research/consumer-complaints/ and see no Beta banner
1. Enable `BETA_NOTICE` flag for all requests at http://localhost:8000/admin/flags/BETA_NOTICE/
1. Reload http://localhost:8000/data-research/consumer-complaints/ and see the Beta banner


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
