### PR TITLE
Exclude API pages from link-icon insertion

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -835,6 +835,8 @@ PARSE_LINKS_EXCLUSION_LIST = [
     r"^/login/",
     # Regulations pages that have their own link markup
     r"^/policy-compliance/rulemaking/regulations/\d+/",
+    # DjangoRestFramework API pages where link icons are intrusive
+    r"^/oah-api/",
 ]
 
 # Required by django-extensions to determine the execution directory used by


### PR DESCRIPTION
Link icons are intrusive on API pages handled by Django Rest Framework.
Since the API pages are not aimed at routine users, we can exclude
them from link-insertion middleware via settings.

## Testing
#### Behold link icons on DRF API pages
- https://www.consumerfinance.gov/oah-api/county/?state=FL
- https://www.consumerfinance.gov/oah-api/rates/rate-checker?loan_amount=200000&price=400000&state=va&loan_type=conf&maxfico=720&minfico=700&loan_term=30&rate_structure=fixed

----

<img width="1222" alt="link_icon_countylimit" src="https://user-images.githubusercontent.com/515885/109217588-06e52100-7784-11eb-99ab-de74daa1eb1c.png">

----

<img width="1195" alt="link-icon-ratechecker" src="https://user-images.githubusercontent.com/515885/109217563-0056a980-7784-11eb-80c7-ed3b7b23221f.png">



#### Check out this branch and revisit locally:
- http://localhost:8000/oah-api/county/?state=FL
- http://localhost:8000/oah-api/rates/rate-checker?loan_amount=200000&price=400000&state=va&loan_type=conf&maxfico=720&minfico=700&loan_term=30&rate_structure=fixed
