### PR TITLE
Handle uppercase env vars when naming indexes

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -72,10 +72,11 @@ synonym_analyzer = analyzer(
 
 
 def environment_specific_index(base_name):
-    if settings.DEPLOY_ENVIRONMENT in (None, '', 'local', 'production'):
+    env = settings.DEPLOY_ENVIRONMENT
+    if not env or env.lower() in ('local', 'production'):
         return base_name
     else:
-        return f'{settings.DEPLOY_ENVIRONMENT}-{base_name}'.lower()
+        return f'{env}-{base_name}'.lower()
 
 
 class ElasticsearchTestsMixin:

--- a/cfgov/search/tests/test_elasticsearch_helpers.py
+++ b/cfgov/search/tests/test_elasticsearch_helpers.py
@@ -24,3 +24,14 @@ class TestEnvironmentSpecificIndex(TestCase):
     def test_environment_specific_index_includes_deploy_env(self):
         name = environment_specific_index('index')
         self.assertEqual(name, 'test-index')
+
+    # Handle uppercase deploy environment vars (for Jenkins)
+    @override_settings(DEPLOY_ENVIRONMENT='PRODUCTION')
+    def test_environment_specific_index_excludes_deploy_env_PRODUCTION(self):
+        name = environment_specific_index('index')
+        self.assertEqual(name, 'index')
+
+    @override_settings(DEPLOY_ENVIRONMENT='TEST')
+    def test_environment_specific_index_lowercases_index(self):
+        name = environment_specific_index('index')
+        self.assertEqual(name, 'test-index')


### PR DESCRIPTION
Elasticsearch requires lowercase names for indexes, and we add prefixes, 
based on the DEPLOY_ENVIRONMENT var, to index names to keep them separate.

The DEPLOY_ENVIRONMENT vars on servers are lowercase, but we're not indexing
from servers anymore. We index from Jenkins, where the vars are configured as uppercase.

Our `elasticsearch_helpers` shouldn't assume the case of the variable.
