### PR TITLE
Increase timeout for running functional tests on dev Docker stacks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
 
                 script {
                     LAST_STAGE = env.STAGE_NAME
-                    timeout(time: 15, unit: 'MINUTES') {
+                    timeout(time: 20, unit: 'MINUTES') {
                         // sh "docker-compose -f docker-compose.e2e.yml run e2e -e CYPRESS_baseUrl=https://${CFGOV_HOSTNAME}"
                         sh "docker run -v ${WORKSPACE}/test/cypress:/app/test/cypress -v ${WORKSPACE}/cypress.json:/app/cypress.json -w /app -e CYPRESS_baseUrl=https://${CFGOV_HOSTNAME} -e CI=1 cypress/included:6.5.0 npx cypress run -b chrome --headless"
                     }


### PR DESCRIPTION
Hoping that this eliminates the pattern of the functional tests timing out and the process being killed.

## Todo

Now that we've got a healthy number of these tests, we should probably take a harder look at best practices and performance.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
