### PR TITLE
Embolden links when printed but not their URLs

### DIFF
--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -29,12 +29,13 @@
 */
 
 .respond-to-print({
-    .a-link__icon .a-link_text {
-        border-bottom-style: solid;
+    a {
         font-weight: 500;
     }
 
     a:after {
+        border-bottom: 1px solid @white;
+        font-weight: 300;
         word-break: break-all;
     }
 


### PR DESCRIPTION
Iterates on https://github.com/cfpb/consumerfinance.gov/pull/6263.

Increase the weight of all links (not just external ones with an icon) when a user prints a page and don't underline the URL that gets generated in an :after pseudo element.

In order to "remove" the pseudo element's border, I set its color to white. This works but causes URLs on a gray background to have a barely visible white underline when printing. The alternative solutions involved adding markup to the page and I didn't feel the performance hit of wrapping every link in a span was justified. I'm happy to discuss other options.

<img width="759" alt="white border" src="https://user-images.githubusercontent.com/1060248/109849461-64172180-7c1f-11eb-95b5-1637083faa21.png">

See https://stackoverflow.com/a/21478325
See https://github.local/CFPB/el-camino/issues/299

## Changes

- Print link styles.

## How to test this PR

1. [Emulate print media queries](https://developers.google.com/web/tools/chrome-devtools/css/print-preview) in Chrome.
1. Visit a page with a mix of different link types like our [coronavirus](http://0.0.0.0:8000/coronavirus/mortgage-and-housing-assistance/renter-protections/) [pages](http://0.0.0.0:8000/coronavirus/mortgage-and-housing-assistance/after-you-receive-relief/).
1. Links should be bold and underlined but not their URLs.

## Screenshots

| before | after |
|--------|-------|
| <img width="726" alt="before" src="https://user-images.githubusercontent.com/1060248/109849136-0551a800-7c1f-11eb-9af1-af3aaddca8ba.png">  | <img width="726" alt="after" src="https://user-images.githubusercontent.com/1060248/109849140-07b40200-7c1f-11eb-8083-d9e5f106483b.png">  |

## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens