### PR TITLE
Update fetch method to provide expected response type

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/get-rural-counties.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/get-rural-counties.js
@@ -1,15 +1,15 @@
 require( 'es6-promise' ).polyfill();
-import { get } from 'axios';
+import { fetch } from 'cross-fetch';
 
 /**
  * @param {string} year - A year.
  * @returns {Object} Result of the call to a JSON file.
  */
 function getRuralCounties( year ) {
-  return get(
+  return fetch(
     'https://files.consumerfinance.gov/rural-or-underserved-tool/data/' +
     year + '.json'
-  );
+  ).then( v => v.json() );
 }
 
 export default getRuralCounties;


### PR DESCRIPTION
The `axios` `get` call in this instance was (1) not returning the data structure the code was expecting and (2) causing CORS problems on Chrome. Replaced with `cross-fetch`, already included in our root `package.json`

The reason this was working at all was that there's a fallback check from the object lookup where the Census API is queried. The underlying data structure issue meant that *NO* county was being pulled from the FIPS array, but instead was always falling back to what was designated rural by the census, which is sometimes different than our designations.

Testing:
 - Pull branch and run the frontend build
 - Search for `300 N Main Kingfisher OK` in the tool at `http://localhost:8000/rural-or-underserved-tool/`
 - Should be rural
 - Search for `1700 G St NW Washington DC`
 - Should not be rural