### PR TITLE
Paying for College: Import cfpb-layout instead of reference

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/main.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/main.less
@@ -11,7 +11,7 @@
 @import (reference) "cfpb-forms.less";
 @import (reference) "cfpb-grid.less";
 @import (reference) "cfpb-icons.less";
-@import (reference) "cfpb-layout.less";
+@import (less) "cfpb-layout.less";
 @import (reference) "cfpb-typography.less";
 
 // Import the brand color palette.


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/6259 turn design-system imports in paying for college in references, however, we need some classes from cfpb-layout, so this PR reverts that portion of the PR.

## Changes

- Paying for College: Import cfpb-layout instead of referencing it.


## How to test this PR

1. Compare http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/test/ to production.


## Screenshots

Before:

<img width="1372" alt="Screen Shot 2021-03-05 at 5 53 43 PM" src="https://user-images.githubusercontent.com/704760/110182922-c026a500-7ddb-11eb-9f52-bc8bfa62af29.png">


After:

<img width="1302" alt="Screen Shot 2021-03-05 at 5 53 31 PM" src="https://user-images.githubusercontent.com/704760/110182932-c452c280-7ddb-11eb-98bc-c2626f22e427.png">

