### PR TITLE
Cypress tests: Fix topics filter ID query

### DIFF
--- a/test/cypress/components/filterable-lists.js
+++ b/test/cypress/components/filterable-lists.js
@@ -38,7 +38,7 @@ export class FilterableList {
   }
 
   openTopics() {
-    cy.get( '#topics' ).click();
+    cy.get( '#o-filterable-list-controls_topics' ).click();
   }
 
   selectTopic( topic ) {


### PR DESCRIPTION
Cypress test had outdated ID for topics in the blog filters.

## Changes

- Update topics ID in broken Cypress test.


## How to test this PR

1. PR checks should pass.