### PR TITLE
Paying for College: define `hashes` variable in repay.js

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/repay.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/repay.js
@@ -60,7 +60,7 @@ const pfcDecision = ( function() {
   }
 
   function processHash( position ) {
-    hashes = location.hash.replace( '#', '' ).split( ':' );
+    const hashes = location.hash.replace( '#', '' ).split( ':' );
     $( '.ds-buttons:visible button[data-ds-name="' + hashes[position] + '"]' ).click();
     if ( position + 1 < hashes.length ) {
       processHash( position + 1 );


### PR DESCRIPTION
`hashes` variable wasn't declared in the original code this came from in https://github.com/cfpb/consumerfinance.gov/pull/6307

## Changes

- Paying for College: define `hashes` variable in repay.js


## How to test this PR

1. PR checks should pass.
