### PR TITLE
Fix CodeQA-flagged errors in Python

### DIFF
--- a/cfgov/ask_cfpb/forms.py
+++ b/cfgov/ask_cfpb/forms.py
@@ -1,0 +1,32 @@
+from django import forms
+from django.core.validators import RegexValidator
+
+from ask_cfpb.models.search import make_safe
+
+
+legacy_facet_validator = RegexValidator(
+    regex=r'(?:category|audience|tag)_exact:\S+',
+    message='Not a valid legacy facet',
+)
+
+
+class AutocompleteForm(forms.Form):
+    term = forms.CharField(strip=True)
+
+    def clean_term(self):
+        return make_safe(self.cleaned_data['term'])
+
+
+class SearchForm(forms.Form):
+    q = forms.CharField(strip=True)
+    correct = forms.BooleanField(required=False, initial=True)
+
+    def clean_q(self):
+        return make_safe(self.cleaned_data['q'])
+
+    def clean_correct(self):
+        if 'correct' not in self.data:
+            return self.fields['correct'].initial
+        if self.data['correct'] == '0':
+            self.cleaned_data['correct'] = False
+        return self.cleaned_data['correct']

--- a/cfgov/ask_cfpb/tests/test_forms.py
+++ b/cfgov/ask_cfpb/tests/test_forms.py
@@ -1,0 +1,30 @@
+from django.test import TestCase
+
+from ask_cfpb.forms import AutocompleteForm, SearchForm
+
+
+class AutocompleteFormTestCase(TestCase):
+    def test_clean_term(self):
+        form = AutocompleteForm(data={'term': '    payday^~`[]#<>;|%\\{\\}\\'})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['term'], 'payday')
+
+
+class SearchFormTestCase(TestCase):
+    def test_clean_term(self):
+        form = SearchForm(data={'q': '    payday^~`[]#<>;|%\\{\\}\\'})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['q'], 'payday')
+
+    def test_clean_correct(self):
+        form = SearchForm(data={'q': 'payday'})
+        self.assertTrue(form.is_valid())
+        self.assertTrue(form.cleaned_data['correct'])
+
+        form = SearchForm(data={'q': 'payday', 'correct': '1'})
+        self.assertTrue(form.is_valid())
+        self.assertTrue(form.cleaned_data['correct'])
+
+        form = SearchForm(data={'q': 'payday', 'correct': '0'})
+        self.assertTrue(form.is_valid())
+        self.assertFalse(form.cleaned_data['correct'])

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -296,6 +296,12 @@ class RedirectAskSearchTestCase(TestCase):
         result = redirect_ask_search(request)
         self.assertEqual(result.get("location"), "/ask-cfpb/search/")
 
+    def test_bad_facet(self):
+        request = HttpRequest()
+        request.GET["selected_facets"] = "bad_exact:foo"
+        with self.assertRaises(Http404):
+            redirect_ask_search(request)
+
     def test_redirect_search_uppercase_facet(self):
         """Handle odd requests with uppercase, spaced category names."""
         category_querystring = "selected_facets=category_exact:Prepaid Cards"

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -1,6 +1,7 @@
 import json
 from urllib.parse import urljoin
 
+from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import slugify
@@ -11,8 +12,8 @@ from wagtailsharing.views import ServeView
 
 from bs4 import BeautifulSoup as bs
 
+from ask_cfpb.forms import AutocompleteForm, SearchForm, legacy_facet_validator
 from ask_cfpb.models import AnswerPage, AnswerPageSearch, AnswerResultsPage
-from ask_cfpb.models.search import make_safe
 
 
 def annotate_links(answer_text):
@@ -53,7 +54,7 @@ def view_answer(request, slug, language, answer_id):
     if answer_page.redirect_to_page:
         new_page = answer_page.redirect_to_page
         return redirect(new_page.url, permanent=True)
-    if "{}-{}-{}".format(slug, language, answer_id) != answer_page.slug:
+    if f"{slug}-{language}-{answer_id}" != answer_page.slug:
         return redirect(answer_page.url, permanent=True)
 
     # We don't want to call answer_page.serve(request) here because that
@@ -76,6 +77,9 @@ def view_answer(request, slug, language, answer_id):
 def ask_search(request, language='en', as_json=False):
     if 'selected_facets' in request.GET:
         return redirect_ask_search(request, language=language)
+
+    search_form = SearchForm(request.GET, initial={'q': '', 'correct': True})
+
     language_map = {
         'en': 'ask-cfpb-search-results',
         'es': 'respuestas'
@@ -87,17 +91,17 @@ def ask_search(request, language='en', as_json=False):
     )
 
     # If there's no query string, don't search
-    search_term = request.GET.get('q', '')
-    if not search_term:
+    if not search_form.is_valid():
         results_page.query = ''
         results_page.result_query = ''
         return results_page.serve(request)
 
+    search_term = search_form.cleaned_data['q']
     page = AnswerPageSearch(search_term, language=language)
     response = page.search()
 
     # Check if we want to use the suggestion or not
-    suggest = request.GET.get('correct', '1') == '1'
+    suggest = search_form.cleaned_data['correct']
 
     # Provide a suggestion only when no results are found
     if not response.get('results') and suggest:
@@ -109,8 +113,8 @@ def ask_search(request, language='en', as_json=False):
     if as_json:
         payload = {
             'query': search_term,
-            'result_query': make_safe(search_term).strip(),
-            'suggestion': make_safe(suggestion).strip(),
+            'result_query': search_term.strip(),
+            'suggestion': suggestion.strip(),
             'results': [
                 {
                     'question': result.autocomplete,
@@ -135,13 +139,15 @@ def ask_search(request, language='en', as_json=False):
 
 
 def ask_autocomplete(request, language='en'):
-    term = request.GET.get('term', '')
-    safe_term = make_safe(term)
-    if not safe_term:
+    autocomplete_form = AutocompleteForm(request.GET)
+
+    if not autocomplete_form.is_valid():
         return JsonResponse([], safe=False)
+
+    term = autocomplete_form.cleaned_data['term']
     try:
         results = AnswerPageSearch(
-            search_term=safe_term, language=language).autocomplete()
+            search_term=term, language=language).autocomplete()
         return JsonResponse(results, safe=False)
     except IndexError:
         return JsonResponse([], safe=False)
@@ -171,44 +177,57 @@ def redirect_ask_search(request, language='en'):
     category_facet = 'category_exact:'
     audience_facet = 'audience_exact:'
     tag_facet = 'tag_exact:'
-    if request.GET.get('q'):
-        querystring = request.GET.get('q').strip()
-        if not querystring:
-            return redirect('/ask-cfpb/search/', permanent=True)
+
+    search_form = SearchForm(request.GET)
+    if search_form.is_valid():
+        query = search_form.cleaned_data['q']
         return redirect(
-            '/ask-cfpb/search/?q={query}'.format(
-                query=querystring), permanent=True)
+            f'/ask-cfpb/search/?q={query}',
+            permanent=True
+        )
     else:
         facets = request.GET.getlist('selected_facets')
+
         if not facets or not facets[0]:
             return redirect(
                 '/ask-cfpb/search/', permanent=True)
 
+        try:
+            for facet in facets:
+                legacy_facet_validator(facets)
+        except ValidationError:
+            raise Http404
+
         def redirect_to_category(category, language):
             if language == 'es':
                 return redirect(
-                    '/es/obtener-respuestas/categoria-{category}/'.format(
-                        category=category), permanent=True)
+                    f'/es/obtener-respuestas/categoria-{category}/',
+                    permanent=True
+                )
             return redirect(
-                '/ask-cfpb/category-{category}/'.format(
-                    category=category), permanent=True)
+                f'/ask-cfpb/category-{category}/',
+                permanent=True
+            )
 
         def redirect_to_audience(audience):
             """We currently only offer audience pages to English users."""
             return redirect(
-                '/ask-cfpb/audience-{audience}/'.format(
-                    audience=audience), permanent=True)
+                f'/ask-cfpb/audience-{audience}/',
+                permanent=True
+            )
 
         def redirect_to_tag(tag, language):
             """Handle tags passed with underscore separators."""
             if language == 'es':
                 return redirect(
-                    '/es/obtener-respuestas/buscar-por-etiqueta/{tag}/'.format(
-                        tag=tag), permanent=True)
+                    f'/es/obtener-respuestas/buscar-por-etiqueta/{tag}/',
+                    permanent=True
+                )
             else:
                 return redirect(
-                    '/ask-cfpb/search-by-tag/{tag}/'.format(
-                        tag=tag), permanent=True)
+                    f'/ask-cfpb/search-by-tag/{tag}/',
+                    permanent=True
+                )
 
         # Redirect by facet value, if there is one, starting with category.
         # We want to exhaust facets each time, so we need three loops.

--- a/cfgov/regulations3k/forms.py
+++ b/cfgov/regulations3k/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class SearchForm(forms.Form):
+    q = forms.CharField(strip=True)

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -75,6 +75,16 @@ class RedirectRegulations3kTestCase(TestCase):
             '/policy-compliance/rulemaking/regulations/'
             'search-regulations/results/?regs=1002&q=california')
 
+    def test_redirect_search_invalid(self):
+        request = self.factory.get(
+            '/eregulations/search/1002',
+        )
+        response = redirect_eregs(request)
+        self.assertEqual(
+            response.get('location'),
+            '/policy-compliance/rulemaking/regulations/'
+            'search-regulations/results/?regs=1002&q=')
+
     def test_redirect_invalid_part(self):
         request = self.factory.get(
             '/eregulations/1020-1/2017-20417_20180101')

--- a/cfgov/v1/tests/views/test_login_views.py
+++ b/cfgov/v1/tests/views/test_login_views.py
@@ -65,6 +65,13 @@ class LoginViewsTestCase(TestCase):
         response = self.client.get('/login/check_permissions/?next=/badurl/')
         self.assertRedirects(response, '/admin/')
 
+    def test_check_permissions_next_url_unsafe(self):
+        self.client.login(username='admin', password='admin')
+        response = self.client.get(
+            '/login/check_permissions/?next=https://google.com/'
+        )
+        self.assertRedirects(response, '/admin/')
+
     def test_check_permissions_next_permissions_problem(self):
         User.objects.create_user(
             username='noperm', email='', password='noperm'

--- a/cfgov/v1/views/__init__.py
+++ b/cfgov/v1/views/__init__.py
@@ -130,10 +130,14 @@ def check_permissions(request):
     redirect_to = request.POST.get(REDIRECT_FIELD_NAME,
                                    request.GET.get(REDIRECT_FIELD_NAME, ''))
 
+    if not is_safe_url(url=redirect_to, allowed_hosts=request.get_host()):
+        redirect_to = resolve_url(settings.LOGIN_REDIRECT_URL)
+
     if not request.user.is_authenticated:
         return HttpResponseRedirect(
             "%s?%s=%s" % (settings.LOGIN_URL, REDIRECT_FIELD_NAME, redirect_to)
         )
+
     view, args, kwargs = resolve(redirect_to)
     kwargs['request'] = request
     try:


### PR DESCRIPTION
This PR is intended to fix the errors that CodeQA has flagged. These were predominantly around where we pass parts of URLs off from parameters to redirects without performing any sanitization/validation on them. Most of these changes are in redirects for legacy Ask CFPB and eRegulations URLs to their replacements. 

For the most part, I've fixed this by using Django forms for handling the cleaning/validating of the fields. In Ask CFPB, this means I've created an `AutocompleteForm` and a `SearchForm`, and moved some of the sanitizing that we were doing multiple times in multiple places to the `clean_q` method on that form. 

I've taken a similar approach to the eRegs redirects in creating a `SearchForm`. 

The other place where that CodeQL flagged is in our `check_permissions` method, which handles admin redirects. I've wrapped the destination in `is_safe_url()` to ensure that the the URL is matches the request's allowed hosts.

Where test coverage wasn't, I've added it *before* making the changes to ensure the behavior as it existed remains.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
