### PR TITLE
Enable git+https URLs in our requirements files

### DIFF
--- a/docker/deployable-zipfile/_build.sh
+++ b/docker/deployable-zipfile/_build.sh
@@ -6,6 +6,12 @@ set -e
 # Echo commands.
 set -x
 
+# Set GIT_COMMITTER_NAME to enable us to `pip -e` from git URLs
+# git < 2.6.5 requires either these variables to be set or the user to exist 
+# in passwd file.
+export GIT_COMMITTER_NAME="cf.gov build user"
+export GIT_COMMITTER_EMAIL="tech@cfpb.gov"
+
 build_artifact_name=cfgov_current_build
 build_artifact="$build_artifact_name.zip"
 cfgov_refresh_volume=/cfgov


### PR DESCRIPTION
Using `git+https://` in our requirements files is a useful pattern to do test deploys of libraries and satellite apps to our dev servers. When we moved to our Dockerized artifact building, that ability silently broke.

In order to use `git+https://` URLs in our requirements files, pip needs git to be able to successfully clone. Prior to this change, git could not clone in our build container, failing with the error: `fatal: unable to look up current user in the passwd file: no such user`.

This changes sets `GIT_COMMITTER_NAME` and `GIT_COMMITTER_EMAIL` in our build script. git requires either the user its running as to exist in the `passwd` file *or* for these two variables to be set. By setting them here, we satisfy git's requirements and are able to include `git+https` URLs.

git 2.6.5+ apparently removes this requirement. But that's not what is available in CentOS 7.

You can see it at work [in this build](https://dev-jenkins/job/cf.gov-ansible-docker-build/1517/console) of the [`ccdb5-es7` branch](https://github.com/cfpb/consumerfinance.gov/blob/ccdb5-es7/requirements/libraries.txt#L48)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
