### PR TITLE
Bugfix: Enforcement Actions were using date_filed in post previews

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview.html
@@ -103,8 +103,8 @@
                     {{ date_desc }}
                     {% if 'EventPage' in post.specific_class.__name__ %}
                         {{ time.render(post.specific.start_dt, {'date':true}) }}
-                    {% elif 'EnforcementAction' in post.specific_class.__name__ and post.initial_filing_date %}
-                        {{ time.render(post.initial_filing_date, {'date':true}) }}
+                    {% elif 'EnforcementAction' in post.specific_class.__name__ and post.specific.initial_filing_date %}
+                        {{ time.render(post.specific.initial_filing_date, {'date':true}) }}
                     {% else %}
                         {{ time.render(post.date_published, {'date':true}) }}
                     {% endif %}


### PR DESCRIPTION
The enforcement action filter page should use `initial_filing_date` in their post previews, but they were using `date_filed` instead. This PR fixes that error.

This was happening because the `post` variable is an instance of `AbstractFilterPage`, which doesn't have an `initial_filing_date`. In this template, in order to access that field, which is specific to the `EnforcementActionPage`, we need to use `page.specific` to treat the page as an `EnforcementActionPage`.


## How to test this PR

1. Visit the enforcement actions filter page and filter by date. Notice that the dates above the previews now match the dates in the filter, where they didn't before. 
 
[This filter shows it well](http://localhost:8000/enforcement/actions/?title=&from_date=2019-11-01&to_date=2019-12-31). Previously, all of the posts in that filter showed the date "Mar 19, 2020".


## Screenshots

<img width="678" alt="Screen Shot 2021-03-19 at 3 54 22 PM" src="https://user-images.githubusercontent.com/4295388/111835954-0267e000-88cc-11eb-831f-07a3c84f6518.png">


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance