### PR TITLE
Fix an import sorting flagged by the latest isort release

### DIFF
--- a/cfgov/teachers_digital_platform/models/__init__.py
+++ b/cfgov/teachers_digital_platform/models/__init__.py
@@ -1,7 +1,6 @@
 # flake8: noqa F401
 from teachers_digital_platform.models.activity_index_page import (
-    FACET_LIST, FACET_MAP, ActivityIndexPage, ActivitySetUp,
-    get_activity_setup
+    FACET_LIST, FACET_MAP, ActivityIndexPage, ActivitySetUp, get_activity_setup
 )
 from teachers_digital_platform.models.django import (
     ActivityAgeRange, ActivityBloomsTaxonomyLevel, ActivityBuildingBlock,


### PR DESCRIPTION
The latest version of isort fixes a bug that resulted in this import list being split across multiple lines when it didn't hit the line length limit. This quick change fixes the resulting isort errors.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
