### PR TITLE
Remove the POST from external site interstitial view

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -837,6 +837,9 @@ PARSE_LINKS_EXCLUSION_LIST = [
     r"^/policy-compliance/rulemaking/regulations/\d+/",
     # DjangoRestFramework API pages where link icons are intrusive
     r"^/oah-api/",
+    # External site interstitial (if we're here, the links have already been
+    # parsed)
+    r"^/external-site/",
 ]
 
 # Required by django-extensions to determine the execution directory used by

--- a/cfgov/core/tests/test_views.py
+++ b/cfgov/core/tests/test_views.py
@@ -343,21 +343,6 @@ class TestExternalURLNoticeView(TestCase):
         with self.assertRaises(Http404):
             view(request)
 
-    def test_valid_post_returns_redirect(self):
-        view = ExternalURLNoticeView.as_view()
-        request = self.factory.post("/", {"ext_url": "https://foo.com"})
-        response = view(request)
-        self.assertEqual(
-            (response.status_code, response["Location"]),
-            (302, "https://foo.com"),
-        )
-
-    def test_invalid_post_returns_404(self):
-        view = ExternalURLNoticeView.as_view()
-        request = self.factory.post("/")
-        with self.assertRaises(Http404):
-            view(request)
-
 
 class TranslatedTemplateViewTestCase(TestCase):
 

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -167,14 +167,11 @@ class ExternalURLNoticeView(FormMixin, TemplateView):
         form = self.get_form()
 
         if not form.is_valid():
-            return self.raise_404()
+            raise Http404(
+                'URL invalid, not whitelisted, or signature validation failed'
+            )
 
         return super(ExternalURLNoticeView, self).get(request)
-
-    def raise_404(self):
-        raise Http404(
-            'URL invalid, not whitelisted, or signature validation failed'
-        )
 
 
 class TranslatedTemplateView(TemplateView):

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -171,14 +171,6 @@ class ExternalURLNoticeView(FormMixin, TemplateView):
 
         return super(ExternalURLNoticeView, self).get(request)
 
-    def post(self, request):
-        form = self.get_form()
-
-        if not form.is_valid():
-            return self.raise_404()
-
-        return redirect(form.cleaned_data['validated_url'])
-
     def raise_404(self):
         raise Http404(
             'URL invalid, not whitelisted, or signature validation failed'

--- a/cfgov/jinja2/v1/external-site/index.html
+++ b/cfgov/jinja2/v1/external-site/index.html
@@ -43,14 +43,12 @@
             We’ll take you to the page in:
             <span class="external-site_reload-container"></span>
         </p>
-        <form method="POST" action="{{ url('external-site') }}" id="proceed">
-            <button id="external-site_proceed-btn"
-                    class="a-btn
-                           a-btn__full-on-xs">
-                Proceed to external site
-            </button>
-        {{ form }}
-        </form>
+        <a id="external-site_proceed-btn"
+           href="{{ form.cleaned_data['validated_url'] }}"
+           class="a-btn
+                  a-btn__full-on-xs">
+            Proceed to external site
+        </a>
         {% else %}
             You attempted to reach an external link, but something went wrong.
         {% endif %}

--- a/cfgov/unprocessed/js/modules/ExternalSite.js
+++ b/cfgov/unprocessed/js/modules/ExternalSite.js
@@ -29,7 +29,6 @@ function ExternalSite( element ) {
    */
   function init() {
     _intervalId = setInterval( _tick, INTERVAL );
-    _proceedBtnEl.addEventListener( 'click', _proceedClickedHandler );
   }
 
   /**
@@ -46,9 +45,8 @@ function ExternalSite( element ) {
    * Go to the redirect URL.
    */
   function _gotoUrl() {
-    const _formEl = _dom.querySelector( 'form#proceed' );
     clearInterval( _intervalId );
-    _formEl.submit();
+    document.location = _proceedBtnEl.href;
   }
 
   /**
@@ -59,15 +57,6 @@ function ExternalSite( element ) {
     const content = '<span class=\'external-site_reload-duration\'>' +
                     _duration + '</span> second' + plurality;
     _durationEl.innerHTML = content;
-  }
-
-  /**
-   * Proceed to external site button was clicked.
-   * @param {Object} event Click event object.
-   */
-  function _proceedClickedHandler( event ) {
-    event.stopImmediatePropagation();
-    _gotoUrl();
   }
 
   this.init = init;


### PR DESCRIPTION
This change removes POST support from the external site interstitial view.

The POST was being used to POST URLs that didn't necessarily match the URL in the GET. This was causing issues in production.

The POST also seems unnecessary, as it adds another step through our servers before the redirect, when we can simply link directly to the external site from the button.

This change does require adding `/external-site/` to the parse links exception list, because without it, the user ends up in an endless loop of being sent to /external-site/ when `ParseLinksMiddleware` parses the rendered interstitial page.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)