### PR TITLE
Update robots.txt to remove certain parameter pages from crawling

### DIFF
--- a/cfgov/unprocessed/root/robots.txt
+++ b/cfgov/unprocessed/root/robots.txt
@@ -12,5 +12,13 @@ Disallow: /ask-cfpb/search/
 Disallow: /ask-cfpb/search-by-tag/
 Disallow: /es/obtener-respuestas/buscar/
 Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
+Disallow: *&authors
+Disallow: *?authors
+Disallow: *&categories
+Disallow: *?categories
+Disallow: *&from_date
+Disallow: *&to_date
+Disallow: *?from_date
+Disallow: *?to_date
 
 sitemap: https://www.consumerfinance.gov/sitemap.xml


### PR DESCRIPTION
Robots.txt helps control search engine crawlers from seeing, accessing, and following certain pages and directories on our site (also controls crawl bloat and helps to index pages faster). Our tools rely on following the same directive to minimize inflated numbers and to give us an accurate look at what SEO errors exist.

<!-- Enter an explanation of what the pull request does and why. -->

---

This will add the following parameter pages to be disallowed from crawling by search engine bots. This pages are deindexed and removing from crawl will reduce false positive SEO errors. 

<!-- Feel free to delete any sections that are not applicable to this PR. -->

## How to test this PR

1. Use a crawler like screaming frog or SEMRush and adjust setting to respect robots.txt
2. Use tooling to run a crawl on pages where these parameter changes are present
3. See if pages change from crawled to blocked. 

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)

### Front-end testing
1. Use a crawler like screaming frog, SEMRush, or the [robots.txt testing tool](https://support.google.com/webmasters/answer/6062598?hl=en) to test URLs that have the parameter pages to be blocked.
2. Use tooling to run a crawl on pages where these parameter changes are present
3. See if pages change from crawled to blocked. 