### PR TITLE
Allow limiting of request body sizes

### DIFF
--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -9,8 +9,7 @@ Header always set X-Frame-Options SAMEORIGIN
 Header always set X-XSS-Protection: "1; mode=block"
 Header always set X-Content-Type-Options: nosniff
 
-# Add LimitRequestBody if the value is provided in the LIMIT_REQUEST_BODY 
-# variable.
+# Add LimitRequestBody when LIMIT_REQUEST_BODY env var is set
 <If "-n osenv('LIMIT_REQUEST_BODY')">
     LimitRequestBody "${LIMIT_REQUEST_BODY}" 
 </If>

--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -11,7 +11,7 @@ Header always set X-Content-Type-Options: nosniff
 
 # Add LimitRequestBody when LIMIT_REQUEST_BODY env var is set
 <If "-n osenv('LIMIT_REQUEST_BODY')">
-    LimitRequestBody "${LIMIT_REQUEST_BODY}" 
+        LimitRequestBody "${LIMIT_REQUEST_BODY}" 
 </If>
 
 # Add X-Forwarded headers when APACHE_HTTPS_FORWARDED_HOST envvar is set

--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -5,10 +5,15 @@ LimitRequestFieldSize 8190
 KeepAlive On
 MaxKeepAliveRequests 500
 
-
 Header always set X-Frame-Options SAMEORIGIN
 Header always set X-XSS-Protection: "1; mode=block"
 Header always set X-Content-Type-Options: nosniff
+
+# Add LimitRequestBody if the value is provided in the LIMIT_REQUEST_BODY 
+# variable.
+<If "-n osenv('LIMIT_REQUEST_BODY')">
+    LimitRequestBody "${LIMIT_REQUEST_BODY}" 
+</If>
 
 # Add X-Forwarded headers when APACHE_HTTPS_FORWARDED_HOST envvar is set
 <If "-n osenv('APACHE_HTTPS_FORWARDED_HOST')">

--- a/cfgov/apache/conf/httpd.conf
+++ b/cfgov/apache/conf/httpd.conf
@@ -32,6 +32,7 @@ PassEnv PYTHONHOME
 PassEnv APACHE_UPLOADS_F_ALIAS
 PassEnv APACHE_HTTPS_FORWARDED_HOST
 PassEnv APACHE_PORT
+PassEnv LIMIT_REQUEST_BODY
 
 #
 # ServerRoot: The top of the directory tree under which the server's


### PR DESCRIPTION
This PR adds Apache [`LimitRequestBody`](https://httpd.apache.org/docs/2.4/mod/core.html#limitrequestbody) if `LIMIT_REQUEST_BODY` is provided in the environment.

There is a corresponding PR to our automations to add this value.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
