### PR TITLE
Add the LIMIT_REQUEST_BODY variable for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ ENV APACHE_PROCESS_COUNT 4
 ENV ACCESS_LOG /dev/stdout
 ENV ERROR_LOG /dev/stderr
 ENV STATIC_PATH ${APP_HOME}/cfgov/static/
+ENV LIMIT_REQUEST_BODY 0
 
 # mod_wsgi settings
 ENV CFGOV_PATH ${APP_HOME}


### PR DESCRIPTION
This corresponds to the change in 9a5ee5472 to add this variable in production.

We'll see if this successfully deploys when it gets built.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
