### PR TITLE
Add the old /askcfpb/search URL to robots.txt

### DIFF
--- a/cfgov/unprocessed/root/robots.txt
+++ b/cfgov/unprocessed/root/robots.txt
@@ -10,6 +10,7 @@ Disallow: /hud-api-replace
 Disallow: /yourstory
 Disallow: /ask-cfpb/search/
 Disallow: /ask-cfpb/search-by-tag/
+Disallow: /askcfpb/search/
 Disallow: /es/obtener-respuestas/buscar/
 Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
 


### PR DESCRIPTION
This change disallows robots from our old `/askcfpb/search` endpoint. This should stop robot queries like:

```
GET /askcfpb/search/?selected_facets=audience_exact:Older+Americans&selected_facets=audience_exact:Students&selected_facets=category_exact:debt-collection-and-rehabilitation&selected_facets=category_exact:getting-student-loan&selected_facets=category_exact:other-student-loans-questions&selected_facets=category_exact:protections-and-benefits-servicemembers-students&selected_facets=category_exact:repaying-student-loan&selected_facets=category_exact:student-loans&selected_facets=tag_exact:federal+student+loans&selected_facets=category_exact:co-signing-student-loan
```

that end up in a 301 anyway.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
