### PR TITLE
Remove unused ccdb_content_updates flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -730,8 +730,6 @@ FLAGS = {
     "BETA_EXTERNAL_TESTING": [],
     # Used to hide new youth employment success pages prior to public launch
     "YOUTH_EMPLOYMENT_SUCCESS": [],
-    # Used to hide CCDB landing page updates prior to public launch
-    "CCDB_CONTENT_UPDATES": [],
     # During a Salesforce system outage, the following flag should be enabled
     # to alert users that the Collect community is down.
     "COLLECT_OUTAGE": [

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -32,8 +32,7 @@ class ComplaintLandingView(TemplateView):
         context.update(self.is_ccdb_out_of_date(ccdb_status_json))
 
         context.update({
-            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
-            'ccdb_content_updates': flag_enabled('CCDB_CONTENT_UPDATES')
+            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES')
         })
 
         return context

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -32,7 +32,7 @@ class ComplaintLandingView(TemplateView):
         context.update(self.is_ccdb_out_of_date(ccdb_status_json))
 
         context.update({
-            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES')
+            'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
         })
 
         return context


### PR DESCRIPTION
This flag appears unused as it doesn't appear in the complaint-landing template.

## Removals

- Remove unused `ccdb_content_updates` flag.
