### PR TITLE
Update filter height on resize of window

### DIFF
--- a/cfgov/unprocessed/js/organisms/FilterableListControls.js
+++ b/cfgov/unprocessed/js/organisms/FilterableListControls.js
@@ -53,28 +53,29 @@ function FilterableListControls( element ) {
     const _expandables = Expandable.init( _dom );
     _expandable = _expandables[0];
 
-    /**
-     * Refresh the height of the filterable list control's expandable
-     * to ensure all its children are visible.
-     */
-    function _refreshExpandableHeight() {
-      window.setTimeout(
-        _expandable.transition.expand.bind( _expandable.transition ),
-        250
-      );
-    }
-
     // If multiselects exist on the form, iterate over them.
     multiSelects.forEach( multiSelect => {
       multiSelect.addEventListener( 'expandBegin', _refreshExpandableHeight );
       multiSelect.addEventListener( 'expandEnd', _refreshExpandableHeight );
       multiSelect.addEventListener( 'selectionsUpdated', _refreshExpandableHeight );
     } );
+    window.addEventListener( 'resize', _refreshExpandableHeight );
 
     _formModel.init();
     _initAnalyticsEvents.bind( this )();
 
     return this;
+  }
+
+  /**
+   * Refresh the height of the filterable list control's expandable
+   * to ensure all its children are visible.
+   */
+  function _refreshExpandableHeight() {
+    window.setTimeout(
+      _expandable.transition.expand.bind( _expandable.transition ),
+      250
+    );
   }
 
   /**


### PR DESCRIPTION
Currently when you load https://www.consumerfinance.gov/about-us/blog/ at desktop size and resize down to mobile. The filter crops to the point of un-usability:

![Uploading Screen Shot 2021-04-02 at 4.09.10 PM.png…]()

This PR re-calculates the filter's expandable height on resize of the window.

## Changes

- Make the expandable resize on changes to the window size.


## How to test this PR

1. Visit https://www.consumerfinance.gov/about-us/blog/ and resize the window to see the issue where the filter gets cropped.
2. Pull this branch, run locally, and visit /about-us/blog/ and resize the window to compare to production.
