### PR TITLE
Print styling improvements

### DIFF
--- a/cfgov/unprocessed/css/organisms/summary.less
+++ b/cfgov/unprocessed/css/organisms/summary.less
@@ -50,6 +50,10 @@
             right: 0;
             background: linear-gradient( to bottom, rgba(255,255,255,0) 0%,rgba(255,255,255,1) 100% );
             content: '';
+
+            .respond-to-print({
+                background: none;
+            });
         }
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -225,6 +225,20 @@
         max-width: 90vw;
     }
 
+    // Cap content line lengths at ~ 75 characters. `ch` equals the width of the
+    // font's 0 glyph which is wider than some others (i, f, t, etc.) so setting
+    // it to 62 gives us approximately 75 characters per line.
+    .content_main,
+    .content_intro {
+        dd,
+        dt,
+        li,
+        p,
+        label {
+            max-width: 62ch;
+        }
+    }
+
     // Solving Firefox's longstanding issue of cutting off inline-block
     // elements after one page.
     @-moz-document url-prefix() {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -59,8 +59,9 @@
 
     a[href="/"]:after,
     a[href*="?authors"]:after,
-    a.m-info-unit_heading-link:after {
-        // Don't append hrefs to the logo or author links.
+    a.m-info-unit_heading-link:after,
+    .m-info-unit_content h4 a:after {
+        // Don't append hrefs to the logo, author links or info unit headings.
         content: none;
     }
 
@@ -188,11 +189,13 @@
         display: none !important;
     }
 
-    .o-video-player{
+    .o-video-player {
+        // When printing, shrink video preview images to one column with the :after
+        // URL in a second column next to it.
         &_image-container {
             .grid_column( 6 );
         }
-        &::after {
+        &:after {
             content: "Watch the video at https://www.youtube.com/watch?v=" attr(data-id);
             .grid_column( 6 );
         }
@@ -210,6 +213,7 @@
     .o-feedback,
     .o-search-bar,
     .m-hero_image-wrapper {
+        // Hide unimportant print things
         display: none;
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -167,31 +167,22 @@
         }
 
         // Modifiers
-        &__right {
-            .o-featured-content-module_img {
-                right: 0;
-            }
+        &__right &_img {
+            right: 0;
         }
 
-        &__center {
-            .o-featured-content-module_img {
-                left: 50%;
+        &__center &_img {
+            left: 50%;
 
-                transform: translateX( -50% );
+            transform: translateX( -50% );
 
-                .lt-ie9 & {
-                    position: absolute;
-                    right: -100%;
-                    left: -100%;
-                    margin: auto;
-                }
+            .lt-ie9 & {
+                position: absolute;
+                right: -100%;
+                left: -100%;
+                margin: auto;
             }
         }
-    }
-
-    .o-summary_content[aria-expanded="false"]:after {
-        // Remove the fade gradient when printing
-        background: none;
     }
 
     .o-video-player_play-btn {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -103,10 +103,9 @@
         .content-l_col-2-3 {
             // Ensure content remains vertically aligned by rendering them as a table cell
             display: table-cell !important;
-            .m-info-unit_image {
-                // Print info unit images
-                display: block;
-            }
+        }
+        .content-l_col-1 {
+            .grid_column( 12 );
         }
         .content-l_col-1-2 {
             // Keep 50/50 info unit groups at two columns for print
@@ -119,6 +118,10 @@
         .content-l_col-2-3 {
             // Maintain 2/3 layouts for print
             .grid_column( 8 );
+        }
+        .m-info-unit_image {
+            // Print info unit images
+            display: block;
         }
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -99,7 +99,8 @@
 
     .o-info-unit-group {
         .content-l_col-1-2,
-        .content-l_col-1-3 {
+        .content-l_col-1-3,
+        .content-l_col-2-3 {
             // Ensure content remains vertically aligned by rendering them as a table cell
             display: table-cell;
             .m-info-unit_image {
@@ -114,6 +115,10 @@
         .content-l_col-1-3 {
             // Keep 33/33/33 info unit groups at three columns for print
             .grid_column( 4 );
+        }
+        .content-l_col-2-3 {
+            // Maintain 2/3 layouts for print
+            .grid_column( 8 );
         }
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -77,7 +77,7 @@
         // These pseudo-classes are needed to guarantee specificity
         &:link,
         &:visited {
-            // Replace Design System button and stand-alone link stylings with some generic styling
+            // Replace Design System button link stylings with some generic styling
             all: unset;
             border-bottom: 1px dotted @link-underline;
             color: @link-text;
@@ -92,9 +92,11 @@
         // These pseudo-classes are needed to guarantee specificity
         &:link,
         &:visited {
-            border: 0;
+            // Convert stand-alone (jump) links to standard inline links
+            border-top: 0;
+            display: inline;
             padding-top: unit( 5px / @base-font-size-px, em );
-            padding-bottom: unit( 5px / @base-font-size-px, em );
+            padding-bottom: 0;
         }
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -102,7 +102,7 @@
         .content-l_col-1-3,
         .content-l_col-2-3 {
             // Ensure content remains vertically aligned by rendering them as a table cell
-            display: table-cell;
+            display: table-cell !important;
             .m-info-unit_image {
                 // Print info unit images
                 display: block;
@@ -185,13 +185,19 @@
         display: none !important;
     }
 
+    .o-video-player{
+        &_image-container {
+            .grid_column( 6 );
+        }
+        &::after {
+            content: "Watch the video at https://www.youtube.com/watch?v=" attr(data-id);
+            .grid_column( 6 );
+        }
+    }
+
     .a-tagline {
         // Force the tagline's background image to be visible when printing
         color-adjust: exact;
-    }
-
-    .o-video-player::after {
-        content: "Watch the video at https://www.youtube.com/watch?v=" attr(data-id);
     }
 
     .m-global-eyebrow,

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -131,6 +131,11 @@
             // Print info unit images
             display: block;
         }
+        .m-info-unit__inline .m-info-unit_image {
+            // Preserve inline info unit image layout
+            float: left;
+            margin-right: unit( @grid_gutter-width / @base-font-size-px, em );
+        }
     }
 
     // Force FCMs into multiple columns when printing
@@ -190,7 +195,7 @@
     }
 
     .o-video-player_play-btn {
-        // !important used here to avoid being overriden by a much more specific
+        // !important used here to avoid being overridden by a much more specific
         // selector that sets the display property for this element
         // and to avoid using a selector that specific here.
         display: none !important;

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -100,6 +100,11 @@
         }
     }
 
+    .m-list__links .m-list_item {
+        // Space out stand-alone links by .5em
+        margin-bottom: unit( 8px / @base-font-size-px, em );
+    }
+
     .o-info-unit-group {
         .content-l_col-1-2,
         .content-l_col-1-3,
@@ -141,9 +146,9 @@
         &_visual {
             height: 100%;
             overflow: hidden;
-            padding-right: 0    ;
-            padding-bottom: 0   ;
-            padding-left: 0 ;
+            padding-right: 0;
+            padding-bottom: 0;
+            padding-left: 0;
             position: absolute;
             top: 0;
             right: 0;

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -98,9 +98,22 @@
     }
 
     .o-info-unit-group {
+        .content-l_col-1-2,
+        .content-l_col-1-3 {
+            // Ensure content remains vertically aligned by rendering them as a table cell
+            display: table-cell;
+            .m-info-unit_image {
+                // Print info unit images
+                display: block;
+            }
+        }
         .content-l_col-1-2 {
             // Keep 50/50 info unit groups at two columns for print
             .grid_column( 6 );
+        }
+        .content-l_col-1-3 {
+            // Keep 33/33/33 info unit groups at three columns for print
+            .grid_column( 4 );
         }
     }
 
@@ -153,6 +166,11 @@
                 }
             }
         }
+    }
+
+    .o-summary_content[aria-expanded="false"]:after {
+        // Remove the fade gradient when printing
+        background: none;
     }
 
     .o-video-player_play-btn {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -57,7 +57,7 @@
         content: " (" attr(data-pretty-href) ")";
     }
 
-    a[href="/"]:after,
+    a.o-header_logo-img:after,
     a[href*="?authors"]:after,
     a.m-info-unit_heading-link:after,
     .m-info-unit_content h4 a:after {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -49,7 +49,7 @@
         content: " (cfpb.gov" attr(href) ")";
     }
 
-    a[href^="/ask-cfpb"]:after,
+    a[href^="/ask-cfpb/"]:after,
     a[href^="/external-site"]:after,
     a[href*="consumerfinance.gov/ask-cfpb"]:after,
     a[href*="consumerfinance.gov/external-site"]:after {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -224,6 +224,11 @@
         display: none;
     }
 
+    svg.highcharts-root {
+        // Ensure highcharts charts stay within the viewport and aren't cut off
+        max-width: 90vw;
+    }
+
     // Solving Firefox's longstanding issue of cutting off inline-block
     // elements after one page.
     @-moz-document url-prefix() {

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -58,7 +58,8 @@
     }
 
     a[href="/"]:after,
-    a[href*="?authors"]:after {
+    a[href*="?authors"]:after,
+    a.m-info-unit_heading-link:after {
         // Don't append hrefs to the logo or author links.
         content: none;
     }
@@ -100,6 +101,57 @@
         .content-l_col-1-2 {
             // Keep 50/50 info unit groups at two columns for print
             .grid_column( 6 );
+        }
+    }
+
+    // Force FCMs into multiple columns when printing
+    .o-featured-content-module {
+        display: flex;
+
+        &_text {
+            flex: 1;
+            padding-right: @fcm-visual-width + @grid_gutter-width;
+            padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
+        }
+
+        &_visual {
+            height: 100%;
+            overflow: hidden;
+            padding-right: 0    ;
+            padding-bottom: 0   ;
+            padding-left: 0 ;
+            position: absolute;
+            top: 0;
+            right: 0;
+            width: @fcm-visual-width;
+        }
+
+        &_img {
+            max-width: none;
+            height: 100%;
+            position: absolute;
+        }
+
+        // Modifiers
+        &__right {
+            .o-featured-content-module_img {
+                right: 0;
+            }
+        }
+
+        &__center {
+            .o-featured-content-module_img {
+                left: 50%;
+
+                transform: translateX( -50% );
+
+                .lt-ie9 & {
+                    position: absolute;
+                    right: -100%;
+                    left: -100%;
+                    margin: auto;
+                }
+            }
         }
     }
 

--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -96,6 +96,13 @@
         }
     }
 
+    .o-info-unit-group {
+        .content-l_col-1-2 {
+            // Keep 50/50 info unit groups at two columns for print
+            .grid_column( 6 );
+        }
+    }
+
     .o-video-player_play-btn {
         // !important used here to avoid being overriden by a much more specific
         // selector that sets the display property for this element


### PR DESCRIPTION
Latest (and last, for now) batch of print stylesheet improvements.

## Changes

- Info unit headings no longer append ugly URLs.
- Stand-alone links now look like regular links with an underline and proper spacing.
- Columns (50/50, 33/33/33, 25/75) within info unit groups are preserved when printing instead of stacking a la our mobile layout.
- FCM layouts are preserved instead of stacking.
- Video player containers are shrunk into a 50/50 column with the youtube link in the right column.

## How to test this PR

1. `./frontend.sh`
2. Compare the production print preview of the [consumer resources](https://www.consumerfinance.gov/consumer-tools/) page with the localhost version. The localhost version should have columns.
3. Print preview a [page](https://www.consumerfinance.gov/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/request-forbearance-or-mortgage-relief/) with an FCM and the localhost version should render it in a small, sane manner that doesn't take up half a page.
4. Print preview a [page](https://www.consumerfinance.gov/ask-cfpb/what-is-a-mortgage-loan-modification-en-269/) with a full-width video and the localhost version should shrink the video and put the youtube URL to the right of it.

## Screenshots

| before                 | after |
|------------------------|-------|
| <img width="521" alt="before" src="https://user-images.githubusercontent.com/1060248/113736756-63185a80-96cb-11eb-8edb-0dc686619662.png"> | <img width="521" alt="after" src="https://user-images.githubusercontent.com/1060248/113736836-762b2a80-96cb-11eb-935d-37a4ffd419e5.png"> |
| <img width="529" alt="before" src="https://user-images.githubusercontent.com/1060248/113736899-82af8300-96cb-11eb-8c58-a8af14bc638e.png"> | <img width="529" alt="after" src="https://user-images.githubusercontent.com/1060248/113736699-51cf4e00-96cb-11eb-9f3d-69229e621c4f.png"> |
| <img width="530" alt="before" src="https://user-images.githubusercontent.com/1060248/113736549-32d0bc00-96cb-11eb-8cac-e26510c6a94e.png"> | <img width="531" alt="after" src="https://user-images.githubusercontent.com/1060248/113736566-35331600-96cb-11eb-9873-4a6170d3f9c8.png">  |


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
