### PR TITLE
Simple Chart: Switch data source if on wagtail-sharing page

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -653,6 +653,7 @@ CSP_CONNECT_SRC = (
     "n2.mouseflow.com",
     "api.iperceptions.com",
     "*.qualtrics.com",
+    "raw.githubusercontent.com",
 )
 
 # These specify valid media sources (e.g., MP3 files)

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -644,6 +644,23 @@ class SimpleChart(blocks.StructBlock):
         help_text='General chart information'
     )
 
+    def get_context(self, value, parent_context=None):
+        context = super(SimpleChart, self).get_context(
+            value,
+            parent_context=parent_context
+        )
+
+        request = context['request']
+        if hasattr(request, 'served_by_wagtail_sharing'):
+            shared = request.served_by_wagtail_sharing
+        else:
+            shared = False
+
+        context.update({
+            'served_by_wagtail_sharing': shared,
+        })
+        return context
+
     class Meta:
         label = 'Simple Chart'
         icon = 'image'


### PR DESCRIPTION
WIP: Why doesn't the `get_context` method get called? The [template](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/organisms/simple-chart.html) for the simple-chart organism doesn't get the `context`, and I'm not sure why. I'm comparing it to the [related-posts](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/molecules/related-posts.html) template, which *does* get the `context`, and I'm not sure why they're different.


---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

-


## Removals

-


## Changes

-


## How to test this PR

1.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

