### PR TITLE
Simple Chart: Use staging data on wagtail-sharing pages

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -653,6 +653,7 @@ CSP_CONNECT_SRC = (
     "n2.mouseflow.com",
     "api.iperceptions.com",
     "*.qualtrics.com",
+    "raw.githubusercontent.com",
 )
 
 # These specify valid media sources (e.g., MP3 files)

--- a/cfgov/jinja2/v1/_includes/organisms/simple-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/simple-chart.html
@@ -17,6 +17,13 @@
   {% endif %}
 {%- endmacro %}
 
+{% if request.served_by_wagtail_sharing %}
+{% set data_location = value.data_source.replace('production', 'staging') %}
+{% else %}
+{% set data_location = value.data_source %}
+{% endif %}
+
+
 <div class="o-simple-chart">
     {% if value.figure %}
     <h5>Figure {{ value.figure }}</h5>
@@ -34,7 +41,7 @@
 
     <div class="o-simple-chart_target"
          data-chart-type="{{ value.chart_type }}"
-         data-source='{{ value.data_source }}'
+         data-source='{{ data_location }}'
          data-series='{{ value.data_series }}'
          data-x-axis-data='{{ value.x_axis_data }}'
          data-description="{{ value.description }}"

--- a/cfgov/jinja2/v1/browse-basic/index.html
+++ b/cfgov/jinja2/v1/browse-basic/index.html
@@ -36,7 +36,7 @@
     {% for block in page.content -%}
         {% if block.block_type in ['feedback', 'conference_registration_form'] %}
             {{- form_block.render(block, 'content', loop.index0) -}}
-        {% elif block.block_type in ['job_listing_table'] %}
+        {% elif block.block_type in ['job_listing_table', 'simple_chart'] %}
             {% include_block block %}
         {% else %}
             {{ render_block.render(block, loop.index) }}


### PR DESCRIPTION
If the page is being served via wagtail-sharing (i.e. the request's `served_by_wagtail_sharing` attribute is set to `True`), replace any instances of `production` in the `data_source` field with `staging`. If the page is not being served via wagtail-sharing, do not modify the `data_source` field.

This allows us to provide a staged version of a page with different data than is on production. We're assuming that we can have production and staging data sources that exactly parallel each other in URL structure, but replacing 'staging' with 'production'. We're initially building this with CCPI in mind, but hope this feature is general enough to be used for other charts.


## Changes

- Allow Ajax requests to `raw.githubusercontent.com`, since that's where CCPI data will be stored
- Ensure `simple-chart.html` is rendered with context
- Replace 'production' with 'staging' in the `data_source` field when the page is served by wagtail-sharing


## How to test this PR

1. Run this branch, create a page with a simple-chart on it.
2. Use the following URL in the data-source field: `https://raw.githubusercontent.com/cfpb/consumer-credit-conditions-data/main/production/index_age.csv`
3. Publish the page. See that the x-axis of the chart spans 2013-2020. (I modified the production data to be 2013-2020, and left the staging data as 2004-2020, just so the difference would be obvious at a glance)
4. Add `content.` to the front of the URL in the URL bar (e.g. `content.localhost:8000/test`)
5. See that the x-axis spans 2004-2020, meaning the chart is using staging data. Alternatively, use the dev tools to see that the data URL it's fetching is `https://raw.githubusercontent.com/cfpb/consumer-credit-conditions-data/main/staging/index_age.csv`


## Notes and todos

- We should write documentation about this
- ~~I haven't confirmed how/whether it works if the page has never been published~~. Tested on DEV3, and it seems to work correctly on pages that have never been published


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
