### PR TITLE
Update node versions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and several standalone Django apps for specific parts of the site.
 Full installation and usage instructions are available in
 [our documentation](https://cfpb.github.io/consumerfinance.gov).
 
-This project requires Python 3.6, Node 12, and Gulp 4.
+This project requires Python 3.6, Node 14, and Gulp 4.
 We recommend the use of [virtualenv](https://virtualenv.pypa.io/en/stable/) and
 [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)
 for keeping the project's Python dependencies contained.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,9 +23,9 @@ The standard technology stack for development of consumerfinance.gov within the 
 
 - [Elasticsearch](https://www.elastic.co):
   Used for full-text search capabilities and content indexing.
-- [Node 12](http://nodejs.org) and [yarn](https://yarnpkg.com/):
+- [Node](http://nodejs.org) and [yarn](https://yarnpkg.com/):
   Used for downloading and managing front-end dependencies and assets. Front-end dependencies are listed in the project's [package.json](https://github.com/cfpb/consumerfinance.gov/blob/main/package.json) file.
-- [Gulp 4](https://gulpjs.com/) for running tasks, including compiling front-end assets and running acceptance and unit tests.
+- [Gulp](https://gulpjs.com/) for running tasks, including compiling front-end assets and running acceptance and unit tests.
 - [virtualenv](https://virtualenv.pypa.io/en/stable/)
 - [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/)
 


### PR DESCRIPTION
## Changes

- Update node versions in docs from 12 to 14.
- Remove version from node and gulp in section where other software version number are not provided.
