### PR TITLE
Fix the PFC view and tests for jinja2 use

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -125,7 +125,7 @@
                                     Program type
                                 </dt>
                                 <dd class="verify_value">
-                                    {{program.get_level()}}
+                                    {{program.get_level() if program}}
                                 </dd>
                                 <dt class="verify_heading verify_direct-cost">
                                     Estimated total cost of program

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
@@ -404,7 +404,7 @@
                             period
                         </li>
                         <li class="list_item">
-                            Loan fee of {{ DLOriginationFee }}   of the
+                            Loan fee of {{ DLOriginationFee }} of the
                             total loan amount
                         </li>
                         <li class="list_item">

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
@@ -229,7 +229,7 @@
                             Awarded based on financial need
                         </li>
                         <li class="list_item">
-                            Up to <span data-cap="pell">$X</span> per academic
+                            Up to {{ pellCap }} per academic
                             year
                         </li>
                     </ul>
@@ -246,9 +246,8 @@
                             pursuing higher education
                         </li>
                         <li class="list_item">
-                            Up to <span
-                            data-cap="militaryTuitionAssistance">$X</span> per
-                            academic year depending on your service
+                            Up to {{ militaryAssistanceCap }} per
+                               academic year depending on your service
                         </li>
                     </ul>
                     <p>
@@ -319,9 +318,8 @@
                     <p>
                         For federal student loans, the tool applies the interest
                         rates that apply to loans first disbursed during the
-                        <span data-financial="constantsYear"
-                        data-currency="false">2016-17</span> financial aid award
-                        year. These rates are set by the laws governing federal
+                        {{ constantsYear }} financial aid award year.
+                        These rates are set by the laws governing federal
                         student loan programs, including the Higher Education
                         Act.
                     </p>
@@ -347,17 +345,15 @@
                             Awarded based on financial need
                         </li>
                         <li class="list_item">
-                            Up to <span data-cap="perkins">$X</span> per
+                            Up to {{ perkinsUnderCap }} per
                             academic year for undergraduates
                         </li>
                         <li class="list_item">
-                            Up to <span data-cap="perkinsGrad">$X</span> for
-                            graduate students
+                            Up to {{ perkinsGradCap }} for graduate students
                         </li>
                         <li class="list_item">
-                            <span data-financial="perkinsRate"
-                            data-percentage_value="true">[XX]</span>% interest
-                            rate fixed for the life of the loan
+                            {{ perkinsRate }} interest rate
+                            fixed for the life of the loan
                         </li>
                         <li class="list_item">
                             Repayment starts nine months after you leave school
@@ -386,7 +382,7 @@
                             students
                         </li>
                         <li class="list_item">
-                            Up to <span data-cap="directSubsidized">$X</span>
+                            Up to {{ subsidizedCapYearOne }}
                             per academic year for the first year
                         </li>
                         <li class="list_item">
@@ -394,9 +390,8 @@
                             every year you are in school
                         </li>
                         <li class="list_item">
-                            <span data-financial="subsidizedRate"
-                            data-percentage_value="true"> [XX]</span>% interest
-                            rate fixed for the life of the loan
+                            {{ subsidizedRate }} interest rate
+                            fixed for the life of the loan
                         </li>
                         <li class="list_item">
                             Repayment starts six months after you leave school
@@ -409,9 +404,7 @@
                             period
                         </li>
                         <li class="list_item">
-                            Loan fee of <span data-financial="DLOriginationFee"
-                            data-fee="origination"
-                            data-percentage_value="true">[XX]</span>% of the
+                            Loan fee of {{ DLOriginationFee }}   of the
                             total loan amount
                         </li>
                         <li class="list_item">
@@ -427,20 +420,17 @@
                             For all students, regardless of financial need
                         </li>
                         <li class="list_item">
-                            Up to <span
-                            data-cap="directUnsubsidizedDep">$X</span> for the
+                            Up to {{ unsubsidizedCapYearOne }} for the
                             first year in school for dependent undergraduates
                             <ul>
                                 <li class="list_item__spaced">
                                     Increases as you progress through school, up
-                                    to <span
-                                    data-cap="directUnsubsidizedDepThirdYear">$X
-                                    </span>
+                                    to {{ unsubsidizedCapYearThree }}
                                 </li>
                             </ul>
                         </li>
                         <li class="list_item">
-                            Up to <span data-cap="directUnsubsidized">$X</span>
+                            Up to {{ unsubsidizedCapIndepYearOne }}
                             for the first year for independent undergraduate
                             students (students who are not required to provide
                             parental information when applying for federal
@@ -448,14 +438,12 @@
                             <ul>
                                 <li class="list_item__spaced">
                                     Increases as you progress through school, up
-                                    to <span
-                                    data-cap="directUnsubsidizedThirdYear">$X</span>
+                                    to {{ unsubsidizedCapIndepYearThree }}
                                 </li>
                             </ul>
                         </li>
                         <li class="list_item">
-                            Up to <span
-                            data-cap="directUnsubsidizedGrad">$X</span> for
+                            Up to {{ unsubsidizedCapGrad }} for
                             graduate or professional students – higher annual
                             limits apply to students pursuing degrees in the
                             health professions.
@@ -469,16 +457,13 @@
                             unsubsidized loans your first year.
                         </li>
                         <li class="list_item">
-                            <span data-financial="unsubsidizedRateUndergrad"
-                            data-percentage_value="true">[XX]</span>% interest
-                            rate for undergraduates fixed for the life of the
-                            loan
+                            {{ unsubsidizedRateUndergrad }} interest rate
+                            for undergraduates fixed for the life of the loan
                         </li>
                         <li class="list_item">
-                            <span data-financial="unsubsidizedRateGrad"
-                            data-percentage_value="true">[XX]</span>% interest
-                            rate for graduate or professional students fixed for
-                            the life of the loan
+                            {{ unsubsidizedRateGrad }} interest rate
+                            for graduate or professional students fixed
+                            for the life of the loan
                         </li>
                         <li class="list_item">
                             Interest starts accruing while you are still in
@@ -489,9 +474,7 @@
                             (grace period)
                         </li>
                         <li class="list_item">
-                            Loan fee of <span data-financial="DLOriginationFee"
-                            data-fee="origination"
-                            data-percentage_value="true">[XX]</span>% of the
+                            Loan fee of {{ DLOriginationFee }} of the
                             total loan amount
                         </li>
                     </ul>
@@ -521,9 +504,8 @@
                             including other federal loans
                         </li>
                         <li class="list_item">
-                            <span data-financial="gradPlusRate"
-                            data-percentage_value="true">[XX]</span>% interest
-                            rate fixed for the life of the loan
+                            {{ gradPlusRate }} interest rate
+                            fixed for the life of the loan
                         </li>
                         <li class="list_item">
                             Interest starts accruing while you are still in
@@ -534,10 +516,7 @@
                             (deferment period)
                         </li>
                         <li class="list_item">
-                            Loan fee of <span
-                            data-financial="plusOriginationFee"
-                            data-fee="origination"
-                            data-percentage_value="true">[XX]</span>% of the
+                            Loan fee of {{ plusOriginationFee }} of the
                             total loan amount
                         </li>
                     </ul>
@@ -637,10 +616,9 @@
                     </ul>
                     <p>
                         For private student loans where an interest rate is not
-                        provided we assume a constant interest rate of <span
-                        data-financial="privateLoanRate"
-                        data-percentage_value="true">[XX]</span>%. The tool
-                        allows you to adjust that interest rate to match what
+                        provided we assume a constant interest rate of
+                        {{ privateLoanRate }}. The tool allows you
+                        to adjust that interest rate to match what
                         you have been offered by your lender. However, keep in
                         mind that interest rates on private student loans and or
                         tuition payment plans may be variable and change

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -1,16 +1,21 @@
 import copy
 import json
 import unittest
+from decimal import Decimal
 from unittest import mock
 
 import django
 from django.http import HttpRequest
 from django.urls import reverse
 
-from paying_for_college.models import Program, School
+from model_bakery import baker
+
+from paying_for_college.models import (
+    ConstantCap, ConstantRate, Program, School
+)
 from paying_for_college.views import (
-    EXPENSE_FILE, Feedback, get_json_file, get_program, get_program_length,
-    get_school, validate_oid, validate_pid
+    EXPENSE_FILE, Feedback, format_constants, get_json_file, get_program,
+    get_program_length, get_school, validate_oid, validate_pid
 )
 
 
@@ -132,14 +137,48 @@ class SchoolProgramTest(django.test.TestCase):
         self.assertIs(test3, None)
 
 
+class ConstantsTest(django.test.TestCase):
+
+    def setUp(self):
+        self.dl_origination_fee = baker.make(
+            ConstantRate,
+            name="DL origination fee",
+            slug="DLOriginationFee",
+            value=Decimal('0.01057')
+        )
+        self.perkins_rate = baker.make(
+            ConstantRate,
+            name="Perkins rate",
+            slug="perkinsRate",
+            value=Decimal('0.05000')
+        )
+        self.year_value = baker.make(
+            ConstantCap,
+            name="Constants year",
+            slug="constantsYear",
+            value=2020
+        )
+        self.pell_cap = baker.make(
+            ConstantCap,
+            name="Pell cap",
+            slug="pellCap",
+            value=9293
+        )
+
+    def test_format_constants(self):
+        constants = format_constants()
+        self.assertEqual(constants["DLOriginationFee"], "1.057%")
+        self.assertEqual(constants["perkinsRate"], "5%")
+        self.assertEqual(constants["pellCap"], "$9,293")
+        self.assertEqual(constants["constantsYear"], "2020-21")
+
+
 class OfferTest(django.test.TestCase):
 
     fixtures = ["test_fixture.json", "test_program.json"]
 
     # /paying-for-college2/understanding-your-financial-aid-offer/offer/?[QUERYSTRING]
     def test_offer(self):
-        """request for offer disclosure."""
-
         url = reverse("paying_for_college:disclosures:offer")
         # offer_test_url = reverse("paying_for_college:disclosures:offer_test")
         qstring = (
@@ -174,36 +213,35 @@ class OfferTest(django.test.TestCase):
             "?iped=408039&pid=&oid=f38283b" "5b7c939a058889f997949efa566c616c5"
         )
         resp = self.client.get(url + qstring)
-        self.assertTrue(resp.status_code == 200)
+        self.assertEqual(resp.status_code, 200)
         resp_test = self.client.get(url + qstring)
-        self.assertTrue(resp_test.status_code == 200)
+        self.assertEqual(resp_test.status_code, 200)
         resp2 = self.client.get(url + no_oid)
-        self.assertTrue(resp2.status_code == 200)
-        self.assertTrue("noOffer" in resp2.context["warning"])
+        self.assertEqual(resp2.status_code, 200)
+        self.assertIn(b"noOffer", resp2.content)
         resp3 = self.client.get(url + bad_school)
-        self.assertTrue("noSchool" in resp3.context["warning"])
-        self.assertTrue(resp3.status_code == 200)
+        self.assertIn(b"noSchool", resp3.content)
+        self.assertEqual(resp3.status_code, 200)
         resp4 = self.client.get(url + bad_program)
-        self.assertTrue(resp4.status_code == 200)
-        self.assertTrue("noProgram" in resp4.context["warning"])
+        self.assertEqual(resp4.status_code, 200)
+        self.assertIn(b"noProgram", resp4.content)
         resp5 = self.client.get(url + missing_oid_field)
         self.assertTrue(resp5.status_code == 200)
-        self.assertTrue("noOffer" in resp5.context["warning"])
+        self.assertTrue(b"noOffer" in resp5.content)
         resp6 = self.client.get(url + missing_school_id)
-        self.assertTrue("noSchool" in resp6.context["warning"])
+        self.assertTrue(b"noSchool" in resp6.content)
         self.assertTrue(resp6.status_code == 200)
         resp7 = self.client.get(url + bad_oid)
-        self.assertTrue("noOffer" in resp7.context["warning"])
+        self.assertTrue(b"noOffer" in resp7.content)
         self.assertTrue(resp7.status_code == 200)
         resp8 = self.client.get(url + illegal_program)
-        self.assertTrue("noProgram" in resp8.context["warning"])
+        self.assertTrue(b"noProgram" in resp8.content)
         self.assertTrue(resp8.status_code == 200)
         resp9 = self.client.get(url + no_program)
-        self.assertTrue("noProgram" in resp9.context["warning"])
+        self.assertIn(b"noProgram", resp9.content)
         self.assertTrue(resp9.status_code == 200)
         resp10 = self.client.get(url)
-        self.assertTrue(resp10.context["warning"] == "")
-        self.assertTrue(resp10.status_code == 200)
+        self.assertEqual(resp10.status_code, 404)
 
 
 class APITests(django.test.TestCase):
@@ -217,7 +255,6 @@ class APITests(django.test.TestCase):
     # /paying-for-college2/understanding-your-financial-aid-offer/api/school/155317.json
     def test_school_json(self):
         """api call for school details."""
-
         url = reverse(
             "paying_for_college:disclosures:school-json", args=["155317"]
         )

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -3,7 +3,9 @@ import os
 import re
 from collections import OrderedDict
 
-from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
+from django.http import (
+    Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
+)
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.views.generic import TemplateView, View
@@ -76,7 +78,7 @@ def get_program_length(program, school):
 
 
 def get_school(schoolID):
-    """Try to get a school by ID; return either school or empty string"""
+    """Try to get a school by ID; return either school or empty string."""
     try:
         school = School.objects.get(school_id=int(schoolID))
     except Exception:
@@ -89,7 +91,7 @@ def get_school(schoolID):
 
 
 def get_program(school, programCode):
-    """Try to get latest program; return either program or empty string"""
+    """Try to get latest program; return either program or empty string."""
     if not validate_pid(programCode):
         return None
     programs = Program.objects.filter(program_code=programCode,
@@ -100,16 +102,32 @@ def get_program(school, programCode):
         return None
 
 
+def format_constants():
+    constants = {}
+    rates = ConstantRate.objects.all()
+    caps = ConstantCap.objects.all()
+    for rate in rates:
+        constants[rate.slug] = f"{round((rate.value * 100), 3).normalize()}%"
+    for cap in caps:
+        if cap.slug == "constantsYear":
+            year_value = f"{cap.value}-" + f"{cap.value + 1}"[-2:]
+            constants[cap.slug] = year_value
+        else:
+            constants[cap.slug] = f"${cap.value:,}"
+    return constants
+
+
 class BaseTemplateView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(BaseTemplateView, self).get_context_data(**kwargs)
         context['url_root'] = DISCLOSURE_ROOT
+        context.update(format_constants())
         return context
 
 
 class OfferView(TemplateView):
-    """consult values in querystring and deliver school/program data"""
+    """Consult values in querystring and deliver school/program data."""
 
     def get(self, request, test=False):
         school = None
@@ -119,16 +137,7 @@ class OfferView(TemplateView):
         warning = ''
         OID = ''
         if not request.GET:
-            return render(request, 'paying-for-college/disclosure.html', {
-                'data_js': "0",
-                'school': school,
-                'schoolData': school_data,
-                'program': program,
-                'programData': program_data,
-                'oid': OID,
-                'warning': warning,
-                'url_root': DISCLOSURE_ROOT,
-            })
+            raise Http404
         if 'oid' in request.GET and request.GET['oid']:
             OID = request.GET['oid']
         else:
@@ -262,7 +271,7 @@ class StatsRepresentation(View):
 
 
 class ExpenseRepresentation(View):
-    """deliver BLS expense data in json form"""
+    """Deliver BLS expense data in json form."""
 
     def get(self, request):
         expense_json = get_json_file(EXPENSE_FILE)
@@ -273,7 +282,7 @@ class ExpenseRepresentation(View):
 
 
 class ConstantsRepresentation(View):
-    """deliver stored Constants in json form"""
+    """Deliver stored Constants in json form."""
 
     def get_constants(self):
         constants = OrderedDict()


### PR DESCRIPTION
This PR fixes three bits of the technote rendering.

### Template function calls 
Jinja2 templates run Python code in a more Pythonic way than do Django templates.
Django allows templates to call functions without the standard `()` evocation,
whereas Jinja executes functions with `()` and arguments.

### Tests
The Django test client also does not populate the `context` variable in
Jinja2 responses, so tests can't check `context` for expected values.

In this case, we can just as easily check the `content` of the response
for the values we're expecting.

### Constants

The PFC technote template performed a bunch of span replacement actions to pull in and format 
constants that are stored in the database. These swaps were not working in the jinja2 template. 
Since the constants are available to the technote's view, it seems simpler to format them in the view 
and deliver them at render time without any swapping.   

This PR delivers formatted constants in the text where needed, using the slug names 
that editors see in the database. This makes it easier to see where a constant is being used in the text.

### A semi-related nit

The offer view originally allowed a bare response -- rendering the tool without
any school or program specified, and with no warning dialog. Since the tool is useless and confusing 
in this state, I think it makes sense to return 404 when there is no GET data.
