### PR TITLE
Drop our fork of wagtail-autocomplete and upgrade to 0.6.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -30,7 +30,7 @@ requests==2.22.0
 requests_aws4auth==0.8.0
 requests_toolbelt==0.8.0
 urllib3==1.25.2
-# wagtail-autocomplete==0.6 TODO: Restore when wagtail-autocomplete #77 is merged
+wagtail-autocomplete==0.6.3
 wagtail-flags==5.1.0
 wagtail-inventory==1.2.0
 wagtail-placeholder-images==0.1.1
@@ -40,7 +40,6 @@ wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.2/elasticsearch_dsl-7.2.2-py2.py3-none-any.whl
-https://github.com/cfpb/wagtail-autocomplete/releases/download/0.7/wagtail_autocomplete-0.6-py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
 https://github.com/cfpb/retirement/releases/download/0.15.2/retirement-0.15.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.2/ccdb5_api-1.5.2-py3-none-any.whl


### PR DESCRIPTION
We can cap this timeline now:
- July 2020: we noticed wagtail-autocomplete was causing server errors
- August 2020:
    - We opened a PR with wagtail-autocomplete, and it was approved but not merged
    - We forked the repo with our fix, so that we could stop the server errors
- January 2021: our PR was merged
- April 12, 2021: version 0.6.3 was released, allowing us to use the main repo again.

### Testing
- Check out the branch and run `pip install -r requirements/libraries.txt`
- Locally edit an Ask CFPB answer page that has "related quesions" attached,
such as [en-1793](http://localhost:8000/admin/pages/6208/edit/), and make sure you can remove 
and add related questions and save without server errors.
- At the bottom of the edit page, make sure you can search for, select, and remove
a "redirect to page" entry.
