### PR TITLE
Switch from file-based to DB cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,11 +126,10 @@ USER apache
 
 # Build frontend, cleanup excess file, and setup filesystem
 # - cfgov/f/ - Wagtail file uploads
-# - /tmp/eregs_cache/ - Django file-based cache
 RUN ln -s ${SCL_HTTPD_ROOT}/etc/httpd/modules ${APACHE_SERVER_ROOT}/modules && \
     ln -s ${SCL_HTTPD_ROOT}/etc/httpd/run ${APACHE_SERVER_ROOT}/run && \
     rm -rf cfgov/apache/www cfgov/unprocessed && \
-    mkdir -p cfgov/f /tmp/eregs_cache
+    mkdir -p cfgov/f
 
 # Healthcheck retry set high since database loads take a while
 HEALTHCHECK --start-period=300s --interval=30s --retries=30 \

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -88,8 +88,9 @@ STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
-        'LOCATION': '/tmp/eregs_cache',
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cfgov_default_cache',
+        'TIMEOUT': None,
     },
     'post_preview': {
         'BACKEND': 'django.core.cache.backends.db.DatabaseCache',


### PR DESCRIPTION
This change removes our production file-based default cache in favor of a default database cache.

There will be a corresponding PR to remove permission-setting on `eregs_cache` from our automations, but we already run `createcachetable` for our database post preview cache.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
