### PR TITLE
Update Django Debug Toolbar to address security vulnerability

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,5 +1,5 @@
 -r base.txt
-django-debug-toolbar==1.11
+django-debug-toolbar==3.2.1
 django-sslserver==0.20
 tox-pip-extensions==1.6.0
 tox==3.19.0


### PR DESCRIPTION
This PR updates Django Debug Toolbar to 3.2.1. This bumps us up a few versions (we were on 1.11) and addresses [this security vulnerability](https://www.djangoproject.com/weblog/2021/apr/14/debug-toolbar-security-releases/).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
