### PR TITLE
Fix video player image stretching in Safari

### DIFF
--- a/cfgov/unprocessed/css/organisms/video-player.less
+++ b/cfgov/unprocessed/css/organisms/video-player.less
@@ -85,12 +85,12 @@
     transition: opacity .25s;
     // Needed for IE11 to not stretch the image.
     flex-shrink: 0;
+    align-self: center;
 
     // Using the default CFPB cover card image.
     &[src^="/static/img/cfpb_video_cover_card_954x200"] {
         padding: unit( 60px / @base-font-size-px, em );
         box-sizing: border-box;
-        align-self: center;
 
         // Overrides values set in featured-content-module.less file in the DS.
         &.o-featured-content-module_img {


### PR DESCRIPTION
Due to a flex box alignment issue, video player preview images are stretched vertically on Safari at small screen sizes. This PR applies `align-self:center` to the class to prevent the stretching.


## Changes

- Apply `align-self:center` generally to `.o-video-player_image` class to prevent image stretching in Safari


## How to test this PR

1. Check out branch and run gulp
2. Navigate to [housing assistance forbearance page locally](http://localhost:8000/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/learn-about-forbearance/) on Safari with browser width reduced and verify that image is not stretched


## Screenshots

### Production

<img width="527" alt="Screen Shot 2021-04-21 at 9 27 17 AM" src="https://user-images.githubusercontent.com/778171/115590361-b8d13300-a285-11eb-918c-607f577273cc.png">


### With align-self: center

<img width="542" alt="Screen Shot 2021-04-21 at 9 26 49 AM" src="https://user-images.githubusercontent.com/778171/115590494-e1f1c380-a285-11eb-9cc0-32788f1e5756.png">





## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
