### PR TITLE
Add `createcachetable` command to Python Docker service

### DIFF
--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -106,6 +106,7 @@ services:
 
                 if [ $$django_tables_exist -gt 0 ] || [ $$REFRESH_DB == 'true' ]; then
                     ./refresh-data.sh
+                    ./cfgov/manage.py createcachetable
                 fi
 
                 ./cfgov/manage.py update_index


### PR DESCRIPTION
In an attempt to eliminate an error we're seeing on launch:

```
django.db.utils.ProgrammingError: relation "cfgov_default_cache" does not exist
```

## How to test this PR

1. We'll see if the Docker stack for this PR deploys successfully.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

[skip-ci]