### PR TITLE
Remove unused reference to CI_CHECK_MIGRATIONS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,6 @@ deps=
     -r{toxinidir}/requirements/test.txt
 commands=
     coverage erase
-    {env:CI_CHECK_MIGRATIONS:echo "Skipping CI-only step"}
     python -b -m coverage run --source='.' manage.py test {posargs}
 
 


### PR DESCRIPTION
Commit 13ca4101153f14fe7f507a543894db96f8af9be1 modified how and when we validate Django migrations as part of CI, but it left behind this dangling line. This line can be removed without any side effects:

https://github.com/cfpb/consumerfinance.gov/search?q=CI_CHECK_MIGRATIONS