### PR TITLE
Enable default cache locally based on env var

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -33,6 +33,7 @@ export WAGTAIL_SHARING_HOSTNAME=content.localhost
 # Location used by refresh_data.sh for retrieving latest database dump.
 #export CFGOV_PROD_DB_LOCATION=<some_database_dump_url>
 
+#export ENABLE_DEFAULT_CACHE=1
 #export ENABLE_POST_PREVIEW_CACHE=1
 #export EMAIL_HOST=<email_server_hostname>
 #export ADMIN_EMAILS=<comma_delimited_list_of_emails>

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -85,6 +85,14 @@ CACHES = {
     for k in ("default", "post_preview")
 }
 
+# Optionally enable default cache
+if os.environ.get("ENABLE_DEFAULT_CACHE"):
+    CACHES["default"] = {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "default_cache",
+        "TIMEOUT": None,
+    }
+
 # Optionally enable cache for post_preview
 if os.environ.get("ENABLE_POST_PREVIEW_CACHE"):
     CACHES["post_preview"] = {


### PR DESCRIPTION
This change enables our default cache locally based on an environment variable. This will enable us to use the default cache in local development more easily.

## How to test this PR

Set `ENABLE_DEFAULT_CACHE` in `.env` (see `.env_SAMPLE` in this PR).

Run `./cfgov/manage.py createcachetable`

Run `./cfgov/manage.py shell` and:

```python
from django.core.cache import cache
cache.set('my_key', 'hello, world!', 10)
cache.get('my_key')
```

You should get hello, world! back.

Then wait 10 seconds and try again:

```python
cache.get('my_key')
```

And you should get nothing.

## Notes and todos

- We should settle on use cases of the Django cache and document them, along with this env var to enable the cache locally.

## Checklist


- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
