### PR TITLE
Disallow the curriculum review tool completion pages in robots.txt

### DIFF
--- a/cfgov/unprocessed/root/robots.txt
+++ b/cfgov/unprocessed/root/robots.txt
@@ -13,5 +13,6 @@ Disallow: /ask-cfpb/search-by-tag/
 Disallow: /askcfpb/search/
 Disallow: /es/obtener-respuestas/buscar/
 Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
+Disallow: /consumer-tools/educator-tools/youth-financial-education/curriculum-review/tool/*
 
 sitemap: https://www.consumerfinance.gov/sitemap.xml


### PR DESCRIPTION
We don't need or want the CRT completion pages indexed for search.
Users should always start upstream.
