### PR TITLE
P4C: update browser tests to reflect interface changes

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
@@ -105,7 +105,7 @@
                 'name':  "programProgress",
                 'label': '<strong>None.</strong> I have no credits or only credits from AP/IB exams.',
                 'value': 'n',
-                'id': 'program-years_spent-0'
+                'id': 'program-years-spent-radio_n'
               })
           }}
           {{
@@ -113,7 +113,7 @@
                 'name':  "programProgress",
                 'label': '<strong>I will be a first-year student.</strong> I have completed 1 - 29 credits, or less than 1 year.',
                 'value': '0',
-                'id': 'program-years_spent-1'
+                'id': 'program-years-spent-radio_0'
               })
           }}
           {{
@@ -121,7 +121,7 @@
                 'name':  "programProgress",
                 'label': '<strong>I will be a second-year student.</strong> I have completed 30 - 59 credits, or less than 2 years.',
                 'value': '1',
-                'id': 'program-years_spent-2'
+                'id': 'program-years-spent-radio_1'
               })
           }}
           {{
@@ -129,7 +129,7 @@
                 'name':  "programProgress",
                 'label': '<strong>I have an associate\'s degree.</strong> I will be a third-year student.',
                 'value': 'a',
-                'id': 'program-years_spent-assoc'
+                'id': 'program-years-spent-radio_a'
               })
           }}
           {{
@@ -137,7 +137,7 @@
                 'name':  "programProgress",
                 'label': '<strong>I will be a third-year student, or beyond.</strong> I have completed 60+ credits, or 2+ years.',
                 'value': '2',
-                'id': 'program-years_spent-3'
+                'id': 'program-years-spent-radio_3'
               })
           }}
         </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/01-school-search.html
@@ -137,7 +137,7 @@
                 'name':  "programProgress",
                 'label': '<strong>I will be a third-year student, or beyond.</strong> I have completed 60+ credits, or 2+ years.',
                 'value': '2',
-                'id': 'program-years-spent-radio_3'
+                'id': 'program-years-spent-radio_2'
               })
           }}
         </div>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/02-costs.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/02-costs.html
@@ -23,7 +23,11 @@
                 })
             }}
 
-            <button class="a-btn" data-costs_offer-answer="y">Continue</button>
+            <button class="a-btn"
+                    data-costs_offer-answer="y"
+                    id="costs-offer-button">
+                Continue
+            </button>
         </div>
     </div>
 

--- a/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -18,11 +18,12 @@ describe( 'Paying For College', () => {
       page.searchResults().should( 'be.visible' );
       page.clickSearchResult( 'Harvard University' );
       page.selectProgram( 'type', 'certificate' );
+      page.selectProgram( 'years-spent', 'n' );
       page.selectProgram( 'length', '1' );
       page.selectProgram( 'housing', 'on-campus' );
       page.selectProgram( 'dependency', 'dependent' );
       page.clickNextStep();
-      page.click( 'No' );
+      page.costsQuestionChoice( 'no' );
       page.setText( 'costs__tuition-fees', '50000' );
       page.setText( 'costs__room-board', '25000' );
       page.setText( 'costs__otherDirect-board', '12500' );
@@ -42,11 +43,12 @@ describe( 'Paying For College', () => {
       page.searchResults().should( 'be.visible' );
       page.clickSearchResult( 'Harvard University' );
       page.selectProgram( 'type', 'associates' );
+      page.selectProgram( 'years-spent', 'n' );
       page.selectProgram( 'length', '2' );
       page.selectProgram( 'housing', 'off-campus' );
       page.selectProgram( 'dependency', 'dependent' );
       page.clickNextStep( );
-      page.click( 'Yes' );
+      page.costsQuestionChoice( 'yes' );
       page.setText( 'costs__tuition-fees', '100000' );
       page.setText( 'costs__room-board', '50000' );
       page.setText( 'costs__otherDirect-board', '25000' );
@@ -66,10 +68,11 @@ describe( 'Paying For College', () => {
       page.searchResults().should( 'be.visible' );
       page.clickSearchResult( 'Harvard University' );
       page.selectProgram( 'type', 'graduate' );
+      page.selectProgram( 'years-spent', 'n' );
       page.selectProgram( 'length', '4' );
       page.selectProgram( 'housing', 'off-campus' );
       page.clickNextStep( );
-      page.click( 'No' );
+      page.costsQuestionChoice( 'no' );
       page.setText( 'costs__tuition-fees', '400000' );
       page.setText( 'costs__room-board', '200000' );
       page.setText( 'costs__otherDirect-board', '100000' );
@@ -83,8 +86,6 @@ describe( 'Paying For College', () => {
         cy.wrap( el ).should( 'contain', '$797,500' );
       } );
       page.clickNextStep( );
-      page.setText( 'grants__pell', '9000' );
-      page.setText( 'grants__seog', '10000' );
       page.setText( 'grants__otherFederal', '11000' );
       page.setText( 'grants__state', '12000' );
       page.setText( 'grants__school', '13000' );
@@ -95,7 +96,7 @@ describe( 'Paying For College', () => {
       page.setText( 'scholarships__state', '17000' );
       page.setText( 'scholarships__school', '18000' );
       page.setText( 'scholarships__other', '19000' );
-      cy.get( '[data-financial-item="total_grantsScholarships"]' ).should( 'contain', '$158,500' );
+      cy.get( '[data-financial-item="total_grantsScholarships"]' ).should( 'contain', '$139,500' );
       page.clickNextStep( );
       page.setText( 'workStudy__workStudy', '50000' );
       cy.get( '[data-financial-item="total_workStudy"]' ).should( 'contain', '$50,000' );
@@ -112,7 +113,7 @@ describe( 'Paying For College', () => {
       page.setText( 'loans__nonprofitLoan', '40000' );
       page.setText( 'loans__nonprofitLoanRate', '3' );
       page.setText( 'loans__nonprofitLoanFee', '2' );
-      cy.get( '[data-financial-item="total_publicLoans"]' ).should( 'contain', '$197,700' );
+      cy.get( '[data-financial-item="total_publicLoans"]' ).first().should( 'contain', '$197,700' );
       page.clickNextStep( );
       page.setText( 'savings__personal', '10000' );
       page.setText( 'savings__family', '20000' );
@@ -140,11 +141,12 @@ describe( 'Paying For College', () => {
       page.searchResults().should( 'be.visible' );
       page.clickSearchResult( 'Harvard University' );
       page.selectProgram( 'type', 'bachelors' );
+      page.selectProgram( 'years-spent', 'n' );
       page.selectProgram( 'length', '3' );
       page.selectProgram( 'housing', 'on-campus' );
       page.selectProgram( 'dependency', 'dependent' );
       page.clickNextStep( );
-      page.click( 'Yes' );
+      page.costsQuestionChoice( 'yes' );
       page.setText( 'costs__tuition-fees', '200000' );
       page.setText( 'costs__room-board', '100000' );
       page.setText( 'costs__otherDirect-board', '50000' );
@@ -170,7 +172,7 @@ describe( 'Paying For College', () => {
       page.setText( 'scholarships__state', '1000' );
       page.setText( 'scholarships__school', '2000' );
       page.setText( 'scholarships__other', '3000' );
-      cy.get( '[data-financial-item="total_grantsScholarships"]' ).should( 'contain', '$54,793' );
+      cy.get( '[data-financial-item="total_grantsScholarships"]' ).first().should( 'contain', '$54,793' );
       page.clickNextStep( );
       page.setText( 'workStudy__workStudy', '50000' );
       cy.get( '[data-financial-item="total_workStudy"]' ).should( 'contain', '$50,000' );
@@ -187,7 +189,7 @@ describe( 'Paying For College', () => {
       page.setText( 'loans__nonprofitLoan', '40000' );
       page.setText( 'loans__nonprofitLoanRate', '3' );
       page.setText( 'loans__nonprofitLoanFee', '2' );
-      cy.get( '[data-financial-item="total_publicLoans"]' ).should( 'contain', '$197,700' );
+      cy.get( '[data-financial-item="total_publicLoans"]' ).first().should( 'contain', '$197,700' );
       page.clickNextStep( );
       page.setText( 'savings__personal', '10000' );
       page.setText( 'savings__family', '20000' );
@@ -196,7 +198,7 @@ describe( 'Paying For College', () => {
       page.setText( 'income__jobOnCampus', '50000' );
       page.setText( 'income__employerAssist', '60000' );
       page.setText( 'income_otherFunding', '70000' );
-      cy.get( '[data-financial-item="total_otherResources"]' ).should( 'contain', '$280,000' );
+      cy.get( '[data-financial-item="total_otherResources"]' ).first().should( 'contain', '$280,000' );
       page.clickNextStep( );
       page.clickNextStep( );
       page.clickNextStep( );

--- a/test/cypress/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -1,9 +1,5 @@
 export class PfcFinancialPathToGraduation {
 
-  click( name ) {
-    cy.get( '.a-btn' ).contains( name ).click();
-  }
-
   clickGetStarted() {
     cy.get( '.btn__get-started' ).click();
   }
@@ -51,5 +47,10 @@ export class PfcFinancialPathToGraduation {
 
   actionPlan( name ) {
     cy.get( `#action-plan_${ name }` ).check( { force: true } );
+  }
+
+  costsQuestionChoice( name ) {
+    cy.get( `label[for="costs-offer-radio_${ name }"]` ).click();
+    cy.get( '#costs-offer-button' ).click();
   }
 }


### PR DESCRIPTION
P4C browser tests are failing due to recently released grad path tool updates. This PR updates the tests to reflect the interface changes.


## Changes

- ID updates in grad path tool
- Updates to grad path tests
  - Handle new progress question on first screen
  - Update costs question handling to reflect new radio + button format
  - Remove PELL and SEOG entries from graduate test
## How to test this PR

1. Check out branch 
2. `yarn run cypress open` and run `your-financial-path-to-graduation` tests under Paying for College


## Screenshots

### New progress field on first screen
<img width="612" alt="Screen Shot 2021-04-28 at 3 33 57 PM" src="https://user-images.githubusercontent.com/778171/116481077-581e9900-a837-11eb-9fd9-04387bc39f40.png">


### Costs question updates
<img width="612" alt="Screen Shot 2021-04-28 at 3 34 10 PM" src="https://user-images.githubusercontent.com/778171/116481083-5a80f300-a837-11eb-8bd5-670b809b03ca.png">


### PELL & SEOG removed as options for graduate students
<img width="617" alt="Screen Shot 2021-04-28 at 3 34 26 PM" src="https://user-images.githubusercontent.com/778171/116481092-5d7be380-a837-11eb-894b-3d328db139d8.png">


<img width="1199" alt="Screen Shot 2021-04-28 at 3 29 11 PM" src="https://user-images.githubusercontent.com/778171/116480633-89e33000-a836-11eb-8be8-684af09a2c67.png">





## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
