### PR TITLE
Opt consumerfinance.gov out of Google's FLoC cohorts

### DIFF
--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -36,3 +36,6 @@ Header always set X-Content-Type-Options: nosniff
 # <LocationMatch ^\/company-signup\/$>
 #         Header always set Edge-Control: no-store
 # </LocationMatch>
+
+# Opt out of Google's Federated Learning of Cohorts approach to tracking
+Header always set Permissions-Policy: interest-cohort=()


### PR DESCRIPTION
CFPB should be a trusted resource for all of our visitors. They should be able to trust they won't be placed into an advertising cohort to have, for example, high-interest loans advertised at them if they use our mortgage information and tools.

This change sets the `Permissions-Policy: interest-cohort=()` to declare consumerfinance.gov should not be included in a browser's cohort calculation, per [web.dev's FLoC explainer](https://web.dev/floc/#how-can-websites-opt-out-of-the-floc-computation).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
