### PR TITLE
Improve filterable list performance

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
+++ b/cfgov/jinja2/v1/_includes/organisms/filterable-list.html
@@ -35,15 +35,14 @@
 
    show_post_tags: Whether to render the tags in post previews.
 
+   has_unfiltered_results: Whether the filterable list has anything to filter.
+
    ========================================================================== #}
 
 {% import 'organisms/filterable-list-controls.html' as filterable_list_controls with context %}
 {% import 'molecules/notification.html' as notification with context %}
 
 {# SHOW A NOTIFICATION IF THERE'S NOTHING TO FILTER. #}
-
-{% set has_unfiltered_results = filter_data.form.filterable_pages.first() %}
-
 {% if not has_unfiltered_results and value.no_posts_message %}
     {{ notification.render(
         'information',
@@ -52,7 +51,6 @@
         value.no_posts_explanation
     ) }}
 {% elif has_unfiltered_results %}
-
     <div class="o-filterable-list">
         {% set form = filter_data.form %}
         {% set posts = filter_data.page_set %}

--- a/cfgov/v1/apps.py
+++ b/cfgov/v1/apps.py
@@ -3,14 +3,14 @@ from django.contrib.auth import get_user_model
 from django.contrib.staticfiles import storage
 from django.db.models.signals import post_save
 
-from .signals import user_save_callback
-
 
 class V1AppConfig(AppConfig):
     name = 'v1'
     verbose_name = 'V1'
 
     def ready(self):
+        from v1.signals import user_save_callback
+
         user_model = get_user_model()
         post_save.connect(user_save_callback, sender=user_model)
         # Interesting situation: we use this pattern to account for

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -2,6 +2,7 @@ from collections import Counter
 from datetime import date
 
 from django import forms
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.forms import widgets
 
@@ -121,14 +122,57 @@ class FilterableListForm(forms.Form):
         self.wagtail_block = kwargs.pop('wagtail_block')
         self.filterable_categories = kwargs.pop('filterable_categories')
 
+        # This cache key is used for caching authors, topics, page_ids, and
+        # the full set of Elasticsearch results for this form used to generate
+        # them.
+        # Default the cache key prefix to this form's hash if it's not
+        # provided.
+        self.cache_key_prefix = kwargs.pop('cache_key_prefix', hash(self))
+
         super(FilterableListForm, self).__init__(*args, **kwargs)
 
         clean_categories(selected_categories=self.data.get('categories'))
 
-        self.all_filterable_results = self.filterable_search.get_raw_results()
-        page_ids = [result.meta.id for result in self.all_filterable_results]
+        self.all_filterable_results = self.get_all_filterable_results()
+        page_ids = self.get_all_page_ids()
         self.set_topics(page_ids)
         self.set_authors(page_ids)
+
+    def get_all_filterable_results(self):
+        """ Get all filterable document results from Elasticsearch
+
+        This set of results is used to populate the list of all page_ids,
+        below, which is in turn used for populating topics and authors
+        relevant to those pages.
+
+        This first document in this result set is also used to determine the
+        earliest post date, also below, when a to_date is given but
+        from_date is not.
+        """
+        # Cache the full list of filterable results. This avoids having to
+        # generate the same list with every request. When a filterable page is
+        # is saved, the cache key for this fix prefix will be deleted.
+        all_filterable_results = cache.get(
+            f"{self.cache_key_prefix}-all_filterable_results"
+        )
+        if all_filterable_results is None:
+            all_filterable_results = self.filterable_search.get_raw_results()
+            cache.set(
+                f"{self.cache_key_prefix}-all_filterable_results",
+                all_filterable_results,
+                3600,
+            )
+        return all_filterable_results
+
+    def get_all_page_ids(self):
+        """ Return a list of all possible filterable page ids """
+        page_ids = cache.get(f"{self.cache_key_prefix}-page_ids")
+        if page_ids is None:
+            page_ids = [
+                result.meta.id for result in self.all_filterable_results
+            ]
+            cache.set(f"{self.cache_key_prefix}-page_ids", page_ids, 3600)
+        return page_ids
 
     def get_categories(self):
         categories = self.cleaned_data.get('categories')
@@ -186,16 +230,29 @@ class FilterableListForm(forms.Form):
     # Populate Topics' choices
     def set_topics(self, page_ids):
         if self.wagtail_block:
-            self.fields['topics'].choices = self.wagtail_block.block \
-                .get_filterable_topics(page_ids, self.wagtail_block.value)
+            # Cache the topics for this filterable list form to avoid
+            # repeated database lookups of the same data.
+            topics = cache.get(f"{self.cache_key_prefix}-topics")
+            if topics is None:
+                topics = self.wagtail_block.block.get_filterable_topics(
+                    page_ids,
+                    self.wagtail_block.value
+                )
+                cache.set(f"{self.cache_key_prefix}-topics", topics, 3600)
+
+            self.fields['topics'].choices = topics
 
     # Populate Authors' choices
     def set_authors(self, page_ids):
-        authors = Tag.objects.filter(
-            v1_cfgovauthoredpages_items__content_object__id__in=page_ids
-        ).values_list('slug', 'name')
-        options = self.prepare_options(arr=authors)
-
+        # Cache the authors for this filterable list form to avoid
+        # repeated database lookups of the same data.
+        options = cache.get(f"{self.cache_key_prefix}-authors")
+        if options is None:
+            authors = Tag.objects.filter(
+                v1_cfgovauthoredpages_items__content_object__id__in=page_ids
+            ).values_list('slug', 'name')
+            options = self.prepare_options(arr=authors)
+            cache.set(f"{self.cache_key_prefix}-authors", options, 3600)
         self.fields['authors'].choices = options
 
     def clean(self):

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -125,10 +125,8 @@ class FilterableListForm(forms.Form):
 
         clean_categories(selected_categories=self.data.get('categories'))
 
-        # TODO: This results in duplication with get_page_set's
-        # to_querystring. Find a way not to duplicate.
-        self.filterable_pages = self.filterable_search.search()
-        page_ids = self.filterable_pages.values_list('id', flat=True)
+        self.all_filterable_results = self.filterable_search.get_raw_results()
+        page_ids = [result.meta.id for result in self.all_filterable_results]
         self.set_topics(page_ids)
         self.set_authors(page_ids)
 
@@ -170,11 +168,10 @@ class FilterableListForm(forms.Form):
         return results
 
     def first_page_date(self):
-        first_post = self.filterable_pages.order_by('date_published').first()
-        if first_post:
-            return first_post.date_published
-        else:
-            return date(2010, 1, 1)
+        if len(self.all_filterable_results) > 0:
+            first_post = self.all_filterable_results[0]
+            return first_post.date_published.date()
+        return date(2010, 1, 1)
 
     def prepare_options(self, arr):
         """

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -160,7 +160,6 @@ class FilterableListForm(forms.Form):
             cache.set(
                 f"{self.cache_key_prefix}-all_filterable_results",
                 all_filterable_results,
-                3600,
             )
         return all_filterable_results
 
@@ -171,7 +170,7 @@ class FilterableListForm(forms.Form):
             page_ids = [
                 result.meta.id for result in self.all_filterable_results
             ]
-            cache.set(f"{self.cache_key_prefix}-page_ids", page_ids, 3600)
+            cache.set(f"{self.cache_key_prefix}-page_ids", page_ids)
         return page_ids
 
     def get_categories(self):
@@ -238,7 +237,7 @@ class FilterableListForm(forms.Form):
                     page_ids,
                     self.wagtail_block.value
                 )
-                cache.set(f"{self.cache_key_prefix}-topics", topics, 3600)
+                cache.set(f"{self.cache_key_prefix}-topics", topics)
 
             self.fields['topics'].choices = topics
 
@@ -252,7 +251,7 @@ class FilterableListForm(forms.Form):
                 v1_cfgovauthoredpages_items__content_object__id__in=page_ids
             ).values_list('slug', 'name')
             options = self.prepare_options(arr=authors)
-            cache.set(f"{self.cache_key_prefix}-authors", options, 3600)
+            cache.set(f"{self.cache_key_prefix}-authors", options)
         self.fields['authors'].choices = options
 
     def clean(self):

--- a/cfgov/v1/management/commands/archive_pages.py
+++ b/cfgov/v1/management/commands/archive_pages.py
@@ -103,7 +103,8 @@ class Command(BaseCommand):
                 )
 
             # Get the filterable list QuerySet and filter it.
-            filtered_pages = filterable_page.get_filterable_queryset().filter(
+            filtered_pages = filterable_page.get_filterable_search().search(
+            ).filter(
                 published_date_filter,
                 is_archived="no",
             )

--- a/cfgov/v1/management/commands/restore_archive_pages.py
+++ b/cfgov/v1/management/commands/restore_archive_pages.py
@@ -103,7 +103,8 @@ class Command(BaseCommand):
                 )
 
             # Get the filterable list QuerySet and filter it.
-            filtered_pages = filterable_page.get_filterable_queryset().filter(
+            filtered_pages = filterable_page.get_filterable_search().search(
+            ).filter(
                 published_date_filter,
                 is_archived="yes",
             )

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -10,6 +10,10 @@ from wagtail.search import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
+from v1.documents import (
+    EnforcementActionFilterablePagesDocumentSearch,
+    EventFilterablePagesDocumentSearch
+)
 from v1.models.base import CFGOVPage
 from v1.models.enforcement_action_page import EnforcementActionPage
 from v1.models.filterable_list_mixins import (
@@ -89,6 +93,10 @@ class EnforcementActionsFilterPage(BrowseFilterablePage):
     def get_model_class():
         return EnforcementActionPage
 
+    @staticmethod
+    def get_search_class():
+        return EnforcementActionFilterablePagesDocumentSearch
+
 
 class EventArchivePage(BrowseFilterablePage):
     template = 'browse-filterable/index.html'
@@ -103,6 +111,10 @@ class EventArchivePage(BrowseFilterablePage):
     def get_form_class():
         from .. import forms
         return forms.EventArchiveFilterForm
+
+    @staticmethod
+    def get_search_class():
+        return EventFilterablePagesDocumentSearch
 
 
 class NewsroomLandingPage(CategoryFilterableMixin, BrowseFilterablePage):

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -84,8 +84,9 @@ class FilterableListMixin(RoutablePageMixin):
         if flag_enabled('HIDE_ARCHIVE_FILTER_OPTIONS', request=request):
             has_archived_posts = False
         else:
-            has_archived_posts = (
-                form.filterable_pages.filter(is_archived='yes').count() > 0
+            has_archived_posts = any(
+                result for result in form.all_filterable_results
+                if result.is_archived == 'yes'
             )
 
         context.update({
@@ -93,6 +94,7 @@ class FilterableListMixin(RoutablePageMixin):
             'get_secondary_nav_items': get_secondary_nav_items,
             'has_active_filters': has_active_filters,
             'has_archived_posts': has_archived_posts,
+            'has_unfiltered_results': filterable_search.count() > 0,
         })
 
         return context

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -65,6 +65,9 @@ class FilterableListMixin(RoutablePageMixin):
             prefix=self.get_filterable_root()
         )
 
+    def get_cache_key_prefix(self):
+        return self.url
+
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(
             request, *args, **kwargs
@@ -77,7 +80,7 @@ class FilterableListMixin(RoutablePageMixin):
             wagtail_block=self.get_filterable_list_wagtail_block(),
             filterable_categories=self.filterable_categories,
             filterable_search=filterable_search,
-            cache_key_prefix=self.pk,
+            cache_key_prefix=self.get_cache_key_prefix(),
         )
         filter_data = self.process_form(request, form)
 
@@ -157,9 +160,6 @@ class FilterableListMixin(RoutablePageMixin):
             self.get_template(request, *args, **kwargs),
             context
         )
-
-        # Set a shorter TTL in Akamai
-        response['Edge-Control'] = 'cache-maxage=10m'
 
         # Set noindex for crawlers if needed
         if self.do_not_index:

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -34,6 +34,10 @@ class FilterableListMixin(RoutablePageMixin):
     def get_form_class():
         return FilterableListForm
 
+    @staticmethod
+    def get_search_class():
+        return FilterablePagesDocumentSearch
+
     def get_filterable_list_wagtail_block(self):
         return next(
             (b for b in self.content if b.block_type == 'filter_controls'),
@@ -41,7 +45,6 @@ class FilterableListMixin(RoutablePageMixin):
         )
 
     def get_filterable_root(self):
-
         filterable_list_block = self.get_filterable_list_wagtail_block()
         if filterable_list_block is None:
             return '/'
@@ -51,14 +54,16 @@ class FilterableListMixin(RoutablePageMixin):
 
         return '/'
 
-    def get_filterable_queryset(self):
+    def get_filterable_search(self):
+        """Return a FilterablePagesDocumentSearch object"""
         site = self.get_site()
 
         if not site:
-            return self.get_model_class().objects.none()
+            return None
 
-        return FilterablePagesDocumentSearch(
-            prefix=self.get_filterable_root()).search()
+        return self.get_search_class()(
+            prefix=self.get_filterable_root()
+        )
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(
@@ -66,22 +71,25 @@ class FilterableListMixin(RoutablePageMixin):
         )
 
         form_data, has_active_filters = self.get_form_data(request.GET)
-        queryset = self.get_filterable_queryset()
+        filterable_search = self.get_filterable_search()
+        form = self.get_form_class()(
+            form_data,
+            wagtail_block=self.get_filterable_list_wagtail_block(),
+            filterable_categories=self.filterable_categories,
+            filterable_search=filterable_search,
+        )
+        filter_data = self.process_form(request, form)
+
         # flag check to enable or disable archive filter options
         if flag_enabled('HIDE_ARCHIVE_FILTER_OPTIONS', request=request):
             has_archived_posts = False
         else:
-            has_archived_posts = queryset.filter(is_archived='yes').count() > 0
-        form = self.get_form_class()(
-            form_data,
-            filterable_pages=queryset,
-            wagtail_block=self.get_filterable_list_wagtail_block(),
-            filterable_root=self.get_filterable_root(),
-            filterable_categories=self.filterable_categories
-        )
+            has_archived_posts = (
+                form.filterable_pages.filter(is_archived='yes').count() > 0
+            )
 
         context.update({
-            'filter_data': self.process_form(request, form),
+            'filter_data': filter_data,
             'get_secondary_nav_items': get_secondary_nav_items,
             'has_active_filters': has_active_filters,
             'has_archived_posts': has_archived_posts,
@@ -170,7 +178,7 @@ class CategoryFilterableMixin:
     filterable_categories = []
     """Determines page categories to be filtered; see filterable_pages."""
 
-    def get_filterable_queryset(self):
+    def get_filterable_search(self):
         """Return the queryset of pages to be filtered by this page.
 
         The class property filterable_categories can be set to a list of page
@@ -179,6 +187,8 @@ class CategoryFilterableMixin:
         By default this is an empty list and all page tags are eligible.
         """
         category_names = get_category_children(self.filterable_categories)
-        return FilterablePagesDocumentSearch(
-            prefix=self.get_filterable_root(),
-            categories=category_names).search()
+        filterable_search = self.get_search_class()(
+            prefix=self.get_filterable_root()
+        )
+        filterable_search.filter_categories(categories=category_names)
+        return filterable_search

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -75,6 +75,7 @@ class FilterableListMixin(RoutablePageMixin):
 
         form_data, has_active_filters = self.get_form_data(request.GET)
         filterable_search = self.get_filterable_search()
+        has_unfiltered_results = filterable_search.count() > 0
         form = self.get_form_class()(
             form_data,
             wagtail_block=self.get_filterable_list_wagtail_block(),
@@ -98,7 +99,7 @@ class FilterableListMixin(RoutablePageMixin):
             'get_secondary_nav_items': get_secondary_nav_items,
             'has_active_filters': has_active_filters,
             'has_archived_posts': has_archived_posts,
-            'has_unfiltered_results': filterable_search.count() > 0,
+            'has_unfiltered_results': has_unfiltered_results,
         })
 
         return context

--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -77,6 +77,7 @@ class FilterableListMixin(RoutablePageMixin):
             wagtail_block=self.get_filterable_list_wagtail_block(),
             filterable_categories=self.filterable_categories,
             filterable_search=filterable_search,
+            cache_key_prefix=self.pk,
         )
         filter_data = self.process_form(request, form)
 

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -41,7 +41,9 @@ class TestNewsroomLandingPage(ElasticsearchTestsMixin, TestCase):
         )
 
     def test_no_pages_by_default(self):
-        self.assertFalse(self.newsroom_page.get_filterable_queryset().exists())
+        filterable_search = self.newsroom_page.get_filterable_search()
+        result = filterable_search.search()
+        self.assertFalse(result.exists())
 
     def make_page_with_category(self, category_name, parent):
         page = AbstractFilterPage(title='test', slug='test')
@@ -56,13 +58,22 @@ class TestNewsroomLandingPage(ElasticsearchTestsMixin, TestCase):
 
     def test_no_pages_matching_categories(self):
         self.make_page_with_category('test', parent=self.site_root)
-        self.assertFalse(self.newsroom_page.get_filterable_queryset().exists())
+
+        filterable_search = self.newsroom_page.get_filterable_search()
+        result = filterable_search.search()
+        self.assertFalse(result.exists())
 
     def test_page_matches_categories(self):
         self.make_page_with_category('op-ed', parent=self.site_root)
-        self.assertTrue(self.newsroom_page.get_filterable_queryset().exists())
+
+        filterable_search = self.newsroom_page.get_filterable_search()
+        result = filterable_search.search()
+        self.assertTrue(result.exists())
 
     def test_page_in_other_site_not_included(self):
         wagtail_root = Page.objects.get(pk=1)
         self.make_page_with_category('op-ed', parent=wagtail_root)
-        self.assertFalse(self.newsroom_page.get_filterable_queryset().exists())
+
+        filterable_search = self.newsroom_page.get_filterable_search()
+        result = filterable_search.search()
+        self.assertFalse(result.exists())

--- a/cfgov/v1/tests/models/test_filterable_list_mixins.py
+++ b/cfgov/v1/tests/models/test_filterable_list_mixins.py
@@ -59,9 +59,7 @@ class TestFilterableListMixin(TestCase):
             def get_site(self):
                 return None
 
-        self.assertFalse(
-            MockPageInDefaultSite().get_filterable_queryset().exists()
-        )
+        self.assertIsNone(MockPageInDefaultSite().get_filterable_search())
 
     # FilterableListMixin.set_do_not_index tests
     def test_do_not_index_is_false_by_default(self):
@@ -192,7 +190,8 @@ class FilterableListRelationsTestCase(ElasticsearchTestsMixin, TestCase):
         filter_controls['value']['filter_children'] = True
         self.set_filterable_controls(self.filter_controls)
 
-        qs = self.filterable_page.get_filterable_queryset()
+        filterable_search = self.filterable_page.get_filterable_search()
+        qs = filterable_search.search()
         self.assertEqual(qs.count(), 1)
         self.assertEqual(qs[0].pk, self.child_page.pk)
         self.assertEqual("/test/", self.filterable_page.get_filterable_root())

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -197,15 +197,16 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         from_date_dt = datetime(2021, 1, 16)
         from_date = datetime.date(from_date_dt)
 
-        results = EventFilterablePagesDocumentSearch(
-            prefix='/',
+        search = EventFilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=['test-topic'],
             categories=['test-category'],
             authors=['test-author'],
             to_date=to_date,
             from_date=from_date,
-            title='Event Test',
-            archived=['no']).search()
+            archived=['no']
+        )
+        results = search.search(title='Event Test')
         self.assertTrue(results.filter(title=self.event.title).exists())
 
     def test_search_blog_dates(self):
@@ -214,15 +215,16 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         from_date_dt = datetime.today() - relativedelta(months=1)
         from_date = datetime.date(from_date_dt)
 
-        results = FilterablePagesDocumentSearch(
-            prefix='/',
+        search = FilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=[],
             categories=[],
             authors=[],
             to_date=to_date,
             from_date=from_date,
-            title=None,
-            archived=None).search()
+            archived=None,
+        )
+        results = search.search(title=None)
         self.assertTrue(results.filter(title=self.blog.title).exists())
 
     def test_search_enforcement_actions(self):
@@ -231,17 +233,18 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         from_date_dt = datetime.today() - relativedelta(months=1)
         from_date = datetime.date(from_date_dt)
 
-        results = EnforcementActionFilterablePagesDocumentSearch(
-            prefix='/',
+        search = EnforcementActionFilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=[],
             categories=[],
             authors=[],
             to_date=to_date,
             from_date=from_date,
-            title=None,
             statuses=['expired-terminated-dismissed'],
             products=['Debt Collection'],
-            archived=None).search()
+            archived=None
+        )
+        results = search.search(title=None)
         self.assertTrue(results.filter(title=self.enforcement.title).exists())
 
     def test_search_enforcement_actions_no_statuses(self):
@@ -250,30 +253,32 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         from_date_dt = datetime.today() - relativedelta(months=1)
         from_date = datetime.date(from_date_dt)
 
-        results = EnforcementActionFilterablePagesDocumentSearch(
-            prefix='/',
+        search = EnforcementActionFilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=[],
             categories=[],
             authors=[],
             to_date=to_date,
             from_date=from_date,
-            title=None,
             statuses=[],
             products=[],
-            archived=None).search()
+            archived=None
+        )
+        results = search.search(title=None)
         self.assertTrue(results.filter(title=self.enforcement.title).exists())
 
     @override_settings(FLAGS={"EXPAND_FILTERABLE_LIST_SEARCH": [("boolean", True)]})
     def test_search_title_multimatch_enabled(self):
-        results = FilterablePagesDocumentSearch(
-            prefix='/',
+        search = FilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=[],
             categories=[],
             authors=[],
             to_date=None,
             from_date=None,
-            title="Foo",
-            archived=None).search()
+            archived=None
+        )
+        results = search.search(title="Foo")
         self.assertTrue(results.filter(title=self.blog_title_match).exists())
         self.assertTrue(results.filter(title=self.blog_content_match.title).exists())
         self.assertTrue(results.filter(title=self.blog_preview_match.title).exists())
@@ -281,15 +286,17 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
 
     @override_settings(FLAGS={"EXPAND_FILTERABLE_LIST_SEARCH": [("boolean", False)]})
     def test_search_title_multimatch_disabled(self):
-        results = FilterablePagesDocumentSearch(
-            prefix='/',
+        search = FilterablePagesDocumentSearch(prefix='/')
+        search.filter(
             topics=[],
             categories=[],
             authors=[],
             to_date=None,
             from_date=None,
-            title="Foo",
-            archived=None).search()
+            archived=None
+        )
+        results = search.search(title="Foo")
+
         self.assertTrue(results.filter(title=self.blog_title_match).exists())
         self.assertFalse(results.filter(title=self.blog_content_match.title).exists())
         self.assertFalse(results.filter(title=self.blog_preview_match.title).exists())

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import date, datetime
 from io import StringIO
 
 from django.test import TestCase, override_settings
@@ -9,8 +9,7 @@ from pytz import timezone
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
 from v1.documents import (
     EnforcementActionFilterablePagesDocumentSearch,
-    EventFilterablePagesDocumentSearch,
-    FilterablePagesDocumentSearch
+    EventFilterablePagesDocumentSearch, FilterablePagesDocumentSearch
 )
 from v1.forms import (
     EnforcementActionsFilterForm, EventArchiveFilterForm, FilterableListForm
@@ -172,6 +171,12 @@ class TestFilterableListForm(ElasticsearchTestsMixin, TestCase):
         page_set = form.get_page_set()
         self.assertEqual(len(page_set), 1)
         self.assertEqual(page_set[0].specific, self.category_blog)
+
+    def test_first_page_date(self):
+        form = self.setUpFilterableForm()
+        self.assertEqual(form.first_page_date(), self.blog1.date_published)
+        form.all_filterable_results = []
+        self.assertEqual(form.first_page_date(), date(2010, 1, 1))
 
 
 class TestFilterableListFormArchive(ElasticsearchTestsMixin, TestCase):

--- a/cfgov/v1/tests/test_forms.py
+++ b/cfgov/v1/tests/test_forms.py
@@ -16,6 +16,7 @@ class TestFilterableListForm(TestCase):
         mock_init.return_value = None
         page_ids = [1, 2, 3, 4, 5]
         form = FilterableListForm()
+        form.cache_key_prefix = 'test'
         form.fields = {'authors': mock.Mock()}
         form.set_authors(page_ids=page_ids)
         mock_tag_objects.filter.assert_called_with(v1_cfgovauthoredpages_items__content_object__id__in=page_ids)

--- a/cfgov/v1/tests/test_signals.py
+++ b/cfgov/v1/tests/test_signals.py
@@ -1,9 +1,18 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from django.contrib.auth.models import User
 from django.utils import timezone
 
+from wagtail.core.models import Site
+
 from model_bakery import baker
+
+from v1.models import (
+    BlogPage, CFGOVPage, CFGOVPageCategory, NewsroomLandingPage,
+    SublandingFilterablePage
+)
+from v1.signals import invalidate_filterable_list_caches
+from v1.tests.wagtail_pages.helpers import publish_page, save_new_page
 
 
 class UserSaveTestCase(TestCase):
@@ -69,3 +78,64 @@ class UserSaveTestCase(TestCase):
         user = self.make_user(password='foo', is_superuser=True)
         first_phi = user.passwordhistoryitem_set.latest()
         self.assertLess(first_phi.locked_until, timezone.now())
+
+
+class FilterableListInvalidationTestCase(TestCase):
+
+    def setUp(self):
+        self.root_page = Site.objects.first().root_page
+
+        self.filterable_list_page = SublandingFilterablePage(
+            title='Blog'
+        )
+        self.root_page.add_child(instance=self.filterable_list_page)
+        self.filterable_list_page.save()
+
+        self.category_filterable_list_page = NewsroomLandingPage(
+            title="News"
+        )
+        self.root_page.add_child(instance=self.category_filterable_list_page)
+        self.category_filterable_list_page.save()
+
+        self.blog_page = BlogPage(title='test blog')
+        self.filterable_list_page.add_child(instance=self.blog_page)
+        self.blog_page.categories.add(CFGOVPageCategory(name='op-ed'))
+        self.blog_page.save()
+
+        self.non_filterable_page = CFGOVPage(title='Page')
+        self.root_page.add_child(instance=self.non_filterable_page)
+        self.non_filterable_page.save()
+
+    @mock.patch('v1.signals.PurgeBatch')
+    @mock.patch('v1.signals.cache')
+    def test_invalidate_filterable_list_caches(
+        self, mock_cache, mock_purge_batch,
+    ):
+        invalidate_filterable_list_caches(None, instance=self.blog_page)
+
+        for cache_key_prefix in (
+            self.filterable_list_page.get_cache_key_prefix(),
+            self.category_filterable_list_page.get_cache_key_prefix()
+        ):
+            mock_cache.delete.assert_any_call(
+                f"{cache_key_prefix}-all_filterable_results"
+            )
+            mock_cache.delete.assert_any_call(
+                f"{cache_key_prefix}-page_ids"
+            )
+            mock_cache.delete.assert_any_call(
+                f"{cache_key_prefix}-topics"
+            )
+            mock_cache.delete.assert_any_call(
+                f"{cache_key_prefix}-authors"
+            )
+
+        mock_purge_batch().add_page.assert_any_call(self.filterable_list_page)
+
+    @mock.patch('django.core.cache.cache')
+    def test_invalidate_filterable_list_caches_does_nothing(self, mock_cache):
+        invalidate_filterable_list_caches(
+            None,
+            instance=self.non_filterable_page
+        )
+        mock_cache.delete.assert_not_called()


### PR DESCRIPTION
This PR makes a number of changes to our filterable lists.

- The `FilterablePagesDocumentSearch` class has been refactored to more easily share an instance.
- The `FilterablePagesDocumentSearch` object is now shared between `FilterableListMixin` and `FilterableListForm` (instead of two separate instances being used).
- `FilterableListForm` now uses the Django cache to cache the list of authors, topics, and all filterable pages to avoid repeatedly fetching and querying the information when it has not changed.
- We have a signal handler that will purge the Django cache and the frontend Akamai cache when a filterable page for has been published or unpublished.

All of these changes should improve the overall performance of our filterable lists. This reduces duplicate queries that we previous had that constructed Django querysets from Elasticsearch results two separate times during a single request cycle, and the addition of cached values on the `FilterableListForm` should provide further improvement. Finally, implementing a signal handler that will only purge filterable lists from Akamai when their filterable pages are changed means we can eliminate our 10-minute maxage on those pages.

Note: This is not a full refactor of filterable lists. We still have quite a lot of improvements we can make. Separation of concerns between `FilterableListMixin`, `FilterableListForm`, and `FilterablePagesDocumentSearch` is still vague, and there's a lot cross reference between `FilterableListMixin` and `FilterableListForm` that could be eliminated. The goal here is performance improvement, which I believe this achieves, and the refactoring that is done has been done to enable that without making the diff so complex that the performance-specific changes can't be seen.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
