### PR TITLE
Remove sender from filterable list signal handler

### DIFF
--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -66,7 +66,7 @@ def invalidate_filterable_list_caches(sender, **kwargs):
 
     # There's nothing to do if this page isn't a filterable page
     if not isinstance(page, AbstractFilterPage):
-        pass
+        return
 
     # Determine which filterable list page this page might belong
     # First, check to see if it has any ancestors that are
@@ -114,11 +114,5 @@ def invalidate_filterable_list_caches(sender, **kwargs):
     batch.purge()
 
 
-page_published.connect(
-    invalidate_filterable_list_caches,
-    sender=AbstractFilterPage
-)
-page_unpublished.connect(
-    invalidate_filterable_list_caches,
-    sender=AbstractFilterPage
-)
+page_published.connect(invalidate_filterable_list_caches)
+page_unpublished.connect(invalidate_filterable_list_caches)


### PR DESCRIPTION
I made an assumption that the `sender` of a Django signal could be a superclass. It cannot be. This change removes the specific sender model for publish/unpublish signals. Now the signal handler will process any publish/unpublished signal, and test if the instance is an instance of `AbstractFilterPage` (which does work).

I've also fixed that `if` so that it `return`s instead of `pass`ing.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
