### PR TITLE
Upgrade elasticsearch and kibana docker images to 7.13.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
         volumes:
             - ./cfgov/search/resources/:/usr/share/elasticsearch/config/synonyms
     kibana:
-        image: blacktop/kibana:7.10.1
+        image: elasticsearch/kibana:7.13.3
         depends_on:
             - elasticsearch
         ports:

--- a/docker/elasticsearch/7/Dockerfile
+++ b/docker/elasticsearch/7/Dockerfile
@@ -1,4 +1,4 @@
-FROM blacktop/elasticsearch:7.10.1
+FROM elasticsearch/elasticsearch:7.13.3
 
 # Set User to Non Root
 USER elasticsearch


### PR DESCRIPTION
Security vulnerabilities were discovered in version 7.10.1

## Removals

- Stop using blacktop docker images as they have not been updated for months

## Changes

- Start using official elasticsearch and kibana docker images which were updated last month
- The following files are impacted:
1. Dockerfile
2. docker-compose.yml
3. Jenkinsfile

## How to test this PR

Verify applications that use elasticsearch7 are not impacted:
1. AskCFPB
2. Filterable lists
3. Paying For College
4. Regulations
5. Teachers Digital Platform

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance