### PR TITLE
Update REG_BASE in regulations3k insert_section_links.py script

### DIFF
--- a/cfgov/regulations3k/scripts/insert_section_links.py
+++ b/cfgov/regulations3k/scripts/insert_section_links.py
@@ -7,7 +7,7 @@ from regulations3k.models import Part, Section
 from regulations3k.scripts.ecfr_importer import PART_ALLOWLIST
 
 
-REG_BASE = '/policy-compliance/rulemaking/regulations/{}/'
+REG_BASE = '/rules-policy/regulations/{}/'
 SECTION_RE = re.compile(r'(?:§|Section|12 CFR)\W+([^\s]+)')
 PARTS_RE = re.compile(
     r'(?P<part>\d{4})[.-](?P<section>[0-9A-Z]+)(?P<ids>\([a-zA-Z0-9)(]+)?')


### PR DESCRIPTION
The path to regulations has recently been changed.
This is a simple one line change to replace `/policy-compliance/rulemaking/regulations/` with `/rules-policy/regulations/`

## How to test this PR

1. tox -e unittest-current regulations3k

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
