### PR TITLE
Update Spanish content for FWB about page

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -92,10 +92,25 @@
         {{ _('The tool allows you to compare your financial well-being score to other adults in the United States.') }}
         {{ _('The comparison of your score to others’ scores is made possible by our national survey. In late 2016, we collected responses to our financial well-being scale in a nationwide survey of U.S. adults for the first time.') }}
     </p>
-    <a class="a-link__jump"
-       href="/data-research/research-reports/financial-well-being-america/">
-        <span class="a-link_text">{{ _('See the report') }}</span>
-    </a>
+    <ul class="m-list m-list__links">
+        <li class="m-list_item">
+            <a class="m-list_link" href="/data-research/research-reports/financial-well-being-america/">
+                {{ _('See the report') }}
+            </a>
+        </li>
+    </ul>
+    {% if (current_language == 'es') %}
+    <p>
+        También puede comparar su puntuación con la de otros Hispanos o Latinos en el 2018.
+    </p>
+    <ul class="m-list m-list__links">
+        <li class="m-list_item">
+            <a class="m-list_link" href="/data-research/research-reports/measuring-financial-well-being-hispanics-2018-benchmarks/">
+                {{ _('See the report') }}
+            </a>
+        </li>
+    </ul>
+    {% endif %}
 {% endblock %}
 
 {% block content_sidebar %}


### PR DESCRIPTION
Adds a paragraph and link to an additional report to the end of the financial well-being survey's about page.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- Paragraph and link to an additional report

## Changes

- The single jump link that was at the end of the page is now a link list to get the margin between that and the new paragraph that follows it correct (`.a-link__jump + p` has no margin in between them).

## How to test this PR

1. Fire up /consumer-tools/financial-well-being/about/es/ and make sure it looks like the screenshot below
2. Make sure the new link points to /data-research/research-reports/measuring-financial-well-being-hispanics-2018-benchmarks/
3. Make sure the English about page, /consumer-tools/financial-well-being/about/, is unchanged from what's in production

## Screenshots

![fwb-about-es](https://user-images.githubusercontent.com/1862695/117038703-f5fde200-acd5-11eb-9d34-d0ab539aecaa.png)

## Notes and todos

- There is no change needed for the English about page; this content should only appear on the Spanish page
- I kept the link text as the translated string of `{{ _('See the report') }}` even though it only appears on the Spanish page just in case we ever want to change that translation globally

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)