### PR TITLE
CR Tool: update crtool release number to 2.1.4

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,4 +44,4 @@ https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home
 https://github.com/cfpb/retirement/releases/download/0.15.2/retirement-0.15.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.5.2/ccdb5_api-1.5.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.3/crtool-2.1.3-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
Security Update for the Curriculum Review Tool. Update from release 2.1.3 to 2.1.4. 

See [PR #420](https://github.com/cfpb/curriculum-review-tool/pull/420)
