### PR TITLE
Paying for College - Non-first-year fixes

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
@@ -358,7 +358,7 @@ main.college-costs {
 	}
 
 	&[data-state_programprogress="0"],
-	&[data-state_programprogress="n"] {
+	&:not( [data-state_programprogress="n"] ) {
 		[data-state-based-visibility="is_first_year-true"] {
 			display: block;
 		}

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/state-based.less
@@ -358,7 +358,7 @@ main.college-costs {
 	}
 
 	&[data-state_programprogress="0"],
-	&:not( [data-state_programprogress="n"] ) {
+	&[data-state_programprogress="n"] {
 		[data-state-based-visibility="is_first_year-true"] {
 			display: block;
 		}

--- a/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/models/financial-model.js
@@ -167,13 +167,21 @@ const financialModel = {
   _enforceLimits: () => {
     let unsubCap = 0;
     const errors = {};
+    const yearMap = {
+      n: 'yearOne',
+      0: 'yearOne',
+      1: 'yearTwo',
+      a: 'yearThree',
+      2: 'yearThree'
+    };
 
-    // get the caps from the constants model
+    // Determine progress, set "year" variable
+    const year = yearMap[getStateValue( 'programProgress' )];
 
     // First, enforce subsidized cap
     const subResult = enforceRange( financialModel.values.fedLoan_directSub,
       0,
-      getConstantsValue( 'subCaps' ).yearOne );
+      getConstantsValue( 'subCaps' )[year] );
     if ( subResult !== false ) {
       financialModel.values.fedLoan_directSub = subResult.value;
       // Reserve for later error handling
@@ -181,6 +189,7 @@ const financialModel = {
         errors.fedLoan_directSub = subResult.error;
       }
     }
+
 
     // Calculate unsubsidized loan cap based on subsidized loan amount
     if ( getStateValue( 'programType' ) === 'graduate' ) {
@@ -195,9 +204,9 @@ const financialModel = {
       financialModel.values.fellowAssist_assistantship = 0;
 
       if ( getStateValue( 'programDependency' ) === 'independent' ) {
-        unsubCap = Math.max( 0, getConstantsValue( 'totalIndepCaps' ).yearOne );
+        unsubCap = Math.max( 0, getConstantsValue( 'totalIndepCaps' )[year] );
       } else {
-        unsubCap = Math.max( 0, getConstantsValue( 'totalCaps' ).yearOne );
+        unsubCap = Math.max( 0, getConstantsValue( 'totalCaps' )[year] );
       }
     }
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
@@ -35,6 +35,7 @@ function calculateDirectLoanDebt( directSub, directUnsub, rateUnsub, programLeng
   };
   let progress = getStateValue( 'programProgress' );
   let percentSub = 1;
+  let percentUnsub = 1;
   let subPrincipal = 0;
   let unsubPrincipal = 0;
   let unsubInterest = 0;

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
@@ -5,6 +5,7 @@
 import { calcInterestAtGrad, calcMonthlyPayment } from './debt-utils.js';
 import { getConstantsValue, getStateValue } from '../dispatchers/get-model-values.js';
 import { financialModel } from '../models/financial-model.js';
+import { stringToNum } from '../util/number-utils.js';
 
 // Please excuse some uses of underscore for code/HTML property clarity!
 /* eslint camelcase: ["error", {properties: "never"}] */
@@ -25,9 +26,15 @@ function calculateDirectLoanDebt( directSub, directUnsub, rateUnsub, programLeng
     n: 0,
     a: 2
   };
+  const yearMap = {
+    n: 'yearOne',
+    0: 'yearOne',
+    1: 'yearTwo',
+    a: 'yearThree',
+    2: 'yearThree'
+  };
   let progress = getStateValue( 'programProgress' );
   let percentSub = 1;
-  let percentUnsub = 1;
   let subPrincipal = 0;
   let unsubPrincipal = 0;
   let unsubInterest = 0;
@@ -48,37 +55,34 @@ function calculateDirectLoanDebt( directSub, directUnsub, rateUnsub, programLeng
   }
 
   // Determine percent of borrowing versus caps
-  percentSub = directSub / subCaps.yearOne;
-  percentUnsub = directUnsub / ( totalCaps.yearOne - directSub );
+  percentSub = directSub / subCaps[yearMap[progress]];
 
-
-  // Iterate through each year of the program
-  // Note that "progress" refers to number of years completed, thus a user has 0 progress
-  // until they start their second year. An associate's degree represents 2 years of school,
-  // so when progress = 'a' (for Associates), then progress is set to '2'
+  /* Iterate through each year of the program
+     Note that "progress" refers to number of years completed, thus a user has 0 progress
+     until they start their second year. An associate's degree represents 2 years of school,
+     so when progress = 'a' (for Associates), then progress is set to '2' */
 
   // Translate progress value to number where necessary
   if ( progressMap.hasOwnProperty( progress ) ) {
-    progress = progressMap[ progress ];
+    progress = progressMap[progress];
   }
 
   for ( let x = 0; x < programLength; x++ ) {
-    if ( x + progress === 0 ) {
+    const progressNumber = stringToNum( progress ) + x;
+    if ( progressNumber === 0 ) {
       subPrincipal += directSub;
       unsubPrincipal += directUnsub;
       unsubInterest += directUnsub * rateUnsub * programLength;
-    } else if ( x + progress === 1 ) {
+    } else if ( progressNumber === 1 ) {
       const subAmount = percentSub * subCaps.yearTwo;
-      const unsubAmount = percentUnsub * ( totalCaps.yearTwo - subAmount );
       subPrincipal += subAmount;
-      unsubPrincipal += unsubAmount;
-      unsubInterest += unsubAmount * rateUnsub * ( programLength - x );
+      unsubPrincipal += directUnsub;
+      unsubInterest += directUnsub * rateUnsub * ( programLength - x );
     } else {
       const subAmount = percentSub * subCaps.yearThree;
-      const unsubAmount = percentUnsub * ( totalCaps.yearThree - subAmount );
       subPrincipal += subAmount;
-      unsubPrincipal += unsubAmount;
-      unsubInterest += unsubAmount * rateUnsub * ( programLength - x );
+      unsubPrincipal += directUnsub;
+      unsubInterest += directUnsub * rateUnsub * ( programLength - x );
     }
   }
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/util/debt-calculator.js
@@ -56,6 +56,7 @@ function calculateDirectLoanDebt( directSub, directUnsub, rateUnsub, programLeng
 
   // Determine percent of borrowing versus caps
   percentSub = directSub / subCaps[yearMap[progress]];
+  percentUnsub = directUnsub / totalCaps[yearMap[progress]];
 
   /* Iterate through each year of the program
      Note that "progress" refers to number of years completed, thus a user has 0 progress
@@ -75,14 +76,16 @@ function calculateDirectLoanDebt( directSub, directUnsub, rateUnsub, programLeng
       unsubInterest += directUnsub * rateUnsub * programLength;
     } else if ( progressNumber === 1 ) {
       const subAmount = percentSub * subCaps.yearTwo;
+      const unsubAmount = percentUnsub * totalCaps.yearTwo;
       subPrincipal += subAmount;
-      unsubPrincipal += directUnsub;
-      unsubInterest += directUnsub * rateUnsub * ( programLength - x );
+      unsubPrincipal += unsubAmount;
+      unsubInterest += unsubAmount * rateUnsub * ( programLength - x );
     } else {
       const subAmount = percentSub * subCaps.yearThree;
+      const unsubAmount = percentUnsub * totalCaps.yearThree;
       subPrincipal += subAmount;
-      unsubPrincipal += directUnsub;
-      unsubInterest += directUnsub * rateUnsub * ( programLength - x );
+      unsubPrincipal += unsubAmount;
+      unsubInterest += unsubAmount * rateUnsub * ( programLength - x );
     }
   }
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/app-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/app-view.js
@@ -53,7 +53,7 @@ const appView = {
 
   _handleCopyLinkBtn: event => {
     if ( navigator.clipboard ) {
-      navigator.clipboard.writeText( window.location.href ).then( function () {
+      navigator.clipboard.writeText( window.location.href ).then( function() {
         const target = event.target;
         const btn = closest( target, 'button' );
         const copyBtnDefaultText = btn.querySelector( '#default-text' );

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -6,12 +6,14 @@ import {
   getStateValue
 } from '../dispatchers/get-model-values.js';
 import {
+  recalculateFinancials,
   refreshExpenses,
   updateFinancial,
   updateSchoolData
 } from '../dispatchers/update-models.js';
 import {
   updateFinancialView,
+  updateFinancialViewAndFinancialCharts,
   updateGradMeterChart,
   updateRepaymentMeterChart
 } from '../dispatchers/update-view.js';
@@ -266,6 +268,8 @@ function _handleResultButtonClick( event ) {
 function _handleProgramRadioClick( event ) {
   const container = closest( event.target, '.m-form-field' );
   const input = container.querySelector( 'input' );
+  const recalcProps = [ 'programProgress', 'programLength', 'programType',
+    'programDependency' ];
 
   // Update the model with program info
   const prop = input.getAttribute( 'name' );
@@ -273,6 +277,11 @@ function _handleProgramRadioClick( event ) {
   updateState.byProperty( prop, value );
   if ( prop === 'programType' ) {
     schoolView._updateProgramList();
+  }
+
+  if ( recalcProps.indexOf( prop ) !== -1 ) {
+    recalculateFinancials();
+    updateFinancialViewAndFinancialCharts();
   }
 }
 


### PR DESCRIPTION
This Pull Request fixes problems with the calculations of federal Direct loans for non-first-year students. It also fixes the limits enforced on Direct subsidized loans based on "progress" of the student (years they have spent in a program).

## Changes
- Change calculations to fix non-first-year debt totals
- Change Direct loan limits to match non-first-year limits
- Change CSS to fix some errors in non-first-year content

## How to test this PR
* Pull it down and get it running.
* The following should be true:
  * The limit for first-year students Federal Direct subsidized loans should be $3500
  * Second-year should be $4500
  * Third year should be $5500
  * Debt totals should reflect that we are assuming the user increases their subsidized loan amount each year (so that the percentage of total subsidized loan limit is taken each year)
  * Feel free to ask questions if anything doesn't make sense!
