### PR TITLE
Remove leading slash from image in Profiling Django docs

### DIFF
--- a/docs/profiling-django.md
+++ b/docs/profiling-django.md
@@ -90,7 +90,7 @@ the total time for the Django request/response cycle.
 
 For example:
 
-![Example SnakeViz Icicle view showing a class-based view call stack](/img/profiling-django-snakeviz.png)
+![Example SnakeViz Icicle view showing a class-based view call stack](img/profiling-django-snakeviz.png)
 
 This visualization shows the request/response cycle 
 took 27.2s in the root view. 


### PR DESCRIPTION
The "Profiling Django" document has a broken image because the image path has a leading slash. This change removes it.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
