### PR TITLE
Mega Menu: translate submit a complaint text to spanish on spanish-version of page

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -70,13 +70,21 @@
                 aria-label="{{ nav_title | safe }}"
                 {% endif %}>
                 {% if nav_depth == 1 -%}
-                    {% set complaint_url = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
-                    {% set complaint_item = {
-                        'text': 'Submit a Complaint',
-                        'url': complaint_url,
-                        'icon_pre': 'complaint'
-                    }
-                    %}
+                    {% if language == 'es' %}
+                        {% set complaint_item = {
+                            'text': 'Enviar una queja',
+                            'url': '/es/enviar-una-queja/',
+                            'icon_pre': 'complaint'
+                        }
+                        %}
+                    {% else %}
+                        {% set complaint_item = {
+                            'text': 'Submit a Complaint',
+                            'url': '/complaint/',
+                            'icon_pre': 'complaint'
+                        }
+                        %}
+                    {% endif %}
                     {{ _nav_item( nav_depth, complaint_item, language ) }}
                 {%- endif %}
                 {%- for item in group.nav_items %}


### PR DESCRIPTION
## Changes

- Mega Menu: translate submit a complaint text to spanish on spanish-version of page.


## How to test this PR

1. Pull branch and build
2. visit homepage or any other standard page. 
3. Resize to mobile and open the hamburger menu.
4. See that "Submit a Complaint" at that top of the menu is in english.
5. Visit /es/ spanish page open the hamburger menu and see that the complaint link is translated into spanish.


## Screenshots

Before:
<img width="502" alt="Screen Shot 2021-05-14 at 10 27 15 AM" src="https://user-images.githubusercontent.com/704760/118284938-fc8f1500-b49e-11eb-92ec-3c82372b7be2.png">

After:
<img width="500" alt="Screen Shot 2021-05-14 at 10 24 14 AM" src="https://user-images.githubusercontent.com/704760/118284969-044eb980-b49f-11eb-99d4-2bb8a1759ec4.png">
