### PR TITLE
Add googleoptimize to CSP frame and ajax items

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -621,6 +621,7 @@ CSP_FRAME_SRC = (
     "*.consumerfinance.gov",
     "*.googletagmanager.com",
     "*.google-analytics.com",
+    "*.googleoptimize.com",
     "optimize.google.com",
     "www.youtube.com",
     "*.doubleclick.net",

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -647,6 +647,7 @@ CSP_CONNECT_SRC = (
     "'self'",
     "*.consumerfinance.gov",
     "*.google-analytics.com",
+    "*.googleoptimize.com",
     "*.tiles.mapbox.com",
     "api.mapbox.com",
     "bam.nr-data.net",


### PR DESCRIPTION
Googleoptimize was added to the CSP settings in https://github.com/cfpb/consumerfinance.gov/pull/6454, but it is still being blocked. This adds it to the frame and ajax settings.

## Changes

- Add googleoptimize to CSP frame and ajax items


## How to test this PR

1. Will be tested on production.
