### PR TITLE
Paying for College - School search dropdown fix

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/search.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/search.less
@@ -6,6 +6,7 @@
 		border: 1px solid black;
 		position: absolute;
 		display: none;
+		width: 100%;
 		z-index: 1;
 
 		&.active {

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -203,9 +203,11 @@ function _handleInputChange( event ) {
   _keyupDelay = setTimeout( function() {
     const searchTerm = schoolView._searchBox.value.trim();
     // TODO - clean up searchbox text, remove non-alphanumeric characters
-    if ( !searchTerm ) {
+    // Searches of less than 3 characters are prevented in the API fetch, so
+    // we represent that visually by hiding the search results DIV
+    if ( searchTerm.length < 3 ) {
       schoolView._searchResults.classList.remove( 'active' );
-    } else if ( searchTerm.length > 2 ) {
+    } else {
       schoolSearch( searchTerm )
         .then( resp => {
           _formatSearchResults( resp.responseText );

--- a/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/views/school-view.js
@@ -201,14 +201,18 @@ let _keyupDelay;
 function _handleInputChange( event ) {
   clearTimeout( _keyupDelay );
   _keyupDelay = setTimeout( function() {
-    const searchTerm = schoolView._searchBox.value;
+    const searchTerm = schoolView._searchBox.value.trim();
     // TODO - clean up searchbox text, remove non-alphanumeric characters
-    schoolSearch( searchTerm )
-      .then( resp => {
-        _formatSearchResults( resp.responseText );
-      }, error => {
-        console.log( error );
-      } );
+    if ( !searchTerm ) {
+      schoolView._searchResults.classList.remove( 'active' );
+    } else if ( searchTerm.length > 2 ) {
+      schoolSearch( searchTerm )
+        .then( resp => {
+          _formatSearchResults( resp.responseText );
+        }, error => {
+          console.log( error );
+        } );
+    }
   }, 500 );
 }
 

--- a/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -29,6 +29,16 @@ describe( 'Paying For College', () => {
       page.enter( 'American' );
       page.searchResults().should( 'be.visible' );
     } );
+    it.only( 'Selecting college should add its details to the DOM', () => {
+      page.clickGetStarted( );
+      page.enter( 'Harvard University' );
+      page.searchResults().should( 'be.visible' );
+      page.clickSearchResult( 'Harvard University' );
+      cy.get( '[data-school-item="school"]' ).should( 'contain', 'Harvard University' );
+      cy.get( '[data-school-item="city"]' ).should( 'contain', 'Cambridge' );
+      cy.get( '[data-school-item="state"]' ).should( 'contain', 'MA' );
+      cy.get( '[data-school-item="control"]' ).should( 'contain', 'Private' );
+    } );
     it( 'certificate should display total_costs', () => {
       page.clickGetStarted( );
       page.enter( 'Harvard University' );

--- a/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -29,7 +29,7 @@ describe( 'Paying For College', () => {
       page.enter( 'American' );
       page.searchResults().should( 'be.visible' );
     } );
-    it.only( 'Selecting college should add its details to the DOM', () => {
+    it( 'Selecting college should add its details to the DOM', () => {
       page.clickGetStarted( );
       page.enter( 'Harvard University' );
       page.searchResults().should( 'be.visible' );

--- a/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -21,7 +21,7 @@ describe( 'Paying For College', () => {
       page.clickGetStarted( );
       page.enter( 'uni' );
       page.searchResults().should( 'be.visible' );
-      page.typeText( 'search__school-input', `{backspace}` )
+      page.typeText( 'search__school-input', '{backspace}' );
       page.searchResults().should( 'not.be.visible' );
     } );
     it( 'American college search should return results', () => {

--- a/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/integration/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -7,6 +7,23 @@ describe( 'Paying For College', () => {
     cy.visit( '/paying-for-college/your-financial-path-to-graduation/' );
   } );
   describe( 'Your Financial Path To Graduation', () => {
+    it( '2 character college search should not show results', () => {
+      page.clickGetStarted( );
+      page.enter( 'un' );
+      page.searchResults().should( 'not.be.visible' );
+    } );
+    it( '3 character college search should show results', () => {
+      page.clickGetStarted( );
+      page.enter( 'uni' );
+      page.searchResults().should( 'be.visible' );
+    } );
+    it( 'deleting to 2 characters in college search should hide results', () => {
+      page.clickGetStarted( );
+      page.enter( 'uni' );
+      page.searchResults().should( 'be.visible' );
+      page.typeText( 'search__school-input', `{backspace}` )
+      page.searchResults().should( 'not.be.visible' );
+    } );
     it( 'American college search should return results', () => {
       page.clickGetStarted( );
       page.enter( 'American' );

--- a/test/cypress/pages/paying-for-college/your-financial-path-to-graduation.js
+++ b/test/cypress/pages/paying-for-college/your-financial-path-to-graduation.js
@@ -33,6 +33,10 @@ export class PfcFinancialPathToGraduation {
     cy.get( '#search-results' ).should( 'not.be.visible' );
   }
 
+  typeText( name, value ) {
+    cy.get( `#${ name }` ).type( value );
+  }
+
   setText( name, value ) {
     cy.get( `#${ name }` ).clear().type( value );
   }


### PR DESCRIPTION
This pull request fixes a bug which causes the results of the school search remain on screen when a school is deleted from the box. 

## Additions
- Adds a check for an empty string in the search bar, and hides the results list when found
- Prevents requests to the search API when the string length is less than 2. This simply reinforces code already found in the API call function.

## How to test this PR
1. Pull this PR down.
2. Search for a school, but don't select a result. Instead, delete characters. The results box should disappear once your search term reaches 2 characters or less.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
