### PR TITLE
Add google optimize anti-flicker script

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -161,7 +161,17 @@
 #}
     {% if flag_enabled('AB_TESTING') %}
     {# Begin Google Optimize #}
-    <script async src="https://www.googleoptimize.com/optimize.js?id=GTM-KHB8MB"></script>
+    {# Optimize anti-flicker snippet. #}
+    <style>.async-hide { opacity: 0 !important} </style>
+    <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+    })(window,document.documentElement,'async-hide','dataLayer',4000,
+    {'GTM-KMMLRS':true});</script>
+    {#
+      NOTE: We don't include the googleoptimize.com/optimize.js script call here
+      because we are including optimize via GTM.
+    #}
     {# End Google Optimize #}
     {% endif %}
 


### PR DESCRIPTION
When testing the A/B optimize script, the change in the hero flicker was apparent, so we should add the anti-flicker script detailed in https://support.google.com/optimize/answer/7100284

Also, remove the inline optimize script as we're delivering it via GTM.

## Removals

- Remove inline optimize script.


## Changes

- Adds optimize anti-flicker script.


## How to test this PR

1. Will be tested on production :-\
