### PR TITLE
Scope oversized headings to full width text groups

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -367,7 +367,7 @@
 // Used on our story pages
 // @TODO: Expose heading class modifiers in wagtail
 .content__supersize-headings {
-    h2 {
+    .o-full-width-text-group h2 {
         .h1();
     }
 }


### PR DESCRIPTION
W/r/t https://github.com/cfpb/consumerfinance.gov/pull/6465, We only want to bump headings within full width text blocks and not components like FCMs.