### PR TITLE
Add a tox env for backend test coverage

### DIFF
--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -138,7 +138,14 @@ From the root of `consumerfinance.gov`.
 
 ### Coverage
 
-To see Python code coverage information, run
+To see Python code coverage information immediately following a test run, 
+you can add the `coverage` env to the list of envs for tox to run:
+
+```sh
+tox -e lint -e unittest -e coverage
+```
+
+You can also run coverage directly to see coverage information from a previous test run:
 
 ```sh
 coverage report -m

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,5 +1,5 @@
 coverage==4.5.1
-diff_cover==2.6.0
+diff_cover==5.1.2
 pluggy==0.13.1
 tox==3.19.0
 tox-pip-extensions==1.6.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,5 @@
 coverage==4.5.1
+diff_cover==5.1.2
 django-sslserver==0.20
 freezegun==0.3.12
 github3.py==0.9.6

--- a/tox.ini
+++ b/tox.ini
@@ -216,3 +216,16 @@ commands=
     python manage.py makemessages
     python manage.py compilemessages
     git diff --quiet locale/*/LC_MESSAGES/django.mo
+
+[testenv:coverage]
+# Invoke with: tox -e coverage
+# Report out the coverage of changes on the current branch against the main 
+# branch. This will fail if the coverage of changes is below 100%. This env 
+# requires a coverage file and should only be run after unittest-current or 
+# unittest-future.
+basepython={[current-config]basepython}
+deps=
+    -r{toxinidir}/requirements/test.txt
+commands=
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100


### PR DESCRIPTION
This small change adds a tox env that will run `diff-cover` on the coverage generated by `unittest-current` or `unittest-future`. This is intended as a convenience means of reporting out the change in test coverage vs `main` that doesn't require running `diff-cover` directly.

I have not changed the GitHub actions for now, as I think it's important to maintain consistency between the backend and frontend actions.

## How to test this PR

1. Run `tox -e unittest-current` on a branch with changes from `main`, and then run `tox -e coverage`. Alternatively, run `tox -e unittest-current,coverage`. Observe that coverage is reported out like it is in our GitHub Actions.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
