### PR TITLE
Teacher's Digital Platform: Update Financial literacy activities finder results count to 25 per page

### DIFF
--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -393,13 +393,13 @@ def validate_results_per_page(request):
     A utility for parsing the requested number of results per page.
 
     This should catch an invalid number of results and always return
-    a valid number of results, defaulting to 5.
+    a valid number of results, defaulting to 25.
     """
     raw_results = request.GET.get('results')
     if raw_results in ['10', '25', '50']:
         return int(raw_results)
     else:
-        return 5
+        return 25
 
 
 def validate_page_number(request, paginator):

--- a/cfgov/teachers_digital_platform/tests/models/test_pages_utility_definitions.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_pages_utility_definitions.py
@@ -14,7 +14,7 @@ class PagingTestCases(TestCase, WagtailTestUtils):
 
     def test_validate_results_per_page_default_id_five(self):
         mock_request = HttpRequest()
-        default_per_page = 5
+        default_per_page = 25
         results_per_page = validate_results_per_page(mock_request)
         self.assertEqual(results_per_page, default_per_page)
 


### PR DESCRIPTION
See https://[GHE]/CFPB/el-camino/issues/365

## Changes

- Teacher's Digital Platform: Update Financial literacy activities finder results count to 25


## How to test this PR

1. Search on http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/ should have 25 results or less per page. Compare to 5 results or less on production https://www.consumerfinance.gov/consumer-tools/educator-tools/youth-financial-education/teach/activities/
