### PR TITLE
Removed outdated job link comment

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -18,10 +18,6 @@
 
     Also, you can see more of our code at https://github.com/cfpb
 
-    And by the way, there’s another hidden message somewhere on the following
-    page: https://www.consumerfinance.gov/jobs/technology-innovation-fellows/.
-    See if you can find it! Hint: picture yourself embedded in our work.
-
     ============================================================================
 -->
 {% endif %}

--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -3,23 +3,6 @@
 {% load static from staticfiles %}
 
 <!DOCTYPE html>
-<!--
-    ============================================================================
-
-    Hey! If you're viewing this, you should probably come work on our Technology
-    & Innovation team. We're always looking for a few great designers,
-    developers, data scientists, and network, infrastructure, privacy and
-    security pros. Keep an eye on our job opportunities at:
-    https://www.consumerfinance.gov/jobs/
-
-    Also, you can see more of our code at https://github.com/cfpb
-
-    And by the way, there’s another hidden message somewhere on the following
-    page: https://www.consumerfinance.gov/jobs/technology-innovation-fellows/.
-    See if you can find it! Hint: picture yourself embedded in our work.
-
-    ============================================================================
--->
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" dir="ltr" lang="{% trans "en-US" %}"> <![endif]-->


### PR DESCRIPTION
Closes https://github.com/cfpb/consumerfinance.gov/issues/3531

## Removals

- Removes recruiting code comment that is on a legacy page and is not under a flag.

## Changes

- Removes reference to `https://www.consumerfinance.gov/jobs/technology-innovation-fellows/` that is now redirecting to the careers page, which is also linked to earlier in the code comment.


## How to test this PR

1. Since these are code comments, just look at the changes in the PR.
