### PR TITLE
Have New Relic ignore exceptions that generate HTTP 429

### DIFF
--- a/cfgov/newrelic.ini
+++ b/cfgov/newrelic.ini
@@ -236,7 +236,7 @@ error_collected.enabled = true
 #
 # This setting is only compatible with some web frameworks, as some
 # frameworks do not use exceptions to return HTTP responses.
-error_collector.ignore_status_codes = 100-102 200-208 226 300-308 429
+error_collector.ignore_status_codes = 100-102 200-208 226 300-308 404 429
 
 # Adds message properties to tracer attributes. Set this to false to turn
 # it off. This option is automatically enabled in high security mode.

--- a/cfgov/newrelic.ini
+++ b/cfgov/newrelic.ini
@@ -236,7 +236,7 @@ error_collected.enabled = true
 #
 # This setting is only compatible with some web frameworks, as some
 # frameworks do not use exceptions to return HTTP responses.
-error_collector.ignore_status_codes = 100-102 200-208 226 300-308
+error_collector.ignore_status_codes = 100-102 200-208 226 300-308 429
 
 # Adds message properties to tracer attributes. Set this to false to turn
 # it off. This option is automatically enabled in high security mode.

--- a/cfgov/newrelic.ini
+++ b/cfgov/newrelic.ini
@@ -171,7 +171,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors =
+error_collector.ignore_classes =
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this

--- a/requirements/deployment.txt
+++ b/requirements/deployment.txt
@@ -1,2 +1,2 @@
 -r base.txt
-newrelic==5.20.1.150
+newrelic==6.4.3.160


### PR DESCRIPTION
This change adds 429: Too Many Requests to our list of ignored status codes for New Relic. We occasionally have [`rest_framework.exceptions.Throttled`](https://www.django-rest-framework.org/api-guide/exceptions/#throttled) show up in our error violations, when it shouldn't because that's a valid exception to throw when we intend to throttle API requests.

Per the [New Relic documentation](https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration/#error-ignore-status-codes), it sounds like this should work, because Django does use exceptions to return HTTP responses. If this doesn't work, we can add the exception to [`error_collector.expected_classes`](https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration/#error-ignore).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
