### PR TITLE
Update breadcrumbs to use canonical path

### DIFF
--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -9,7 +9,7 @@
     <div class="content_wrapper">
         <nav class="breadcrumbs" aria-label="Breadcrumbs">
             <a href="/" class="breadcrumbs_link">Home</a>
-            <a href="/credit-cards/" class="breadcrumbs_link">Credit cards</a>
+            <a href="/data-research/credit-card-data/" class="breadcrumbs_link">Credit cards</a>
         </nav>
     </div>
     <div class="content_wrapper">


### PR DESCRIPTION
Previously, the breadcrumbs on the Credit Card Agreement Database page contained a link to a non-existent page, `/credit-cards/`. Redirects.conf redirects that URL to `/data-research/credit-card-data/`. Now, the breadcrumbs will point to the canonical path instead of a redirect.

## Screenshots
![Screen Shot 2021-07-06 at 3 43 58 PM](https://user-images.githubusercontent.com/4295388/124663724-724ca700-de78-11eb-8c11-50fac59bd7b9.png)



## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
