### PR TITLE
Fix the closing local section of .env_SAMPLE

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -192,8 +192,7 @@ export WATCHMAN_TOKENS=''
 # Local envvar overrides and virtualenv hook
 if [ $(uname -s) = "Darwin" ]; then
   export CFGOV_HOSTNAME=localhost:8000
-  export DATABASE_URL=postgres://cfpb:${PGPASSWORD}@localhost/cfgov
+  export DATABASE_URL=postgres://cfpb@localhost/cfgov
   export ES_HOST=localhost
   export ES7_HOST=localhost
-  source activate-virtualenv.sh
 fi


### PR DESCRIPTION
Based on recent onboarding feedback, the final section of the .env_SAMPLE file should be simplified. 
- The DATABASE_URL fails for people who don't have a PGPASSWORD set, and is unnecessary for those who do.
- We're reworking how we manage virtual environments, and we can drop the closing activation line.

This won't affect anyone's current environment, only those who are starting fresh.