### PR TITLE
Pin Wagtail to 2.13

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==2.12.5
+wagtail==2.13.3


### PR DESCRIPTION
Pin Wagtail to 2.13.3. This will upgrade us to Wagtail 2.13.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
