### PR TITLE
Run our internal functional test job against PR deployments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -252,7 +252,7 @@ pipeline {
                 }
                 echo "Running functional tests against https://${CFGOV_HOSTNAME}"
                 build job: 'cf.gov-functional-tests', parameters: [
-                    [$class: 'StringParameterValue', name: 'BASE_URL', value: env.CFGOV_HOSTNAME],
+                    [$class: 'StringParameterValue', name: 'BASE_URL', value: "https://${env.CFGOV_HOSTNAME}/"],
                     [$class: 'StringParameterValue', name: 'GIT_TAG', value: env.GIT_COMMIT],
                 ]
                 postGitHubStatus("jenkins/functional-tests", "success", "Passed", env.RUN_DISPLAY_URL)
@@ -277,7 +277,7 @@ pipeline {
                 changeUrl = env.CHANGE_URL ? env.CHANGE_URL : env.GIT_URL
 
                 if (env.DEPLOY_SUCCESS == false) {
-                    postGitHubStatus("jenkins/deploy", "failure", "Failed", "https://${env.CFGOV_HOSTNAME}/")
+                    postGitHubStatus("jenkins/deploy", "failure", "Failed", env.RUN_DISPLAY_URL)
                     postGitHubStatus("jenkins/functional-tests", "error", "Cancelled", env.RUN_DISPLAY_URL)
                     deployText = "failed" 
                 } else {


### PR DESCRIPTION
This change has our dev Docker deploys run our internally defined functional test job against the newly deployed stack and report back to PRs.

This should give us the benefit of running the functional test suite against PRs again.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
