### PR TITLE
Catch an ElasticSearch RequestError in autocomplete

### DIFF
--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -1,3 +1,5 @@
+from elasticsearch7.exceptions import RequestError
+
 from ask_cfpb.documents import AnswerPageDocument
 
 
@@ -22,13 +24,19 @@ class AnswerPageSearch:
         self.suggestion = None
 
     def autocomplete(self):
-        s = AnswerPageDocument.search().filter(
-            "term", language=self.language).query(
-            'match', autocomplete=self.search_term)
-        results = [
-            {'question': result.autocomplete, 'url': result.url}
-            for result in s[:20]
-        ]
+        try:
+            s = AnswerPageDocument.search().filter(
+                "term", language=self.language
+            ).query(
+                'match', autocomplete=self.search_term
+            )
+        except RequestError:
+            results = []
+        else:
+            results = [
+                {'question': result.autocomplete, 'url': result.url}
+                for result in s[:20]
+            ]
         return results
 
     def search(self):


### PR DESCRIPTION
Occasionally we hit an `elasticsearch7.exceptions.RequestError` in the Ask CFPB autocomplete search method because the `search_phase_execution_exception` character limit is reached. This change catches that error so that it doesn’t propogate, and returns an empty of list of autocomplete results instead.

I've also added explicit tests for `AnswerPageSearch.autocomplete`.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
