### PR TITLE
Enable line breaks in table cells

### DIFF
--- a/cfgov/unprocessed/js/admin/table-block.js
+++ b/cfgov/unprocessed/js/admin/table-block.js
@@ -615,7 +615,7 @@ import { stateToHTML } from 'draft-js-export-html';
           }
         ],
         enableHorizontalRule: false,
-        enableLineBreak: false,
+        enableLineBreak: true,
         inlineStyles: [
           {
             type: 'BOLD',


### PR DESCRIPTION
We enable only a subset of available rich text features in the editor we use for table content; currently line breaks are not enabled. We now need line breaks for a couple of tables, so we're enabling them. See GHE/CFGOV/platform/issues/4096 for more details.

---

## Additions

- Enable line breaks in table cells

## How to test this PR

1. Go to a page with a table on it. /consumer-tools/educator-tools/resources-for-older-adults/financial-security-as-you-age/ is a great example (and the reason we need to enable line breaks).
2. Add some line breaks to some table cells either with the Draftail line break button or with `shift + return`.
3. Preview the page and make sure the line breaks show up. Note! For some reason tables with line breaks in them render with two `<br>`s. This doesn't happen in non-table rich text content, so there's something weird going on with the table editor. In fact, the whole table editor is pretty weird and complicated, and we're willing to live with the double `<br>` for now instead of trying to debug where the extra line break is coming from.

## Notes and todos

- As noted above, a single line break entered into a table cell renders as two `<br>`s. We've decided it's not worth tracking down where that extra `<br>` is coming from for now.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets