### PR TITLE
Fix Ask CFPB table block rendering

### DIFF
--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -1,6 +1,8 @@
 from django.test import TestCase, override_settings
 
-from ask_cfpb.models.blocks import FAQ, AskAnswerContent, HowTo, Tip
+from ask_cfpb.models.blocks import (
+    FAQ, AskAnswerContent, AskContent, HowTo, Tip
+)
 
 
 @override_settings(LANGUAGE_CODE='en-US', LANGUAGES=(('en', 'English'),))
@@ -117,6 +119,36 @@ class SchemaBlocksTestCase(TestCase):
             '<div itemprop="text">Answer content</div>'
             '</div>'
             '</div>'
+            '</div>'
+        )
+        html = block.render(data)
+        self.assertHTMLEqual(html, expected_html)
+
+
+class AskContentTestCase(TestCase):
+    def test_table_block_autoescape(self):
+        block = AskContent()
+        data = block.to_python([
+            {
+                'type': 'table_block',
+                'value': {
+                    'data': [
+                        [
+                            'Column',
+                            '<p>Column with HTML<br/></p>',
+                        ],
+                    ],
+                    'has_data': True,
+                },
+            },
+        ])
+        expected_html = (
+            '<div class="row table_block-row">'
+            '<table class="o-table">'
+            '<tbody>'
+            '<tr><td>Column</td><td><p>Column with HTML<br/></p></td></tr>'
+            '</tbody>'
+            '</table>'
             '</div>'
         )
         html = block.render(data)

--- a/cfgov/jinja2/v1/_includes/ask/content-block.html
+++ b/cfgov/jinja2/v1/_includes/ask/content-block.html
@@ -19,6 +19,10 @@
     {% endif %}
     {% if block.block_type == 'text' %}
         {{ block.value.content | richtext | safe }}
+    {% elif block.block_type == 'table_block' %}
+        {% autoescape off %}
+            {% include_block block %}
+        {% endautoescape %}
     {% else %}
         {% include_block block %}
     {% endif %}


### PR DESCRIPTION
Prior to [Wagtail 2.12.5](https://docs.wagtail.io/en/stable/releases/2.12.5.html) `include_block` was improperly escaping HTML, resulting in CVE-2021-32681 (🎩  to @niqjohnson for catching this). Unfortunately we were relying on that behavior for rendering of table blocks in Ask CFPB content.

This fix explicitly turns off autoescape for table blocks in Ask CFPB content blocks.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
