### PR TITLE
CCDB: Remove non-responsive header and footer CSS

### DIFF
--- a/cfgov/legacy/templates/front/base_update.html
+++ b/cfgov/legacy/templates/front/base_update.html
@@ -91,11 +91,6 @@
     {% block page_css %}
     {% endblock %}
 
-    <!--[if lt IE 9]>
-    <link rel="stylesheet" href="{% static 'css/header.nonresponsive.css' %}"/>
-    <link rel="stylesheet" href="{% static 'css/footer.nonresponsive.css' %}"/>
-    <![endif]-->
-
     <!--[if gt IE 8]><!-->
     <link rel="stylesheet" href="{% static 'css/header.css' %}"/>
     <link rel="stylesheet" href="{% static 'css/footer.css' %}"/>

--- a/cfgov/unprocessed/css/on-demand/footer.less
+++ b/cfgov/unprocessed/css/on-demand/footer.less
@@ -1,6 +1,6 @@
 /* ==========================================================================
    consumerfinance.gov
-   Main Less file for the nonresponsive on-demand footer
+   Main Less file for the on-demand footer
    ========================================================================== */
 
 

--- a/cfgov/unprocessed/css/on-demand/header.less
+++ b/cfgov/unprocessed/css/on-demand/header.less
@@ -1,6 +1,6 @@
 /* ==========================================================================
    consumerfinance.gov
-   Main Less file for the nonresponsive on-demand header
+   Main Less file for the on-demand header
    ========================================================================== */
 
 

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -74,8 +74,6 @@ function stylesOnDemand() {
   return gulp.src( configStyles.cwd + '/on-demand/*.less' )
     .pipe( gulpNewer( {
       dest:  configStyles.dest,
-      // ext option required because this subtask uses multiple source files
-      ext:   '.nonresponsive.css',
       extra: configStyles.otherBuildTriggerFiles
     } ) )
     .pipe( gulpLess( configStyles.settings ) )
@@ -84,17 +82,7 @@ function stylesOnDemand() {
       autoprefixer()
     ] ) )
     .pipe( gulpHeader( configBanner, { pkg: configPkg } ) )
-    .pipe( gulp.dest( configStyles.dest ) )
-    .pipe( gulpPostcss( [
-      postcssUnmq( {
-        width: '75em'
-      } )
-    ] ) )
-    .pipe( gulpCleanCss( { compatibility: 'ie8' } ) )
-    .pipe( gulpRename( {
-      suffix:  '.nonresponsive',
-      extname: '.css'
-    } ) )
+    .pipe( gulpCleanCss( { compatibility: '*' } ) )
     .pipe( gulp.dest( configStyles.dest ) );
 }
 


### PR DESCRIPTION
Our legacy base template that ccdb-ui uses has special non-responsive styles for the header and footer that appear to do nothing. The page is unusable in IE9 anyway. 

## Removals

- non-responsive header and footer CSS and associated gulp tasks.

## How to test this PR

1. Pull branch, build and run a local server.
2. Boot up Sauce Connect.
3. In Sauce Labs IE9 compare http://localhost:8000/data-research/consumer-complaints/search/ to https://www.consumerfinance.gov/data-research/consumer-complaints/search/
4. There should be a menu (albeit difficult to see with all the reloading that happens)
