### PR TITLE
Expand fake-school options

### DIFF
--- a/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
@@ -18,7 +18,7 @@ from paying_for_college.disclosures.scripts.api_utils import (
     DECIMAL_MAP, MODEL_MAP
 )
 from paying_for_college.models import (
-    CONTROL_MAP, FAKE_SCHOOL_PK, OFFICE_IDS, PROGRAM_LEVELS, Program, School
+    CONTROL_MAP, FAKE_SCHOOL_PKS, OFFICE_IDS, PROGRAM_LEVELS, Program, School
 )
 
 
@@ -168,7 +168,7 @@ def update(exclude_ids=[], single_school=None, store_programs=False):
     """
     programs_created = 0
 
-    excluded_ids = OFFICE_IDS + [FAKE_SCHOOL_PK] + exclude_ids
+    excluded_ids = OFFICE_IDS + FAKE_SCHOOL_PKS + exclude_ids
     no_data = []  # API failed to respond or provided no data
     closed = []  # schools that have closed since our last scrape
     job_msg = (

--- a/cfgov/paying_for_college/models/__init__.py
+++ b/cfgov/paying_for_college/models/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa F401
 
 from paying_for_college.models.disclosures import (
-    CONTROL_MAP, DEFAULT_EXCLUSIONS, FAKE_SCHOOL_PK, HIGHEST_DEGREES, LEVELS,
+    CONTROL_MAP, DEFAULT_EXCLUSIONS, FAKE_SCHOOL_PKS, HIGHEST_DEGREES, LEVELS,
     NOTIFICATION_TEMPLATE, OFFICE_IDS, PROGRAM_LEVELS, REGION_MAP,
     REGION_NAMES, Alias, ConstantCap, ConstantRate, Contact, DisclosureBase,
     Feedback, Nickname, Notification, Program, School, csw, get_region,

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -16,7 +16,13 @@ import requests
 # Our database has a fake school for demo purposes
 # It should be discoverable via search and API calls, but should be excluded
 # from cohort calculations and from College Scorecard API updates.
-FAKE_SCHOOL_PK = 999999
+FAKE_SCHOOL_PKS = [
+    999999,
+    999998,
+    999997,
+    999996,
+]
+
 # Our database also has 49 entries for school or school system home offices,
 # which should be excluded from school processing and comparisons.
 OFFICE_IDS = [
@@ -27,7 +33,7 @@ OFFICE_IDS = [
     231156, 242671, 403399, 438665, 443368, 446978, 448336, 448381, 454218,
     461087, 481191, 483090, 485467,
 ]
-DEFAULT_EXCLUSIONS = OFFICE_IDS + [FAKE_SCHOOL_PK]
+DEFAULT_EXCLUSIONS = OFFICE_IDS + FAKE_SCHOOL_PKS
 REGION_MAP = {'MW': ['IL', 'IN', 'IA', 'KS', 'MI', 'MN',
                      'MO', 'NE', 'ND', 'OH', 'SD', 'WI'],
               'NE': ['CT', 'ME', 'MA', 'NH', 'NJ',

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -13,8 +13,8 @@ from django.db import models
 import requests
 
 
-# Our database has a fake school for demo purposes
-# It should be discoverable via search and API calls, but should be excluded
+# Our database has fake schools for demo purposes
+# They should be discoverable via search and API calls, but should be excluded
 # from cohort calculations and from College Scorecard API updates.
 FAKE_SCHOOL_PKS = [
     999999,

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -22,7 +22,7 @@ from paying_for_college.disclosures.scripts.notification_tester import (
     send_test_notifications
 )
 from paying_for_college.models import (
-    FAKE_SCHOOL_PK, Alias, Notification, Program, School
+    FAKE_SCHOOL_PKS, Alias, Notification, Program, School
 )
 
 
@@ -398,7 +398,7 @@ class TestScripts(django.test.TestCase):
         self.assertEqual(
             mock_get_data.call_count,
             School.objects.filter(operating=True).exclude(
-                pk=FAKE_SCHOOL_PK).count())
+                pk__in=FAKE_SCHOOL_PKS).count())
 
     def check_compile_net_prices(self, control):
         mock_api_data = self.mock_results.get('results')[0]


### PR DESCRIPTION
We've had an obviously fictional school – Example University – in our paying_for_college database for several years, for demo purposes. Now we want to have three more options, in order to show schools typical of different sizes.

This change adds three demo-school primary keys to be excluded from updates
and most other live operations. So the former `FAKE_SCHOOL_PK` constant becomes a list.

This should have no effect on the legacy EFIP tool or the financial-path tool.
