### PR TITLE
Allow HomePages to be created anywhere

### DIFF
--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -55,9 +55,6 @@ class HomePage(CFGOVPage):
         ),
     ])
 
-    # Sets page to only be createable at the root
-    parent_page_types = ['wagtailcore.Page']
-
     objects = PageManager()
 
     def get_context(self, request):


### PR DESCRIPTION
Currently HomePages can only be created at the site root. We want themto be able to exist elsewhere for better multi-language support. This commit removes this restriction to allow for creation of HomePages at any location in the page tree.

See platform#4103 for additional context.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)