### PR TITLE
Add filterable lists page to documentation sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
 - Supporting Features:
     - Caching: caching.md
     - Feature Flags: feature-flags.md
+    - Filterable Lists: filterable-lists.md
     - Search: search.md
     - Split Testing: split-testing.md
     - Translation: translation.md


### PR DESCRIPTION
#6356 added a new documentation page about filterable lists, but neglected to add it to the mkdocs configuration, so it doesn't show up in the sidebar. This commit adds it to the "Supporting Features" part of the documentation.

## Screenshots

![image](https://user-images.githubusercontent.com/654645/127513746-edf4d5d5-44ae-4baa-a0fe-f729e23c2fb4.png)