### PR TITLE
Handle filterable list results without aggregation

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -882,3 +882,16 @@ CSRF_REQUIRED_PATHS = (
     "/admin",
     "/django-admin",
 )
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'cfgov_default_cache',
+        'TIMEOUT': None,
+    },
+    'post_preview': {
+        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
+        'LOCATION': 'post_preview_cache',
+        'TIMEOUT': None,
+    }
+}

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -84,30 +84,16 @@ if os.environ.get("ENABLE_DEBUG_TOOLBAR"):
 
 MIDDLEWARE += CSP_MIDDLEWARE
 
-# Disable caching when working locally
-CACHES = {
-    k: {
-        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-        "TIMEOUT": 0,
-    }
-    for k in ("default", "post_preview")
-}
-
-# Optionally enable default cache
-if os.environ.get("ENABLE_DEFAULT_CACHE"):
-    CACHES["default"] = {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "default_cache",
-        "TIMEOUT": None,
-    }
-
-# Optionally enable cache for post_preview
-if os.environ.get("ENABLE_POST_PREVIEW_CACHE"):
-    CACHES["post_preview"] = {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "post_preview_cache",
-        "TIMEOUT": None,
-    }
+# Disable caching unless enabled via environment variable
+for _cache_name, _cache_envvar in (
+    ('default', 'ENABLE_DEFAULT_CACHE'),
+    ('post_preview', 'ENABLE_POST_PREVIEW_CACHE'),
+):
+    if not os.getenv(_cache_envvar):
+        CACHES[_cache_name] = {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            "TIMEOUT": 0,
+        }
 
 # Use a mock GovDelivery API instead of the real thing,
 # unless the GOVDELIVERY_BASE_URL environment variable is set.

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -86,19 +86,6 @@ STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesSto
 
 STATIC_ROOT = os.environ['DJANGO_STATIC_ROOT']
 
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-        'LOCATION': 'cfgov_default_cache',
-        'TIMEOUT': None,
-    },
-    'post_preview': {
-        'BACKEND': 'django.core.cache.backends.db.DatabaseCache',
-        'LOCATION': 'post_preview_cache',
-        'TIMEOUT': None,
-    }
-}
-
 # ALLOWED_HOSTS should be defined as a JSON list in the ALLOWED_HOSTS
 # environment variable.
 try:


### PR DESCRIPTION
#6532 added a new Elasticsearch aggregation to filterable list search results, but neglected to account for cached ES results that may not have that aggregation.

This commit adds a check so that old cached data won't cause search pages to 500. The cache will still need to be manually cleared for now to get the language choices to properly update.

As discussed with @willbarton, this is a temporary fix that can hopefully be improved with a smarter strategy overall around these caches (including perhaps getting rid of them altogether).

I've also included a setting change here to make it easier to enable Django caches locally.