### PR TITLE
Update the ccdb5-api and ccdb5-ui releases for Elasticsearch 7

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,6 +44,6 @@ wagtailmedia==0.6.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.2/elasticsearch_dsl-7.2.2-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.5.2/ccdb5_api-1.5.2-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.6.1/ccdb5_api-1.6.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/2.4.2/ccdb5_ui-2.4.2-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
CCDB is the last consumerfinance.gov app using Elasticsearch 2, and this change
moves all operations to our AWS Elasticsearch 7 service.

The CCDB code imported here is running on our DEV5 server for testing.

~This PR needs to **HOLD** until we get a release date.~
Release date is 9/13. PR should **not be merged** until then.