### PR TITLE
Add ability to preview the 2021 home page version

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page_2021.html
+++ b/cfgov/v1/jinja2/v1/home_page_2021.html
@@ -3,7 +3,7 @@
 {% import "organisms/card-group.html" as card_group with context %}
 
 {% block title -%}
-    {{ _('Consumer Financial Protection Bureau') }}
+    {{ _('Consumer Financial Protection Bureau') }} (2021)
 {%- endblock %}
 
 {% block css %}

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -1,4 +1,8 @@
+from collections import OrderedDict
+
 from django.db import models
+from django.template.response import TemplateResponse
+from django.utils.cache import patch_cache_control
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.edit_handlers import (
@@ -73,11 +77,32 @@ class HomePage(CFGOVPage):
 
         return context
 
+    TEMPLATES = ['v1/home_page.html', 'v1/home_page_2021.html']
+
     def get_template(self, request, *args, **kwargs):
-        return [
-            super().get_template(request, *args, **kwargs),
-            'v1/home_page_2021.html',
-        ][bool(flag_enabled('HOME_PAGE_2021', request=request))]
+        return self.TEMPLATES[
+            bool(flag_enabled('HOME_PAGE_2021', request=request))
+        ]
+
+    @property
+    def preview_modes(self):
+        return super().preview_modes + [('home_page_2021', '2021 version')]
+
+    def serve_preview(self, request, mode_name):
+        template_name = self.TEMPLATES[
+            list(OrderedDict(self.preview_modes).keys()).index(mode_name)
+        ]
+
+        # See wagtail.core.models.Page.serve_preview.
+        request.is_preview = True
+        response = TemplateResponse(
+            request,
+            template_name,
+            self.get_context(request)
+        )
+        patch_cache_control(response, private=True)
+
+        return response
 
 
 class HomePageInfoUnit(Orderable, ClusterableModel):

--- a/cfgov/v1/tests/models/test_home_page.py
+++ b/cfgov/v1/tests/models/test_home_page.py
@@ -1,0 +1,19 @@
+from django.test import RequestFactory, TestCase
+
+from v1.models import HomePage
+
+
+class HomePageTests(TestCase):
+    def setUp(self):
+        self.request = RequestFactory().get('/')
+        self.page = HomePage(title='home', live=True)
+
+    def check_preview_template(self, preview_mode, expected_template):
+        response = self.page.serve_preview(self.request, preview_mode)
+        self.assertEqual(response.template_name, expected_template)
+
+    def test_preview_default_template(self):
+        self.check_preview_template('', 'v1/home_page.html')
+
+    def test_preview_2021_template(self):
+        self.check_preview_template('home_page_2021', 'v1/home_page_2021.html')


### PR DESCRIPTION
#6560 added a new stub template for a new 2021 version of the website home page. This commit adds the ability to preview this new version directly from the Wagtail editor, without having to publish it, and in the production environment where the new template is not yet enabled.

On the page edit view, the Preview button now becomes a dropdown with the ability to preview the new template:

![image](https://user-images.githubusercontent.com/654645/128554142-e554d078-45e8-4353-b162-1592971dbdcd.png)

This commit also includes a minor edit to the stub template to make it easier to distinguish from the current one.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)