### PR TITLE
Rural or underserved tool: Show error when API call is down

### DIFF
--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -49,46 +49,48 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
             </div>
 
-            <div class="content-l_col content-l_col-1">
-                {# Display errors here. #}
-                <div id="file-error"
-                        class="block
-                            block__flush-top
-                            block__flush-bottom
-                            block__padded-bottom
-                            u-hidden">
-                    <div class="m-notification
-                                m-notification__visible
-                                m-notification__error">
-                        {{ svg_icon('error-round') }}
-                        <div class="m-notification_content">
-                            <div class="h4 m-notification_message">
-                                Formatting error
-                            </div>
-                            <div class="m-notification_explanation">
-                                <strong>We've noticed the following errors:</strong>
-                                <div id="file-error-desc"></div>
+            <div class="content-l">
+                <div class="content-l_col content-l_col-1">
+                    {# Display errors here. #}
+                    <div id="file-error"
+                            class="block
+                                block__flush-top
+                                block__flush-bottom
+                                block__padded-bottom
+                                u-hidden">
+                        <div class="m-notification
+                                    m-notification__visible
+                                    m-notification__error">
+                            {{ svg_icon('error-round') }}
+                            <div class="m-notification_content">
+                                <div class="h4 m-notification_message">
+                                    Formatting error
+                                </div>
+                                <div class="m-notification_explanation">
+                                    <strong>We've noticed the following errors:</strong>
+                                    <div id="file-error-desc"></div>
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div id="process-error"
-                        class="block
-                            block__flush-top
-                            block__flush-bottom
-                            block__padded-bottom
-                            u-hidden">
-                    <div class="m-notification
-                                m-notification__visible
-                                m-notification__error">
-                        {{ svg_icon('error-round') }}
-                        <div class="m-notification_content">
-                            <div class="h4 m-notification_message">
-                                Processing error
-                            </div>
-                            <div class="m-notification_explanation">
-                                <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
-                                <ul id="process-error-desc"></ul>
+                    <div id="process-error"
+                            class="block
+                                block__flush-top
+                                block__flush-bottom
+                                block__padded-bottom
+                                u-hidden">
+                        <div class="m-notification
+                                    m-notification__visible
+                                    m-notification__error">
+                            {{ svg_icon('error-round') }}
+                            <div class="m-notification_content">
+                                <div class="h4 m-notification_message">
+                                    Processing error
+                                </div>
+                                <div class="m-notification_explanation">
+                                    <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
+                                    <ul id="process-error-desc"></ul>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -88,7 +88,9 @@ home price, down payment, and more can affect mortgage interest rates.
                                     Processing error
                                 </div>
                                 <div class="m-notification_explanation">
-                                    <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
+                                    <p>
+                                        <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
+                                    </p>
                                     <ul id="process-error-desc"></ul>
                                 </div>
                             </div>

--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -49,51 +49,54 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
             </div>
 
+            <div class="content-l_col content-l_col-1">
+                {# Display errors here. #}
+                <div id="file-error"
+                        class="block
+                            block__flush-top
+                            block__flush-bottom
+                            block__padded-bottom
+                            u-hidden">
+                    <div class="m-notification
+                                m-notification__visible
+                                m-notification__error">
+                        {{ svg_icon('error-round') }}
+                        <div class="m-notification_content">
+                            <div class="h4 m-notification_message">
+                                Formatting error
+                            </div>
+                            <div class="m-notification_explanation">
+                                <strong>We've noticed the following errors:</strong>
+                                <div id="file-error-desc"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="process-error"
+                        class="block
+                            block__flush-top
+                            block__flush-bottom
+                            block__padded-bottom
+                            u-hidden">
+                    <div class="m-notification
+                                m-notification__visible
+                                m-notification__error">
+                        {{ svg_icon('error-round') }}
+                        <div class="m-notification_content">
+                            <div class="h4 m-notification_message">
+                                Processing error
+                            </div>
+                            <div class="m-notification_explanation">
+                                <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
+                                <ul id="process-error-desc"></ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <div id="search-tool" class="content-l">
                 <div class="content-l_col content-l_col-1">
-                    {# Display errors here. #}
-                    <div id="fileError"
-                         class="block
-                                block__flush-top
-                                block__flush-bottom
-                                block__padded-bottom
-                                u-hidden">
-                        <div class="m-notification
-                                    m-notification__visible
-                                    m-notification__error">
-                            {{ svg_icon('error-round') }}
-                            <div class="m-notification_content">
-                                <div class="h4 m-notification_message">
-                                    Formatting error
-                                </div>
-                                <div class="m-notification_explanation">
-                                    <strong>We've noticed the following errors:</strong>
-                                    <div id="fileErrorDesc"></div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div id="processError"
-                         class="block
-                                block__flush-top
-                                block__flush-bottom
-                                block__padded-bottom
-                                u-hidden">
-                        <div class="m-notification
-                                    m-notification__visible
-                                    m-notification__error">
-                            {{ svg_icon('error-round') }}
-                            <div class="m-notification_content">
-                                <div class="h4 m-notification_message">
-                                    Processing error
-                                </div>
-                                <div class="m-notification_explanation">
-                                    <strong>The following addresses were not processed because the server was temporarily unavailable. To try again, start a new search.</strong>
-                                    <ul id="processErrorDesc"></ul>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
 
                     <h2>
                         Check status of properties for loans extended in

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
@@ -24,9 +24,8 @@ function callCensus( address, rural, cb ) {
       if ( error ) {
         const addressElement = DT.createEl( '<li>' + address + '</li>' );
 
-        DT.addEl( DT.getEl( '#processErrorDesc' ), addressElement );
-
-        DT.removeClass( '#processError', 'u-hidden' );
+        DT.addEl( DT.getEl( '#process-error-desc' ), addressElement );
+        DT.removeClass( '#process-error', 'u-hidden' );
 
         count.incrementTotal();
       }

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -82,7 +82,7 @@ window.callbacks.censusAPI = function( data, rural ) {
         addressUtils.render( result );
         count.updateCount( result.type );
       } ) )
-      .catch( function( error ) {
+      .catch( function() {
         const addressElement = DT.createEl( '<li>' + result.address + '</li>' );
         DT.addEl( DT.getEl( '#process-error-desc' ), addressElement );
         DT.removeClass( '#process-error', 'u-hidden' );

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -77,7 +77,9 @@ window.callbacks.censusAPI = function( data, rural ) {
         count.updateCount( result.type );
       } ) )
       .catch( function( error ) {
-        console.log( error );
+        const addressElement = DT.createEl( '<li>' + result.address + '</li>' );
+        DT.addEl( DT.getEl( '#process-error-desc' ), addressElement );
+        DT.removeClass( '#process-error', 'u-hidden' );
       } );
   } else {
     result.input = data.result.input.address.address;

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/content-control.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/content-control.js
@@ -10,7 +10,7 @@ const monthNames = [
 /**
  * Hide the data sections. These get shown as needed in addresses.js (render)
  */
-function hideData() {
+function _hideData() {
   DT.addClass( '#rural', 'u-hidden' );
   DT.addClass( '#notRural', 'u-hidden' );
   DT.addClass( '#duplicate', 'u-hidden' );
@@ -39,60 +39,34 @@ function setup() {
     'Report generated ' + monthNames[monthIndex] + ' ' + day + ', ' + year
   );
 
-  DT.addClass( '#fileError', 'u-hidden' );
-  DT.addClass( '#errorMessage', 'u-hidden' );
+  DT.addClass( '#file-error', 'u-hidden' );
+  DT.addClass( '#error-message', 'u-hidden' );
   DT.removeClass( '#spinner', 'u-hidden' );
 
   count.reset();
-  this.resetHTML();
-  this.showResults();
+  _resetHTML();
+  _showResults();
 }
 
 /**
  * Show the results of a search.
  */
-function showResults() {
+function _showResults() {
   // hide search-tool and about
   DT.addClass( '#search-tool', 'u-hidden' );
-  hideData();
+  _hideData();
 
   // show the results
   DT.removeClass( '#results', 'u-hidden' );
 }
 
 /**
- * Show search tool content.
- */
-function showSearchTool() {
-  // show search-tool and about
-  DT.removeClass( '#search-tool', 'u-hidden' );
-
-  // hide the results
-  DT.addClass( '#results', 'u-hidden' );
-
-  hideData();
-}
-
-/**
  * Clear the body of all the tables (data).
  */
-function resetHTML() {
+function _resetHTML() {
   DT.changeElHTML( 'tbody', '' );
 }
 
-/**
- * Show an error message.
- * @param {string} message - An error message.
- */
-function error( message ) {
-  DT.changeElHTML( '#errorMessage', message );
-  DT.removeClass( '#errorMessage', 'u-hidden' );
-}
-
 export default {
-  setup,
-  showResults,
-  showSearchTool,
-  resetHTML,
-  error
+  setup
 };

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
@@ -19,8 +19,8 @@ function setFileName( fileName ) {
  * Clear errors.
  */
 function resetError() {
-  DT.addClass( '#fileError', 'u-hidden' );
-  DT.addClass( '#processError', 'u-hidden' );
+  DT.addClass( '#file-error', 'u-hidden' );
+  DT.addClass( '#process-error', 'u-hidden' );
   DT.changeElHTML( '.js-error-message', '' );
 }
 
@@ -29,8 +29,8 @@ function resetError() {
  * @param {string} message - An error message.
  */
 function setError( message ) {
-  DT.changeElHTML( '#fileErrorDesc', message );
-  DT.removeClass( '#fileError', 'u-hidden' );
+  DT.changeElHTML( '#file-error-desc', message );
+  DT.removeClass( '#file-error', 'u-hidden' );
 }
 
 /**


### PR DESCRIPTION
When the census API calls don't return what we expect the app just logs an error to the console. This PR changes that to show an error notification.

## Changes

- Add error notification logic when the call to the census API fails.
- Remove unused content JS.
- Change camel case `id` names to dashes.
- Wrap process error notification text in a paragraph so it's spaced adequately from the list of addresses.
- Move the error notifications to their own blocks outside of the search tool (so they show up on the results view too).


## How to test this PR

1. Pull branch and enter an address. The API is returning an error right now so it should show an error notification.


## Screenshots

<img width="958" alt="Screen Shot 2021-08-06 at 3 14 29 PM" src="https://user-images.githubusercontent.com/704760/128560761-a7c88d4c-5802-49fa-81dc-bf6760e413a3.png">

<img width="964" alt="Screen Shot 2021-08-06 at 3 14 11 PM" src="https://user-images.githubusercontent.com/704760/128560756-d1742b2d-c9ba-42ca-a6ce-1c6ffa157053.png">
