### PR TITLE
Rural or underserved tool: Update tigerweb API version mappings

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
@@ -11,7 +11,7 @@ const jsonP = require( 'jsonp-p' ).default;
 function callTiger( x, y, layer ) {
   // See versions at https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb
   const apiVersion = 'tigerWMS_ACS2019';
-  const url = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/'+
+  const url = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/' +
               apiVersion + '/MapServer/' +
               layer +
               '/query' +

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
@@ -9,7 +9,10 @@ const jsonP = require( 'jsonp-p' ).default;
  * @returns {Promise} A promise returned from the API.
  */
 function callTiger( x, y, layer ) {
-  const url = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/tigerWMS_Current/MapServer/' +
+  // See versions at https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb
+  const apiVersion = 'tigerWMS_ACS2019';
+  const url = 'https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/'+
+              apiVersion + '/MapServer/' +
               layer +
               '/query' +
               '?geometryType=esriGeometryPoint' +

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -48,11 +48,17 @@ window.callbacks.censusAPI = function( data, rural ) {
     result.x = data.result.addressMatches[0].coordinates.x;
     result.y = data.result.addressMatches[0].coordinates.y;
 
+    /*
+    In the 2019 tigerweb API the layer IDs/name mappings are as follows:
+    84 = Counties
+    64 = 2010 Census Urban Clusters
+    62 = 2010 Census Urbanized Areas
+    */
     axios.all(
       [
-        tiger( result.x, result.y, '86' ),
-        tiger( result.x, result.y, '66' ),
-        tiger( result.x, result.y, '64' )
+        tiger( result.x, result.y, '84' ),
+        tiger( result.x, result.y, '64' ),
+        tiger( result.x, result.y, '62' )
       ]
     )
       .then( axios.spread( function( censusCounty, censusUC, censusUA ) {


### PR DESCRIPTION
We built this tool for some prior year version of the tigerweb API, but pegged it to current. In the years since it has updated and the layer mappings don't work anymore.

## Changes

- Change API version and layer mappings from current to 2019.

## How to test this PR

1. Pull branch, `gulp clean && gulp build`, and visit http://localhost:8000/rural-or-underserved-tool/ and enter an address and see that it resolves. Compare to production where it hangs and has a console.log error.
