### PR TITLE
Expand try/except around Ask CFPB autocomplete

### DIFF
--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -30,13 +30,12 @@ class AnswerPageSearch:
             ).query(
                 'match', autocomplete=self.search_term
             )
-        except RequestError:
-            results = []
-        else:
             results = [
                 {'question': result.autocomplete, 'url': result.url}
                 for result in s[:20]
             ]
+        except RequestError:
+            results = []
         return results
 
     def search(self):


### PR DESCRIPTION
It seems that Elasticsearch can throw a `RequestError` due to `maxClauseCount ` at any point during the autocomplete query. We had put this `try`/`except` in place as a stop-gap until we have some better user-facing limitations and errors for the Ask CFPB autocomplete (#6537). This expands the `try` to cover both the query initialization and when we access its data.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)