### PR TITLE
Update Tell Your Story relief stats

### DIFF
--- a/cfgov/jinja2/v1/your-story/index.html
+++ b/cfgov/jinja2/v1/your-story/index.html
@@ -151,7 +151,7 @@
     <p>
         Your stories help us understand what’s happening in the
         financial world. Since we began in 2011, we’ve helped return
-        $4 billion to American consumers as a result of our enforcement
+        $14.4 billion to American consumers as a result of our enforcement
         actions. Your stories help us to do that—your stories matter.
     </p>
     <div class="block


### PR DESCRIPTION
Updates the relief amount on the Tell Your Story landing page to the current amount.

---

## Changes

-  $4 billion -> $14.4 billion

## How to test this PR

1. Confirm the text on `/your-story/` says "Since we began in 2011, we’ve helped return $14.4 billion to American consumers as a result of our enforcement actions."

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)