### PR TITLE
Add mobile styles for survey quesitons

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
@@ -5,10 +5,14 @@ ul.tdp-survey__choice-question {
     &.tdp-survey__atype-H,
     &.tdp-survey__atype-I {
         border-bottom: 1px solid @gray-20;
-        display: flex;
         margin: 10px 0 30px;
         padding: 0 0 20px 25px;
         position: relative;
+        .respond-to-min(@bp-sm-min, {
+            @supports ( display: flex ) {
+                display: flex;
+            }
+        });
         li {
             list-style: none;
             padding-right: 2rem;
@@ -20,6 +24,10 @@ ul.tdp-survey__choice-question {
                 display: block;
                 margin-bottom: 5px;
                 transform: scale(1.5);
+                .respond-to-max(@bp-xs-max, {
+                    display: inline-block;
+                    margin-right: 5px;
+                });
             }
             &:last-of-type {
                 padding-right: 0;
@@ -32,15 +40,17 @@ ul.tdp-survey__choice-question {
         }
         label {
             &::before {
-                background-color: @gray-40;
-                content: '';
-                height: 1px;
-                left: 12px;
-                position: absolute;
-                top: 6px;
-                width: 100%;
+                .respond-to-min(@bp-sm-min, {
+                    background-color: @gray-40;
+                    content: '';
+                    height: 1px;
+                    left: 12px;
+                    position: absolute;
+                    top: 6px;
+                    width: 100%; 
+                });
             }
-        }
+        }       
     }
     &.tdp-survey__atype-GetGame,
     &.tdp-survey__atype-GameThink,


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->

mobile breakpoint for survey questions

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

-


## Removals

-


## Changes

-


## How to test this PR

1.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
