### PR TITLE
Change invalid :not selector to an equivalent selector

### DIFF
--- a/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuMobile.js
@@ -52,7 +52,7 @@ function MegaMenuMobile( menus ) {
     _activeMenuDom = _rootMenuContentDom;
 
     // Make root level links disabled to tab and voiceover navigation on init.
-    _rootLinksDom = _rootMenuContentDom.querySelectorAll( 'a:not(.o-mega-menu_content-2 a)' );
+    _rootLinksDom = _rootMenuContentDom.querySelectorAll( 'a.o-mega-menu_content-1-link,.m-global-eyebrow a' );
 
     return this;
   }


### PR DESCRIPTION
Follow on to https://github.com/cfpb/consumerfinance.gov/pull/6568

The :not selector in that code is actually invalid, per https://www.w3.org/TR/selectors-3/#negation (simple selectors only in negation, the white space in a combinator).

I just changed the selector here to match the same set of links that were being matched by the :not() selector in lenient browsers.

To test this equivalence in devtools:

```
const menu =document.getElementsByClassName('o-mega-menu')[0]
let a = menu.querySelectorAll( 'a:not(.o-mega-menu_content-2 a)' )
let b = menu.querySelectorAll( 'a.o-mega-menu_content-1-link,.m-global-eyebrow a' )
;(() => {
  if(a.length !== b.length) return console.log('UNEQUAL')
  for(let i = 0; i <a.length; i++){
    if(a[i] !== b[i]) return console.log('UNEQUAL')
  }
  console.log('All links match')
})()
```





