### PR TITLE
Retirement: Fix actionable tooltips color and size

### DIFF
--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -13,9 +13,7 @@ form {
 }
 
 #claiming-social-security .input-labels_block .cf-icon-svg {
-  color: @pacific;
-  font-size: 0.8em;
-  margin-top: 3px;
+  margin-top: 1px;
 }
 
 #claiming-social-security input[type='text'] {
@@ -903,6 +901,8 @@ form {
 #claiming-social-security *[data-tooltip-target] {
     cursor: auto;
     border-bottom: none;
+    color: @pacific;
+    font-size: 0.9rem;
 }
 
 #claiming-social-security #tooltip-container {


### PR DESCRIPTION
See https://[GHE]/CFGOV/platform/issues/3177

## Changes

- Change color of tooltip icons from black to blue. 
- Adjust tooltip icon size to make them small in the body copy.


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/retirement/before-you-claim/ and check the (?) tooltip icons. They should be pacific instead of black and slightly smaller (except the top one, which gets a little larger).


## Screenshots

Before:
<img width="292" alt="Screen Shot 2021-08-18 at 11 42 30 AM" src="https://user-images.githubusercontent.com/704760/129929046-4fa811b9-9284-46cf-b623-891c1d898d78.png">

<img width="776" alt="Screen Shot 2021-08-18 at 11 42 49 AM" src="https://user-images.githubusercontent.com/704760/129929049-07318695-f6f1-4434-9274-a36d04a026b8.png">


After:
<img width="309" alt="Screen Shot 2021-08-18 at 11 42 24 AM" src="https://user-images.githubusercontent.com/704760/129929112-02f907de-0d5d-41e2-9076-961620e5afda.png">

<img width="827" alt="Screen Shot 2021-08-18 at 11 42 19 AM" src="https://user-images.githubusercontent.com/704760/129929121-148053ca-26b4-467f-b8ea-076a38ab545c.png">
