### PR TITLE
Buying a House: Fix misplaced closing quote in disclosures template

### DIFF
--- a/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/v1/owning-a-home/_templates/brand-footer.html
@@ -85,8 +85,8 @@
           a-link__icon
           a-link__no-wrap"
    href="{{ link.url }}"
-   aria-label="{{ link.label }}>
-    <span class="a-link_text"">
+   aria-label="{{ link.label }}">
+    <span class="a-link_text">
         {{ link.text | safe }}
     </span>
     {{ svg_icon('download') }}


### PR DESCRIPTION

## Changes

- Ending quote was on the wrong line and was messing up the markup.


## How to test this PR

1. Check the markup for links on http://localhost:8000/owning-a-home/closing-disclosure/
