### PR TITLE
Add a back-end 50-character limit to autocomplete submissions

### DIFF
--- a/cfgov/ask_cfpb/forms.py
+++ b/cfgov/ask_cfpb/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import RegexValidator
 
-from ask_cfpb.models.search import make_safe
+from ask_cfpb.models.search import ASK_AUTOCOMPLETE_MAX, make_safe
 
 
 legacy_facet_validator = RegexValidator(
@@ -14,7 +14,7 @@ class AutocompleteForm(forms.Form):
     term = forms.CharField(strip=True)
 
     def clean_term(self):
-        return make_safe(self.cleaned_data['term'])
+        return make_safe(self.cleaned_data['term'])[:ASK_AUTOCOMPLETE_MAX]
 
 
 class SearchForm(forms.Form):

--- a/cfgov/ask_cfpb/forms.py
+++ b/cfgov/ask_cfpb/forms.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.core.validators import RegexValidator
 
-from ask_cfpb.models.search import ASK_AUTOCOMPLETE_MAX, make_safe
+from ask_cfpb.models.search import make_safe
+from search.models import AUTOCOMPLETE_MAX_CHARS
 
 
 legacy_facet_validator = RegexValidator(
@@ -14,7 +15,7 @@ class AutocompleteForm(forms.Form):
     term = forms.CharField(strip=True)
 
     def clean_term(self):
-        return make_safe(self.cleaned_data['term'])[:ASK_AUTOCOMPLETE_MAX]
+        return make_safe(self.cleaned_data['term'])[:AUTOCOMPLETE_MAX_CHARS]
 
 
 class SearchForm(forms.Form):

--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -1,14 +1,13 @@
 from elasticsearch7.exceptions import RequestError
 
 from ask_cfpb.documents import AnswerPageDocument
+from search.models import AUTOCOMPLETE_MAX_CHARS
 
 
 UNSAFE_CHARACTERS = [
     '#', '%', ';', '^', '~', '`', '|',
     '<', '>', '[', ']', '{', '}', '\\'
 ]
-# maximum length of autocomplete form entries before we call a halt
-ASK_AUTOCOMPLETE_MAX = 50
 
 
 def make_safe(term):
@@ -30,7 +29,7 @@ class AnswerPageSearch:
             s = AnswerPageDocument.search().filter(
                 "term", language=self.language
             ).query(
-                'match', autocomplete=self.search_term
+                'match', autocomplete=self.search_term[:AUTOCOMPLETE_MAX_CHARS]
             )
         except RequestError:
             results = []

--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -7,6 +7,8 @@ UNSAFE_CHARACTERS = [
     '#', '%', ';', '^', '~', '`', '|',
     '<', '>', '[', ']', '{', '}', '\\'
 ]
+# maximum length of autocomplete form entries before we call a halt
+ASK_AUTOCOMPLETE_MAX = 50
 
 
 def make_safe(term):

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -129,6 +129,17 @@ class AnswerPageSearchTest(TestCase):
         )
 
     @mock.patch.object(AnswerPageDocument, 'search')
+    def test_ask_search_autocomplete_honors_max_chars(self, mock_search):
+        valid_term = "You saw the masterpiece, she looks a log like you!"
+        overage = " This is overage text that should not appear in the query"
+        too_long_term = valid_term + overage
+        self.client.get(
+            reverse("ask-autocomplete-en"),
+            {"term": too_long_term}
+        )
+        self.assertTrue(mock_search.called_with(valid_term))
+
+    @mock.patch.object(AnswerPageDocument, 'search')
     def test_ask_search_autocomplete(self, mock_search):
         mock_return = mock.Mock()
         mock_return.autocomplete = "Autocomplete question"
@@ -156,17 +167,17 @@ class AnswerPageSearchTest(TestCase):
         mock_return = mock.Mock()
         mock_return.autocomplete = "Autocomplete question"
         mock_return.url = "https://autocomplete"
-        mock_search().filter().query.side_effect = RequestError()
+        for error in [RequestError(), IndexError()]:
+            mock_search().filter().query.side_effect = error
+            response = self.client.get(
+                reverse("ask-autocomplete-en"), {"term": "test"}
+            )
 
-        response = self.client.get(
-            reverse("ask-autocomplete-en"), {"term": "test"}
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            mock_search.called_with(language="en", search_term="test")
-        )
-        self.assertEqual(response.json(), [])
+            self.assertEqual(response.status_code, 200)
+            self.assertTrue(
+                mock_search.called_with(language="en", search_term="test")
+            )
+            self.assertEqual(response.json(), [])
 
     @mock.patch("ask_cfpb.views.AnswerPageSearch")
     def test_ask_search_es(self, mock_search):

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -130,7 +130,7 @@ class AnswerPageSearchTest(TestCase):
 
     @mock.patch.object(AnswerPageDocument, 'search')
     def test_ask_search_autocomplete_honors_max_chars(self, mock_search):
-        valid_term = "You saw the masterpiece, she looks a log like you!"
+        valid_term = "You saw the masterpiece, she looks a lot like you!"
         overage = " This is overage text that should not appear in the query"
         too_long_term = valid_term + overage
         self.client.get(

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -147,6 +147,10 @@ class AnswerPagePreviewTestCase(TestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response.url, self.english_answer_page2.url)
 
+    def test_redirect_view_with_no_recognized_facet(self):
+        response = self.client.get("/askcfpb/search/?selected_facets=hoodoo")
+        self.assertEqual(response.status_code, 404)
+
 
 class AnswerViewTestCase(TestCase):
     def test_annotate_links(self):

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.shortcuts import render
-from django.urls import reverse
+from django.urls import re_path, reverse
 from django.utils.html import format_html
 
 from wagtail.admin.menu import MenuItem
@@ -9,12 +9,6 @@ from wagtail.core.models import Page
 
 from ask_cfpb.models import Answer, AnswerPage
 from ask_cfpb.scripts import export_ask_data
-
-
-try:
-    from django.urls import re_path
-except ImportError:
-    from django.conf.urls import url as re_path
 
 
 def export_data(request):

--- a/cfgov/jinja2/v1/_includes/organisms/ask-search.html
+++ b/cfgov/jinja2/v1/_includes/organisms/ask-search.html
@@ -32,7 +32,7 @@
     autocomplete=True,
     placeholder='',
     is_subsection=True,
-    max_length=50
+    max_length=autocomplete_max_chars
 ) %}
 <div class="o-search-bar">
     <form method="get" action="{{ _('/ask-cfpb/search/') }}">

--- a/cfgov/search/models.py
+++ b/cfgov/search/models.py
@@ -1,6 +1,9 @@
 from django.db import models
 
 
+AUTOCOMPLETE_MAX_CHARS = 50
+
+
 class Synonym(models.Model):
     synonym = models.CharField(
         max_length=500,

--- a/cfgov/v1/jinja2_environment.py
+++ b/cfgov/v1/jinja2_environment.py
@@ -9,6 +9,8 @@ from django.utils.translation import ugettext, ungettext
 
 from jinja2 import Environment
 
+from search.models import AUTOCOMPLETE_MAX_CHARS
+
 
 class RelativeTemplatePathEnvironment(Environment):
     """Jinja2 environment that supports template loading with relative paths.
@@ -36,6 +38,7 @@ class RelativeTemplatePathEnvironment(Environment):
     This logic adds relative paths to the template search tree, that take
     precendence over the default loader source directories.
     """
+
     def join_path(self, template, parent):
         dirname = os.path.dirname(parent)
         segments = dirname.split('/')
@@ -96,6 +99,7 @@ def environment(**options):
 
     # Expose various Django methods into the Jinja2 environment.
     env.globals.update({
+        'autocomplete_max_chars': AUTOCOMPLETE_MAX_CHARS,
         'get_messages': messages.get_messages,
         'reverse': reverse,
         'static': staticfiles_storage.url,


### PR DESCRIPTION
Most of long autocomplete entries will be blocked by front-end code,
but if bots or mischief-makers send long autocomplete requests to our back end,
this change will happily ignore anything over 50 chars.

The constant, `AUTOCOMPLETE_MAX_CHARS`, will live in cfgov/search/models.py.  
It is used to limit the autocomplete queries sent to Elasticsearch to 50 characters,     
and gets delivered to the template and JS via jinja2.environment.globals.

## Testing

Turn on readable Elasticsearch logging by setting this env variable locally (courtesy of @chosak):
```
export ENABLE_ES_LOGGING=1
```
This lets you easily see the request that the back end sends to Elasticsearch in the runserver console.

Then send way more than 50 characters to the ask_cfpb autocomplete API:

```
http://localhost:8000/ask-cfpb/api/autocomplete/?term=You saw the masterpiece, she looks a lot like you! wrapping her left arm around your right ready to walk you through You saw the masterpiece she looks a lot like you wrapping her left arm around your right ready to walk you through You saw the masterpiece she looks a lot like you wrapping her left arm around your right ready to walk you through You saw the masterpiece she looks a lot like you wrapping her left arm around your right ready to walk you through You saw the masterpiece she looks a lot like you wrapping her left arm around your right ready to walk you through You saw the masterpiece she looks a lot like you wrapping her left arm around your right ready to walk you through
```

You should see that the query goes to Elasticsearch as

```json
{
    "autocomplete": "You saw the masterpiece, she looks a lot like you!"
}
```

