### PR TITLE
Fix rural and underserved tool content

### DIFF
--- a/cfgov/jinja2/v1/rural-or-underserved/_templates/expandable.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/_templates/expandable.html
@@ -21,7 +21,7 @@
     <button class="o-expandable_header o-expandable_target"
             title="Expand content">
         <h3 class="h4 o-expandable_header-left o-expandable_label">
-            {{ heading }}
+            {{ heading|safe }}
         </h3>
         <span class="o-expandable_header-right o-expandable_link">
             <span class="o-expandable_cue o-expandable_cue-open">
@@ -36,7 +36,7 @@
     </button>
     <div class="o-expandable_content">
         <p>
-            {{ content }}
+            {{ content|safe }}
         </p>
     </div>
 </div>


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->

A link in one of the expandables on the rural and underserved tool page was getting rendered with escaped HTML. This PR adds the `safe` filter to the `expandable.render` macro to get the HTML to render. Technically the `safe` filter was only needed on `{{ content }}`, but I added it on ``{{ heading }}`` for good measure.

---

## Additions

- `safe` filter to `expandable.render` macro

## How to test this PR

1. Load up `/rural-or-underserved-tool/`
2. Open up the "I typed in an address and a different address was found. Why?" expandable
3. Make sure the link in that content renders as a link instead of escaped HTML
4. Make sure nothing else on the page has changed

## Screenshots

Before | After
---- | ----
![before](https://user-images.githubusercontent.com/1862695/130131743-6bd2bceb-7215-440b-89e7-a1dde2640c49.png) | ![after](https://user-images.githubusercontent.com/1862695/130131745-78f8769f-0ac8-4b61-9aa4-e11aac75d8e8.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)