### PR TITLE
[WIP] fix spacing for car/labels

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
@@ -26,7 +26,7 @@
         </p>
         <p class="h1">Congratulations, {{ overall.heading_html|safe }}</p>
         <p class="h3"> {{ overall.msg_html|safe }}</p>
-        {% set car_position = ((overall.position_idx +1) * 140) - 50 %}
+        {% set car_position = overall.position_idx %}
         {% if car_position < 2 >= 0 %}
             {% set car_position = (car_position * 100) + (40) %}
         {% elif car_position < 5 >= 2 %}

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-graph.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-graph.html
@@ -1,3 +1,8 @@
+<div class="tdp-survey-results__wrapper">
+  <span class="tdp-survey-results__marker starting-out{% if level == 0 %} active{% endif %}">Starting out</span>
+  <span class="tdp-survey-results__marker on-the-road{% if level == 1 %} active{% endif %}">On the road</span>
+  <span class="tdp-survey-results__marker well-on-your-way{% if level == 2 %} active{% endif %}">Well on your way</span>
+</div>
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 810 123">
     <g>
       <g>
@@ -5,39 +10,12 @@
         <path d="M 270 33 V 119" stroke="{{ stroke_color }}" />
       </g>
       <g>
-        <rect x="271" y="32" width="360" height="88" fill="{{ color }}" class="svg-on-the-road" style="fill-opacity: .6;"/>
+        <rect x="271" y="32" width="361" height="88" fill="{{ color }}" class="svg-on-the-road" style="fill-opacity: .6;"/>
         <path d="M 631 33 V 119" stroke="{{ stroke_color }}" />
       </g>
       <g>
         <rect x="632" y="32" width="180" height="88" fill="{{ color }}" class="well-on-your-way" style="fill-opacity: 1;"/>
       </g>
-
-      {% if level != 0 %}
-      <text transform="translate(0 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="500">Starting out</text>
-      {% else %}
-      <text transform="translate(25 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="700">Starting out</text>
-      <g id="marker">
-        <path d="M10.61,29.31 C10.6957769,29.4156487 10.8239306,29.4778948 10.96,29.48 L10.96,29.48 C11.0928794,29.4763328 11.2173386,29.4141032 11.3,29.31 C11.3,29.31 13.73,26.14 16.11,22.31 C19.32,17.11 20.96,13.17 20.96,10.57 C20.96,5.0471525 16.4828475,0.57 10.96,0.57 C5.4371525,0.57 0.96,5.0471525 0.96,10.57 C0.96,13.22 2.59,17.18 5.8,22.36 C8.18,26.17 10.59,29.28 10.61,29.31 Z" id="Path"></path>
-      </g>
-      {% endif %}
-        
-      {% if level != 1 %}
-      <text transform="translate(265 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="500">On the road</text>
-      {% else %}
-      <text transform="translate(285 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="700">On the road</text>
-      <g id="marker" transform="translate(259 0)">
-        <path d="M10.61,29.31 C10.6957769,29.4156487 10.8239306,29.4778948 10.96,29.48 L10.96,29.48 C11.0928794,29.4763328 11.2173386,29.4141032 11.3,29.31 C11.3,29.31 13.73,26.14 16.11,22.31 C19.32,17.11 20.96,13.17 20.96,10.57 C20.96,5.0471525 16.4828475,0.57 10.96,0.57 C5.4371525,0.57 0.96,5.0471525 0.96,10.57 C0.96,13.22 2.59,17.18 5.8,22.36 C8.18,26.17 10.59,29.28 10.61,29.31 Z" id="Path"></path>
-      </g>
-      {% endif %}
-
-      {% if level != 2 %}
-      <text transform="translate(630 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="500">Well on your way</text>
-      {% else %}
-      <text transform="translate(645 20)" font-size="18" fill="#101820" font-family="AvenirNext-Medium, Avenir Next" font-weight="700">Well on your way</text>
-      <g id="marker" transform="translate(620 0)">
-        <path d="M10.61,29.31 C10.6957769,29.4156487 10.8239306,29.4778948 10.96,29.48 L10.96,29.48 C11.0928794,29.4763328 11.2173386,29.4141032 11.3,29.31 C11.3,29.31 13.73,26.14 16.11,22.31 C19.32,17.11 20.96,13.17 20.96,10.57 C20.96,5.0471525 16.4828475,0.57 10.96,0.57 C5.4371525,0.57 0.96,5.0471525 0.96,10.57 C0.96,13.22 2.59,17.18 5.8,22.36 C8.18,26.17 10.59,29.28 10.61,29.31 Z" id="Path"></path>
-      </g>
-      {% endif %}
 
       <line y1="73" x2="810" y2="73" fill="none" stroke="#101820" stroke-miterlimit="10" stroke-dasharray="4 6"/>
     </g>

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
@@ -123,3 +123,38 @@
         margin-left: 0.3rem;
     }
 }
+
+.tdp-survey-results__wrapper {
+    position: relative;
+}
+
+.tdp-survey-results__marker {
+    background-position: left center;
+    background-repeat: no-repeat;
+    background-size: 13px;
+    display: none;
+    position: absolute;
+    .respond-to-min(@bp-xl-min, {
+        display: block;
+    });
+    &.starting-out {
+        left: 0%;
+    }
+    &.on-the-road {
+        left: 32.5%;
+    }
+    &.well-on-your-way {
+        left: 77.5%;
+    }
+    &.active {
+        background-image:url("/static/apps/teachers-digital-platform/img/marker.svg");
+        font-weight: 700;
+        padding-left: 17px;
+        .respond-to-max(@bp-lg-max, {
+            display: block;
+            left: 0;
+            margin-bottom: -10px;
+            position: relative;
+        });
+    }
+}

--- a/cfgov/unprocessed/apps/teachers-digital-platform/img/marker.svg
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/img/marker.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="21px" height="30px" viewBox="0 0 21 30" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>marker</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="svg" transform="translate(-272.000000, -14.000000)" fill="#000000" fill-rule="nonzero">
+            <g id="marker" transform="translate(272.000000, 14.000000)">
+                <path d="M10.61,29.31 C10.6957769,29.4156487 10.8239306,29.4778948 10.96,29.48 L10.96,29.48 C11.0928794,29.4763328 11.2173386,29.4141032 11.3,29.31 C11.3,29.31 13.73,26.14 16.11,22.31 C19.32,17.11 20.96,13.17 20.96,10.57 C20.96,5.0471525 16.4828475,0.57 10.96,0.57 C5.4371525,0.57 0.96,5.0471525 0.96,10.57 C0.96,13.22 2.59,17.18 5.8,22.36 C8.18,26.17 10.59,29.28 10.61,29.31 Z" id="Path"></path>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->


---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

-


## Removals

-


## Changes

-


## How to test this PR

1.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
