### PR TITLE
[WIP] Add form mobile, increase expandable mobile to the 900px bp

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
@@ -118,7 +118,7 @@
                     </button>
                 </div>
 
-                <div class="u-visually-hidden-on-mobile">
+                <div class="u-visually-hidden-on-tablet">
                     <h3 class="h4 o-expandable_label">Your survey progress</h3>
                     <p>
                         <span class="tdp-survey-progress-out-of"></span> questions completed

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
@@ -37,17 +37,17 @@ ul.tdp-survey__choice-question {
                     display: inline-block;
                     margin-right: 5px;
                 });
-                &:focus {
-                    outline: none;
-                    &::after {
-                        content: '';
-                        height: 30px;
-                        outline: dotted 1px #0072ce;
-                        outline-offset: 1px;
-                        position: absolute;
-                        width: 90px;
-                    }
-                }
+                // &:focus {
+                //     outline: none;
+                //     &::after {
+                //         content: '';
+                //         height: 30px;
+                //         outline: dotted 1px #0072ce;
+                //         outline-offset: 1px;
+                //         position: absolute;
+                //         width: 90px;
+                //     }
+                // }
             }
             &:last-of-type {
                 padding-right: 0;

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey.less
@@ -1,5 +1,5 @@
 .tdp-survey-layout {
-    .respond-to-max(@bp-xs-max, {
+    .respond-to-max(@bp-sm-max, {
         @supports ( display: flex ) {
             display: flex;
             flex-direction: column-reverse;
@@ -17,7 +17,7 @@ ul.tdp-survey__choice-question {
         margin: 10px 0 30px;
         padding: 0 0 20px 25px;
         position: relative;
-        .respond-to-min(@bp-sm-min, {
+        .respond-to-min(@bp-lg-min, {
             @supports ( display: flex ) {
                 display: flex;
             }
@@ -33,7 +33,7 @@ ul.tdp-survey__choice-question {
                 display: block;
                 margin-bottom: 5px;
                 transform: scale(1.5);
-                .respond-to-max(@bp-xs-max, {
+                .respond-to-max(@bp-med-max, {
                     display: inline-block;
                     margin-right: 5px;
                 });
@@ -60,7 +60,7 @@ ul.tdp-survey__choice-question {
         }
         label {
             &::before {
-                .respond-to-min(@bp-sm-min, {
+                .respond-to-min(@bp-lg-min, {
                     background-color: @gray-40;
                     content: '';
                     height: 1px;
@@ -146,7 +146,7 @@ p {
 .tdp-survey-sidebar__mobile-control {
     display: flex;
     flex-direction: column-reverse;
-    .respond-to-min(@bp-sm-min, {
+    .respond-to-min(@bp-med-min, {
         display: none;
     });
 }
@@ -309,4 +309,11 @@ p {
             text-indent: 0 !important;
         }
     }
+}
+
+.u-visually-hidden-on-tablet {
+    display: none;
+    .respond-to-min(@bp-med-min, {
+        display: block;
+    });
 }

--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/expandable-mobile.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/expandable-mobile.js
@@ -1,7 +1,7 @@
 import ExpandableTransition from '@cfpb/cfpb-expandables/src/ExpandableTransition';
 
 const MOBILE_COLLAPSED_CLASS = 'o-expandable__mobile-collapsed';
-const MOBILE_WIDTH = 800;
+const MOBILE_WIDTH = 900;
 
 let innerWidth;
 

--- a/test/unit_tests/apps/teachers-digital-platform/js/expandable-mobile-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/expandable-mobile-spec.js
@@ -78,7 +78,7 @@ describe( 'expandable-mobile', () => {
    */
 
   it( 'should remove the OPEN_DEFAULT class on narrow innerWidth', () => {
-    setInnerWidth(800);
+    setInnerWidth(900);
 
     expect( expandableDiv.classList.contains( OPEN_DEFAULT_CLASS ) )
       .toEqual( true );
@@ -89,7 +89,7 @@ describe( 'expandable-mobile', () => {
   } );
 
   it( 'should leave the OPEN_DEFAULT class for tablet innerWidth', () => {
-    setInnerWidth(801);
+    setInnerWidth(901);
 
     expect( expandableDiv.classList.contains( OPEN_DEFAULT_CLASS ) )
       .toEqual( true );
@@ -100,7 +100,7 @@ describe( 'expandable-mobile', () => {
   } );
 
   it( 'should always remove its MOBILE_COLLAPSED_CLASS (narrow)', () => {
-    setInnerWidth(800);
+    setInnerWidth(900);
 
     beforeExpandableTransitionInit();
     expect( expandableDiv.classList.contains( MOBILE_COLLAPSED_CLASS ) )
@@ -109,7 +109,7 @@ describe( 'expandable-mobile', () => {
   } );
 
   it( 'should always remove its MOBILE_COLLAPSED_CLASS (wide)', () => {
-    setInnerWidth(801);
+    setInnerWidth(901);
 
     beforeExpandableTransitionInit();
     expect( expandableDiv.classList.contains( MOBILE_COLLAPSED_CLASS ) )


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->


---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

-


## Removals

-


## Changes

-


## How to test this PR

1.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
