### PR TITLE
Exempt local admin operations from CSRF rules

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -892,7 +892,7 @@ CSRF_REQUIRED_PATHS = (
 # Django 2.2 Baseline required settings
 # exempt beta from CSRF settings until it's converted to https
 
-if DEPLOY_ENVIRONMENT != "beta":
+if DEPLOY_ENVIRONMENT and DEPLOY_ENVIRONMENT != "beta":
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_HTTPONLY = True
     CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
We had to exempt beta admin from our baseline CSRF rules because beta currently
uses http for the admin site. But the same applies to local operations, which
also normally use http. An AOVPN user encountered the same admin errors locally today working in docker.
