### PR TITLE
Update actions/setup-node to v2 from v1

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
             node-version: '14.x'
 


### PR DESCRIPTION
Not totally sure of the implication of this, but the docs show `@v2` with node 14, which is the version we have set https://github.com/actions/setup-node
 
## Changes

- Update actions/setup-node to v2 from v1


## How to test this PR

1. PR checks should pass.
