### PR TITLE
Limit Akamai caching of sitemap.xml

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -21,6 +21,7 @@ from wagtailautocomplete.urls.admin import (
 from ask_cfpb.views import (
     ask_autocomplete, ask_search, redirect_ask_search, view_answer
 )
+from core.decorators import add_headers
 from core.views import (
     ExternalURLNoticeView, govdelivery_subscribe, regsgov_comment
 )
@@ -443,7 +444,10 @@ urlpatterns = [
             'diversity_inclusion'),
             namespace='diversity_inclusion')),
 
-    re_path(r'^sitemap\.xml$', sitemap),
+    re_path(
+        r'^sitemap\.xml$',
+        add_headers(sitemap, {'Edge-Control': 'no-cache'})
+    ),
 
     re_path(
         r'^consumer-tools/educator-tools/youth-financial-education/',

--- a/cfgov/core/decorators.py
+++ b/cfgov/core/decorators.py
@@ -1,0 +1,22 @@
+from functools import wraps
+
+
+def add_headers(view, headers):
+    """Wrapper that adds HTTP headers to a view's response.
+
+    Usage:
+
+      from app.views import myview
+      wrapped_view = add_headers(myview, {'key': 'value', ...})
+
+    """
+    @wraps(view)
+    def inner(request, *args, **kwargs):
+        response = view(request, *args, **kwargs)
+
+        for k, v in headers.items():
+            response[k] = v
+
+        return response
+
+    return inner

--- a/cfgov/core/tests/test_decorators.py
+++ b/cfgov/core/tests/test_decorators.py
@@ -1,0 +1,20 @@
+from django.http import HttpRequest, HttpResponse
+from django.test import SimpleTestCase
+
+from core.decorators import add_headers
+
+
+def view(request, *args, **kwargs):
+    return HttpResponse('ok')
+
+
+class AddHeadersTests(SimpleTestCase):
+    def test_adds_headers(self):
+        request = HttpRequest()
+
+        response = view(request)
+        self.assertNotIn('Test-Header', response)
+
+        wrapped_view = add_headers(view, {'Test-Header': 'test'})
+        response_with_headers = wrapped_view(request)
+        self.assertEquals(response_with_headers['Test-Header'], 'test')


### PR DESCRIPTION
This commit adds an Edge-Control: no-cache header to the sitemap.xml view, which changes how Akamai will cache the sitemap.

Currently, the sitemap is cached like most every other page on the site: served from cache for 7 days without revalidation with the origin, then revalidated after that and re-sent from origin if necessary. This is problematic for the sitemap because it should be updated whenever a new page is published.

With this change, the Akamai-specific Edge-Control header is used, described thusly [in the Akamai docs](https://techdocs.akamai.com/start/docs/caching):

> The Edge-Control header is an Akamai-specific HTTP response header header that provides controls and parameters on content served through the edge network. On the Akamai network, Edge-Control settings settings override Cache-Control and Expires headers.

It works similarly to the standard Cache-Control header, so setting it to no-cache [should work like this](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control):

> The response may be stored by any cache, even if the response is normally non-cacheable. However, the stored response MUST always go through validation with the origin server first before using it

If I understand this correctly, this means that requests to sitemap.xml will always trigger revalidation with the origin, but Akamai will return 304 Not Modified if the content is the same, which should properly use the Last-Modified header.

## How to test this PR

To verify this behavior, you can run a local server and do:

```sh
$ curl -Is http://localhost:8000/sitemap.xml | grep Edge-Control
Edge-Control: no-cache
```

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)