### PR TITLE
Consolidate decorator to prevent Akamai caching

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -21,7 +21,7 @@ from wagtailautocomplete.urls.admin import (
 from ask_cfpb.views import (
     ask_autocomplete, ask_search, redirect_ask_search, view_answer
 )
-from core.decorators import add_headers
+from core.decorators import akamai_no_store
 from core.views import (
     ExternalURLNoticeView, govdelivery_subscribe, regsgov_comment
 )
@@ -444,10 +444,7 @@ urlpatterns = [
             'diversity_inclusion'),
             namespace='diversity_inclusion')),
 
-    re_path(
-        r'^sitemap\.xml$',
-        add_headers(sitemap, {'Edge-Control': 'no-cache'})
-    ),
+    re_path(r'^sitemap\.xml$', akamai_no_store(sitemap)),
 
     re_path(
         r'^consumer-tools/educator-tools/youth-financial-education/',

--- a/cfgov/core/decorators.py
+++ b/cfgov/core/decorators.py
@@ -1,8 +1,8 @@
-from functools import wraps
+from functools import partial, wraps
 
 
 def add_headers(view, headers):
-    """Wrapper that adds HTTP headers to a view's response.
+    """Decorator that adds HTTP headers to a view's response.
 
     Usage:
 
@@ -20,3 +20,9 @@ def add_headers(view, headers):
         return response
 
     return inner
+
+
+akamai_no_store = partial(add_headers, headers={
+    'Edge-Control': 'no-store',
+    'Akamai-Cache-Control': 'no-store',
+})

--- a/cfgov/core/tests/test_decorators.py
+++ b/cfgov/core/tests/test_decorators.py
@@ -1,20 +1,31 @@
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
 
-from core.decorators import add_headers
+from core.decorators import add_headers, akamai_no_store
 
 
 def view(request, *args, **kwargs):
     return HttpResponse('ok')
 
 
-class AddHeadersTests(SimpleTestCase):
-    def test_adds_headers(self):
-        request = HttpRequest()
+@akamai_no_store
+def view_no_store(request, *args, **kwargs):
+    return HttpResponse('no store')
 
-        response = view(request)
+
+class DecoratorTests(SimpleTestCase):
+    def setUp(self):
+        self.request = HttpRequest()
+
+    def test_adds_headers(self):
+        response = view(self.request)
         self.assertNotIn('Test-Header', response)
 
         wrapped_view = add_headers(view, {'Test-Header': 'test'})
-        response_with_headers = wrapped_view(request)
+        response_with_headers = wrapped_view(self.request)
         self.assertEquals(response_with_headers['Test-Header'], 'test')
+
+    def test_akamai_no_store(self):
+        response = view_no_store(self.request)
+        self.assertEquals(response['Edge-Control'], 'no-store')
+        self.assertEquals(response['Akamai-Cache-Control'], 'no-store')

--- a/cfgov/teachers_digital_platform/tests/test_views.py
+++ b/cfgov/teachers_digital_platform/tests/test_views.py
@@ -1,1 +1,0 @@
-# from django.test import TestCase

--- a/cfgov/teachers_digital_platform/views.py
+++ b/cfgov/teachers_digital_platform/views.py
@@ -1,6 +1,5 @@
 import re
 import time
-from functools import wraps
 from typing import Dict
 
 from django.core import signing
@@ -13,6 +12,8 @@ from django.views.decorators.vary import vary_on_cookie
 
 from formtools.wizard.views import NamedUrlCookieWizardView
 
+from core.decorators import akamai_no_store
+
 from .resultsContent import ResultsContent
 from .surveys import AVAILABLE_SURVEYS, ChoiceList, Question, get_survey
 from .UrlEncoder import UrlEncoder
@@ -20,19 +21,6 @@ from .UrlEncoder import UrlEncoder
 
 _tdp = 'teachers_digital_platform'
 _signer = signing.Signer()
-
-
-def akamai_never_cache(view_func):
-    """
-    Decorator that adds headers to a response so that it will never be cached.
-    """
-    @wraps(view_func)
-    def _wrapped_view_func(request, *args, **kwargs):
-        response = view_func(request, *args, **kwargs)
-        response['Edge-Control'] = 'no-store'
-        response['Akamai-Cache-Control'] = 'no-store'
-        return response
-    return _wrapped_view_func
 
 
 class SurveyWizard(NamedUrlCookieWizardView):
@@ -104,7 +92,7 @@ class SurveyWizard(NamedUrlCookieWizardView):
 
     @method_decorator(never_cache)
     @method_decorator(vary_on_cookie)
-    @method_decorator(akamai_never_cache)
+    @method_decorator(akamai_no_store)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 
@@ -158,7 +146,7 @@ def _handle_result_url(request: HttpRequest, raw: str, code: str,
 
 @never_cache
 @vary_on_cookie
-@akamai_never_cache
+@akamai_no_store
 def student_results(request: HttpRequest):
     """
     Request handler for the student results page
@@ -180,7 +168,7 @@ def student_results(request: HttpRequest):
 
 @never_cache
 @vary_on_cookie
-@akamai_never_cache
+@akamai_no_store
 def view_results(request: HttpRequest):
     """
     Request handler for the view results page
@@ -202,7 +190,7 @@ def view_results(request: HttpRequest):
 
 @never_cache
 @vary_on_cookie
-@akamai_never_cache
+@akamai_no_store
 def _grade_level_page(request: HttpRequest, key: str):
     survey = get_survey(key)
     rendered = render_to_string(


### PR DESCRIPTION
Followup to #6647; use no-store instead of no-cache for the cf.gov sitemap.xml file. Consolidate logic that does this with existing TDP view logic that does the same thing.

## How to test this PR

```
$ curl -Is http://localhost:8000/sitemap.xml | grep Edge-Control
Edge-Control: no-store
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)