### PR TITLE
Wagtail: Error Update

### DIFF
--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 from wagtail.core import blocks
+from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.images.blocks import ImageChooserBlock
 
 from url_or_relative_url_field.forms import URLOrRelativeURLFormField
@@ -51,16 +50,15 @@ class Hyperlink(blocks.StructBlock):
 
         try:
             data = super(Hyperlink, self).clean(data)
-        except ValidationError as e:
-            error_dict.update(e.params)
+        except StructBlockValidationError as e:
+            error_dict.update(e.block_errors)
 
         if self.required:
             if not data['text']:
                 error_dict.update({'text': is_required('Text')})
 
         if error_dict:
-            raise ValidationError("Hyperlink validation errors",
-                                  params=error_dict)
+            raise StructBlockValidationError(block_errors=error_dict)
         else:
             return data
 
@@ -124,8 +122,8 @@ class ImageBasic(blocks.StructBlock):
 
         try:
             data = super(ImageBasic, self).clean(data)
-        except ValidationError as e:
-            error_dict.update(e.params)
+        except StructBlockValidationError as e:
+            error_dict.update(e.block_errors)
 
         if not self.required and not data['upload']:
             return data
@@ -134,8 +132,7 @@ class ImageBasic(blocks.StructBlock):
             error_dict.update({'upload': is_required("Upload")})
 
         if error_dict:
-            raise ValidationError("ImageBasic validation errors",
-                                  params=error_dict)
+            raise StructBlockValidationError(block_errors=error_dict)
         else:
             return data
 

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -1,9 +1,9 @@
-from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.forms.utils import ErrorList
 from django.utils.safestring import mark_safe
 
 from wagtail.core import blocks
+from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.images.blocks import ImageChooserBlock
 
 from v1.atomic_elements import atoms
@@ -52,13 +52,10 @@ class TextIntroduction(blocks.StructBlock):
 
         # Eyebrow requires a heading.
         if cleaned.get('eyebrow') and not cleaned.get('heading'):
-            raise ValidationError(
-                'Validation error in TextIntroduction: '
-                'pre-heading requires heading',
-                params={'heading': ErrorList([
+            raise StructBlockValidationError(
+                block_errors={'heading': ErrorList([
                     'Required if a pre-heading is entered.'
-                ])}
-            )
+                ])})
 
         return cleaned
 
@@ -226,13 +223,10 @@ class ContactEmail(blocks.StructBlock):
         cleaned = super(ContactEmail, self).clean(value)
 
         if not cleaned.get('emails'):
-            raise ValidationError(
-                "Validation error in ContactEmail: "
-                "at least one email address is required",
-                params={'heading': ErrorList([
+            raise StructBlockValidationError(
+                block_errors={'heading': ErrorList([
                     "At least one email address is required."
-                ])}
-            )
+                ])})
 
         return cleaned
 

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 
 from django import forms
 from django.apps import apps
-from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
@@ -14,6 +13,7 @@ from django.utils.safestring import mark_safe
 
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.core import blocks
+from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.core.models import Page
 from wagtail.core.rich_text import expand_db_html
 from wagtail.images import blocks as images_blocks
@@ -130,10 +130,8 @@ class InfoUnitGroup(blocks.StructBlock):
         if cleaned.get('format') == '25-75':
             for unit in cleaned.get('info_units'):
                 if not unit['image']['upload']:
-                    raise ValidationError(
-                        ('Validation error in InfoUnitGroup: '
-                         '25-75 with no image'),
-                        params={'format': ErrorList([
+                    raise StructBlockValidationError(
+                        block_errors={'format': ErrorList([
                             'Info units must include images when using the '
                             '25/75 format. Search for an "FPO" image if you '
                             'need a temporary placeholder.'
@@ -1012,21 +1010,19 @@ class VideoPlayer(blocks.StructBlock):
         if not cleaned['video_id']:
             if getattr(self.meta, 'required', True):
                 errors['video_id'] = ErrorList([
-                    ValidationError('This field is required.'),
+                    StructBlockValidationError(
+                        block_errors='This field is required.'),
                 ])
             elif cleaned['thumbnail_image']:
                 errors['thumbnail_image'] = ErrorList([
-                    ValidationError(
-                        'This field should not be used if YouTube video ID is '
-                        'not set.'
+                    StructBlockValidationError(
+                        block_errors='This field should not be '
+                        'used if YouTube video ID is not set.'
                     )
                 ])
 
         if errors:
-            raise ValidationError(
-                'Validation error in VideoPlayer',
-                params=errors
-            )
+            raise StructBlockValidationError(block_errors=errors)
 
         return cleaned
 

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -1,10 +1,10 @@
 from io import StringIO
 
 from django.core import management
-from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TestCase
 
 from wagtail.core.blocks import StreamValue
+from wagtail.core.blocks.struct_block import StructBlockValidationError
 
 from scripts import _atomic_helpers as atomic
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
@@ -171,7 +171,7 @@ class ContactEmailTests(SimpleTestCase):
     def test_clean_email_required(self):
         block = ContactEmail()
         value = block.to_python({'emails': []})
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(StructBlockValidationError):
             block.clean(value)
 
     def test_clean_valid(self):
@@ -233,7 +233,7 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except ValidationError:
+        except StructBlockValidationError:
             self.fail('no heading and no eyebrow should not fail validation')
 
     def test_text_intro_with_just_heading_passes_validation(self):
@@ -242,14 +242,14 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except ValidationError:
+        except StructBlockValidationError:
             self.fail('heading without eyebrow should not fail validation')
 
     def test_text_intro_with_eyebrow_but_no_heading_fails_validation(self):
         block = TextIntroduction()
         value = block.to_python({'eyebrow': 'Eyebrow'})
 
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(StructBlockValidationError):
             block.clean(value)
 
     def test_text_intro_with_heading_and_eyebrow_passes_validation(self):
@@ -261,7 +261,7 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except ValidationError:
+        except StructBlockValidationError:
             self.fail('eyebrow with heading should not fail validation')
 
 


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This pull request is to replace an older validation error with its newer version for when we update wagtail. The point is to make sure when new page previews are being made incorrectly the error is still reported correctly.

---


## Changes

 instead of using ValidationError in atoms molecules and organisms, we will now use StructBlockValidationError. It functions more or less the same, the big differences is the removal of the first string and changing params into block_errors


## How to test this PR

1.go to the admin wagtail page
2.click add a new page
3. create an error in the page like adding a red header with no header and click preview
4. there should be an error on the header now saying a header is required


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
