### PR TITLE
Remove underlined space in related content links

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/related-content.html
+++ b/cfgov/jinja2/v1/_includes/molecules/related-content.html
@@ -42,10 +42,11 @@
         {% for link in value.links %}
             <li class="m-list_item">
                 <a href="{{ link.url }}"
-                   class="m-list_link"
-                   {% if link.aria_label %}aria-label="{{ link.aria_label }}"{% endif %}>
-                    {{ link.text }}
-                </a>
+                  class="m-list_link"
+                  {%- if link.aria_label -%}
+                    aria-label="{{ link.aria_label }}"
+                  {% endif -%}
+                >{{ link.text }}</a>
             </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
If a related content link gets an icon (external link or download), the icon will be incorrectly connected to the link text with an underline. This commit makes a slight change to the template markup to fix this.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/654645/132395948-d4a0ef77-0e5e-4e0d-b72d-126a007f1b03.png)|![image](https://user-images.githubusercontent.com/654645/132395981-f2e3d562-1632-4299-9371-4c8bd074f76b.png)|


## How to test this PR

Run a local server and visit http://localhost:8000/data-research/, then compare the sidebar links to production at https://www.consumerfinance.gov/data-research/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)