### PR TITLE
Properly translate mega menu previews

### DIFF
--- a/cfgov/mega_menu/tests/test_model_admin.py
+++ b/cfgov/mega_menu/tests/test_model_admin.py
@@ -13,24 +13,27 @@ class ModelAdminTests(TestCase, WagtailTestUtils):
 
     @classmethod
     def setUpTestData(cls):
-        Menu.objects.create(language='en', submenus=json.dumps([
-            {
-                'type': 'submenu',
-                'value': {
-                    'columns': [
-                        {
-                            'heading': 'Test column heading',
-                            'links': [
-                                {
-                                    'url': '/foo/bar/',
-                                    'text': 'Test menu link',
-                                },
-                            ],
-                        },
-                    ],
-                },
+        submenus = json.dumps([{
+            'type': 'submenu',
+            'value': {
+                'columns': [
+                    {
+                        'heading': 'Test column heading',
+                        'links': [
+                            {
+                                'url': '/foo/bar/',
+                                'text': 'Test menu link',
+                            },
+                        ],
+                    },
+                ],
             },
-        ]))
+        }])
+
+        Menu.objects.bulk_create([
+            Menu(language=language, submenus=submenus)
+            for language in ('en', 'es')
+        ])
 
     def test_index_view_contains_preview_button(self):
         response = self.client.get('/admin/mega_menu/menu/')
@@ -39,3 +42,12 @@ class ModelAdminTests(TestCase, WagtailTestUtils):
     def test_preview_view(self):
         response = self.client.get('/admin/mega_menu/menu/preview/en/')
         self.assertContains(response, 'Test column heading')
+
+    def test_preview_view_renders_using_correct_language(self):
+        response = self.client.get('/admin/mega_menu/menu/preview/en/')
+        self.assertContains(response, 'An official website')
+        self.assertNotContains(response, 'Un sitio web oficial')
+
+        response = self.client.get('/admin/mega_menu/menu/preview/es/')
+        self.assertNotContains(response, 'An official website')
+        self.assertContains(response, 'Un sitio web oficial')

--- a/cfgov/mega_menu/views.py
+++ b/cfgov/mega_menu/views.py
@@ -17,6 +17,6 @@ class MenuPreviewView(WMABaseView):
         return self.model_admin.get_preview_template()
 
     def render_to_response(self, context, **response_kwargs):
-        translation.activate(self.language)
-        self.request.LANGUAGE_CODE = translation.get_language()
-        return super().render_to_response(context, **response_kwargs)
+        with translation.override(self.language):
+            response = super().render_to_response(context, **response_kwargs)
+            return response.render()


### PR DESCRIPTION
Currently, the mega menu preview view ([for example](http://localhost:8000/admin/mega_menu/menu/preview/es/)) doesn't properly render using non-English translations.

This is because even though translations are activated during the view render call itself, TemplateViews return a TemplateResponse that isn't actually rendered until after the view logic has ended. Wagtail has [some custom logic](https://github.com/wagtail/wagtail/blob/cf064f2b9990e90f5c5ca5d4405fe75a16604e0a/wagtail/admin/auth.py#L174-L191) that ensures that admin views render in the user's default language, which overrides custom languages as in the menu preview.

This commit manually renders the template view response so that it gets rendered while the proper translation is activated.

Fixes internal platform#4190.

## How to test this PR

[Create a Spanish-language mega menu](http://localhost:8000/admin/mega_menu/menu/create/) with some content, and then visit [its preview view](http://localhost:8000/admin/mega_menu/menu/preview/es/) and verify that all content is in Spanish.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)