### PR TITLE
Remove dead flag from regulations3k tests

### DIFF
--- a/cfgov/regulations3k/tests/test_blocks.py
+++ b/cfgov/regulations3k/tests/test_blocks.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Page
@@ -12,9 +12,6 @@ from regulations3k.models.django import EffectiveVersion, Part
 from regulations3k.models.pages import RegulationLandingPage, RegulationPage
 
 
-@override_settings(
-    FLAGS={'REGULATIONS3K': [('boolean', True)]}
-)
 class RegulationsListTestCase(TestCase):
 
     def setUp(self):

--- a/cfgov/regulations3k/tests/test_pages.py
+++ b/cfgov/regulations3k/tests/test_pages.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase
 
 from model_bakery import baker
 
@@ -10,7 +10,6 @@ from regulations3k.models import (
 )
 
 
-@override_settings(FLAGS={'REGULATIONS3K': [('boolean', True)]})
 class PagesRegulations3kTestCase(TestCase):
 
     def setUp(self):

--- a/cfgov/regulations3k/tests/test_views.py
+++ b/cfgov/regulations3k/tests/test_views.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase
 
 from model_bakery import baker
 
@@ -8,7 +8,6 @@ from regulations3k.models import EffectiveVersion, Part
 from regulations3k.views import get_version_date, redirect_eregs
 
 
-@override_settings(FLAGS={'REGULATIONS3K': [('boolean', True)]})
 class RedirectRegulations3kTestCase(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This should have no effect on the tests or any other code.
