### PR TITLE
revert CCDB5 update

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,6 +44,6 @@ wagtailmedia==0.6.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/elasticsearch-dsl-py/releases/download/7.2.2/elasticsearch_dsl-7.2.2-py2.py3-none-any.whl
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.6.1/ccdb5_api-1.6.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-ui/releases/download/2.4.2/ccdb5_ui-2.4.2-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.5.2/ccdb5_api-1.5.2-py3-none-any.whl
+https://github.com/cfpb/ccdb5-ui/releases/download/2.3.1/ccdb5_ui-2.3.1-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
Until bugs are resolved, we need to go back to the ES2 CCDB releases.