### PR TITLE
[TDP survey] inline numbered svgs

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
@@ -236,13 +236,14 @@
         <div class="o-well block">
             <h2>Three things you can do to get farther down the road on your money journey</h2>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-one.svg') }}" alt="1."> Explore your strengths</h3>
+            <h3 class="numbered-header">
+                <span aria-label="1.">{% include 'apps/teachers-digital-platform/img/icon-1.svg' %}</span> Explore your strengths</h3>
             <p>The <a href="https://files.consumerfinance.gov/f/documents/cfpb_building_block_activities_middle-school-assessment-student-worksheet.pdf">Taking the next steps on your money journey</a> worksheet can help you think about your strengths and set goals to get the money future you want.</p>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-two.svg') }}" alt="2.">  Talk with your teacher</h3>
+            <h3 class="numbered-header"><span aria-label="2.">{% include 'apps/teachers-digital-platform/img/icon-2.svg' %}</span> Talk with your teacher</h3>
             <p>Talk with your teacher about your money map. Your teacher can review your goals and find the right activities to support your progress on your money journey.</p>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-three.svg') }}" alt="3.">  Talk with a parent or trusted adult</h3>
+            <h3 class="numbered-header"><span aria-label="3.">{% include 'apps/teachers-digital-platform/img/icon-3.svg' %}</span> Talk with a parent or trusted adult</h3>
             <p>Talk with a parent or trusted adult about your money journey. You can explore these resources to help guide your conversation:</p>
 
             <ul>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
@@ -236,13 +236,13 @@
         <div class="o-well block">
             <h2>Three things you can do to get farther down the road on your money journey</h2>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-one.svg') }}" alt="1."> Explore your strengths</h3>
+            <h3 class="numbered-header"><span aria-label="1.">{% include 'apps/teachers-digital-platform/img/icon-1.svg' %}</span> Explore your strengths</h3>
             <p>The <a href="https://files.consumerfinance.gov/f/documents/cfpb_building_block_activities_high-school-assessment-student-worksheet.pdf">Taking the next steps on your money journey</a> worksheet can help you think about your strengths and set goals to get the money future you want.</p>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-two.svg') }}" alt="2."> Talk with your teacher</h3>
+            <h3 class="numbered-header"><span aria-label="2.">{% include 'apps/teachers-digital-platform/img/icon-2.svg' %}</span> Talk with your teacher</h3>
             <p>Talk with your teacher about your money map. Your teacher can review your goals and find the right activities to support your progress on your money journey.</p>
 
-            <h3 class="numbered-header"><img src="{{ static('apps/teachers-digital-platform/img/icon-three.svg') }}" alt="3."> Talk with a parent or trusted adult</h3>
+            <h3 class="numbered-header"><span aria-label="3.">{% include 'apps/teachers-digital-platform/img/icon-3.svg' %}</span> Talk with a parent or trusted adult</h3>
             <p>Talk with a parent or trusted adult about your money journey. You can explore these resources to help guide your conversation:</p>
 
             <ul>

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
@@ -30,8 +30,8 @@
     .numbered-header {
         align-items: center;
         display: flex;
-        img {
-            padding-right: 10px;
+        svg {
+            margin-right: 10px;
         }
     }
     .o-expandable_content {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-1.svg
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-1.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Path</title>
     <g id="Designs---r3.0" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-2.svg
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-2.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Fill 352</title>
     <g id="Designs---r3.0" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-3.svg
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/img/icon-3.svg
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Path</title>
     <g id="Designs---r3.0" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">


### PR DESCRIPTION
Inlines the numbered SVGs on TDP survey results pages

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

#### Accessibility

- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)
