### PR TITLE
Remove code for retired feature flags

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -708,9 +708,6 @@ FLAGS = {
         # Boolean to turn it off explicitly unless enabled by another condition
         {"condition": "boolean", "value": False},
     ],
-    # Fix for margin-top when using the text inset
-    # When enabled, the top margin of full-width text insets is increased
-    "INSET_TEST": [],
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -711,10 +711,6 @@ FLAGS = {
     # Fix for margin-top when using the text inset
     # When enabled, the top margin of full-width text insets is increased
     "INSET_TEST": [],
-    # The next version of the public consumer complaint database
-    "CCDB5_RELEASE": [],
-    # The Trends feature inside Consumer Complaints
-    "CCDB5_TRENDS": [],
     # Google Optimize code snippets for A/B testing
     # When enabled this flag will add various Google Optimize code snippets.
     # Intended for use with path conditions.
@@ -731,8 +727,6 @@ FLAGS = {
     # Controls the /beta_external_testing endpoint, which Jenkins jobs
     # query to determine whether to refresh Beta database.
     "BETA_EXTERNAL_TESTING": [],
-    # Used to hide new youth employment success pages prior to public launch
-    "YOUTH_EMPLOYMENT_SUCCESS": [],
     # During a Salesforce system outage, the following flag should be enabled
     # to alert users that the Collect community is down.
     "COLLECT_OUTAGE": [

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -302,15 +302,12 @@ urlpatterns = [
     ),
 
     # CCDB5-API
-    flagged_re_path(
-        'CCDB5_RELEASE',
+    re_path(
         r'^data-research/consumer-complaints/search/api/v1/',
         include('complaint_search.urls')
     ),
-
-    # If 'CCDB5_RELEASE' is True, include CCDB5 urls.
-    flagged_re_path(
-        'CCDB5_RELEASE',
+    # CCDB5-UI
+    re_path(
         r'^data-research/consumer-complaints/search/',
         include('ccdb5_ui.config.urls')),
 
@@ -342,8 +339,7 @@ urlpatterns = [
     # educational resources
     re_path(
         r'^consumer-tools/educator-tools/resources-youth-employment-programs/transportation-tool/$',  # noqa: E501
-        FlaggedTemplateView.as_view(
-            flag_name='YOUTH_EMPLOYMENT_SUCCESS',
+        TemplateView.as_view(
             template_name='youth_employment_success/index.html'
         ),
         name='youth_employment_success'


### PR DESCRIPTION
These feature flags are no longer needed, but have references in code:
- `CCDB5_RELEASE`
- `CCDB5_TRENDS`
- `INSET_TEST`
- `YOUTH_EMPLOYMENT_SUCCESS`

Once this change is merged, we can delete the flag references in Wagtail
to complete the removal from code and database.
