### PR TITLE
Remove Elasticsearch2 from Docker configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,24 +4,15 @@ volumes:
     postgres_data:
 
 services:
-    elasticsearch2:
-        build:
-            context: ./
-            dockerfile: ./docker/elasticsearch/Dockerfile
-        ports:
-            - 127.0.0.1:9000:9200
-            - 127.0.0.1:9100:9300
     elasticsearch:
         build:
             context: ./
-            dockerfile: ./docker/elasticsearch/7/Dockerfile
+            dockerfile: ./docker/elasticsearch/Dockerfile
         ports:
             - 127.0.0.1:9200:9200
             - 127.0.0.1:9300:9300
         environment:
             discovery.type: single-node
-        volumes:
-            - ./cfgov/search/resources/:/usr/share/elasticsearch/config/synonyms
     kibana:
         image: docker.elastic.co/kibana/kibana:7.13.4
         depends_on:
@@ -40,7 +31,6 @@ services:
             POSTGRES_DB: cfgov
         ports:
             - 127.0.0.1:5432:5432
-
     python:
         build:
             context: .
@@ -49,15 +39,12 @@ services:
                 scl_python_version: rh-python36
         depends_on:
             - elasticsearch
-            - elasticsearch2
             - postgres
         stdin_open: true
         tty: true
         environment:
-            ES7_HOST: elasticsearch
-            ES_HOST: elasticsearch2
+            ES_HOST: elasticsearch
             ES_PORT: 9200
-
     docs:
         build:
             context: ./

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -61,6 +61,7 @@ services:
       DATABASE_URL: postgres://cfpb@postgres/cfgov
       DJANGO_ADMIN_USERNAME: admin
       ES_PORT: 9200
+      ES_HOST: elasticsearch
       ES7_HOST: elasticsearch
       GOVDELIVERY_BASE_URL: https://stage-api.govdelivery.com/
       GOVDELIVERY_ACCOUNT_CODE: USCFPB

--- a/docker/elasticsearch/7/Dockerfile
+++ b/docker/elasticsearch/7/Dockerfile
@@ -1,4 +1,0 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.13.4
-
-# Set User to Non Root
-USER elasticsearch

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,31 +1,4 @@
-FROM centos:7
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.13.4
 
-# Update and install OS dependencies
-RUN yum update -y && \
-    yum install -y java-1.8.0-openjdk && \
-    yum clean all && rm -rf /var/cache/yum
-
-# Install ElasticSearch
-RUN adduser -s /bin/false elasticsearch
-RUN curl https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.3.5/elasticsearch-2.3.5.tar.gz -o /opt/elasticsearch.tar.gz
-
-RUN cd /opt && \
-    tar -xvf elasticsearch.tar.gz && \
-    rm -rf elasticsearch.tar.gz && \
-    mv elasticsearch-2.3.5 elasticsearch 
-
-WORKDIR /opt/elasticsearch
-COPY cfgov/search/resources/synonyms_en.txt config/analysis/synonyms_en.txt
-COPY cfgov/search/resources/synonyms_es.txt config/analysis/synonyms_es.txt
-# is this still needed?
-RUN bin/plugin install org.codelibs/elasticsearch-dataformat/2.3.0
-
-RUN chown -R elasticsearch:elasticsearch ./
-
-
-
-EXPOSE 9200
+# Set User to Non Root
 USER elasticsearch
-
-CMD [ "/opt/elasticsearch/bin/elasticsearch", "-Des.network.host=0.0.0.0" ]
-

--- a/docker/elasticsearch/docker-entrypoint-es-plugins.sh
+++ b/docker/elasticsearch/docker-entrypoint-es-plugins.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# setting up prerequisites
-
-plugin install org.codelibs/elasticsearch-dataformat/2.3.0
-
-exec /docker-entrypoint.sh elasticsearch


### PR DESCRIPTION
Now that consumer complaints are being indexed in Elasticsearch-7, we no longer
need to support operations in the unsupported version 2.

This change removes references to Elasticsearch-2 from configurations
and stops building ES2 containers.

## Testing
To test, you'll need to take down your local cfgov Docker environment and bring it up again.

I tested by removing all containers, networks, etc with `docker system prune -af`, and starting fresh with this configuration, and it delivered a working set of services minus ES2.

For testing, you should be able to just take your local stack down and up, but be aware that you'll probably have to restore postgres and elasticsearch data after this:

```bash
docker-compose down
docker-compose up
```

Then check `docker-compse ps` to see that Elasticsearch2 is no longer running:

```bash
docker-compose ps

            Name                           Command               State                         Ports
---------------------------------------------------------------------------------------------------------------------------
cfgov-refresh_docs_1            sh /src/consumerfinance.go ...   Up      127.0.0.1:8888->8888/tcp
cfgov-refresh_elasticsearch_1   /bin/tini -- /usr/local/bi ...   Up      127.0.0.1:9200->9200/tcp, 127.0.0.1:9300->9300/tcp
cfgov-refresh_kibana_1          /bin/tini -- /usr/local/bi ...   Up      127.0.0.1:5601->5601/tcp
cfgov-refresh_postgres_1        docker-entrypoint.sh postgres    Up      127.0.0.1:5432->5432/tcp
cfgov-refresh_python_1          ./docker-entrypoint.sh pyt ...   Up      127.0.0.1:8000->8000/tcp
```
