### PR TITLE
Update ccdb5-api version to 1.6.2 to remove elasticsearch7 imports

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,7 +18,6 @@ django-url-or-relative-url-field==0.1.2
 django-watchman==0.15.0
 edgegrid-python==1.0.10
 elasticsearch==7.10.1
-elasticsearch7==7.10.1
 elasticsearch-dsl==7.3.0
 govdelivery==1.4.0
 Jinja2==2.11.3
@@ -43,6 +42,6 @@ wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.6.1/ccdb5_api-1.6.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.6.2/ccdb5_api-1.6.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.4.4/ccdb5_ui-2.4.4-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
This is the last vestige of our use fo the custom elasticsearch7 library.
Now that ccdb5-api is no longer importing it, we can remove it from requirements.

