### PR TITLE
Fixed contrast error for tabs

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/tab.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/tab.less
@@ -32,7 +32,7 @@
         border-left: 0;
         border-right: 0;
         background: @gray-5;
-        color: @gray-80;
+        color: @gray;
     }
 
     button:hover,


### PR DESCRIPTION
## Changes

-Changed color of tab text to fix contrast error

## Test this PR

-Go to /owning-a-home/closing-disclosure/
-Turn on WAVE and test that there are no contrast errors on the tabs

Related [ghe]/CFGOV/platform/issues/3616