### PR TITLE
Create new template debug outline

### DIFF
--- a/cfgov/v1/jinja2/v1/template_debug.html
+++ b/cfgov/v1/jinja2/v1/template_debug.html
@@ -20,7 +20,8 @@
 }
 
 .test-case_render {
-    border: 1px #b4b5b6 dotted;
+    outline: 1px dashed rgb( 0, 0, 0, 0.1 );
+    outline-offset: 10px;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Changes

- Changes template debug view example outline to an actual offset outline.


## How to test this PR

1. Visit a template debug view and see there's a light dashed outline around examples.


## Screenshots
<img width="1272" alt="Screen Shot 2021-09-29 at 10 31 35 AM" src="https://user-images.githubusercontent.com/704760/135290266-8dfee784-79e6-48f1-95e7-1128ab3d8e3b.png">

