### PR TITLE
Quarterly update to credit card agreements page

### DIFF
--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -52,6 +52,11 @@
                 </p>
                 <ul class="m-list m-list__links u-mt15 cc-links">
                     <li class="m-list m-list__links">
+                          <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2021_Q2.zip">
+                              Download all most recent agreements (Q2-2021)
+                          </a>
+                    </li>
+                    <li class="m-list m-list__links">
                       <span>
                           Q1-2021 agreements may include omissions due to the Bureau’s COVID-19
                           <a href=" https://files.consumerfinance.gov/f/documents/cfpb_data-collection-statement_covid-19_2020-03.pdf">
@@ -59,7 +64,7 @@
                           </a>.
                       </span><br/>
                           <a href="https://files.consumerfinance.gov/a/assets/Credit_Card_Agreements_2021_Q1.zip">
-                              Download all most recent agreements (Q1-2021)
+                              Archived Q1-2021 agreements
                           </a>
                     </li>
                     <li class="m-list m-list__links">


### PR DESCRIPTION
Add a link to Q2 2021 credit card agreements. This update does not include the regulatory flexibility statement, because the stakeholder let us know that it does not apply beginning in Q2 2021.

We are set to publish this change (along with the updated set of credit card agreements in the dropdown) on Monday, 10/4/2021.

## Additions

- Link to Q2 2021 credit card agreements.

## Screenshots

![Screen Shot 2021-10-01 at 2 45 25 PM](https://user-images.githubusercontent.com/4295388/135671411-a77487a1-7207-40e8-b30d-b024db2cc7e3.png)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance