### PR TITLE
Fix the link picker for table blocks

### DIFF
--- a/cfgov/templates/wagtailadmin/css/table-block.css
+++ b/cfgov/templates/wagtailadmin/css/table-block.css
@@ -12,6 +12,10 @@
   left: 0 !important;
 }
 
+.handsontableInputHolder .Draftail-Editor__wrapper {
+    overflow-y: visible !important;
+}
+
 .handsontable,
 .handsontable .wtHolder {
   height: 100% !important;

--- a/cfgov/unprocessed/js/admin/rich-text-table.js
+++ b/cfgov/unprocessed/js/admin/rich-text-table.js
@@ -1,5 +1,12 @@
 import { stateToHTML } from 'draft-js-export-html';
 
+const body = document.querySelector( 'body' );
+function _handleModalClicks( event ) {
+  if ( document.querySelector( '.modal-open' ) ) {
+    event.stopImmediatePropagation();
+  }
+}
+
 // https://handsontable.com/docs/7.2.2/tutorial-cell-editor.html
 ( function( Handsontable ) {
   console.log( 'INIT 2' );
@@ -160,12 +167,15 @@ import { stateToHTML } from 'draft-js-export-html';
     // Clear the TEXTAREA's style and hide it
     this.TEXTAREA.style.cssText = null;
     this.TEXTAREA.style.display = 'none';
+
+    body.addEventListener( 'mousedown', _handleModalClicks);
   };
 
   RichTextEditor.prototype.close = function() {
     Handsontable.editors.TextEditor.prototype.close.call( this );
     // Remove the Draftail editor for this cell
     this.TEXTAREA_PARENT.querySelector( '.Draftail-Editor__wrapper' ).remove();
+    body.removeEventListener( 'mousedown', _handleModalClicks);
   };
 
   // Register the rich text editor

--- a/cfgov/v1/atomic_elements/tables.py
+++ b/cfgov/v1/atomic_elements/tables.py
@@ -58,6 +58,7 @@ class AtomicTableBlock(TableBlock):
             table_options=table_options
         )
         collected_table_options['editor'] = 'RichTextEditor'
+        collected_table_options['outsideClickDeselects'] = False
         return collected_table_options
 
     class Meta:


### PR DESCRIPTION
This is truly the hackiest hack I have ever hacked, but this seems to be a reliable way to be able to interact with the Wagtail link picker while editing a table cell. The main change is the `_handleModalClicks` event handler that stops `mousedown` propagation when both a table editor is open and a modal is showing. No propagation means the table editor's `close` method never gets called when you click anything with a Wagtail modal showing, which was the only reliable way I could find to make the link picker work when editing a table cell.

I was hoping to use something less hacky like [Handsontable hooks](https://handsontable.com/docs/api/hooks/), but (a) I couldn't actually get a hook working (probably a better JS developer could) and (b) I didn't see a hook that would prevent the editor from closing when you click on something (they have a [hook that works for preventing the editor from closing with certain keystrokes](https://handsontable.com/docs/cell-editor/#use-arrow-up-and-arrow-down-to-change-selected-value), but I couldn't find an equivalent for mouse clicks).

I was also hopeful that setting `outsideClickDeselects` to `false` would have done the job, but it turns out that option only stops the cell from being un-outlined when you click outside of the grid instead of also preventing the editor from closing as I'd assumed. But I still set that option here since it makes for nicer experience when you add links—it's easier to tell which cell you were just editing if the outline remains.

The other change is the small CSS fix that prevents the edit/delete link popover from getting clipped when you click on an existing link in a table cell Draftail instance.

If anyone can think of any better way to accomplish these things, I will gladly trash this PR in favor of anything less hacky.

---

## Additions

- `_handleModalClicks` event handler to prevent table cell Draftail editors from being closed when you click on a link in the Wagtail link picker


## Changes

- `outsideClickDeselects` set to `false` to keep the just-edited cell outlined
- `.handsontableInputHolder .Draftail-Editor__wrapper` `overflow-y` set to visible to prevent the link editor popover from being clipped


## How to test this PR

1. Edit any Wagtail page with a table. /consumer-tools/educator-tools/adult-financial-education/cfpb_finex/ is a great example, but that's mostly what I was testing on, so you might want to try other pages (all administrative adjudication docket pages have tables on them).
2. Try adding a link to a table cell. The link picker should work as normal, the rich text editor should work as normal, and the table data should update as normal.
3. Try editing an existing link in a table cell. The edit link popover should be fully visible.

## Notes and todos

- This is not the world's most beautiful JS—any suggestions on cleaning it up?

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets