### PR TITLE
Add django-cors-headers and env var for origins

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -1,8 +1,10 @@
+import json
 import os
 import secrets
 from pathlib import Path
 
 from django.conf import global_settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
 import dj_database_url
@@ -99,6 +101,7 @@ INSTALLED_APPS = (
     "teachers_digital_platform",
     "wagtailmedia",
     "django_elasticsearch_dsl",
+    "corsheaders",
 
     # Satellites
     "ccdb5_ui",
@@ -139,6 +142,7 @@ WAGTAILSEARCH_BACKENDS = {
 MIDDLEWARE = (
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "core.middleware.PathBasedCsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -560,9 +564,9 @@ CSP_MEDIA_SRC = (
 )
 
 # FEATURE FLAGS
-# Flags can be declared here with an empty list, which will evaluate as false 
-# until the flag is enabled in the Wagtail admin, or with a list of conditions. 
-# Each condition should be a tuple or dict in one of these forms: 
+# Flags can be declared here with an empty list, which will evaluate as false
+# until the flag is enabled in the Wagtail admin, or with a list of conditions.
+# Each condition should be a tuple or dict in one of these forms:
 # (condition-string, value) or {"condition": condition-string, "value": value}
 # An optional 3rd value, "required," can be set to True. It defaults to False.
 # Flags can also be created (and deleted) in the Wagtail admin.
@@ -794,3 +798,15 @@ CACHES = {
         'TIMEOUT': None,
     }
 }
+
+# Set our CORS allowed origins based on a JSON list in the
+# CORS_ALLOWED_ORIGINS environment variable.
+try:
+    CORS_ALLOWED_ORIGINS = json.loads(
+        os.environ.get("CORS_ALLOWED_ORIGINS", "[]")
+    )
+except (TypeError, ValueError):
+    raise ImproperlyConfigured(
+        "Environment variable CORS_ALLOWED_ORIGINS is not valid JSON. "
+        "Expected a JSON array of allowed origins."
+    )

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -5,6 +5,7 @@ beautifulsoup4==4.8.2
 boto3==1.7.80
 dj-database-url==0.5.0
 djangorestframework==3.11.2
+django-cors-headers==3.9.0
 django-csp==3.4
 django-elasticsearch-dsl==7.1.4
 django-extensions==2.1.3


### PR DESCRIPTION
This PR adds the [django-cors-headers](https://pypi.org/project/django-cors-headers/) package to automatically add Cross-Origin Resource Sharing (CORS) headers via settings and middleware to allow origins specified in the `CORS_ALLOWED_ORIGINS` environment variable.

The intended use of this is to permit GovDelivery subscriptions from the [HMDA pages](https://ffiec.cfpb.gov/).

## How to test this PR

To test the CORS Access-Control-Allow-Origin header, set the `CORS_ALLOWED_ORIGINS` environment variable to a valid JSON array of origins:

```bash
export CORS_ALLOWED_ORIGINS=[\"https://example.com\"]
./runserver.sh
```

Then send the `Origin` header in a test request with one of those origins:

```bash
curl -I -H "Origin: https://example.com" http://localhost:8000
```

And observe the `Access-Control-Allow-Origin` header in the response with that origin:

```http
Access-Control-Allow-Origin: https://example.com
```

## Notes and todos

- To use this in deployments, this will require adding the `CORS_ALLOWED_ORIGINS` variable to our Ansible config.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)