### PR TITLE
Mega Menu and Global search: Handle tabbing out with focusout event

### DIFF
--- a/cfgov/unprocessed/js/modules/TabTrigger.js
+++ b/cfgov/unprocessed/js/modules/TabTrigger.js
@@ -1,21 +1,6 @@
 // Required modules.
 import EventObserver from '@cfpb/cfpb-atomic-component/src/mixins/EventObserver.js';
 
-// Key code for the tab key on the keyboard.
-const KEY_TAB = 9;
-
-/**
- * Dynamically creates an HTML element and attaches it to a DOM node.
- * @param  {string} type - The type of HTML node to create.
- * @param  {HTMLNode} target - An HTML element to insert the new node into.
- * @returns {HTMLNode} The newly created HTML node.
- */
-function createElement( type, target ) {
-  const elem = document.createElement( type );
-  target.appendChild( elem );
-  return elem;
-}
-
 /**
  * TabTrigger
  * @class
@@ -28,38 +13,28 @@ function createElement( type, target ) {
  */
 function TabTrigger( element ) {
 
-  const _this = this;
-
   /**
    * @returns {TabTrigger} An instance.
    */
   function init() {
-    const _tabTriggerDom = createElement( 'button', element );
-    _tabTriggerDom.className = 'u-tab-trigger u-visually-hidden';
-    _tabTriggerDom.setAttribute( 'aria-hidden', 'true' );
-
-    /*
-    The tab trigger is hidden, but is used to listen for keyup events
-    when the tab key is pressed on it while it has focus, so that
-    the menu can be collapsed.
-     */
-    _tabTriggerDom.innerText = 'Collapse';
-
-    _tabTriggerDom.addEventListener( 'keyup', _handleTabPress );
+    element.addEventListener( 'focusout', _handleFocusOut.bind( this ) );
 
     return this;
   }
 
   /**
-   * Event handler for when the tab key is pressed.
-   * @param {KeyboardEvent} event
-   *   The event object for the keyboard key press.
+   * @param {FocusEvent} event
+   * @returns {boolean} True if tabPressed is dispatched, false otherwise.
    */
-  function _handleTabPress( event ) {
-    if ( event.keyCode === KEY_TAB ) {
-      _this.dispatchEvent( 'tabPressed' );
-    }
+  function _handleFocusOut( event ) {
+    /* If focus is still in the element, do nothing.
+       The relatedTarget parameter is the EventTarget losing focus. */
+    if ( element.contains( event.relatedTarget ) ) return false;
+
+    this.dispatchEvent( 'tabPressed' );
+    return true;
   }
+
   // Attach public events.
   const eventObserver = new EventObserver();
   this.addEventListener = eventObserver.addEventListener;

--- a/cfgov/unprocessed/js/organisms/MegaMenu.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenu.js
@@ -90,10 +90,10 @@ function MegaMenu( element ) {
       _mobileNav.resume();
     }
 
-    _dom.classList.remove( 'u-hidden' );
-
     _tabTrigger.init();
     _tabTrigger.addEventListener( 'tabPressed', _handleTabPress );
+
+    _dom.classList.remove( 'u-hidden' );
 
     return this;
   }
@@ -192,7 +192,9 @@ function MegaMenu( element ) {
    * @returns {MegaMenu} An instance.
    */
   function collapse() {
-    if ( !viewportIsIn( DESKTOP ) ) {
+    if ( viewportIsIn( DESKTOP ) ) {
+      _desktopNav.collapse();
+    } else {
       _mobileNav.collapse();
     }
 

--- a/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
+++ b/cfgov/unprocessed/js/organisms/MegaMenuDesktop.js
@@ -151,6 +151,17 @@ function MegaMenuDesktop( baseClass, menus ) {
   }
 
   /**
+   * Close the mega menu.
+   * @returns {MegaMenuDesktop} A instance.
+   */
+   function collapse() {
+     // Close the menu.
+    _updateMenuState( null );
+
+    return this;
+  }
+
+  /**
    * Add events necessary for the desktop menu behaviors.
    * @returns {boolean} Whether it has successfully been resumed or not.
    */
@@ -268,6 +279,7 @@ function MegaMenuDesktop( baseClass, menus ) {
   this.removeEventListener = eventObserver.removeEventListener;
   this.dispatchEvent = eventObserver.dispatchEvent;
 
+  this.collapse = collapse;
   this.handleEvent = handleEvent;
   this.init = init;
   this.resume = resume;


### PR DESCRIPTION
A longstanding issue is we create a hidden button after the mega menu and global search that when tabbed to would close either component. This hidden button is flagged as an accessibility issue.

## Changes

- Uses `focusout` event instead of introducing a hidden button for closing the mega menu and global search on tabbing out of each component.


## How to test this PR

1. Pull branch and `gulp clean && gulp build` 
2. Run a local server and visit any page.
3. Try the menu and global search at different screen sizes and in different browsers. You should be able to expand either and then tab through them and then when tabbed out of the open search or menu they should close.

