### PR TITLE
Remove async from inline scripts

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -404,10 +404,9 @@
       window.cfpbHudSettings.mapbox_access_token = "{{ mapbox_access_token }}";
     </script>
 
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/find-a-housing-counselor/js/common.js') }}'
           ];

--- a/cfgov/jinja2/v1/complaint/complaint-landing.html
+++ b/cfgov/jinja2/v1/complaint/complaint-landing.html
@@ -303,10 +303,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             'https://files.consumerfinance.gov/ccdb/metadata.js',
             '{{ static('apps/ccdb-landing-map/js/index.js') }}'

--- a/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/closing-disclosure/index.html
@@ -106,10 +106,9 @@ Use the CFPB's tool to double-check that all the details about your loan are cor
 
 {% block javascript %}
     {{ super() }}
-     <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/owning-a-home/js/common.js') }}',
             '{{ static('apps/owning-a-home/js/form-explainer/index.js') }}'

--- a/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/explore-rates/index.html
@@ -631,10 +631,9 @@ home price, down payment, and more can affect mortgage interest rates.
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/owning-a-home/js/common.js') }}',
             '{{ static('apps/owning-a-home/js/explore-rates/index.js') }}'

--- a/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
+++ b/cfgov/jinja2/v1/owning-a-home/loan-estimate/index.html
@@ -104,10 +104,9 @@ Use the CFPB's tool to review your Loan Estimate to make sure it reflects what y
 
 {% block javascript %}
     {{ super() }}
-     <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/owning-a-home/js/common.js') }}',
             '{{ static('apps/owning-a-home/js/form-explainer/index.js') }}'

--- a/cfgov/jinja2/v1/rural-or-underserved/index.html
+++ b/cfgov/jinja2/v1/rural-or-underserved/index.html
@@ -21,10 +21,9 @@ home price, down payment, and more can affect mortgage interest rates.
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/rural-or-underserved-tool/js/common.js') }}'
           ];

--- a/cfgov/jinja2/v1/youth_employment_success/index.html
+++ b/cfgov/jinja2/v1/youth_employment_success/index.html
@@ -69,16 +69,14 @@ This tool helps youth plan how to get to work, budget for transportation costs, 
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   var htmlEl = document.documentElement;
 
   if (htmlEl.className.indexOf('no-js') === -1) {
     !function () {
-      {# Include site - wide JavaScript. #}
       var s = [
         '{{ static('apps/youth-employment-success/js/index.js') }}'
       ];
-
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/choose-a-student-loan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/choose-a-student-loan.html
@@ -11,7 +11,7 @@
 {%- endblock %}
 
 {% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom 
+    {{ super() }} content__flush-bottom
 {%- endblock %}
 
 {% block content_main -%}
@@ -43,10 +43,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static("apps/paying-for-college/js/quiz.js") }}'
           ];

--- a/cfgov/paying_for_college/jinja2/paying-for-college/choose_a_loan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/choose_a_loan.html
@@ -787,13 +787,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/paying-for-college/js/guides.js') }}'
-          ];
+        '{{ static('apps/paying-for-college/js/guides.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
@@ -70,10 +70,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/paying-for-college/js/college-costs.js') }}'
           ];

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3341,13 +3341,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/paying-for-college/js/disclosures/index.js') }}'
-          ];
+        '{{ static('apps/paying-for-college/js/disclosures/index.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_feedback.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_feedback.html
@@ -45,10 +45,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/paying-for-college/js/disclosure-feedback.js') }}'
           ];

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
@@ -1072,13 +1072,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/paying-for-college/js/disclosures/index.js') }}'
-          ];
+        '{{ static('apps/paying-for-college/js/disclosures/index.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/manage_your_money.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/manage_your_money.html
@@ -577,13 +577,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/paying-for-college/js/guides.js') }}'
-          ];
+        '{{ static('apps/paying-for-college/js/guides.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/repay_student_debt.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/repay_student_debt.html
@@ -2659,13 +2659,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/paying-for-college/js/repay.js') }}'
-          ];
+        '{{ static('apps/paying-for-college/js/repay.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/paying_for_college/jinja2/paying-for-college/repaying-student-debt.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/repaying-student-debt.html
@@ -1491,10 +1491,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/paying-for-college/js/repay.js') }}'
           ];

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -153,10 +153,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('js/routes/data-research/prepaid-accounts/search-agreements/index.js') }}'
           ];

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -313,10 +313,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/regulations3k/js/index.js') }}',
             '{{ static('apps/regulations3k/js/permalinks.js') }}'

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -47,10 +47,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/regulations3k/js/index.js') }}',
             '{{ static('apps/regulations3k/js/recent-notices.js') }}'

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -211,10 +211,9 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script async>
+    <script>
       if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
+        !function() {
           var s = [
             '{{ static('apps/regulations3k/js/index.js') }}'
             {% if page.results.search_query %}

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -971,10 +971,9 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
         '{{ static('apps/retirement/js/index.js') }}'
       ];

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/base.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/base.html
@@ -48,7 +48,6 @@
 {% block javascript scoped -%}
 {# Conditional comment used to block IE8 and under from receiving JS #}
 <!--[if gt IE 8]><!-->
-    {# Include site-wide JavaScript. #}
     <script src="{{ static('apps/teachers-digital-platform/js/index.js') }}"></script>
 <!--<![endif]-->
 

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -1048,13 +1048,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/financial-well-being/js/home.js') }}'
-          ];
+        '{{ static('apps/financial-well-being/js/home.js') }}'
+      ];
       jsl(s);
     }()
   }

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -724,13 +724,12 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script async>
+<script>
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function () {
-      {# Include site - wide JavaScript. #}
+    !function() {
       var s = [
-            '{{ static('apps/financial-well-being/js/results.js') }}'
-          ];
+        '{{ static('apps/financial-well-being/js/results.js') }}'
+      ];
       jsl(s);
     }()
   }


### PR DESCRIPTION
Inline `<script>…</script>` tags don't need an `async` attribute, because they aren't requesting a script file. 

## Removals

- `async` attribute on inline scripts.
- `{# Include site-wide JavaScript. #}` code comment that isn't actually with the site-wide JavaScript.


## Changes

- Minor formatting to make the formatting consistent.


## How to test this PR

1. PR checks should pass.
