### PR TITLE
Fix link icon markup on links with another icon

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -156,6 +156,30 @@ class LinkUtilsTests(SimpleTestCase):
         signed_url = signed_redirect(url)
         self.check_external_link(signed_url, expected_pretty_href=url)
 
+    def test_external_link_if_link_already_includes_left_icon(self):
+        url = 'https://example.com'
+        tag = (
+            f'<a class="a-link" href="{url}">'
+            '<svg></svg>'
+            '<span class="a-link_text">foo</span>'
+            '</a>'
+        )
+        path = '/about-us/blog/'
+
+        expected_href = signed_redirect(url)
+        expected_html = (
+            '<a class="a-link a-link__icon" '
+            'data-pretty-href="https://example.com" '
+            f'href="{expected_href}">'
+            '<svg></svg>'
+            '<span class="a-link_text">foo</span> '
+            f'{self.external_link_icon}'
+            '</a>'
+        )
+
+        expected_tag = BeautifulSoup(expected_html, 'html.parser')
+        self.assertEqual(add_link_markup(tag, path), str(expected_tag))
+
     def test_ask_short_url(self):
         # Valid Ask CFPB URLs
         urls = [

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -216,8 +216,8 @@ def add_link_markup(tag, request_path):
             span = soup.new_tag('span', **icon_classes)
             span.contents = list(tag.contents)
 
-        tag.clear()
-        tag.append(span)
+            tag.clear()
+            tag.append(span)
 
         tag.append(' ')
         tag.append(icon_soup)

--- a/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
+++ b/cfgov/jinja2/v1/_includes/organisms/mega-menu.html
@@ -204,7 +204,7 @@
                                       {{ _content_classes( nav_depth, '-link__current' ) if link.selected else '' }}"
                             href="{{ link.url }}">
                                 {{ svg_icon( link.icon ) }}
-                                <span><span class="a-link_text">{{ link.text }}</span></span>
+                                <span class="a-link_text">{{ link.text }}</span>
                             </a>
                         </li>
                         {% endfor %}


### PR DESCRIPTION
The change #6652 (522b88d4b4bc391ca28661ebac09fcde77ffd477) introduced a bug where links that already include an SVG icon now lose it if another link is added via our link markup.

Specifically, in the mega menu, if an `<a>` includes a child `<svg>`, and then we want to add another `<svg>` for the external link icon ("Order free brochures"), the first icon gets dropped.

This commit fixes our link markup logic so that the original link properly remains behind.

Fixes internal platform#4254.

## How to test this PR

1. Visit the homepage, open the mega menu.

## Notes and todos

Even with this fix, there's still not enough space between the text and the external link icon:

![image](https://user-images.githubusercontent.com/654645/137729219-3aadc9fd-f485-4ebc-b24a-79e309fccdf8.png)

Other external links do have the proper spacing:

![image](https://user-images.githubusercontent.com/654645/137729270-b0d71814-f34b-4332-90d9-a022cf0e4bb8.png)

@anselmbradford suggests this is because the parent container sets flexbox. I'd propose merging this in and then fixing that spacing issue in a subsequent PR.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets