### PR TITLE
Remove two Paying for College URLs from Django

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -252,20 +252,6 @@ urlpatterns = [
         namespace='transcripts')),
 
     re_path(
-        r'^paying-for-college/choose-a-student-loan/$',
-        TemplateView.as_view(
-            template_name='paying-for-college/choose_a_loan.html'
-        ),
-        name='pfc-choose'
-    ),
-    re_path(
-        r'^paying-for-college/manage-your-college-money/$',
-        TemplateView.as_view(
-            template_name='paying-for-college/manage_your_money.html'
-        ),
-        name='pfc-manage'
-    ),
-    re_path(
         r'^paying-for-college/repay-student-debt/$',
         TemplateView.as_view(
             template_name='paying-for-college/repay_student_debt.html'


### PR DESCRIPTION
This commit removes the following URLs so that they are no longer served by Django:

https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/
https://www.consumerfinance.gov/paying-for-college/manage-your-college-money/

The actual templates and associated frontend assets will be cleaned up in a subsequent PR.

## Notes and todos

The content on these pages will be replaced by new Wagtail pages.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)