### PR TITLE
Remove reference to missing docs page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,6 @@ nav:
     - Feature Flags: feature-flags.md
     - Filterable Lists: filterable-lists.md
     - Search: search.md
-    - Split Testing: split-testing.md
     - Translation: translation.md
 - Testing:
     - JavaScript Unit Testing: javascript-unit-tests.md


### PR DESCRIPTION
#6680 removed the split testing documentation, but neglected to remove it from the docs index.

## How to test this PR

To test, `mkdocs serve`.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)