### PR TITLE
Switch smoke tests to use Github instead of S3 for top URLs

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -40,7 +40,7 @@ TIMEOUT = 30
 ALLOWED_TIMEOUTS = 1
 FULL = False
 BASE = 'https://www.consumerfinance.gov'
-GIT_URI = 'https://github.cfpb.gov/raw/CFGOV/cfgov-top-pages/main/top_pages.txt'
+S3_URI = 'https://files.consumerfinance.gov/build/smoketests/smoketest_urls.json'  # noqa: E501
 
 # Fall-back list of top 20 URLs, as of April 2, 2021, from hubcap/wiki
 # All URLs in the list should be canonical locations of the given pages,


### PR DESCRIPTION
Redefining the default top 20 URLs and now grabbing up to date top URLs from github instead of S3.




---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- Git hub raw link to the txt file of the top 20 URLS


## Removals

- S3 link to a json of the old top 20 URLs


## Changes

- The default APPs list will now be used instead of getting it from S3 as the GitHub file only contains URLs


## How to test this PR

1. Pull in a local copy of the code
2. run ./cfgov/scripts/http_smoke_test.py -v from the top directory
3. compare the list of URLs checked to the list  found [here](https://github.cfpb.gov/CFGOV/cfgov-top-pages/blob/main/top_pages.txt) 


## Checklist


- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

