### PR TITLE
Update functional testing docs

### DIFF
--- a/docs/functional-testing.md
+++ b/docs/functional-testing.md
@@ -1,32 +1,45 @@
 # Functional Testing with Cypress
 
-In order to ensure that as we upgrade our wagtail/django dependencies our backend python code is still functional from a frontend perspective we are integrating a new browser testing tool [Cypress](https://www.cypress.io). The goal is to implement and maintain a testing suite that enables confidence in dependency upgrades.
+We use [Cypress](https://www.cypress.io) for functional testing. Our functional tests make sure that common elements and critical pages are working correctly on the front end by simulating interactions with consumerfinance.gov in a browser. They're particularly useful in giving us confidence that our code is working as intended through dependency upgrades.
 
 ## Installing Cypress
 
-We have included Cypress as a dependency of this project, and so the only steps that need to be taken are doing a fresh `yarn` if you haven't already.
+We have included Cypress as a dependency of this project. The only installation step is doing a fresh `yarn` if you haven't already.
 
-## Running Cypress
+## Running Cypress tests
 
-We support both a headless docker container to execute our cypress tests as well as the already installed desktop application that comes packaged with cypress. The test files are located in the `test/cypress/integration/` directory.
+### Docker
 
-* To run a single docker container use `docker-compose -f docker-compose.e2e.yml run admin-tests`
-* To run all docker containers execute `docker-compose -f docker-compose.e2e.yml up`
-  - If you have not previously set up a local Docker network, you will need to stop any running consumerfinance.gov Docker containers, run `docker network create cfgov`, start the containers again, and then run the above command.
+We support a headless Docker container to execute our Cypress tests. The test files are located in the `test/cypress/integration/` directory.
 
-* To run the desktop cypress aplication execute `yarn run cypress open` and select your test file to execute.
+If you have not previously set up a local Docker network, you will need to stop any running consumerfinance.gov Docker containers, run `docker network create cfgov`, and start the containers again before you run these commands.
 
-* To run the tests from the commandline you can also invoke them via `yarn run cypress run`. You can read more about different command line arguments in the [Command-Line Documentation](https://docs.cypress.io/guides/guides/command-line.html#Options) provided by Cypress.
+* `docker-compose -f docker-compose.e2e.yml run admin-tests` runs a single Docker container (the Wagtail admin test suite, in this case)
+* `docker-compose -f docker-compose.e2e.yml up` runs all Docker containers
 
-* To run the tests against a server other than `http://localhost:8000`, you can pass in an override for the `baseUrl` config value; for example:`yarn run cypress open --config baseUrl=http://staging_url`.
+### Cypress app
 
-## Writing Cypress Tests
+To run the desktop Cypress app execute `yarn run cypress open` from the command line. From the app, you can select the tests you want to run and the browser you want to run them in.
 
-When developing new tests for Cypress it is important to consider what the test is trying to accomplish. We want to ensure that we are not polluting our cypress tests with things that can be tested at another level, we are seeking to only test the integration aspect of our UI hosted via Wagtail/Django and custom python code within our backend.
+### Command line
 
-When adding a test it is often helpful to separate the arrange/act code from the actual assertions in order to improve the readability of our testing code. To do this we have adopted the page model of testing, where we define a page within the application and the methods of interacting with the page separate from the test file itself where we define the assertions. We call these files "helpers" and label them as such (example: `megamenu-helpers.js`), and we include them alongside the test files themselves in the `test/cypress/integration/` folder. (They are ignored when running tests thanks to the configuration of `cypress.json`.)
+You can run functional tests from the command line with `yarn run cypress run`. That will run all tests in the `test/cypress/integration/` directory with the default test configuration: headless, in Cypress's default Electron browser, and against `localhost:8000`. You might want to modify the test run with some common arguments:
 
-For example consider the ConsumerTools Page "helper":
+* `--spec test/cypress/integration/{path/to/test.js}` runs a single test suite
+* `--browser chrome` runs the tests in Chrome, which is what we use to run tests in our continuous integration pipeline
+* `--headed` shows the browser and Cypress output as the tests run, handy for watching what's happening during the tests
+* `--no-exit` will keep the browser and Cypress output open after the tests complete, handy to inspect any errors
+* `--config baseUrl={url}` will run the tests against a server other than `localhost:8000`
+
+Cypress's [command line documentation](https://docs.cypress.io/guides/guides/command-line.html#Options) has the list of all the options you can set.
+
+## Writing Cypress tests
+
+When developing new tests for Cypress, it is important to consider what the test is trying to accomplish. We want to ensure that we are not polluting our Cypress tests with things that can be tested at another level, like in unit tests.
+
+When adding a test it is often helpful to separate the arrange/act code from the actual assertions in order to improve the readability of our testing code. To do this we have adopted the page model of testing, where we define a page within the application and the methods of interacting with the page separate from the test file itself where we define the assertions. We call these files "helpers" and label them as such (example: `megamenu-helpers.js`), and we include them alongside the test files themselves in the `test/cypress/integration/` directory. (They are ignored when running tests thanks to the configuration of `cypress.json`.)
+
+For example consider the `ConsumerTools` page "helper":
 
 ```javascript
 export default class ConsumerTools {


### PR DESCRIPTION
After I forgot how to run Cypress tests for the millionth time I took a pass at updating our functional testing docs with better instructions for running tests from the command line. While I was in there I also made some changes that hopefully improve organization and readability.

---

## Changes

- Revise functional testing docs

## How to test this PR

1. Fire up the docs page locally at http://localhost:8888/functional-testing/ (automatically running if you're using Docker, started with `mkdocs serve -a :8888` if you're running locally)

## Screenshots

![functional-testing](https://user-images.githubusercontent.com/1862695/140374502-0768028e-a5b6-4397-b6a3-afb4045f579c.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo