### PR TITLE
Grab the node rpm package directly, prevently mirror mismatch trouble

### DIFF
--- a/docker/deployable-zipfile/Dockerfile
+++ b/docker/deployable-zipfile/Dockerfile
@@ -24,6 +24,7 @@ RUN mkdir -p ${HOME} && chmod 777 ${HOME}
 # Python 3 to be enabled at login.
 RUN yum -y update && \
     yum install -y centos-release-scl && \
+    rpm -i https://rpm.nodesource.com/pub_14.x/el/7/x86_64/nodejs-14.18.1-1nodesource.x86_64.rpm && \
     curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y rh-python36 gcc git nodejs yarn && \


### PR DESCRIPTION
Fixes the weird `[Errno -1] Package does not match intended download.` issue on build by grabbing the package directly beforehand.