### PR TITLE
Simplify Elasticsearch environment variables

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -88,9 +88,8 @@ export NODE_ENV=development
 # Elasticsearch - for indexing and storing searchable content.
 ##############################################################
 
-export ES_PORT=9200
-export ES_HOST=elasticsearch
-export ES7_HOST=elasticsearch
+#export ES7_HOST=localhost
+#export ES_PORT=9200
 
 ##########################################################
 # Complaint Search Elasticsearch (ES) Indexes Information.
@@ -190,6 +189,4 @@ export WATCHMAN_TOKENS=''
 if [ $(uname -s) = "Darwin" ]; then
   export CFGOV_HOSTNAME=localhost:8000
   export DATABASE_URL=postgres://cfpb@localhost/cfgov
-  export ES_HOST=localhost
-  export ES7_HOST=localhost
 fi

--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -88,7 +88,7 @@ export NODE_ENV=development
 # Elasticsearch - for indexing and storing searchable content.
 ##############################################################
 
-#export ES7_HOST=localhost
+#export ES_HOST=localhost
 #export ES_PORT=9200
 
 ##########################################################

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -315,7 +315,7 @@ HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
 )
 
 # ElasticSearch 7 Configuration
-ES7_HOST = os.getenv('ES7_HOST', 'localhost')
+ES_HOST = os.getenv('ES_HOST', 'localhost')
 ES_PORT = os.getenv("ES_PORT", "9200")
 ELASTICSEARCH_BIGINT = 50000
 ELASTICSEARCH_DEFAULT_ANALYZER = "snowball"
@@ -329,7 +329,7 @@ if os.environ.get('USE_AWS_ES', False):
     )
     ELASTICSEARCH_DSL = {
         'default': {
-            'hosts': [{'host': ES7_HOST, 'port': 443}],
+            'hosts': [{'host': ES_HOST, 'port': 443}],
             'http_auth': awsauth,
             'use_ssl': True,
             'connection_class': RequestsHttpConnection,
@@ -338,7 +338,7 @@ if os.environ.get('USE_AWS_ES', False):
     }
 else:
     ELASTICSEARCH_DSL = {
-        "default": {"hosts": f"http://{ES7_HOST}:{ES_PORT}"}
+        "default": {"hosts": f"http://{ES_HOST}:{ES_PORT}"}
     }
 
 ELASTICSEARCH_DSL_SIGNAL_PROCESSOR = 'search.elasticsearch_helpers.WagtailSignalProcessor'

--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -102,7 +102,7 @@ class ElasticsearchTestsMixin:
         # running on GitHub Actions, in which case something is wrong and we
         # want the tests to fail.
         try:
-            socket.create_connection((settings.ES7_HOST, settings.ES_PORT))
+            socket.create_connection((settings.ES_HOST, settings.ES_PORT))
         except OSError as e:  # pragma: nocover
             if os.getenv('GITHUB_ACTIONS'):
                 raise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         stdin_open: true
         tty: true
         environment:
-            ES7_HOST: elasticsearch
+            ES_HOST: elasticsearch
     docs:
         build:
             context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,7 @@ services:
         stdin_open: true
         tty: true
         environment:
-            ES_HOST: elasticsearch
-            ES_PORT: 9200
+            ES7_HOST: elasticsearch
     docs:
         build:
             context: ./

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -60,8 +60,6 @@ services:
       APACHE_UPLOADS_F_ALIAS: /src/consumerfinance.gov/cfgov/f/
       DATABASE_URL: postgres://cfpb@postgres/cfgov
       DJANGO_ADMIN_USERNAME: admin
-      ES_PORT: 9200
-      ES_HOST: elasticsearch
       ES7_HOST: elasticsearch
       GOVDELIVERY_BASE_URL: https://stage-api.govdelivery.com/
       GOVDELIVERY_ACCOUNT_CODE: USCFPB

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -60,7 +60,7 @@ services:
       APACHE_UPLOADS_F_ALIAS: /src/consumerfinance.gov/cfgov/f/
       DATABASE_URL: postgres://cfpb@postgres/cfgov
       DJANGO_ADMIN_USERNAME: admin
-      ES7_HOST: elasticsearch
+      ES_HOST: elasticsearch
       GOVDELIVERY_BASE_URL: https://stage-api.govdelivery.com/
       GOVDELIVERY_ACCOUNT_CODE: USCFPB
       MEDIA_ROOT: /src/consumerfinance.gov/cfgov/f/


### PR DESCRIPTION
This commit tries to simplify how we configure Elasticsearch via environment variables, for virtualenv/local Docker/deployed Docker.

Currently, as of #6695, Django will use the combination of ES7_HOST and ES_PORT to configure the Elasticsearch client. ES_HOST is no longer used anywhere, since our migration to Elasticsearch 7.x. In Django settings, these default to localhost/9200 if the environment variables are not defined.

This PR changes this so we standardize everywhere to ES_HOST and ES_PORT.

With this change, the following configurations are still supported:

1. Local virtualenv - these settings are now no longer set in .env, but default to localhost/9200 for a locally-running Elasticsearch. The definitions have been left in .env_SAMPLE commented out for documentation purposes.

2. Local Docker - port defaults to 9200, but ES_HOST is set in docker-compose.yml to "elasticsearch" instead.

3. Deployed Docker stack - port defaults to 9200, but ES_HOST is set in docker-stack.yml to "elasticsearch" instead.

## Notes and todos

- If/when this is merged, there is some cleanup to be done in our internal Ansible deployment scripts to remove reference to the now-deprecated ES7_HOST environment variable.
- (See below) We also need to modify [the ccdb5-api repo](https://github.com/cfpb/ccdb5-api/blob/0310e5245bc28750b892cea096f881f9f3fb38e8/complaint_search/es_interface.py#L39) to update usage of ES7_HOST to ES_HOST.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets