### PR TITLE
Update ccdb5-api version to 1.6.3 to sync env vars

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -43,6 +43,6 @@ wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.6.2/ccdb5_api-1.6.2-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.6.3/ccdb5_api-1.6.3-py3-none-any.whl
 https://github.com/cfpb/ccdb5-ui/releases/download/2.4.4/ccdb5_ui-2.4.4-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
Version 1.6.3 removes references to `ES7_HOST` and `COMPLAINT_DOC_TYPE` from the API.