### PR TITLE
Add HTTP Expires header to EventPages if needed

### DIFF
--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -388,7 +388,7 @@ class EventPage(AbstractFilterPage):
             return 'past'
 
         start = min(filter(None, [self.live_stream_date, self.start_dt]))
-        if self._cached_now > start:
+        if self._cached_now >= start:
             return 'present'
 
         return 'future'

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -1,9 +1,12 @@
-from datetime import date, datetime
+from datetime import date
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
+from django.utils import timezone
+from django.utils.functional import cached_property
+from django.utils.http import http_date
 
 from wagtail.admin.edit_handlers import (
     FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, ObjectList,
@@ -17,12 +20,10 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 from localflavor.us.models import USStateField
-from pytz import timezone
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage, CFGOVPageManager
-from v1.util.datetimes import convert_date
 from v1.util.events import get_venue_coords
 
 
@@ -383,20 +384,11 @@ class EventPage(AbstractFilterPage):
 
     @property
     def event_state(self):
-        if self.end_dt:
-            end = convert_date(self.end_dt, 'America/New_York')
-            if end < datetime.now(timezone('America/New_York')):
-                return 'past'
+        if self.end_dt and self.end_dt < self._cached_now:
+            return 'past'
 
-        if self.live_stream_date:
-            start = convert_date(
-                self.live_stream_date,
-                'America/New_York'
-            )
-        else:
-            start = convert_date(self.start_dt, 'America/New_York')
-
-        if datetime.now(timezone('America/New_York')) > start:
+        start = min(filter(None, [self.live_stream_date, self.start_dt]))
+        if self._cached_now > start:
             return 'present'
 
         return 'future'
@@ -447,3 +439,29 @@ class EventPage(AbstractFilterPage):
         context = super(EventPage, self).get_context(request)
         context['event_state'] = self.event_state
         return context
+
+    def serve(self, request, *args, **kwargs):
+        response = super().serve(request, *args, **kwargs)
+
+        changes_at = [self.start_dt, self.end_dt, self.live_stream_date]
+        future_changes_at = [
+            at for at in changes_at if at and at > self._cached_now
+        ]
+
+        if future_changes_at:
+            response['Expires'] = http_date(min(future_changes_at).timestamp())
+
+        return response
+
+    @cached_property
+    def _cached_now(self):
+        """Cached value of now for use during page rendering.
+
+        This property can be used to retrieve a fixed version of "now"
+        associated with a single EventPage instance. The first time this
+        property is accessed, it will return the current time. Any subsequent
+        accesses will return the same time.
+
+        This allows for a consistent timestamp to be used during page render.
+        """
+        return timezone.now()

--- a/cfgov/v1/tests/models/test_event_page.py
+++ b/cfgov/v1/tests/models/test_event_page.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -45,62 +46,130 @@ class EventPageTests(TestCase):
         self.assertIn('static/-77.039628,38.898238', page.location_image_url())
 
     @freeze_time('2011-01-03')
-    def test_present_event_with_livestream_includes_video_js(self):
+    def test_future_event_with_start_date(self):
         page = EventPage(
-            title='Present event with live_stream_date',
+            title='Future event with start date',
+            start_dt=datetime.datetime(2011, 1, 5, tzinfo=pytz.UTC)
+        )
+        save_new_page(page)
+        self.assertEqual('future', page.event_state)
+
+        # Should not include video JavaScript.
+        self.assertNotIn('video-player.js', page.page_js)
+
+        # Page should send HTTP Expires header for its start time.
+        response = self.client.get('/future-event-with-start-date/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Expires'], 'Wed, 05 Jan 2011 00:00:00 GMT')
+
+    @freeze_time('2011-01-03')
+    def test_future_event_with_livestream_date(self):
+        page = EventPage(
+            title='Future event with livestream date',
+            start_dt=datetime.datetime(2011, 1, 5, tzinfo=pytz.UTC),
+            live_stream_date=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC)
+        )
+        save_new_page(page)
+        self.assertEqual('future', page.event_state)
+
+        # Should not include video JavaScript.
+        self.assertNotIn('video-player.js', page.page_js)
+
+        # Page should send HTTP Expires header for its live stream time,
+        # because it comes before the start time.
+        response = self.client.get('/future-event-with-livestream-date/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Expires'], 'Tue, 04 Jan 2011 00:00:00 GMT')
+
+    @freeze_time('2011-01-03')
+    def test_present_event_with_livestream_and_end_date(self):
+        page = EventPage(
+            title='Present event with livestream',
             start_dt=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC),
-            end_dt=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC),
-            live_stream_date=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC)
+            live_stream_date=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC),
+            end_dt=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC)
         )
         save_new_page(page)
         self.assertEqual('present', page.event_state)
+
+        # Should include video JavaScript.
         self.assertIn('video-player.js', page.page_js)
 
+        # Page should send HTTP Expires header for its end time.
+        response = self.client.get('/present-event-with-livestream/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Expires'], 'Tue, 04 Jan 2011 00:00:00 GMT')
+
     @freeze_time('2011-01-03')
-    def test_past_event_with_video_includes_video_js(self):
+    def test_present_event_without_livestream_or_end_date(self):
         page = EventPage(
-            title='Past event with archive_video_id',
+            title='Present event without livestream',
+            start_dt=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC)
+        )
+        save_new_page(page)
+        self.assertEqual('present', page.event_state)
+
+        # Should not include video JavaScript without livestream.
+        self.assertNotIn('video-player.js', page.page_js)
+
+        # Page should not send HTTP Expires header.
+        response = self.client.get('/present-event-without-livestream/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Expires', response)
+
+    @freeze_time('2011-01-03')
+    def test_past_event_with_video(self):
+        page = EventPage(
+            title='Past event with video',
             start_dt=datetime.datetime(2011, 1, 1, tzinfo=pytz.UTC),
             end_dt=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC),
             archive_video_id='Aa1Bb2Cc3Dc'
         )
         save_new_page(page)
         self.assertEqual('past', page.event_state)
+
+        # Should include video JavaScript.
         self.assertIn('video-player.js', page.page_js)
 
+        # Page should not send HTTP Expires header.
+        response = self.client.get('/past-event-with-video/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Expires', response)
+
     @freeze_time('2011-01-03')
-    def test_video_js_not_included_on_event_when_not_needed(self):
+    def test_past_event_without_video(self):
         page = EventPage(
-            title='Future event with no end date',
-            start_dt=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC)
-        )
-        save_new_page(page)
-        self.assertEqual('future', page.event_state)
-        self.assertNotIn('video-player.js', page.page_js)
-
-        page = EventPage(
-            title='Future event with end date',
-            start_dt=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC),
-            end_dt=datetime.datetime(2011, 1, 5, tzinfo=pytz.UTC)
-        )
-        save_new_page(page)
-        self.assertEqual('future', page.event_state)
-        self.assertNotIn('video-player.js', page.page_js)
-
-        page = EventPage(
-            title='Present event with no live_stream_date',
-            start_dt=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC),
-            end_dt=datetime.datetime(2011, 1, 4, tzinfo=pytz.UTC)
-        )
-        save_new_page(page)
-        self.assertEqual('present', page.event_state)
-        self.assertNotIn('video-player.js', page.page_js)
-
-        page = EventPage(
-            title='Past event with no archive_video_id',
+            title='Past event without video',
             start_dt=datetime.datetime(2011, 1, 1, tzinfo=pytz.UTC),
             end_dt=datetime.datetime(2011, 1, 2, tzinfo=pytz.UTC)
         )
         save_new_page(page)
         self.assertEqual('past', page.event_state)
         self.assertNotIn('video-player.js', page.page_js)
+
+        # Page should not send HTTP Expires header.
+        response = self.client.get('/past-event-without-video/')
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('Expires', response)
+
+    def assertValidationFails(self, expected_msg, **kwargs):
+        page = EventPage(
+            title='test',
+            start_dt=datetime.datetime.now(pytz.UTC),
+            **kwargs
+        )
+
+        with self.assertRaisesRegex(ValidationError, expected_msg):
+            save_new_page(page)
+
+    def test_failing_validation_venue_image(self):
+        self.assertValidationFails(
+            'Required if "Venue image type" is "Image".',
+            venue_image_type='image'
+        )
+
+    def test_failing_validation_post_event_image(self):
+        self.assertValidationFails(
+            'Required if "Post-event image type" is "Image".',
+            post_event_image_type='image'
+        )


### PR DESCRIPTION
This commit adds the HTTP Expires header to EventPages if they have a state change in the future, for example before an event begins or during an event with an end timestamp.

This header will allow for (a) client browsers to properly refetch the page when its state has changed and (b) downstream caches like Akamai to automatically expire cached versions of the page.

HTTP Expires headers are of the form "Tue, 04 Jan 2011 00:00:00 GMT".

Addresses internal platform#4081.

## How to test this PR

The unit tests validate that calling `page.serve()` on EventPages in the past, present, and future all return the proper and expected `Expires` header (or lack thereof). This is also confirmable manually if you use the Django server and create EventPages in Wagtail that are past, present, or future. I've also confirmed that the header makes it through Apache - this is testable if you use our prod-like Docker setup.

## Notes and todos

We'll need to modify our Akamai configuration to pass through and honor `Expires` to properly expire EventPages, but that has to be done elsewhere.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets