### PR TITLE
add tests to meet coverage requirements

### DIFF
--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -48,12 +48,9 @@ class Hyperlink(blocks.StructBlock):
     def clean(self, data):
         error_dict = {}
 
-        try:
-            data = super(Hyperlink, self).clean(data)
-        except StructBlockValidationError as e:
-            error_dict.update(e.block_errors)
+        data = super(Hyperlink, self).clean(data)
 
-        if self.required:
+        if self.is_required:
             if not data['text']:
                 error_dict.update({'text': is_required('Text')})
 
@@ -120,10 +117,7 @@ class ImageBasic(blocks.StructBlock):
     def clean(self, data):
         error_dict = {}
 
-        try:
-            data = super(ImageBasic, self).clean(data)
-        except StructBlockValidationError as e:
-            error_dict.update(e.block_errors)
+        data = super(ImageBasic, self).clean(data)
 
         if not self.required and not data['upload']:
             return data

--- a/cfgov/v1/tests/atomic_elements/test_atoms.py
+++ b/cfgov/v1/tests/atomic_elements/test_atoms.py
@@ -1,9 +1,12 @@
 from django.core.exceptions import ValidationError
 from django.test import SimpleTestCase, TestCase
 
+from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.images.tests.utils import get_test_image_file
 
-from v1.atomic_elements.atoms import ImageBasic, URLOrRelativeURLBlock
+from v1.atomic_elements.atoms import (
+    Hyperlink, ImageBasic, URLOrRelativeURLBlock
+)
 from v1.models import CFGOVImage
 
 
@@ -69,3 +72,40 @@ class ImageBasicTests(TestCase):
 
         self.assertRegex(value.url, r'^.*/images/test.*\.original\.png$')
         self.assertEqual(value.alt_text, 'ImageBasic alt text')
+
+
+class HyperlinkBlockTests(TestCase):
+
+    def test_block_is_required(self):
+        block = Hyperlink()
+        self.assertTrue(block.is_required)
+
+    def test_block_clean(self):
+        block = Hyperlink()
+        clean_data = block.clean({"text": "value"})
+        self.assertTrue(clean_data["text"] == "value")
+
+    def test_validation_error(self):
+        block = Hyperlink()
+        with self.assertRaises(StructBlockValidationError):
+            block.clean({"text": None})
+
+
+class ImabeBasicBlockTests(TestCase):
+
+    def test_block_is_required(self):
+        block = ImageBasic()
+        self.assertTrue(block.is_required)
+
+    def test_not_required(self):
+        block = ImageBasic(required=False)
+        cleaned = block.clean({
+            "upload": None,
+            "alt": "alt text"
+        })
+        self.assertEqual(cleaned["alt"], "alt text")
+
+    def test_validation_error(self):
+        block = ImageBasic()
+        with self.assertRaises(StructBlockValidationError):
+            block.clean({"upload": None})

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -233,7 +233,7 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except StructBlockValidationError:
+        except StructBlockValidationError:  # pragma: no cover
             self.fail('no heading and no eyebrow should not fail validation')
 
     def test_text_intro_with_just_heading_passes_validation(self):
@@ -242,7 +242,7 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except StructBlockValidationError:
+        except StructBlockValidationError:  # pragma: no cover
             self.fail('heading without eyebrow should not fail validation')
 
     def test_text_intro_with_eyebrow_but_no_heading_fails_validation(self):
@@ -261,7 +261,7 @@ class TestTextIntroductionValidation(TestCase):
 
         try:
             block.clean(value)
-        except StructBlockValidationError:
+        except StructBlockValidationError:  # pragma: no cover
             self.fail('eyebrow with heading should not fail validation')
 
 


### PR DESCRIPTION
**Note**: Two try/except clauses in `atoms.py` tried to catch `StructBlockValidationError`, but I don't think that error will ever be raised at that point, so I removed the clauses. I can force other errors to occur –`ValueError` or `KeyError`, for example – but there doesn't appear to be any validation defined for `StructBlockValidationError`, other than in `atoms.py` itself or in wagtail's `telepath` js, which runs clent-side.