### PR TITLE
Remove some trailing commas in our data.json file

### DIFF
--- a/cfgov/unprocessed/root/data.json
+++ b/cfgov/unprocessed/root/data.json
@@ -329,7 +329,7 @@
         "agreement",
         "fee",
         "consumer",
-        "financial",
+        "financial"
       ],
       "landingPage": "https://www.consumerfinance.gov/data-research/student-banking/marketing-agreements-and-data/",
       "modified": "2021-12-30",
@@ -371,7 +371,7 @@
         "prepaid",
         "product",
         "type",
-        "agreement",
+        "agreement"
       ],
       "landingPage": "https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/",
       "modified": "2021-09-21",
@@ -383,7 +383,7 @@
         "name": "Consumer Financial Protection Bureau"
       },
       "spatial": "United States",
-      "title": "Prepaid Product Agreements Database",
+      "title": "Prepaid Product Agreements Database"
     },
     
     {
@@ -413,7 +413,7 @@
         "terms",
         "credit card",
         "plans",
-        "survey",
+        "survey"
       ],
       "landingPage": "https://www.consumerfinance.gov/data-research/credit-card-data/terms-credit-card-plans-survey/",
       "modified": "2021-01-31",
@@ -659,7 +659,7 @@
         "agreements",
         "credit card",
         "card",
-        "database",
+        "database"
       ],
       "landingPage": "https://www.consumerfinance.gov/credit-cards/agreements/",
       "modified": "2021-03-31",


### PR DESCRIPTION
Our data.json file was invalid JSON because of some trailing commas, but the [data.gov validator was still seeing it as valid](https://labs.data.gov/dashboard/validate).

This change removes those trailing commas, and the file parses as valid JSON and passes the data.gov validator.

## How to test this PR

1. Confirm that the contents of the data.json file are valid JSON with https://jsonlint.com/
2. Confirm that the contents of the data.json file are valid for the federal data.json schema with https://labs.data.gov/dashboard/validate

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
