### PR TITLE
Refactor privacy forms and improve tests

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -379,6 +379,8 @@ WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = os.environ.get(
     "WAGTAILADMIN_NOTIFICATION_FROM_EMAIL"
 )
 
+PRIVACY_EMAIL_TARGET = os.environ.get("PRIVACY_EMAIL_TARGET", "test@localhost")
+
 
 # Password Policies
 # cfpb_common password rules

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -132,37 +132,31 @@ class PrivacyActForm(forms.Form):
     def clean(self):
         super().clean()
         self.require_address_if_mailing()
-        uploaded_files = self.files.getlist('supporting_documentation')
-        self.limit_file_size(uploaded_files)
-        self.limit_number_of_files(uploaded_files)
+        self.uploaded_files = self.files.getlist('supporting_documentation')
+        self.limit_file_size(self.uploaded_files)
+        self.limit_number_of_files(self.uploaded_files)
         return self.escaped_fields()
 
     # Email message
-    def email_body(self, data):
-        num_files = len(data['uploaded_files'])
-        data.update({'num_files': num_files})
+    def email_body(self):
+        data = self.cleaned_data
+        data.update({
+            'num_files': len(self.uploaded_files),
+            'uploaded_files': self.uploaded_files,
+        })
         return loader.render_to_string(self.email_template, data)
 
     def send_email(self):
-        uploaded_files = self.files.getlist('supporting_documentation')
-        data = self.cleaned_data
-        data.update({'uploaded_files': uploaded_files})
-        subject = self.format_subject(data['requestor_name'])
-        from_email = settings.DEFAULT_FROM_EMAIL
-        recipient_list = ['FOIA@consumerfinance.gov']
-
-        body = self.email_body(data)
-
         email = EmailMessage(
-            subject,
-            body,
-            from_email,
-            recipient_list,
-            reply_to=[data['requestor_email']]
+            subject=self.format_subject(),
+            body=self.email_body(),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            to=['FOIA@consumerfinance.gov'],
+            reply_to=[self.cleaned_data['requestor_email']],
         )
         email.content_subtype = 'html'
 
-        for f in uploaded_files:
+        for f in self.uploaded_files:
             email.attach(f.name, f.read(), f.content_type)
 
         try:
@@ -182,7 +176,8 @@ class DisclosureConsentForm(PrivacyActForm):
         widget=forms.EmailInput(attrs=text_input_attrs),
     )
 
-    def format_subject(self, name):
+    def format_subject(self):
+        name = self.cleaned_data['requestor_name']
         truncated_name = (name[:20] + '...') if len(name) > 24 else name
         return f'Disclosure request from consumerfinance.gov: {truncated_name}'
 
@@ -191,7 +186,8 @@ class DisclosureConsentForm(PrivacyActForm):
 
 class RecordsAccessForm(PrivacyActForm):
     # Inherit form fields from the PrivacyActForm class
-    def format_subject(self, name):
+    def format_subject(self):
+        name = self.cleaned_data['requestor_name']
         truncated_name = (name[:20] + '...') if len(name) > 24 else name
         return f'Records request from consumerfinance.gov: {truncated_name}'
 

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -151,7 +151,7 @@ class PrivacyActForm(forms.Form):
             subject=self.format_subject(),
             body=self.email_body(),
             from_email=settings.DEFAULT_FROM_EMAIL,
-            to=['FOIA@consumerfinance.gov'],
+            to=[settings.PRIVACY_EMAIL_TARGET],
             reply_to=[self.cleaned_data['requestor_email']],
         )
         email.content_subtype = 'html'

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -146,6 +146,11 @@ class PrivacyActForm(forms.Form):
         })
         return loader.render_to_string(self.email_template, data)
 
+    def format_subject(self):
+        name = self.cleaned_data['requestor_name']
+        truncated_name = (name[:20] + '...') if len(name) > 24 else name
+        return self.email_subject + truncated_name
+
     def send_email(self):
         email = EmailMessage(
             subject=self.format_subject(),
@@ -176,19 +181,13 @@ class DisclosureConsentForm(PrivacyActForm):
         widget=forms.EmailInput(attrs=text_input_attrs),
     )
 
-    def format_subject(self):
-        name = self.cleaned_data['requestor_name']
-        truncated_name = (name[:20] + '...') if len(name) > 24 else name
-        return f'Disclosure request from consumerfinance.gov: {truncated_name}'
+    email_subject = 'Disclosure request from consumerfinance.gov: '
 
     email_template = 'privacy/disclosure_consent_email.html'
 
 
 class RecordsAccessForm(PrivacyActForm):
     # Inherit form fields from the PrivacyActForm class
-    def format_subject(self):
-        name = self.cleaned_data['requestor_name']
-        truncated_name = (name[:20] + '...') if len(name) > 24 else name
-        return f'Records request from consumerfinance.gov: {truncated_name}'
+    email_subject = 'Records request from consumerfinance.gov: '
 
     email_template = 'privacy/records_access_email.html'

--- a/cfgov/privacy/tests/test_forms.py
+++ b/cfgov/privacy/tests/test_forms.py
@@ -26,7 +26,7 @@ class RecordsAccessFormTests(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_mailing_address_required(self):
-        data = self.minimum_data
+        data = self.minimum_data.copy()
         data.update({'contact_channel': 'mail'})
         form = RecordsAccessForm(
             data=data,
@@ -38,7 +38,7 @@ class RecordsAccessFormTests(TestCase):
             form.errors['street_address'])
 
     def test_satisfied_mailing_address_requirement(self):
-        data = self.minimum_data
+        data = self.minimum_data.copy()
         data.update({
             'contact_channel': 'mail',
             'street_address': '101 Example Ave.',
@@ -54,31 +54,51 @@ class RecordsAccessFormTests(TestCase):
         self.assertTrue(form.is_valid())
 
     def test_email_subject(self):
-        data = self.minimum_data
         form = RecordsAccessForm(
-            data=data,
+            data=self.minimum_data,
             files=self.minimum_files
         )
+        form.is_valid()  # so form.cleaned_data will be populated
         self.assertEqual(
-            form.format_subject(self.minimum_data['requestor_name']),
+            form.format_subject(),
             'Records request from consumerfinance.gov: Example Person'
         )
 
-    def test_email_body(self):
-        data = self.minimum_data
-        data.update({'uploaded_files': []})
+    def test_subject_line_truncates_long_names(self):
+        data = self.minimum_data.copy()
+        data.update({'requestor_name': 'Rufus Xavier Sarsaparilla'})
         form = RecordsAccessForm(
             data=data,
             files=self.minimum_files
         )
+        form.is_valid()  # so form.cleaned_data will be populated
+        self.assertEqual(
+            form.format_subject(),
+            'Records request from consumerfinance.gov: Rufus Xavier Sarsapa...'
+        )
+
+    def test_email_body(self):
+        data = self.minimum_data.copy()
+        data.update({
+            'contact_channel': 'mail',
+            'street_address': '101 Example Ave.',
+            'city': 'Washington',
+            'state': 'DC',
+            'zip_code': '20002',
+        })
+
+        form = RecordsAccessForm(
+            data=data,
+            files=self.minimum_files
+        )
+        form.is_valid()  # so form.cleaned_data will be populated
+        body = form.email_body()
         self.assertIn(
             'h1>Request for individual access to records protected under the Privacy Act</h1>',  # noqa: E501
-            form.email_body(self.minimum_data),
+            body,
         )
-        self.assertIn(
-            'person@example.com',
-            form.email_body(self.minimum_data),
-        )
+        self.assertIn('person@example.com', body)
+        self.assertIn('101 Example Ave.<br>Washington, DC 20002', body)
 
 
 class DisclosureConsentFormTests(TestCase):
@@ -126,23 +146,37 @@ class DisclosureConsentFormTests(TestCase):
             data=self.minimum_data,
             files=self.minimum_files
         )
+        form.is_valid()  # so form.cleaned_data will be populated
         self.assertEqual(
-            form.format_subject(self.minimum_data['requestor_name']),
+            form.format_subject(),
             'Disclosure request from consumerfinance.gov: Example Person'
+        )
+
+    def test_subject_line_truncates_long_names(self):
+        self.minimum_data.update({
+            'requestor_name': 'Rufus Xavier Sarsaparilla'
+        })
+        form = DisclosureConsentForm(
+            data=self.minimum_data,
+            files=self.minimum_files
+        )
+        form.is_valid()  # so form.cleaned_data will be populated
+        self.assertEqual(
+            form.format_subject(),
+            'Disclosure request from consumerfinance.gov: Rufus Xavier Sarsapa...'  # noqa: E501
         )
 
     def test_email_body(self):
         data = self.minimum_data
-        self.minimum_data.update({'uploaded_files': []})
         form = DisclosureConsentForm(
             data=data,
             files=self.minimum_files
         )
-        self.assertIn(
-            'person@example.com',
-            form.email_body(self.minimum_data),
-        )
+        form.is_valid()  # so form.cleaned_data will be populated
+        body = form.email_body()
         self.assertIn(
             '<h1>Consent for disclosure of records protected under the Privacy Act</h1>',  # noqa: E501
-            form.email_body(self.minimum_data),
+            body,
         )
+        self.assertIn('person@example.com', body)
+        self.assertIn('Please send my records by <b>email</b>.', body)

--- a/cfgov/privacy/tests/test_views.py
+++ b/cfgov/privacy/tests/test_views.py
@@ -1,0 +1,87 @@
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+
+@override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
+class TestRecordsAccessForm(TestCase):
+    def test_invalid_form_post_does_not_send_email(self):
+        self.client.post(
+            reverse('privacy:records_access'),
+            {
+                'description': '',
+                'system_of_record': '',
+                'requestor_name': '',
+                'requestor_email': '',
+                'contact_channel': 'mail',
+            },
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_valid_form_post_sends_email_and_redirects(self):
+        response = self.client.post(
+            reverse('privacy:records_access'),
+            {
+                'description': 'This is a description of the desired records',
+                'requestor_name': 'Example Person',
+                'requestor_email': 'person@example.com',
+                'contact_channel': 'email',
+                'full_name': 'Example Q. Person',
+                'consent': True,
+                'supporting_documentation': []
+            },
+        )
+
+        email = mail.outbox[0]
+        self.assertEqual(
+            email.subject,
+            'Records request from consumerfinance.gov: Example Person',
+        )
+        self.assertIn('Example Q. Person', email.body)
+        self.assertEqual(email.to, ['FOIA@consumerfinance.gov'])
+        self.assertEqual(email.reply_to, ['person@example.com'])
+        self.assertRedirects(response, reverse('privacy:form_submitted'))
+
+
+@override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
+class TestDisclosureConsentForm(TestCase):
+    def test_invalid_form_post_does_not_send_email(self):
+        self.client.post(
+            reverse('privacy:disclosure_consent'),
+            {
+                'description': '',
+                'system_of_record': '',
+                'requestor_name': '',
+                'requestor_email': '',
+                'recipient_name': 'Recipient Person',
+                'recipient_email': 'recipient@example.com',
+                'contact_channel': 'mail',
+            },
+        )
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_valid_form_post_sends_email_and_redirects(self):
+        response = self.client.post(
+            reverse('privacy:disclosure_consent'),
+            {
+                'description': 'This is a description of the desired records',
+                'requestor_name': 'Example Person',
+                'requestor_email': 'person@example.com',
+                'recipient_name': 'Recipient Person',
+                'recipient_email': 'recipient@example.com',
+                'contact_channel': 'email',
+                'full_name': 'Example Q. Person',
+                'consent': True,
+                'supporting_documentation': []
+            },
+        )
+
+        email = mail.outbox[0]
+        self.assertEqual(
+            email.subject,
+            'Disclosure request from consumerfinance.gov: Example Person',
+        )
+        self.assertIn('Recipient Person', email.body)
+        self.assertEqual(email.to, ['FOIA@consumerfinance.gov'])
+        self.assertEqual(email.reply_to, ['person@example.com'])
+        self.assertRedirects(response, reverse('privacy:form_submitted'))

--- a/cfgov/privacy/tests/test_views.py
+++ b/cfgov/privacy/tests/test_views.py
@@ -5,6 +5,13 @@ from django.urls import reverse
 
 @override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
 class TestRecordsAccessForm(TestCase):
+    def test_get_the_form(self):
+        response = self.client.get(reverse('privacy:records_access'))
+        self.assertContains(
+            response,
+            'Request for individual access to records protected under the Privacy Act'  # noqa: E501
+        )
+
     def test_invalid_form_post_does_not_send_email(self):
         self.client.post(
             reverse('privacy:records_access'),
@@ -45,6 +52,13 @@ class TestRecordsAccessForm(TestCase):
 
 @override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
 class TestDisclosureConsentForm(TestCase):
+    def test_get_the_form(self):
+        response = self.client.get(reverse('privacy:disclosure_consent'))
+        self.assertContains(
+            response,
+            'Consent for disclosure of records protected under the Privacy Act'
+        )
+
     def test_invalid_form_post_does_not_send_email(self):
         self.client.post(
             reverse('privacy:disclosure_consent'),

--- a/cfgov/privacy/tests/test_views.py
+++ b/cfgov/privacy/tests/test_views.py
@@ -3,7 +3,10 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 
-@override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
+@override_settings(
+    FLAGS={'PRIVACY_FORMS': [('boolean', True)]},
+    PRIVACY_EMAIL_TARGET='email@foia.gov',
+)
 class TestRecordsAccessForm(TestCase):
     def test_get_the_form(self):
         response = self.client.get(reverse('privacy:records_access'))
@@ -45,12 +48,15 @@ class TestRecordsAccessForm(TestCase):
             'Records request from consumerfinance.gov: Example Person',
         )
         self.assertIn('Example Q. Person', email.body)
-        self.assertEqual(email.to, ['FOIA@consumerfinance.gov'])
+        self.assertEqual(email.to, ['email@foia.gov'])
         self.assertEqual(email.reply_to, ['person@example.com'])
         self.assertRedirects(response, reverse('privacy:form_submitted'))
 
 
-@override_settings(FLAGS={'PRIVACY_FORMS': [('boolean', True)]})
+@override_settings(
+    FLAGS={'PRIVACY_FORMS': [('boolean', True)]},
+    PRIVACY_EMAIL_TARGET='email@foia.gov',
+)
 class TestDisclosureConsentForm(TestCase):
     def test_get_the_form(self):
         response = self.client.get(reverse('privacy:disclosure_consent'))
@@ -96,6 +102,6 @@ class TestDisclosureConsentForm(TestCase):
             'Disclosure request from consumerfinance.gov: Example Person',
         )
         self.assertIn('Recipient Person', email.body)
-        self.assertEqual(email.to, ['FOIA@consumerfinance.gov'])
+        self.assertEqual(email.to, ['email@foia.gov'])
         self.assertEqual(email.reply_to, ['person@example.com'])
         self.assertRedirects(response, reverse('privacy:form_submitted'))


### PR DESCRIPTION
Add tests for Django views and for additional form behavior. Improve some forms code to reduce passing unnecessary variables.

## Additions

- Tests


## Changes

- Refactor `forms.py`


## How to test this PR

1. Make sure no functionality changed from #6759 


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance