### PR TITLE
Delete deprecated Elasticsearch 2 synonyms setting

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -108,8 +108,6 @@ CSP_IMG_SRC += (
     "placekitten.com",
 )
 
-ELASTICSEARCH_SYNONYMS_HOME = './search/resources'
-
 # Add django-cprofile-middleware to enable lightweight local profiling.
 # The middleware's profiling is only available if DEBUG=True
 MIDDLEWARE += ("django_cprofile_middleware.middleware.ProfilerMiddleware",)


### PR DESCRIPTION
The Django setting `ELASTICSEARCH_SYNONYMS_HOME` is no longer needed, now that we have transitioned from Elasticsearch 2.

The setting was introduced in #6098 and then removed in #6122, but this one mention was left behind.

[It's not used anywhere in our code.](https://github.com/search?q=ELASTICSEARCH_SYNONYMS_HOME+user%3Acfpb&type=code)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)