### PR TITLE
PFC: update student loan link in repay tool

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3213,7 +3213,7 @@
                                             financial aid.</p>
                                     </div>
                                     <div>
-                                        <a href="https://www.consumerfinance.gov/paying-for-college/choose-a-loan-path/"
+                                        <a href="https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
                                         target="_blank" rel="noopener noreferrer">Student
                                         loan guide</a>
                                         <p>Choose a student loan that’s right

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
@@ -1049,7 +1049,7 @@
                     </div>
                     <div>
                         <a
-                        href="https://www.consumerfinance.gov/paying-for-college/choose-a-loan-path/"
+                        href="https://www.consumerfinance.gov/paying-for-college/choose-a-student-loan/"
                         target="_blank" rel="noopener noreferrer">Student loan guide</a>
                         <p>
                             Choose a student loan that’s right for you.

--- a/cfgov/paying_for_college/jinja2/paying-for-college/repay_student_debt.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/repay_student_debt.html
@@ -60,7 +60,7 @@
                         <li><a href="/paying-for-college/">Get started</a></li>
                         <li><span tabindex="0" class="fake-link">Student financial guides</span>
                             <ul>
-                                <li><a href="/paying-for-college/choose-a-loan-path/">Student loans</a></li>
+                                <li><a href="/paying-for-college/choose-a-student-loan/">Student loans</a></li>
                                 <li><a href="/paying-for-college/manage-your-college-money/">Student banking</a></li>
                             </ul>
                         </li>


### PR DESCRIPTION
The link to the student loan page in the repay tool nav is currently 404ing. This PR updates it to the new Wagtail page.


## Changes

- Update student loan page links


## How to test this PR

1. Check out branch
2. Navigate to [repay tool](http://localhost:8000/paying-for-college/repay-student-debt/) and verify that the "Student loans" link under "Student financial guides" in the nav goes to the new Wagtail page



## Screenshots

<img width="1472" alt="Screen Shot 2021-11-30 at 12 10 33 PM" src="https://user-images.githubusercontent.com/778171/144120553-c3a6dea2-bc19-44ff-a432-bd1edf2bff38.png">


## Checklist


- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

