### PR TITLE
[simple-chart] Remove leading quotes from comment strings when excel sneaks them in

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -61,7 +61,9 @@ function fetchData( url, isCSV ) {
 
     return prom.then( d => {
       if ( isCSV ) {
-        d = d.replace( /(^"|\n")(#|\/\/)/g, '$2' );
+        /* Excel can put quotes at the start of our # or // comments
+           This strips those quotes */
+        d = d.replace( /^"(#|\/\/)|(\n)"(#|\/\/)/g, '$1$2$3' );
         d = Papa.parse( d, {
           header: true, comments: true, skipEmptyLines: true
         } ).data;

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -61,7 +61,7 @@ function fetchData( url, isCSV ) {
 
     return prom.then( d => {
       if ( isCSV ) {
-        d = d.replace( /\n"(#|\/\/)/g, '$1' );
+        d = d.replace( /(^"|\n")(#|\/\/)/g, '$2' );
         d = Papa.parse( d, {
           header: true, comments: true, skipEmptyLines: true
         } ).data;

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -61,6 +61,7 @@ function fetchData( url, isCSV ) {
 
     return prom.then( d => {
       if ( isCSV ) {
+        d = d.replace( /"##/g, '##' );
         d = Papa.parse( d, {
           header: true, comments: true, skipEmptyLines: true
         } ).data;
@@ -353,7 +354,6 @@ function makeChartOptions( data, target ) {
   if ( xAxisSource && chartType !== 'datetime' ) {
     defaultObj.xAxis.categories = resolveKey( data.raw, xAxisSource );
   }
-
   const formattedSeries = formatSeries( data );
   if ( chartType === 'tilemap' && formattedSeries.length === 1 ) {
     defaultObj = {

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -61,7 +61,7 @@ function fetchData( url, isCSV ) {
 
     return prom.then( d => {
       if ( isCSV ) {
-        d = d.replace( /"##/g, '##' );
+        d = d.replace( /\n"(#|\/\/)/g, '$1' );
         d = Papa.parse( d, {
           header: true, comments: true, skipEmptyLines: true
         } ).data;
@@ -354,6 +354,7 @@ function makeChartOptions( data, target ) {
   if ( xAxisSource && chartType !== 'datetime' ) {
     defaultObj.xAxis.categories = resolveKey( data.raw, xAxisSource );
   }
+
   const formattedSeries = formatSeries( data );
   if ( chartType === 'tilemap' && formattedSeries.length === 1 ) {
     defaultObj = {


### PR DESCRIPTION
Excel will sneak in quotes when saving as csv (appropriate) but this can break our comment-detection logic if it makes a line start with a quote.