### PR TITLE
Apply "Edge-Cache-Tag" to NewsroomLandingPage headers

### DIFF
--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -8,7 +8,8 @@ from v1.models.base import (
 )
 from v1.models.blog_page import BlogPage, LegacyBlogPage
 from v1.models.browse_filterable_page import (
-    BrowseFilterablePage, EventArchivePage, NewsroomLandingPage
+    NEWSROOM_CACHE_TAG, BrowseFilterablePage, EventArchivePage,
+    NewsroomLandingPage
 )
 from v1.models.browse_page import BrowsePage
 from v1.models.caching import CDNHistory

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -22,6 +22,9 @@ from v1.models.filterable_list_mixins import (
 from v1.models.learn_page import EventPage
 
 
+NEWSROOM_CACHE_TAG = "newsroom"
+
+
 class BrowseFilterableContent(StreamBlock):
     """Defines the StreamField blocks for BrowseFilterablePage content.
 
@@ -122,3 +125,8 @@ class NewsroomLandingPage(CategoryFilterableMixin, BrowseFilterablePage):
     filterable_categories = ['Newsroom']
 
     objects = PageManager()
+
+    def serve(self, request, *args, **kwargs):
+        response = super().serve(request, *args, **kwargs)
+        response['Edge-Cache-Tag'] = NEWSROOM_CACHE_TAG
+        return response

--- a/cfgov/v1/models/caching.py
+++ b/cfgov/v1/models/caching.py
@@ -95,6 +95,30 @@ class AkamaiBackend(BaseBackend):
         )
         resp.raise_for_status()
 
+    def post_tags(self, tags):
+        """Request a deletion purge by cache_tags."""
+        _url = os.getenv('AKAMAI_FAST_PURGE_URL')
+        if not _url:
+            logger.info(
+                "Can't purge cache. No value set for 'AKAMAI_FAST_PURGE_URL'"
+            )
+            return
+        url = _url.replace("url", "tag")
+        resp = requests.post(
+            url,
+            headers=self.headers,
+            data=json.dumps({"action": "invalidate", "objects": tags}),
+            auth=self.auth
+        )
+        logger.info(
+            f"Attempted to invalidate by cache_tags {', '.join(tags)}, "
+            f"and got back the response {resp.text}"
+        )
+        resp.raise_for_status()
+
+    def purge_cache_tags(self, tags):
+        self.post_tags(tags)
+
     def purge(self, url):
         self.post(url, 'invalidate')
 

--- a/cfgov/v1/tests/atomic_elements/organisms/test_email_signup.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_email_signup.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.test import TestCase
 
 from scripts import _atomic_helpers as atomic
@@ -26,5 +28,6 @@ class TestEmailSignup(TestCase):
     def test_learn_page_content(self):
         self.check_page_content(LearnPage, 'content')
 
-    def test_newsroom_page_content(self):
+    @mock.patch("v1.models.caching.AkamaiBackend.post_tags")
+    def test_newsroom_page_content(self, mock_post_tags):
         self.check_page_content(NewsroomPage, 'content')

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -6,9 +6,9 @@ from wagtail.core.models import Page, Site
 
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
 from v1.forms import EventArchiveFilterForm
-from v1.models import CFGOVPageCategory
+from v1.models import CFGOVPageCategory, LandingPage
 from v1.models.browse_filterable_page import (
-    EventArchivePage, NewsroomLandingPage
+    NEWSROOM_CACHE_TAG, EventArchivePage, NewsroomLandingPage
 )
 from v1.models.learn_page import AbstractFilterPage
 from v1.util.ref import get_category_children
@@ -25,8 +25,10 @@ class EventArchivePageTestCase(TestCase):
 class TestNewsroomLandingPage(ElasticsearchTestsMixin, TestCase):
     def setUp(self):
         self.newsroom_page = NewsroomLandingPage(title="News", slug='newsroom')
+        self.about_us_page = LandingPage(title="About us", slug="about-us")
         self.site_root = Site.objects.get(is_default_site=True).root_page
-        self.site_root.add_child(instance=self.newsroom_page)
+        self.site_root.add_child(instance=self.about_us_page)
+        self.about_us_page.add_child(instance=self.newsroom_page)
         self.rebuild_elasticsearch_index('v1', stdout=StringIO())
 
     def test_eligible_categories(self):
@@ -79,3 +81,8 @@ class TestNewsroomLandingPage(ElasticsearchTestsMixin, TestCase):
         filterable_search = self.newsroom_page.get_filterable_search()
         result = filterable_search.search()
         self.assertFalse(result.exists())
+
+    def test_cache_tag_applied(self):
+        self.newsroom_page.save_revision().publish()
+        response = self.client.get(self.newsroom_page.url)
+        self.assertEqual(response.get("Edge-Cache-Tag"), NEWSROOM_CACHE_TAG)


### PR DESCRIPTION
The goal is to invalidate Akamai cache on all flavors of the newsroom landing page 
– including all variations of query-string faceting that have been cached – 
when a child page has been published.

The standard cache strategy of purging by URL doesn't work in this case,
because there are limitless query string combinations for categories,
topics, languages, date ranges and keywords.

Applying an Edge-Cache-Tag to all renderings of the NewsroomLandingPage
allows Akamai to invalidate all the variations it has cached at once.

Cache_tag invalidation is triggered when a NewsroomPage or a LegacyNewsroomPage
gets published.

### Testing

We plan to test the triggered cache invalidation on beta.consumerfinance.gov.
In the meantime, you can see that the Edge-Cache-Tag is getting applied to all
variations of /about-us/newsroom/:
- Open your browser dev tools to the Network panel
- Visit <localhost:8000/about-us/newsroom/> and check the response header
for the presence of "Edge-Cache-Tag: newsroom." You may need to hard-refresh
your browser.
- Apply a number of facets and/or search keywords and then see that the result
page also has the tag applied.

This change addresses platform issue `#4136`
