### PR TITLE
Don't allow formtools bug to cause internal errors

### DIFF
--- a/cfgov/teachers_digital_platform/surveys.py
+++ b/cfgov/teachers_digital_platform/surveys.py
@@ -132,6 +132,14 @@ class ChoiceQuestion(Question):
 
     def get_score(self, answer) -> float:
         """Get a single score based on the answer index"""
+
+        # formtools.NamedUrlCookieWizardView appears to have a bug where
+        # valid answer data ("0"..."4") sometimes shows up in
+        # all_cleaned_data as empty string. We can't really handle this
+        # other than to grade with some valid response, below "0".
+        if type(answer) is not str or not answer.isdecimal():
+            answer = '0'
+
         answer = int(answer)
         assert answer >= 0
         assert answer < len(self.choice_list.labels)

--- a/cfgov/teachers_digital_platform/tests/test_surveys.py
+++ b/cfgov/teachers_digital_platform/tests/test_surveys.py
@@ -52,6 +52,13 @@ class SurveyTest(TestCase):
         q1 = page1.questions[0]
         self.assertEqual(q1.get_score('0'), q1.answer_values[0])
 
+    def test_formtools_bugs(self):
+        survey = get_survey('3-5')
+        page1 = survey.pages[0]
+        q1 = page1.questions[0]
+        self.assertEqual(q1.get_score(None), q1.answer_values[0])
+        self.assertEqual(q1.get_score(''), q1.answer_values[0])
+
     def test_field_generation(self):
         survey = get_survey('3-5')
         q1 = survey.pages[0].questions[0]


### PR DESCRIPTION
Handles unexpect missing survey answers by grading them as the first choice.

I examined the cookie `wizard_survey_wizard` contents that resulted in one answer being read as empty string, and--in the cookie--all expected question values were present as a digit string 0 to 4. So I can only conclude that in some cases formtool's FormWizard class or their cookie storage adapter has a bug. I've never experienced this bug testing locally.

## Changes

Handling of non-numeric string answers before the integer cast.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
