### PR TITLE
Privacy forms: minor content edits

### DIFF
--- a/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
+++ b/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
@@ -12,11 +12,11 @@
 {%- endblock %}
 
 {% block desc -%}
-    This form may be used to provide consent and authorize the Bureau to disclose your records to another person or entity. Please provide the information requested below and submit.
+    This form may be used to provide consent and authorize the CFPB to disclose your records to another person or entity. Please provide the information requested below and submit.
 {%- endblock %}
 
 {% block og_desc -%}
-    This form may be used to provide consent and authorize the Bureau to disclose your records to another person or entity. Please provide the information requested below and submit.
+    This form may be used to provide consent and authorize the CFPB to disclose your records to another person or entity. Please provide the information requested below and submit.
 {%- endblock %}
 
 {% block content_main -%}
@@ -43,17 +43,17 @@
     <div class="block block__flush-top">
         <h1>Consent for disclosure of records protected under the Privacy Act</h1>
         <div class="lead-paragraph">
-            <p>This form may be used to provide consent and authorize the Bureau to disclose your records to another person or entity. Please provide the information requested below and submit.</p>
+            <p>This form may be used to provide consent and authorize the CFPB to disclose your records to another person or entity. Please provide the information requested below and submit.</p>
         </div>
         <h2 class="h4">This form may be used if you are:</h2>
         <ul class="m-list">
-            <li class="m-list_item">Providing consent and authorizing the agency to disclose your records to another person or entity</li>
+            <li class="m-list_item">Providing consent and authorizing the CFPB to disclose your records to another person or entity</li>
             <li class="m-list_item">A parent consenting to and authorizing the disclosure of the records of a minor</li>
             <li class="m-list_item">A legal guardian consenting to and authorizing disclosure of the records of an incompetent</li>
         </ul>
         <p>If you have any questions, please contact the CFPB’s FOIA Office at <a href="mailto:FOIA@cfpb.gov">FOIA@cfpb.gov</a> or at (855) 444-3642.</p>
         <h2>Information used for identity-proofing and authentication</h2>
-        <p>Please provide the following information to assist the Bureau in verifying your identity:</p>
+        <p>Please provide the following information to assist the CFPB in verifying your identity:</p>
         <h2 class="h4">Required</h2>
         <ul class="m-list">
             <li class="m-list_item">Full name</li>
@@ -68,7 +68,7 @@
         <p>If you are the parent consenting to and authorizing disclosure of the records of a minor or the legal guardian consenting to and authorizing disclosure of the records of an incompetent, you will be required to provide adequate proof of your legal relationship before action will be taken on any request. If you have any questions, please contact the CFPB’s FOIA Office at <a href="mailto:FOIA@cfpb.gov">FOIA@cfpb.gov</a> or at (855) 444-3642.</p>
         <p>The term guardian means the legal guardian of any individual who has been declared to be incompetent due to physical or mental incapacity or age by a court of competent jurisdiction.</p>
         <h2>Information required to locate the records</h2>
-        <p>This information is required for the agency to be able to match the individual's information provided in this request with the record that pertains to that individual.</p>
+        <p>This information is required for the CFPB to be able to match the individual's information provided in this request with the record that pertains to that individual.</p>
         <p><a class="a-btn a-btn__link" href="/privacy/system-records-notices/">See list of CFPB System of Records Notices (SORNs)</a></p>
     </div>
     <div class="block" style="margin-top:-2em;margin-bottom:.9375em">

--- a/cfgov/privacy/jinja2/privacy/records-access-form.html
+++ b/cfgov/privacy/jinja2/privacy/records-access-form.html
@@ -53,7 +53,7 @@
         </ul>
         <p>If you have any questions, please contact the CFPB’s FOIA Office at <a href="mailto:FOIA@cfpb.gov">FOIA@cfpb.gov</a> or at (855) 444-3642.</p>
         <h2>Information used for identity-proofing and authentication</h2>
-        <p>Please provide the following information to assist the Bureau in verifying your identity:</p>
+        <p>Please provide the following information to assist the CFPB in verifying your identity:</p>
         <h2 class="h4">Required</h2>
         <ul class="m-list">
             <li class="m-list_item">Full name</li>
@@ -68,7 +68,7 @@
         <p>If you are a parent seeking access to the records of a minor or a legal guardian seeking access to the records of an incompetent, you will be required to provide adequate proof of your legal relationship before action will be taken on any request. If you have any questions, please contact the CFPB’s FOIA Office at <a href="mailto:FOIA@cfpb.gov">FOIA@cfpb.gov</a> or at (855) 444-3642.</p>
         <p>The term guardian means the legal guardian of any individual who has been declared to be incompetent due to physical or mental incapacity or age by a court of competent jurisdiction.</p>
         <h2>Additional information required to locate the records</h2>
-        <p>This information is required for the agency to be able to match the individual's information provided in this request with the records that pertain to that individual.</p>
+        <p>This information is required for the CFPB to be able to match the individual's information provided in this request with the records that pertain to that individual.</p>
         <p><a class="a-btn a-btn__link" href="/privacy/system-records-notices/">See list of CFPB System of Records Notices (SORNs)</a></p>
     </div>
     <div class="block" style="margin-top:-2em;margin-bottom:.9375em">


### PR DESCRIPTION
Minor content edits in the Privacy forms: change "agency" and "Bureau" to "CFPB".


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance