### PR TITLE
Introduce distinct search for beta.consumerfinance.gov

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -659,6 +659,8 @@ FLAGS = {
     "ASK_SURVEY_INTERCEPT": [],
     # Hide archive filter options in the filterable UI
     "HIDE_ARCHIVE_FILTER_OPTIONS": [],
+    # Whether robots.txt should block all robots, except for Search.gov.
+    "ROBOTS_TXT_SEARCH_GOV_ONLY": [("environment is", "beta")],
 }
 
 # Watchman tokens, a comma-separated string of tokens used to authenticate

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -6,6 +6,7 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.http import Http404, HttpResponse
 from django.shortcuts import render
+from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView, TemplateView
 
 from wagtail.admin import urls as wagtailadmin_urls
@@ -13,6 +14,7 @@ from wagtail.contrib.sitemaps.views import sitemap
 from wagtailsharing import urls as wagtailsharing_urls
 from wagtailsharing.views import ServeView
 
+from flags.urls import flagged_re_path
 from flags.views import FlaggedTemplateView
 from wagtailautocomplete.urls.admin import (
     urlpatterns as autocomplete_admin_urls
@@ -36,16 +38,6 @@ from v1.views import (
     password_reset_confirm
 )
 from v1.views.documents import DocumentServeView
-
-
-try:
-    from django.urls import include, re_path
-
-    from flags.urls import flagged_re_path
-except ImportError:
-    from django.conf.urls import include, url as re_path
-
-    from flags.urls import flagged_url as flagged_re_path
 
 
 def flagged_wagtail_template_view(flag_name, template_name):
@@ -433,7 +425,11 @@ urlpatterns = [
             'privacy'),
             namespace='privacy')),
 
-    re_path(r'^sitemap\.xml$', akamai_no_store(sitemap)),
+    path('robots.txt', TemplateView.as_view(
+        template_name='robots.txt',
+        content_type='text/plain',
+    )),
+    re_path(r'^sitemap\.xml$', akamai_no_store(sitemap), name='sitemap'),
 
     re_path(
         r'^consumer-tools/educator-tools/youth-financial-education/',

--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -14,10 +14,18 @@
 
 {% macro render( language='en' ) %}
 
+{%- set search_url_base = "https://search.consumerfinance.gov/search" -%}
+{%- set search_url = (
+    search_url_base
+    ~ "?utf8=✓"
+    ~ "&affiliate=" ~ search_gov_affiliate()
+    ~ "&query="
+) -%}
+
 <div class="m-global-search"
      data-js-hook="behavior_flyout-menu">
     <div class="m-global-search_fallback">
-        <a href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=">
+        <a href="{{ search_url }}">
             {{ _('Search') }}
         </a>
     </div>
@@ -39,7 +47,7 @@
          aria-expanded="false"
          role="search">
         <form class="m-global-search_content-form"
-              action="https://search.consumerfinance.gov/search"
+              action="{{ search_url_base }}"
               method="get">
             {#
                 The following two inputs are required by the search portal.
@@ -51,7 +59,7 @@
             <input type="hidden"
                    id="affiliate"
                    name="affiliate"
-                   value="{{ 'cfpb_es' if language == 'es' else 'cfpb' }}">
+                   value="{{ search_gov_affiliate() }}">
 
             <div class="o-form__input-w-btn">
                <div class="o-form__input-w-btn_input-container">
@@ -88,22 +96,22 @@
                 <p class="h5">{{ _('Suggested search terms:') }}</p>
                 <ul class="m-list m-list__horizontal">
                     <li class="m-list_item">
-                        <a class="m-list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=regulations">
+                        <a class="m-list_link" href="{{ search_url }}regulations">
                             {{ _('Regulations') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=compliance+guides">
+                        <a class="m-list_link" href="{{ search_url }}compliance+guides">
                             {{ _('Compliance guides') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=mortgage">
+                        <a class="m-list_link" href="{{ search_url }}mortgage">
                             {{ _('Mortgage') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="https://search.consumerfinance.gov/search?utf8=%E2%9C%93&affiliate=cfpb&query=college+loans">
+                        <a class="m-list_link" href="{{ search_url }}college+loans">
                             {{ _('College loans') }}
                         </a>
                     </li>

--- a/cfgov/jinja2/v1/_includes/organisms/header.html
+++ b/cfgov/jinja2/v1/_includes/organisms/header.html
@@ -8,9 +8,6 @@
 
    Creates markup for Header organism.
 
-   show_banner:     Whether the global banner molecule is included.
-                    Default is false.
-
    show_mega_menu:  Whether the mega menu is included. Default is true.
 
    language:        The page's language value (used to display different
@@ -19,13 +16,13 @@
 
    ========================================================================== #}
 
-{% macro render( show_banner=false, show_mega_menu=true, language='en' ) %}
+{% macro render( show_mega_menu=true, language='en' ) %}
 
 {% set mega_menu_content = show_mega_menu and get_mega_menu_content() %}
 
 <header class="o-header{% if mega_menu_content %} o-header__mega-menu{% endif %}">
 
-    {% if flag_enabled('BETA_NOTICE') and show_banner %}
+    {% if flag_enabled('BETA_NOTICE') %}
     {% import 'molecules/notification.html' as notification with context %}
     <div class="m-global-banner">
       <div class="wrapper

--- a/cfgov/jinja2/v1/_includes/snippets/search_gov.html
+++ b/cfgov/jinja2/v1/_includes/snippets/search_gov.html
@@ -5,7 +5,7 @@
 #}
 <script>
 //<![CDATA[
-  var usasearch_config = { siteHandle: "{{ 'cfpb_es' if language == 'es' else 'cfpb' }}" };
+  var usasearch_config = { siteHandle: "{{ search_gov_affiliate() }}" };
 
   var script = document.createElement("script");
   script.type = "text/javascript";

--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -231,7 +231,6 @@
     {% block header %}
         {% import 'organisms/header.html' as o_header with context %}
         {{ o_header.render(
-            show_banner=true,
             show_mega_menu=true,
             language=language
         ) }}

--- a/cfgov/jinja2/v1/robots.txt
+++ b/cfgov/jinja2/v1/robots.txt
@@ -1,4 +1,14 @@
 User-agent: *
+{#-
+    If this flag is set, we block all robots from the entire site except for
+    the Search.gov robot, which has user-agent "usasearch", as documented at
+    https://search.gov/manual/go-live.html.
+#}
+{% if flag_enabled( 'ROBOTS_TXT_SEARCH_GOV_ONLY' ) -%}
+Disallow: /
+
+User-agent: usasearch
+{% endif -%}
 Disallow: /save-hud-counselors-list
 Disallow: /about-us/the-bureau/leadership-calendar/pdf
 Disallow: /es/obtener-respuestas/*.imprimir.html
@@ -15,4 +25,4 @@ Disallow: /es/obtener-respuestas/buscar/
 Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
 Disallow: /consumer-tools/educator-tools/youth-financial-education/curriculum-review/tool/*
 
-sitemap: https://www.consumerfinance.gov/sitemap.xml
+sitemap: {{ request.build_absolute_uri( url( 'sitemap' ) ) }}

--- a/cfgov/v1/jinja2/v1/header.html
+++ b/cfgov/v1/jinja2/v1/header.html
@@ -19,7 +19,6 @@
 
 {% import 'organisms/header.html' as header with context %}
 {{ header.render(
-    show_banner=show_banner | default( true ),
     show_mega_menu=show_mega_menu | default( true ),
     language=language | default( 'en' )
 ) }}

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -3,7 +3,9 @@ from datetime import date
 
 from django.http import HttpRequest
 from django.template import engines
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import (
+    RequestFactory, SimpleTestCase, TestCase, override_settings
+)
 
 from model_bakery import baker
 
@@ -152,3 +154,24 @@ class TestUniqueIdInContext(TestCase):
                 self.render(self.template, {'request': HttpRequest()}),
                 '1'
             )
+
+
+class SearchGovAffiliateTests(SimpleTestCase):
+    def render(self, context):
+        engine = engines['wagtail-env']
+        template = engine.from_string('{{ search_gov_affiliate() }}')
+        return template.render(context=context)
+
+    def test_default_cfpb(self):
+        self.assertEqual(self.render({}), 'cfpb')
+
+    def test_spanish(self):
+        self.assertEqual(self.render({'language': 'es'}), 'cfpb_es')
+
+    @override_settings(DEPLOY_ENVIRONMENT='beta')
+    def test_beta(self):
+        self.assertEqual(self.render({}), 'cfpb_beta')
+
+    @override_settings(DEPLOY_ENVIRONMENT='beta')
+    def test_beta_spanish(self):
+        self.assertEqual(self.render({'language': 'es'}), 'cfpb_beta_es')

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -48,10 +48,10 @@ Most of consumerfinance.gov's templates are Jinja2. In these templates, two temp
 
 See [Enabling a flag](#enabling-a-flag) below for more on flag conditions.
 
-An example is [the `BETA_NOTICE flag` as implemented in `header.html`](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/organisms/header.html#L21-L56):
+An example is [the `BETA_NOTICE flag` as implemented in `header.html`](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/organisms/header.html#L28-L41):
 
 ```jinja
-{% if flag_enabled('BETA_NOTICE') and show_banner %}
+{% if flag_enabled('BETA_NOTICE') %}
 <div class="m-global-banner">
     <div class="wrapper
                 wrapper__match-content
@@ -85,7 +85,7 @@ The `BETA_NOTICE` [Jinja2](#jinja2) example above when implemented with Django t
 {% load feature_flags %}
 
 {% flag_enabled 'BETA_NOTICE' as beta_flag %}
-{% if beta_flag and show_banner %}
+{% if beta_flag %}
 <div class="m-global-banner">
     <div class="wrapper
                 wrapper__match-content


### PR DESCRIPTION
This PR modifies the behavior of the website when deployed to beta.consumerfinance.gov, so that global site searches use beta-specific search indexes. Recall that our global site search currently uses Search.gov and has two indexes: `cfpb` for regular English-language pages and `cfpb_es` for Spanish-language pages.

This change modifies how the website works on beta such that it uses `cfpb_beta` and `cfpb_beta_es`. This is reflected two ways: first, the header search now queries Search.gov with those affiliate codes; and second, the Search.gov [JavaScript snippet](https://search.gov/manual/code.html) now uses these codes as well. Under the hood this behavior relies on our existing `DEPLOY_ENVIRONMENT` Django setting.

In order to support search on beta, this PR also modifies how we serve our robots.txt file. Currently, robots.txt is a hardcoded text file which allows all robots and disallows certain paths. We currently override robots.txt on beta as part of our (internal) deploy code. With this PR, robots.txt is now served by Django instead, and uses a new `ROBOTS_TXT_SEARCH_GOV_ONLY` feature flag in order to serve different robots directives on beta. Specifically, on beta we will now attempt to block all robots except the Search.gov one, based on its [`usasearch`](https://search.gov/manual/go-live.html) user agent.

Finally, a minor bit of cleanup included here is removal of the `show_banner` parameter to our global header; this is never used and has been superseded by alternate banner code.

## How to test this PR

To test, you can run a local server and verify that searches on http://localhost:8000/ and http://localhost:8000/es/ work as expected (look at the `affiliate=cfpb` part of the search query string when you submit the form), and that the included JS snippet has the right code (look in source for `usasearch_config`).

Then, try running a local server but set the `DEPLOY_ENVIRONMENT` environment variable to `beta`, and confirm that the Search.gov codes update as expected.

## Notes and todos

- This change requires removing the code in our internal deployment repo that overwrites robots.txt on beta; I will open a separate PR for that purpose. Edit: a-c-f#394
- We could use some documentation of how we use Search.gov.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
