### PR TITLE
Don't serve robots.txt from Apache

### DIFF
--- a/cfgov/apache/conf.d/alias.conf
+++ b/cfgov/apache/conf.d/alias.conf
@@ -7,7 +7,6 @@ Alias /foia/quarterly ${STATIC_PATH}/foia/quarterly
 Alias /financial-intuition.xml ${STATIC_PATH}/financial-intuition.xml
 # Facebook site auth
 Alias /lln8595c61g9qnvuwvtlcwo1k6kem8.html ${STATIC_PATH}/lln8595c61g9qnvuwvtlcwo1k6kem8.html
-Alias /robots.txt ${STATIC_PATH}/robots.txt
 Alias /static/f/ ${STATIC_PATH}/nemo/_/f/
 # Preserves legacy URL compatibility, but this is not actually using Wordpress
 Alias /wp-content/themes/cfpb_nemo/_/  ${STATIC_PATH}/nemo/_/


### PR DESCRIPTION
#6788 tried to move robots.txt into Django, but neglected to remove the existing Apache rule for that alias. That was an oversight, which is corrected by this commit.

## How to test this PR

Run a local server and verify that http://localhost:8000/robots.txt still works as expected.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)