### PR TITLE
Add rel="nofollow" to Search.gov links

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -25,7 +25,7 @@
 <div class="m-global-search"
      data-js-hook="behavior_flyout-menu">
     <div class="m-global-search_fallback">
-        <a href="{{ search_url }}">
+        <a rel="nofollow" href="{{ search_url }}">
             {{ _('Search') }}
         </a>
     </div>
@@ -96,22 +96,26 @@
                 <p class="h5">{{ _('Suggested search terms:') }}</p>
                 <ul class="m-list m-list__horizontal">
                     <li class="m-list_item">
-                        <a class="m-list_link" href="{{ search_url }}regulations">
+                        <a class="m-list_link" rel="nofollow"
+                           href="{{ search_url }}regulations">
                             {{ _('Regulations') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="{{ search_url }}compliance+guides">
+                        <a class="m-list_link" rel="nofollow"
+                           href="{{ search_url }}compliance+guides">
                             {{ _('Compliance guides') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="{{ search_url }}mortgage">
+                        <a class="m-list_link" rel="nofollow"
+                           href="{{ search_url }}mortgage">
                             {{ _('Mortgage') }}
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="{{ search_url }}college+loans">
+                        <a class="m-list_link" rel="nofollow"
+                           href="{{ search_url }}college+loans">
                             {{ _('College loans') }}
                         </a>
                     </li>


### PR DESCRIPTION
This change adds rel="nofollow" to several hardcoded links to Search.gov search results. These links point to query results on search.consumerfinance.gov.

The Search.gov team has reached out to us to ask about these hardcoded links; specifically, they see what seems like automated traffic to these search.cf.gov queries, presumably from bots/crawlers.

Adding rel="nofollow" [should](https://developers.google.com/search/docs/advanced/guidelines/qualify-outbound-links) prevent (well-behaved) bots from crawling these links.

## How to test this PR

Our hardcoded suggestions only appear when you try to search at tablet width (~800px). We also have another empty hardcoded search link when you load the page without JavaScript.

## Notes and todos

FEWDs, any downside to making this change?

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)