### PR TITLE
Add documentation for Search.gov site search

### DIFF
--- a/docs/page-search.md
+++ b/docs/page-search.md
@@ -1,6 +1,6 @@
-# Search
+# Page Search
 
-For custom searches on consumerfinance.gov, we use Elasticsearch and the [django-elasticsearch-dsl](https://django-elasticsearch-dsl.readthedocs.io/en/latest/) library, which is a lightweight wrapper around [elasticsearch-dsl](https://elasticsearch-dsl.readthedocs.io/en/latest/).
+For page searches on consumerfinance.gov, we use Elasticsearch and the [django-elasticsearch-dsl](https://django-elasticsearch-dsl.readthedocs.io/en/latest/) library, which is a lightweight wrapper around [elasticsearch-dsl](https://elasticsearch-dsl.readthedocs.io/en/latest/).
 
 - [Indexing](#indexing)
     - [Elasticsearch index configuration](#elasticsearch-index-configuration)

--- a/docs/site-search.md
+++ b/docs/site-search.md
@@ -1,0 +1,35 @@
+# Site Search
+
+Global site search of consumerfinance.gov is implemented using
+[Search.gov](https://search.gov/).
+
+The search box in the site header is linked to this global site search.
+Searches using this method return results at the `search.consumerfinance.gov`
+subdomain. This subdomain is hosted by Search.gov.
+
+We maintain several independent search indexes on Search.gov for various purposes:
+
+- `cfpb`: English-language search for
+  [www.consumerfinance.gov](https://www.consumerfinance.gov).
+- `cfpb_es`: Spanish-language search for pages under
+  [www.consumerfinance.gov/es/](https://www.consumerfinance.gov/es/).
+- `cfpb_beta`: An alternate English-language search index for
+  [beta.consumerfinance.gov](https://beta.consumerfinance.gov).
+- `cfpb_beta_es`: An alternate Spanish-language search index for
+  [beta.consumerfinance.gov/es/](https://beta.consumerfinance.gov/es/).
+
+These search indexes are hardcoded depending on the page being viewed.
+
+Configuration of site search on Search.gov requires an approved login to its
+admin console. The [Search.gov Help Manual](https://search.gov/manual/index.html)
+documents the various configuration options used on our indexes, for example
+text-based "best bets" and our custom visual design.
+
+The website base page template includes
+[the necessary Search.gov code snippets](https://search.gov/manual/code.html)
+required for searching and indexing of site content. Search.gov also makes use of
+the website
+[robots.txt](https://www.consumerfinance.gov/robots.txt)
+and
+[sitemap.xml](https://www.consumerfinance.gov/sitemap.xml)
+files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,8 @@ nav:
     - Caching: caching.md
     - Feature Flags: feature-flags.md
     - Filterable Lists: filterable-lists.md
-    - Search: search.md
+    - Page Search: page-search.md
+    - Site Search: site-search.md
     - Translation: translation.md
 - Testing:
     - JavaScript Unit Testing: javascript-unit-tests.md


### PR DESCRIPTION
We don't currently have any documentation about our use of Search.gov for global site search. This commit adds some.

## Screenshots

New page available under http://localhost:8000/site-search/:

![image](https://user-images.githubusercontent.com/654645/146047040-aa67d7d6-d61e-40d5-bba6-83834d7716ba.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Project documentation has been updated, potentially one or more of: