### PR TITLE
Stop Akamai from caching the beta_external_testing endpoint

### DIFF
--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -153,4 +153,4 @@ class TestBetaRefreshEndpoint(TestCase):
     @override_settings(FLAGS={'BETA_EXTERNAL_TESTING': [('boolean', True)]})
     def test_beta_testing_endpoint_is_no_cache_when_enabled(self):
         response = self.client.get('/beta_external_testing/')
-        self.assertEqual(response["Cache-Control"], "no-store")
+        self.assertEqual(response["Akamai-Cache-Control"], "no-store")

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -149,3 +149,8 @@ class TestBetaRefreshEndpoint(TestCase):
     def test_beta_testing_endpoint_returns_200_when_enabled(self):
         response = self.client.get('/beta_external_testing/')
         self.assertEqual(response.status_code, 200)
+
+    @override_settings(FLAGS={'BETA_EXTERNAL_TESTING': [('boolean', True)]})
+    def test_beta_testing_endpoint_is_no_cache_when_enabled(self):
+        response = self.client.get('/beta_external_testing/')
+        self.assertEqual(response["Cache-Control"], "no-store")

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -69,9 +69,7 @@ def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
 
 
 def empty_200_response(request, *args, **kwargs):
-    response = HttpResponse(status=200)
-    response["Cache-Control"] = "no-store"
-    return response
+    return HttpResponse(status=200)
 
 
 urlpatterns = [
@@ -461,7 +459,8 @@ urlpatterns = [
     flagged_re_path(
         'BETA_EXTERNAL_TESTING',
         r'^beta_external_testing/',
-        empty_200_response),
+        akamai_no_store(empty_200_response)
+    ),
 ]
 
 # Ask CFPB category and subcategory redirects

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -69,7 +69,9 @@ def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
 
 
 def empty_200_response(request, *args, **kwargs):
-    return HttpResponse(status=200)
+    response = HttpResponse(status=200)
+    response["Cache-Control"] = "no-store"
+    return response
 
 
 urlpatterns = [


### PR DESCRIPTION
We use the flagged endpoint `/beta_external_testing/` to signal that
testing is in progress on the beta site. When the flag is taken down,
we want the endpoint to immediately return 404, but the 200 response is getting cached.

This adds an `Akamai-Cache-Control: no-store` header to the 200 response so that
it is never cached.

This satisfies internal GHE platform issue `#4286`

## Testng

- Locally enable the [BETA_EXTERNAL_TESTNIG](http://localhost:8000/admin/flags/BETA_EXTERNAL_TESTING/) flag.
- Open dev tools' network panel and hit <http://localhost:8000/beta_external_testing/>
- Confirm that the endpoint returns a 200 response with a response header of "Akamai-Cache-Control: no-store".
