### PR TITLE
Fix safari boldness and alignment bugs

### DIFF
--- a/cfgov/unprocessed/css/organisms/simple-chart.less
+++ b/cfgov/unprocessed/css/organisms/simple-chart.less
@@ -140,8 +140,8 @@
   .highcharts-range-selector-buttons{
     .highcharts-button:last-child {
       text{
-      font-weight: 500 !important;
-    }
+        font-weight: 500 !important;
+      }
     }
     text {
       color: @gray !important;
@@ -149,12 +149,13 @@
       transform:translate(0, 5px);
       font-size: @base-font-size-px;
       font-weight: 400;
+    }
+    & > text {
       &:first-child{
         transform:translate(48px,-28px);
         .respond-to-max( 600px, {
           transform:translate(128px,-28px)
         })
-
       }
     }
   }
@@ -235,6 +236,10 @@
     .respond-to-max( @bp-xs-max, {
       transform: translateX(0) !important;
     })
+  }
+
+  .highcharts-legend-item tspan {
+    font-weight: 400 !important;
   }
 
   .m-chart-footnote {

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -385,7 +385,7 @@ function makeChartOptions( data, target ) {
 
     defaultObj.tooltip.formatter = function() {
       const label = yAxisLabel ? yAxisLabel + ': ' : '';
-      return `<b>${ this.point.name }</b><br/>${ label }<b>${ Math.round( this.point.value * 10 ) / 10 }</b>`;
+      return `<span style="font-weight:600">${ this.point.name }</span><br/>${ label }<span style="font-weight:600">${ Math.round( this.point.value * 10 ) / 10 }</span>`;
     };
   } else {
     defaultObj.series = formattedSeries;

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/tilemap-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/tilemap-styles.js
@@ -15,7 +15,7 @@ const tilemap = {
       },
       dataLabels: {
         enabled: true,
-        formatter: function() { return `<span style="font-weight:900">${ this.point.state }</span><br/><span style="font-weight:100">${ Math.round( this.point.value ) }</span>`; },
+        formatter: function() { return `<span style="font-weight:500">${ this.point.state }</span><br/><span style="font-weight:300">${ Math.round( this.point.value ) }</span>`; },
         style: {
           textOutline: false,
           fontSize: 14


### PR DESCRIPTION
Currently the range selector layout on safari is quite buggy and legend/tilemap labels are overly bold.

This commit fixes both problems.

Testing:
pull and build, open in safari, should look fine. Compare against content (which looks busted).