### PR TITLE
Cypress: Add To filter date to bound date range in test

### DIFF
--- a/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
+++ b/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
@@ -266,6 +266,8 @@ describe( 'Filter Blog Posts based on content', () => {
     blog.filterItemName( 'loans' );
     // And I type "01/01/2020" in the From date entry field
     blog.filterFromDate( '2020-01-01' );
+    // And I type "01/01/2021" in the To date entry field to bound the date range
+    blog.filterToDate( '2021-01-01' );
     // And I click "Apply filters" button
     blog.applyFilters();
     // Then I should see only results dated "01/01/2020" or later with "loans" in the post title


### PR DESCRIPTION
Cypress tests are failing because it checks that the last entry on the first page of results is a 2020 dated post, but they are all 2021 at this point. This PR adds 1/1/2021 as the To date to bound the date range so the test will be consistent with added posts in the future.

## Changes

- Cypress: Add To filter date to bound date range in test


## How to test this PR

1. PR checks should pass.
2. `yarn run cypress run` should pass.
