### PR TITLE
Fix the test for a virtual environment in backend.sh

### DIFF
--- a/backend.sh
+++ b/backend.sh
@@ -11,7 +11,7 @@ set -e
 
 init() {
   # Ensure that we're in a virtualenv.
-  python -c 'import sys; sys.real_prefix' 2>/dev/null || (
+  python -c 'import sys; sys.prefix != sys.base_prefix' 2>/dev/null || (
     echo 'Please activate your virtualenv before running this script.' &&
     exit 1
   )


### PR DESCRIPTION
The existing test is [specific to](https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv) the virtualenv package that we no longer use.
This uses a generic venv test appropriate for Python 3.

### Testing
Activate a pyenv virtualenv and run `./backend.sh`
You should get an incorrect error message: "Please activate your virtualenv before running this script."

Try running `./backend.sh` on this branch, and you should see requirements install.
