### PR TITLE
manually specify psycopg-binary, now required in >= 2.8.x

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -27,7 +27,7 @@ lxml==4.6.5
 Markdown==3.2.1
 ntplib==0.3.4
 openpyxl==3.0.3
-psycopg2==2.8.6
+psycopg2-binary==2.8.6
 python-dateutil==2.7.3
 regdown==1.0.3
 requests==2.25.1


### PR DESCRIPTION
When updating from psycopg 2.7 to 2.8, the way the binary package is included [has changed](https://www.psycopg.org/docs/install.html#change-in-binary-packages-between-psycopg-2-7-and-2-8).

This restores our 2.7 behavior.