### PR TITLE
restore former wsgi config

### DIFF
--- a/cfgov/apache/conf.d/wsgi.conf
+++ b/cfgov/apache/conf.d/wsgi.conf
@@ -1,6 +1,6 @@
 ServerName https://www.consumerfinance.gov
 
-LoadModule wsgi_module modules/mod_wsgi.so
+LoadModule wsgi_module modules/mod_${SCL_PYTHON_VERSION}-wsgi.so
 
 WSGIApplicationGroup %{GLOBAL}
 WSGIDaemonProcess django home=${CFGOV_CURRENT} processes=${APACHE_PROCESS_COUNT} threads=15 display-name=%{GROUP} lang='en_US.UTF-8' locale='en_US.UTF-8'


### PR DESCRIPTION
We need to temporarily roll back the wsgi config for Python 3.9 while we iron out deployment.  
This will unblock dev server deployments in the interim.