### PR TITLE
Bugfix: Remove dotted asset path by adding fork in the road for app JS vs on-demand JS

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -319,7 +319,12 @@
           #}
           {% if page and page.media %}
             {% for js in page.media %}
-              s.push( '{{ static('js/routes/on-demand/' + js) }}' );
+              // Check whether this JS is coming from our apps or from an on-demand script.
+              if ( '{{ js }}'.substring(0,6) === '/apps/' ) {
+                s.push( '{{ static(js) }}' );
+              } else {
+                s.push( '{{ static('js/routes/on-demand/' + js) }}' );
+              }
             {% endfor %}
           {% endif %}
           {#

--- a/cfgov/v1/blocks.py
+++ b/cfgov/v1/blocks.py
@@ -231,7 +231,7 @@ class RAFToolBlock(blocks.StaticBlock):
         template = '_includes/blocks/raf_tool.html'
 
     class Media:
-        js = ['../../../apps/erap/js/main.js']
+        js = ['/apps/erap/js/main.js']
 
 
 class RAFTBlock(blocks.StructBlock):
@@ -248,4 +248,4 @@ class RAFTBlock(blocks.StructBlock):
         template = '_includes/blocks/raf_tool.html'
 
     class Media:
-        js = ['../../../apps/erap/js/main.js']
+        js = ['/apps/erap/js/main.js']


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/6793 added dotted app asset paths, which broken in production. This PR changes the logic of how the paths for the assets are resolved.

## Changes

- Bugfix: Remove dotted asset path by adding fork in the road for app JS vs on-demand JS


## How to test this PR

1. PR checks should pass.
2. `./frontend.sh` and http://localhost:8000/coronavirus/mortgage-and-housing-assistance/renter-protections/find-help-with-rent-and-utilities/ should load.
