### PR TITLE
Tagline: Add IE11 fix

### DIFF
--- a/cfgov/jinja2/v1/_includes/atoms/tagline.html
+++ b/cfgov/jinja2/v1/_includes/atoms/tagline.html
@@ -14,7 +14,7 @@
 {% macro render( is_large ) %}
 <div class="a-tagline{{ ' a-tagline__large' if is_large else '' }}">
 	<span class="u-usa-flag"></span>
-   <div>
+   <div class="a-tagline_text">
       {{ _('An official website of the') }}
       <span class="u-nowrap">{{ _('United States government') }}</span>
    </div>

--- a/test/unit_tests/mocks/megaMenuSnippet.js
+++ b/test/unit_tests/mocks/megaMenuSnippet.js
@@ -2019,7 +2019,11 @@ Taskforce on Federal Consumer Financial Law
         ">
 
 <div class="a-tagline">
-An official website of the United States government
+    <span class="u-usa-flag"></span>
+    <div class="a-tagline_text">
+        An official website of the
+        <span class="u-nowrap">United States government</span>
+    </div>
 </div>
 
 <div class="m-global-eyebrow_actions">


### PR DESCRIPTION
https://github.com/cfpb/design-system/pull/1314 added `Put tagline text in a container so we can inline-block it for IE11 legacy support.`, however, this change never made it outside of the DS example. 

## Changes

- Add `a-tagline_text` class to tagline text to handle non-grid support scenarios.


## How to test this PR

1. In IE11, the tagline should not wrap.


## Screenshots

before:
<img width="264" alt="Screen Shot 2022-01-13 at 10 27 17 AM" src="https://user-images.githubusercontent.com/704760/149359257-8a1919c0-cd8d-456c-b27c-e70f96603b95.png">

after:
<img width="301" alt="Screen Shot 2022-01-13 at 10 25 31 AM" src="https://user-images.githubusercontent.com/704760/149359272-7d9e0956-e999-4476-b539-03afd162d636.png">

