### PR TITLE
Bump ccdb5-api to version 1.6.4

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -44,5 +44,5 @@ wagtailmedia==0.6.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.6.3/ccdb5_api-1.6.3-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.6.4/ccdb5_api-1.6.4-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl


### PR DESCRIPTION
This change enables cache tags for CCDB API responses, which should resolve
internal GHE 4306.

## Testing
The code has been pushed to DEV4, and an API response like the one below should show `Edge-Cache-Tag: complaints` in the response header.

DEV4/data-research/consumer-complaints/search/api/v1/?date_received_max=2022-01-18&date_received_min=2011-12-01&field=all&size=25&sort=created_date_desc&size=0
