### PR TITLE
Allow Django Rest Framework MethodNotAllowed exception messages in New Relic

### DIFF
--- a/cfgov/newrelic.ini
+++ b/cfgov/newrelic.ini
@@ -297,6 +297,7 @@ strip_exception_messages.whitelist =
     requests.exceptions:ConnectionError
     requests.exceptions:HTTPError
     urllib2:URLError
+    rest_framework.exceptions:MethodNotAllowed
 
 # Transaction event data allows the New Relic UI to show additional
 # information such as histograms and percentiles.


### PR DESCRIPTION

This change adds `rest_framework.exceptions:MethodNotAllowed` to our list of exceptions that are allowed to include their message in New Relic.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
