### PR TITLE
Mock less in form_module_handlers tests

### DIFF
--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -5,11 +5,13 @@ from django.test import (
     RequestFactory, SimpleTestCase, TestCase, override_settings
 )
 
+from wagtail.core.blocks import BoundBlock
 from wagtail.core.models import Site
 from wagtail.core.whitelist import Whitelister as Allowlister
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
 
+from v1.blocks import Feedback
 from v1.models.base import CFGOVPage
 from v1.models.resources import Resource
 from v1.wagtail_hooks import form_module_handlers, get_resource_tags
@@ -17,79 +19,23 @@ from v1.wagtail_hooks import form_module_handlers, get_resource_tags
 
 class TestFormModuleHandlers(TestCase):
     def setUp(self):
-        mock.patch('v1.wagtail_hooks.hooks.register')
-        self.page = mock.Mock()
-        self.request = mock.Mock()
         self.context = {}
+        self.page = CFGOVPage(title='live', slug='test')
+        self.request = RequestFactory().get('/')
 
-    @mock.patch('builtins.hasattr')
     @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_sets_context(self, mock_getstreamfields, mock_hasattr):
-        mock_hasattr.return_value = True
-        child = mock.Mock()
-        mock_getstreamfields().items.return_value = [('name', [child])]
+    def test_sets_context(self, mock_getstreamfields):
+        child = BoundBlock(Feedback(), value='')
+        mock_getstreamfields().items.return_value = [('feedback', [child])]
         form_module_handlers(self.page, self.request, self.context)
-        assert 'form_modules' in self.context
+        self.assertIn('form_modules', self.context)
+        self.assertIsInstance(self.context['form_modules']['feedback'], dict)
 
     @mock.patch('v1.wagtail_hooks.util.get_streamfields')
     def test_does_not_set_context(self, mock_getstreamfields):
         mock_getstreamfields().items.return_value = []
         form_module_handlers(self.page, self.request, self.context)
-        assert 'form_modules' not in self.context
-
-    @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_calls_get_streamfields(self, mock_getstreamfields):
-        form_module_handlers(self.page, self.request, self.context)
-        mock_getstreamfields.assert_called_with(self.page)
-
-    @mock.patch('builtins.hasattr')
-    @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_checks_child_block_if_set_form_context_exists(
-            self, mock_getstreamfields, mock_hasattr):
-        child = mock.Mock()
-        streamfields = {'name': [child]}
-        mock_getstreamfields.return_value = streamfields
-        form_module_handlers(self.page, self.request, self.context)
-        mock_hasattr.assert_called_with(child.block, 'get_result')
-
-    @mock.patch('builtins.hasattr')
-    @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_sets_context_fieldname_if_not_set(
-            self, mock_getstreamfields, mock_hasattr):
-        child = mock.Mock()
-        streamfields = {'name': [child]}
-        mock_getstreamfields.return_value = streamfields
-        mock_hasattr.return_value = True
-        form_module_handlers(self.page, self.request, self.context)
-        assert 'name' in self.context['form_modules']
-        self.assertIsInstance(self.context['form_modules']['name'], dict)
-
-    @mock.patch('builtins.hasattr')
-    @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_calls_child_block_get_result(
-            self, mock_getstreamfields, mock_hasattr):
-        child = mock.Mock()
-        streamfields = {'name': [child]}
-        mock_getstreamfields.return_value = streamfields
-        mock_hasattr.return_value = True
-        form_module_handlers(self.page, self.request, self.context)
-        child.block.get_result.assert_called_with(
-            self.page,
-            self.request,
-            child.value,
-            child.block.is_submitted()
-        )
-
-    @mock.patch('builtins.hasattr')
-    @mock.patch('v1.wagtail_hooks.util.get_streamfields')
-    def test_calls_child_block_is_submitted(
-            self, mock_getstreamfields, mock_hasattr):
-        child = mock.Mock()
-        streamfields = {'name': [child]}
-        mock_getstreamfields.return_value = streamfields
-        mock_hasattr.return_value = True
-        form_module_handlers(self.page, self.request, self.context)
-        child.block.is_submitted.assert_called_with(self.request, 'name', 0)
+        self.assertNotIn('form_modules', self.context)
 
 
 class TestServeLatestDraftPage(TestCase):


### PR DESCRIPTION
This change removes our mocking of a page, a request, and `hasattr` in the tests for the `form_module_handler` context hook. I've kept the mock of `get_streamfields` as it seems a decent way to inject only the field we want to test with into the handler.

This change also removes several superfluous tests that appear to have been built around the mocking.

This should fix some recursion errors we're seeing in backend tests since Python 3.8.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
