### PR TITLE
Update the search index as part of refresh-data.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,8 +23,6 @@ if ! psql ${DATABASE_URL} -c 'SELECT COUNT(*) FROM auth_user' &> /dev/null; then
     fi
     echo "Create the cache table..."
     ./cfgov/manage.py createcachetable
-    echo "Update the search indexes..."
-    ./cfgov/manage.py search_index --rebuild -f --parallel
 fi
 
 # Do first-time build of the front-end if necessary

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -8,9 +8,8 @@
 
 set -e
 
-refresh_dump_name=$1
-
-USAGE=$(cat << 'EOF'
+usage() {
+    cat << EOF
 Please download a recent database dump before running this script:
 
   ./refresh-data.sh production_django.sql.gz
@@ -20,8 +19,14 @@ download it for you:
 
   export CFGOV_PROD_DB_LOCATION=https://example.com/production_django.sql.gz
   ./refresh-data.sh
+
+Additional options:
+
+      --noindex  Do not update search indexes after refreshing
+
 EOF
-)
+    exit 1;
+}
 
 download_data() {
     echo 'Downloading fresh production Django database dump...'
@@ -54,24 +59,46 @@ refresh_data() {
     ./cfgov/manage.py migrate --noinput --fake-initial
     echo 'Setting up initial data'
     ./cfgov/manage.py runscript initial_data
+}
+
+update_index() {
     echo 'Updating search indexes'
     ./cfgov/manage.py search_index --rebuild -f
 }
 
-if [[ -z "$refresh_dump_name" ]]; then
-    if [[ -z "$CFGOV_PROD_DB_LOCATION" ]]; then
-        printf "%s\n\n" "$USAGE"
-        exit 1
-    fi
+get_data() {
+    if [[ -z "$refresh_dump_name" ]]; then
+        if [[ -z "$CFGOV_PROD_DB_LOCATION" ]]; then
+            usage
+        fi
 
-    refresh_dump_name='production_django.sql.gz'
-    download_data
-else
-    if [[ $refresh_dump_name != *.sql.gz ]]; then
-        echo "Input dump '$refresh_dump_name' expected to end with .sql.gz."
-        exit 2
+        refresh_dump_name='production_django.sql.gz'
+        download_data
+    else
+        if [[ $refresh_dump_name != *.sql.gz ]]; then
+            echo "Input dump '$refresh_dump_name' expected to end with .sql.gz."
+            exit 2
+        fi
     fi
-fi
+}
 
+noindex=false
+for arg in "$@"; do
+    shift
+    case "$arg" in
+        "--noindex")
+            noindex=1
+            ;;
+        *)
+            refresh_dump_name=$arg
+            ;;
+    esac
+done
+
+get_data
 check_data
 refresh_data
+
+if [[ $noindex -ne 1 ]]; then
+    update_index
+fi

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -54,6 +54,8 @@ refresh_data() {
     ./cfgov/manage.py migrate --noinput --fake-initial
     echo 'Setting up initial data'
     ./cfgov/manage.py runscript initial_data
+    echo 'Updating search indexes'
+    ./cfgov/manage.py search_index --rebuild -f
 }
 
 if [[ -z "$refresh_dump_name" ]]; then


### PR DESCRIPTION
This change adds `./cfgov/manage.py search_index --rebuild -f` to our `refresh-data.sh` script so that we update the search indexes with the contents of the newly refreshed data when we refresh it.

This also moves the command out of the `docker-entrypoint.sh` script that gets run in our Python container. That script includes a call to `refresh-data.sh`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)