### PR TITLE
Add v1/tests to Python flake8 checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,11 +1,11 @@
 [flake8]
-ignore = 
+ignore =
     # There's nothing wrong with assigning lambdas
     E731,
     # PEP8 weakly recommends Knuth-style line breaks before binary
     # operators
     W503, W504
-exclude = 
+exclude =
     # These are directories that it's a waste of time to traverse
     .git,
     .tox,
@@ -34,9 +34,5 @@ exclude =
     # Our settings files might need to conform to different readability
     # standards
     cfgov/cfgov/settings/*,
-
-    # Now we come to the bits we exclude because they haven't had a
-    # proper cleanup yet.
-    cfgov/v1/tests,
 
 # max-complexity = 10

--- a/cfgov/v1/tests/atomic_elements/organisms/test_contact_expandables.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_contact_expandables.py
@@ -1,6 +1,5 @@
 import json
 
-from django.http import HttpRequest
 from django.test import TestCase
 
 from wagtail.core import blocks
@@ -136,4 +135,4 @@ class ContactExpandableGroupTests(WagtailTestUtils, TestCase):
         # all 10 Contacts, even though they are split up between two different
         # ContactExpandableGroup blocks.
         with self.assertNumQueries(1):
-            html = block.render(value)
+            block.render(value)

--- a/cfgov/v1/tests/atomic_elements/organisms/test_filterable_list.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_filterable_list.py
@@ -47,20 +47,38 @@ class TestFilterableList(TestCase):
 
     def set_up_filterable_list_page(self, value):
         self.page = BrowseFilterablePage(title='Browse filterable page')
-        self.page.content = StreamValue(self.page.content.stream_block, [value], True)
+        self.page.content = StreamValue(
+            self.page.content.stream_block,
+            [value],
+            True
+        )
         helpers.publish_page(child=self.page)
         self.block = self.page.get_filterable_list_wagtail_block()
 
     def test_get_filterable_topics_sort_by_frequency(self):
         self.set_up_filterable_list_page(self.topics_by_frequency())
         self.set_up_published_pages()
-        topics = FilterableList().get_filterable_topics(self.page_ids, self.block.value)
-        expected_topics = ['C-tag-3-instances', 'B-tag-2-instances', 'A-tag-1-instance']
+        topics = FilterableList().get_filterable_topics(
+            self.page_ids,
+            self.block.value
+        )
+        expected_topics = [
+            'C-tag-3-instances',
+            'B-tag-2-instances',
+            'A-tag-1-instance',
+        ]
         self.assertEqual([x[1] for x in topics], expected_topics)
 
     def test_get_filterable_topics_sort_alphabetically(self):
         self.set_up_filterable_list_page(self.alphabetical_topics())
         self.set_up_published_pages()
-        topics = FilterableList().get_filterable_topics(self.page_ids, self.block.value)
-        expected_topics = ['A-tag-1-instance', 'B-tag-2-instances', 'C-tag-3-instances']
+        topics = FilterableList().get_filterable_topics(
+            self.page_ids,
+            self.block.value
+        )
+        expected_topics = [
+            'A-tag-1-instance',
+            'B-tag-2-instances',
+            'C-tag-3-instances',
+        ]
         self.assertEqual([x[1] for x in topics], expected_topics)

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -61,10 +61,7 @@ class OrganismsTestCase(TestCase):
 
     def test_well(self):
         """Well content correctly displays on a Landing Page"""
-        landing_page = LandingPage(
-                title='Landing Page',
-                slug='landing',
-        )
+        landing_page = LandingPage(title='Landing Page', slug='landing')
         landing_page.content = StreamValue(
             landing_page.content.stream_block,
             [atomic.well],
@@ -77,8 +74,8 @@ class OrganismsTestCase(TestCase):
     def test_main_contact_info(self):
         """Main contact info correctly displays on a Sublanding Page"""
         sublanding_page = SublandingPage(
-                title='Sublanding Page',
-                slug='sublanding',
+            title='Sublanding Page',
+            slug='sublanding',
         )
         contact = self.get_contact()
         sublanding_page.content = StreamValue(
@@ -94,14 +91,12 @@ class OrganismsTestCase(TestCase):
         self.assertContains(response, '123 abc street')
         self.assertContains(response, 'this is a heading')
         self.assertContains(response, 'this is a body')
-        self.assertNotContains(response, 'Contact Information') # Only shown on sidebar
+        # Only shown on sidebar
+        self.assertNotContains(response, 'Contact Information')
 
     def test_sidebar_contact_info(self):
         """Sidebar contact info correctly displays on a Landing Page"""
-        landing_page = LandingPage(
-                title='Landing Page',
-                slug='landing',
-        )
+        landing_page = LandingPage(title='Landing Page', slug='landing')
         contact = self.get_contact()
         landing_page.sidefoot = StreamValue(
             landing_page.sidefoot.stream_block,
@@ -116,14 +111,12 @@ class OrganismsTestCase(TestCase):
         self.assertContains(response, '123 abc street')
         self.assertContains(response, 'this is a heading')
         self.assertContains(response, 'this is a body')
-        self.assertContains(response, 'Contact Information') # This is specific to sidebar
+        # This is specific to sidebar
+        self.assertContains(response, 'Contact Information')
 
     def test_full_width_text(self):
         """Full width text content correctly displays on a Learn Page"""
-        learn_page = LearnPage(
-                title='Learn Page',
-                slug='learn',
-        )
+        learn_page = LearnPage(title='Learn Page', slug='learn')
         learn_page.content = StreamValue(
             learn_page.content.stream_block,
             [atomic.full_width_text],
@@ -166,10 +159,7 @@ class OrganismsTestCase(TestCase):
 
     def test_tableblock(self):
         """Table correctly displays on a Learn Page"""
-        learn_page = LearnPage(
-                title='Learn Page',
-                slug='learn',
-        )
+        learn_page = LearnPage(title='Learn Page', slug='learn')
         learn_page.content = StreamValue(
             learn_page.content.stream_block,
             [atomic.table_block],
@@ -182,7 +172,7 @@ class OrganismsTestCase(TestCase):
         self.assertContains(response, 'Row 2-1')
 
     def test_tableblock_missing_attributes(self):
-        """Table correctly displays when value dictionary is missing attributes"""
+        """Table correctly displays when value dict is missing attributes"""
         table_context = dict(atomic.table_block)
         value = table_context.get('value')
         del value['first_row_is_table_header']
@@ -220,10 +210,7 @@ class OrganismsTestCase(TestCase):
 
     def test_item_introduction(self):
         """Item introduction correctly displays on a Learn Page"""
-        learn_page = LearnPage(
-                title='Learn Page',
-                slug='learn',
-        )
+        learn_page = LearnPage(title='Learn Page', slug='learn')
         learn_page.header = StreamValue(
             learn_page.header.stream_block,
             [atomic.item_introduction],
@@ -264,8 +251,7 @@ class OrganismsTestCase(TestCase):
         self.assertNotContains(response, 'In year-over-year credit tightness')
 
     def test_data_snapshot_with_optional_fields(self):
-        """ Data Snapshot with inquiry and tightness information correctly renders
-        fields on a Browse Page"""
+        """Test rendering of Data Snapshot with inquiry and tightness data"""
         browse_page = BrowsePage(
             title='Browse Page',
             slug='browse',
@@ -312,10 +298,10 @@ class OrganismsTestCase(TestCase):
         self.assertContains(response, 'Volume of credit cards originated')
         self.assertContains(response, 'foo/bar.csv')
         self.assertContains(response, 'Data not final.')
-        self.assertContains(
-            response,
-            'The most recent data available in this visualization are for April 2016'
-        )
+        self.assertContains(response, (
+            'The most recent data available in this visualization are for '
+            'April 2016'
+        ))
         self.assertContains(response, 'January 2018')
 
     def test_resource_list(self):
@@ -432,7 +418,7 @@ class FeaturedContentTests(TestCase):
             ],
             'video': {
                 'video_id': '1V0Ax9OIc84',
-		'thumbnail_image': self.image.pk,
+                'thumbnail_image': self.image.pk,
             },
         })
 
@@ -566,7 +552,7 @@ class VideoPlayerTests(SimpleTestCase):
 
         try:
             block.clean(value)
-        except ValidationError as e:  # pragma: nocover
+        except ValidationError:  # pragma: nocover
             self.fail('Optional VideoPlayers should not require sub-fields')
 
     def test_invalid_video_id(self):
@@ -582,7 +568,7 @@ class VideoPlayerTests(SimpleTestCase):
 
         try:
             block.clean(value)
-        except ValidationError as e:  # pragma: nocover
+        except ValidationError:  # pragma: nocover
             self.fail('VideoPlayer should support valid YouTube IDs')
 
     def test_render(self):

--- a/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
@@ -116,9 +116,10 @@ class RelatedPostsTestCase(TestCase):
         helpers.save_new_page(self.events_child1, self.events_parent)
 
         # mock a stream block that dictates how to retrieve the related posts
-        # note that because of the way that the related_posts_category_lookup function
-        # works i.e. by consulting a hard-coded object, the specific_categories
-        # slot of the dict has to be something that it can actually find.
+        # note that because of the way that the related_posts_category_lookup
+        # function works i.e. by consulting a hard-coded object, the
+        # specific_categories slot of the dict has to be something that it can
+        # actually find.
         self.block_value = {
             'limit': 3,
             'show_heading': True,

--- a/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
@@ -11,7 +11,10 @@ from v1.atomic_elements.tables import RichTextTableInput
 
 class TestRichTextTableInput(TestCase):
     def test_rich_text_table_js_included(self):
-        assert 'apps/admin/js/rich-text-table.js' in RichTextTableInput().media._js
+        self.assertIn(
+            'apps/admin/js/rich-text-table.js',
+            RichTextTableInput().media._js
+        )
 
 
 class TestAtomicTableBlock(TestCase):

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -25,10 +25,16 @@ class MoleculesTestCase(ElasticsearchTestsMixin, TestCase):
     @classmethod
     def setUpTestData(cls):
         # Create a clean index for the test suite
-        management.call_command('search_index', action='rebuild', force=True, models=['v1'], stdout=StringIO())
+        management.call_command(
+            'search_index',
+            action='rebuild',
+            force=True,
+            models=['v1'],
+            stdout=StringIO()
+        )
 
     def test_text_intro(self):
-        """Text introduction value correctly displays on a Browse Filterable Page"""
+        """Text introduction value correctly displays on a BFP"""
         bfp = BrowseFilterablePage(
             title='Browse Filterable Page',
             slug='browse-filterable-page',
@@ -152,7 +158,7 @@ class MoleculesTestCase(ElasticsearchTestsMixin, TestCase):
         self.assertContains(response, 'this is an expandable')
 
     def test_related_metadata(self):
-        """Related metadata heading correctly displays on a Document Detail Page"""
+        """Related metadata heading correctly displays on a DDP"""
         ddp = DocumentDetailPage(
             title='Document Detail Page',
             slug='ddp',

--- a/cfgov/v1/tests/handlers/test_handler.py
+++ b/cfgov/v1/tests/handlers/test_handler.py
@@ -11,5 +11,5 @@ class TestHandler(TestCase):
         self.handler = Handler(self.page, self.request, self.context)
 
     def test_process_raises_NotImplementedError(self):
-        with self.assertRaises(NotImplementedError) as nie:
+        with self.assertRaises(NotImplementedError):
             self.handler.process()

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.core.cache import cache, caches
 from django.template import engines
-from django.test import Client, TestCase, override_settings
+from django.test import TestCase, override_settings
 
 from scripts import _atomic_helpers as atomic
 from search.elasticsearch_helpers import ElasticsearchTestsMixin

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -1,5 +1,4 @@
 import re
-from datetime import date
 
 from django.http import HttpRequest
 from django.template import engines
@@ -10,7 +9,7 @@ from django.test import (
 from model_bakery import baker
 
 from v1.atomic_elements.atoms import ImageBasic
-from v1.jinja2tags import complaint_issue_banner, email_popup, image_alt_value
+from v1.jinja2tags import email_popup, image_alt_value
 from v1.models import CFGOVImage, CFGOVRendition
 
 

--- a/cfgov/v1/tests/management/commands/test_add_images.py
+++ b/cfgov/v1/tests/management/commands/test_add_images.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.test import Client, RequestFactory, TestCase
+from django.test import RequestFactory, TestCase
 
 from PIL import Image
 
@@ -13,26 +13,28 @@ from PIL import Image
 # from v1.management.commands.add_images import Command as cmd
 
 
-def create_image(storage, filename, size=(100, 100), image_mode='RGB', image_format='PNG'):
-   """
-   Generate a test image, returning the filename that it was saved as.
+def create_image(
+    storage, filename, size=(100, 100), image_mode='RGB', image_format='PNG'
+):
+    """
+    Generate a test image, returning the filename that it was saved as.
 
-   If ``storage`` is ``None``, the BytesIO containing the image data
-   will be passed instead.
-   """
-   data = BytesIO()
-   Image.new(image_mode, size).save(data, image_format)
-   data.seek(0)
-   if not storage:
-       return data
-   image_file = ContentFile(data.read())
-   return storage.save(filename, image_file)
+    If ``storage`` is ``None``, the BytesIO containing the image data
+    will be passed instead.
+    """
+    data = BytesIO()
+    Image.new(image_mode, size).save(data, image_format)
+    data.seek(0)
+    if not storage:
+        return data
+    image_file = ContentFile(data.read())
+    return storage.save(filename, image_file)
 
 
 class TestAddImages(TestCase):
     def setUp(self):
         self.filename = os.path.join(
-            settings.PROJECT_ROOT,'legacy/static/images/cfpblogo.png'
+            settings.PROJECT_ROOT, 'legacy/static/images/cfpblogo.png'
         )
         self.factory = RequestFactory()
         self.request = self.factory.get('/')

--- a/cfgov/v1/tests/management/commands/test_add_images.py
+++ b/cfgov/v1/tests/management/commands/test_add_images.py
@@ -3,19 +3,13 @@ from io import BytesIO
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase
 
 from PIL import Image
 
 
-# from v1.management.commands.add_images import Command as cmd
-
-
-def create_image(
-    storage, filename, size=(100, 100), image_mode='RGB', image_format='PNG'
-):
+def create_image(size=(100, 100), image_mode='RGB', image_format='PNG'):
     """
     Generate a test image, returning the filename that it was saved as.
 
@@ -25,10 +19,7 @@ def create_image(
     data = BytesIO()
     Image.new(image_mode, size).save(data, image_format)
     data.seek(0)
-    if not storage:
-        return data
-    image_file = ContentFile(data.read())
-    return storage.save(filename, image_file)
+    return data
 
 
 class TestAddImages(TestCase):
@@ -42,8 +33,7 @@ class TestAddImages(TestCase):
 
     def test_add_image(self):
         filename_only = os.path.split(self.filename)[-1]
-        logo = create_image(None, filename_only)
-        # cmd.add_image(self, self.filename)
+        logo = create_image()
         image_file = SimpleUploadedFile(filename_only, logo.getvalue())
         post_data = {
             'title': filename_only,

--- a/cfgov/v1/tests/management/commands/test_export_feedback.py
+++ b/cfgov/v1/tests/management/commands/test_export_feedback.py
@@ -40,7 +40,7 @@ class LookupPageSlug(TestCase):
 
         page = create_simple_page(self.root_page, duplicate_slug)
         create_simple_page(page, duplicate_slug)
-        
+
         with self.assertRaises(argparse.ArgumentTypeError):
             lookup_page_slug(duplicate_slug)
 
@@ -155,8 +155,8 @@ class TestExportFeedback(TestCase):
 
     def test_export_between_dates_only_some(self):
         output = self.call_command(
-                from_date=self.first_timestamp.date(),
-                to_date=self.first_timestamp.date() + timedelta(days=1)
+            from_date=self.first_timestamp.date(),
+            to_date=self.first_timestamp.date() + timedelta(days=1)
         )
 
         # Output should contain only the first set of feedback.

--- a/cfgov/v1/tests/management/commands/test_makemessages.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages.py
@@ -6,7 +6,6 @@ from unittest import skipUnless
 from django.core.management import call_command
 from django.core.management.utils import find_command
 from django.test import SimpleTestCase
-from django.utils._os import upath
 
 
 # https://github.com/django/django/blob/1.11.18/tests/i18n/test_extraction.py

--- a/cfgov/v1/tests/management/commands/test_restore_archive_pages.py
+++ b/cfgov/v1/tests/management/commands/test_restore_archive_pages.py
@@ -15,7 +15,7 @@ from v1.models import BlogPage
 from v1.models.browse_filterable_page import BrowseFilterablePage
 
 
-class TestRestoreArchivePages(ElasticsearchTestsMixin,TestCase):
+class TestRestoreArchivePages(ElasticsearchTestsMixin, TestCase):
 
     def setUp(self):
         self.filterable_page = BrowseFilterablePage(

--- a/cfgov/v1/tests/management/commands/test_search_pagerevisions.py
+++ b/cfgov/v1/tests/management/commands/test_search_pagerevisions.py
@@ -1,5 +1,3 @@
-import argparse
-import io
 import tempfile
 from io import StringIO
 

--- a/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
+++ b/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
@@ -14,122 +14,139 @@ from v1.tests.wagtail_pages.helpers import publish_page
 
 
 class UpdateChartBlockDatesTestCase(TestCase):
-        def test_get_inquiry_month(self):
-            with open('./v1/tests/fixtures/data_snapshot.json') as json_data:
-                data = json.load(json_data)
-            markets = data['markets']
-            data_source_crc = 'consumer-credit-trends/credit-cards/inq_data_CRC.csv'
-            data_source_mtg = 'consumer-credit-trends/mortgages/crt_data_MTG.csv'
-            data_source_other = 'consumer-credit-trends/student-loans/num_data_STU.csv'
-            
-            self.assertEqual(get_inquiry_month(markets, data_source_crc), '2018-06-01')
-            self.assertNotEqual(get_inquiry_month(markets, data_source_crc), '2018-02-01')
-            self.assertEqual(get_inquiry_month(markets, data_source_mtg), '2017-09-01')
-            self.assertNotEqual(get_inquiry_month(markets, data_source_mtg), '2018-06-01')
-            self.assertNotEqual(get_inquiry_month(markets, data_source_other), '2018-06-01')
-            self.assertIs(get_inquiry_month(markets, data_source_other), None)
+    def test_get_inquiry_month(self):
+        with open('./v1/tests/fixtures/data_snapshot.json') as json_data:
+            data = json.load(json_data)
+        markets = data['markets']
+        data_source_crc = \
+            'consumer-credit-trends/credit-cards/inq_data_CRC.csv'
+        data_source_mtg = 'consumer-credit-trends/mortgages/crt_data_MTG.csv'
+        data_source_other = \
+            'consumer-credit-trends/student-loans/num_data_STU.csv'
 
-        def test_chart_block(self):
-            """ Management command correctly updates chart block dates"""
-            browse_page = BrowsePage(
-                title='Browse Page',
-                slug='browse',
-            )
+        self.assertEqual(
+            get_inquiry_month(markets, data_source_crc),
+            '2018-06-01'
+        )
+        self.assertNotEqual(
+            get_inquiry_month(markets, data_source_crc),
+            '2018-02-01'
+        )
+        self.assertEqual(
+            get_inquiry_month(markets, data_source_mtg),
+            '2017-09-01'
+        )
+        self.assertNotEqual(
+            get_inquiry_month(markets, data_source_mtg),
+            '2018-06-01'
+        )
+        self.assertNotEqual(
+            get_inquiry_month(markets, data_source_other),
+            '2018-06-01'
+        )
+        self.assertIsNone(get_inquiry_month(markets, data_source_other))
 
-            # Adds a Chart Block to a browse page
-            browse_page.content = StreamValue(
-                browse_page.content.stream_block,
-                [atomic.chart_block],
-                True
-            )
-            publish_page(child=browse_page)
+    def test_chart_block(self):
+        """ Management command correctly updates chart block dates"""
+        browse_page = BrowsePage(
+            title='Browse Page',
+            slug='browse',
+        )
 
-            # Call management command to update values
-            filename = os.path.join(
-                settings.PROJECT_ROOT,
-                'v1/tests/fixtures/data_snapshot.json'
-            )
-            call_command(
-                'update_chart_block_dates',
-                '--snapshot_file={}'.format(filename)
-            )
-            response = self.client.get('/browse/')
+        # Adds a Chart Block to a browse page
+        browse_page.content = StreamValue(
+            browse_page.content.stream_block,
+            [atomic.chart_block],
+            True
+        )
+        publish_page(child=browse_page)
 
-            # Tests last_updated_projected_data is correct
-            self.assertContains(
-                response,
-                'The most recent data available in this visualization are for July 2018'
-            )
+        # Call management command to update values
+        filename = os.path.join(
+            settings.PROJECT_ROOT,
+            'v1/tests/fixtures/data_snapshot.json'
+        )
+        call_command(
+            'update_chart_block_dates',
+            '--snapshot_file={}'.format(filename)
+        )
+        response = self.client.get('/browse/')
 
-            # Tests date_published is correct
-            self.assertContains(response, 'October 2018')
+        # Tests last_updated_projected_data is correct
+        self.assertContains(response, (
+            'The most recent data available in this visualization are for '
+            'July 2018'
+        ))
 
-        def test_chart_block_inquiry_activity(self):
-            """ Management command correctly updates chart block dates for inquiry index charts"""
-            browse_page = BrowsePage(
-                title='Browse Page',
-                slug='browse',
-            )
+        # Tests date_published is correct
+        self.assertContains(response, 'October 2018')
 
-            # Adds a Chart Block to a browse page
-            browse_page.content = StreamValue(
-                browse_page.content.stream_block,
-                [atomic.chart_block_inquiry_activity],
-                True
-            )
-            publish_page(child=browse_page)
+    def test_chart_block_inquiry_activity(self):
+        """Command correctly updates chart block dates for inquiry index"""
+        browse_page = BrowsePage(
+            title='Browse Page',
+            slug='browse',
+        )
 
-            # Call management command to update values
-            filename = os.path.join(
-                settings.PROJECT_ROOT,
-                'v1/tests/fixtures/data_snapshot.json'
-            )
-            call_command(
-                'update_chart_block_dates',
-                '--snapshot_file={}'.format(filename)
-            )
-            response = self.client.get('/browse/')
+        # Adds a Chart Block to a browse page
+        browse_page.content = StreamValue(
+            browse_page.content.stream_block,
+            [atomic.chart_block_inquiry_activity],
+            True
+        )
+        publish_page(child=browse_page)
 
-            # Tests last_updated_projected_data is correct
-            self.assertContains(
-                response,
-                'The most recent data available in this visualization are for June 2018'
-            )
+        # Call management command to update values
+        filename = os.path.join(
+            settings.PROJECT_ROOT,
+            'v1/tests/fixtures/data_snapshot.json'
+        )
+        call_command(
+            'update_chart_block_dates',
+            '--snapshot_file={}'.format(filename)
+        )
+        response = self.client.get('/browse/')
 
-            # Tests date_published is correct
-            self.assertContains(response, 'October 2018')
+        # Tests last_updated_projected_data is correct
+        self.assertContains(response, (
+            'The most recent data available in this visualization are for '
+            'June 2018'
+        ))
 
-        def test_chart_block_credit_tightness(self):
-            """ Management command correctly updates chart block dates for credit tightness charts"""
-            browse_page = BrowsePage(
-                title='Browse Page',
-                slug='browse',
-            )
+        # Tests date_published is correct
+        self.assertContains(response, 'October 2018')
 
-            # Adds a Chart Block to a browse page
-            browse_page.content = StreamValue(
-                browse_page.content.stream_block,
-                [atomic.chart_block_credit_tightness],
-                True
-            )
-            publish_page(child=browse_page)
+    def test_chart_block_credit_tightness(self):
+        """Command correctly updates chart block dates for credit tightness."""
+        browse_page = BrowsePage(
+            title='Browse Page',
+            slug='browse',
+        )
 
-            # Call management command to update values
-            filename = os.path.join(
-                settings.PROJECT_ROOT,
-                'v1/tests/fixtures/data_snapshot.json'
-            )
-            call_command(
-                'update_chart_block_dates',
-                '--snapshot_file={}'.format(filename)
-            )
-            response = self.client.get('/browse/')
+        # Adds a Chart Block to a browse page
+        browse_page.content = StreamValue(
+            browse_page.content.stream_block,
+            [atomic.chart_block_credit_tightness],
+            True
+        )
+        publish_page(child=browse_page)
 
-            # Tests last_updated_projected_data is correct
-            self.assertContains(
-                response,
-                'The most recent data available in this visualization are for February 2018'
-            )
+        # Call management command to update values
+        filename = os.path.join(
+            settings.PROJECT_ROOT,
+            'v1/tests/fixtures/data_snapshot.json'
+        )
+        call_command(
+            'update_chart_block_dates',
+            '--snapshot_file={}'.format(filename)
+        )
+        response = self.client.get('/browse/')
 
-            # Tests date_published is correct
-            self.assertContains(response, 'October 2018')
+        # Tests last_updated_projected_data is correct
+        self.assertContains(response, (
+            'The most recent data available in this visualization are for '
+            'February 2018'
+        ))
+
+        # Tests date_published is correct
+        self.assertContains(response, 'October 2018')

--- a/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
+++ b/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
@@ -12,86 +12,89 @@ from v1.tests.wagtail_pages.helpers import publish_page
 
 
 class UpdateDataSnapshotValuesTestCase(TestCase):
-        def test_data_snapshot(self):
-            """ Management command correctly updates data snapshot values"""
-            browse_page = BrowsePage(
-                title='Browse Page',
-                slug='browse',
-            )
+    def test_data_snapshot(self):
+        """ Management command correctly updates data snapshot values"""
+        browse_page = BrowsePage(title='Browse Page', slug='browse')
 
-            # Adds a STU market to a browse page
-            browse_page.content = StreamValue(
-                browse_page.content.stream_block,
-                [atomic.data_snapshot],
-                True
-            )
-            publish_page(child=browse_page)
+        # Adds a STU market to a browse page
+        browse_page.content = StreamValue(
+            browse_page.content.stream_block,
+            [atomic.data_snapshot],
+            True
+        )
+        publish_page(child=browse_page)
 
-            # Call management command to update values
-            filename = os.path.join(
-                settings.PROJECT_ROOT,
-                'v1/tests/fixtures/data_snapshot.json'
-            )
-            call_command(
-                'update_data_snapshot_values',
-                '--snapshot_file={}'.format(filename)
-            )
-            response = self.client.get('/browse/')
+        # Call management command to update values
+        filename = os.path.join(
+            settings.PROJECT_ROOT,
+            'v1/tests/fixtures/data_snapshot.json'
+        )
+        call_command(
+            'update_data_snapshot_values',
+            '--snapshot_file={}'.format(filename)
+        )
+        response = self.client.get('/browse/')
 
-            # July 2018 data:
-            self.assertContains(response, '917,007') # Student loans originated
-            self.assertContains(response, '$16.6 billion') # Dollar volume of new loans
-            self.assertContains(response, '48.0% increase') # In year-over-year originations
-            self.assertContains(response, 'July&nbsp;2018')
-            self.assertContains(response, 'Loans originated')
-            self.assertContains(response, 'Dollar value of new loans')
-            self.assertContains(response, 'In year-over-year originations')
-            # Should not contain inquiry and tightness values
-            self.assertNotContains(response, 'In year-over-year inquiries')
-            self.assertNotContains(
-                response,
-                'In year-over-year credit tightness'
-            )
+        # July 2018 data:
+        # Student loans originated
+        self.assertContains(response, '917,007')
+        # Dollar volume of new loans
+        self.assertContains(response, '$16.6 billion')
+        # In year-over-year originations
+        self.assertContains(response, '48.0% increase')
+        self.assertContains(response, 'July&nbsp;2018')
+        self.assertContains(response, 'Loans originated')
+        self.assertContains(response, 'Dollar value of new loans')
+        self.assertContains(response, 'In year-over-year originations')
+        # Should not contain inquiry and tightness values
+        self.assertNotContains(response, 'In year-over-year inquiries')
+        self.assertNotContains(
+            response,
+            'In year-over-year credit tightness'
+        )
 
-        def test_data_snapshot_with_inquiry_and_tightness(self):
-            """ Management command correctly updates data snapshot values
-            for market that contains inquiry and tightness data"""
-            browse_page = BrowsePage(
-                title='Browse Page',
-                slug='browse',
-            )
+    def test_data_snapshot_with_inquiry_and_tightness(self):
+        """ Management command correctly updates data snapshot values
+        for market that contains inquiry and tightness data"""
+        browse_page = BrowsePage(
+            title='Browse Page',
+            slug='browse',
+        )
 
-            # Adds a AUT market to a browse page
-            browse_page.content = StreamValue(
-                browse_page.content.stream_block,
-                [atomic.data_snapshot_with_optional_fields],
-                True
-            )
-            publish_page(child=browse_page)
+        # Adds a AUT market to a browse page
+        browse_page.content = StreamValue(
+            browse_page.content.stream_block,
+            [atomic.data_snapshot_with_optional_fields],
+            True
+        )
+        publish_page(child=browse_page)
 
-            # Call management command to update values
-            filename = os.path.join(
-                settings.PROJECT_ROOT,
-                'v1/tests/fixtures/data_snapshot.json'
-            )
-            call_command(
-                'update_data_snapshot_values',
-                '--snapshot_file={}'.format(filename)
-            )
-            # July 2018 
-            response = self.client.get('/browse/')
-            self.assertContains(response, '2.5 million') # Auto loans originated
-            self.assertContains(response, '$54.6 billion') # Dollar volume of new loans
-            self.assertContains(response, '7.3% increase') # In year-over-year originations 
-            self.assertContains(response, 'July&nbsp;2018')
-            self.assertContains(response, 'Loans originated')
-            self.assertContains(response, 'Dollar value of new loans')
-            self.assertContains(response, 'In year-over-year originations')
-            # Inquiry and tightness values
-            self.assertContains(response, '7.9% increase')
-            self.assertContains(response, '2.8% increase')
-            self.assertContains(response, 'In year-over-year inquiries')
-            self.assertContains(
-                response,
-                'In year-over-year credit tightness'
-            )
+        # Call management command to update values
+        filename = os.path.join(
+            settings.PROJECT_ROOT,
+            'v1/tests/fixtures/data_snapshot.json'
+        )
+        call_command(
+            'update_data_snapshot_values',
+            '--snapshot_file={}'.format(filename)
+        )
+        # July 2018
+        response = self.client.get('/browse/')
+        # Auto loans originated
+        self.assertContains(response, '2.5 million')
+        # Dollar volume of new loans
+        self.assertContains(response, '$54.6 billion')
+        # In year-over-year originations
+        self.assertContains(response, '7.3% increase')
+        self.assertContains(response, 'July&nbsp;2018')
+        self.assertContains(response, 'Loans originated')
+        self.assertContains(response, 'Dollar value of new loans')
+        self.assertContains(response, 'In year-over-year originations')
+        # Inquiry and tightness values
+        self.assertContains(response, '7.9% increase')
+        self.assertContains(response, '2.8% increase')
+        self.assertContains(response, 'In year-over-year inquiries')
+        self.assertContains(
+            response,
+            'In year-over-year credit tightness'
+        )

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -7,26 +7,34 @@ from v1.models.base import CFGOVPage
 
 class TestAuthorNames(TestCase):
 
-    def test_authors_get_sorted_alphabetically_by_default(self): 
+    def test_authors_get_sorted_alphabetically_by_default(self):
         with patch.object(CFGOVPage, 'alphabetize_authors') as mock:
             CFGOVPage().get_authors()
         mock.assert_called_with()
 
     def test_alphabetize_authors_by_last_name(self):
         page = CFGOVPage()
-        page.authors.add('Ross Karchner', 'Richa Agarwal', 'Andy Chosak', 'Will Barton')
-        expected_result = ['Richa Agarwal', 'Will Barton', 'Andy Chosak', 'Ross Karchner']
+        page.authors.add(
+            'Ross Karchner', 'Richa Agarwal', 'Andy Chosak', 'Will Barton'
+        )
+        expected_result = [
+            'Richa Agarwal', 'Will Barton', 'Andy Chosak', 'Ross Karchner'
+        ]
         author_names = [a.name for a in page.alphabetize_authors()]
         self.assertEqual(author_names, expected_result)
-    
+
     def test_no_authors(self):
         page = CFGOVPage()
         self.assertEqual(page.alphabetize_authors(), [])
 
     def test_author_with_middle_name(self):
         page = CFGOVPage()
-        page.authors.add('Jess Schafer', 'Richa Something Agarwal', 'Sarah Simpson')
-        expected_result = ['Richa Something Agarwal', 'Jess Schafer', 'Sarah Simpson']
+        page.authors.add(
+            'Jess Schafer', 'Richa Something Agarwal', 'Sarah Simpson'
+        )
+        expected_result = [
+            'Richa Something Agarwal', 'Jess Schafer', 'Sarah Simpson'
+        ]
         author_names = [a.name for a in page.alphabetize_authors()]
         self.assertEqual(author_names, expected_result)
 
@@ -36,7 +44,3 @@ class TestAuthorNames(TestCase):
         expected_result = ['Vic Kumar', 'John Smith', 'Mary Smith']
         author_names = [a.name for a in page.alphabetize_authors()]
         self.assertEqual(author_names, expected_result)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/cfgov/v1/tests/models/test_blog_page.py
+++ b/cfgov/v1/tests/models/test_blog_page.py
@@ -1,7 +1,5 @@
 from django.test import RequestFactory, TestCase
 
-from wagtail.core.models import Site
-
 from v1.models import BlogPage, SublandingFilterablePage
 from v1.tests.wagtail_pages.helpers import save_new_page
 

--- a/cfgov/v1/tests/models/test_images.py
+++ b/cfgov/v1/tests/models/test_images.py
@@ -96,17 +96,17 @@ class CFGOVImageTest(TestCase):
         )
 
     def test_twitter_card_large(self):
-        """ Twitter card property should be true if meta image is large """
+        """Twitter card property should be true if meta image is large"""
         image = CFGOVImage(width=1200, height=600)
         self.assertTrue(image.should_display_summary_large_image)
 
     def test_twitter_card_small(self):
-        """ Twitter card property should be false if meta image is small """
+        """Twitter card property should be false if meta image is small"""
         image = CFGOVImage(width=100, height=50)
         self.assertFalse(image.should_display_summary_large_image)
 
     def test_twitter_card_large_bad_ratio(self):
-        """ Twitter card property should be false if meta image ratio isn't ~ 50% """
+        """Twitter card property should be false if meta image ratio < 50%"""
         image = CFGOVImage(width=1200, height=100)
         self.assertFalse(image.should_display_summary_large_image)
 

--- a/cfgov/v1/tests/models/test_resources.py
+++ b/cfgov/v1/tests/models/test_resources.py
@@ -1,5 +1,3 @@
-from unittest import skipIf
-
 from django.test import TestCase
 
 from v1.models.resources import Resource

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from unittest import skipIf
-
 from django.test import TestCase
 
 from wagtail.core.models import Site

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -1,11 +1,8 @@
 import datetime as dt
 import json
 from io import StringIO
-from unittest import mock
 
-from django.test import TestCase, override_settings
-
-from wagtail.core.blocks import StreamValue
+from django.test import TestCase
 
 from scripts import _atomic_helpers as atomic
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
@@ -47,12 +44,18 @@ class SublandingPageTestCase(ElasticsearchTestsMixin, TestCase):
         # order of retrieval in test situations, otherwise the `date_published`
         # can vary due to commit order
 
-        self.child1_of_post1 = AbstractFilterPage(title='child 1 of post 1',
-                                                  date_published=dt.date(2016, 9, 1))
-        self.child2_of_post1 = AbstractFilterPage(title='child 2 of post 1',
-                                                  date_published=dt.date(2016, 9, 2))
-        self.child1_of_post2 = AbstractFilterPage(title='child 1 of post 2',
-                                                  date_published=dt.date(2016, 9, 3))
+        self.child1_of_post1 = AbstractFilterPage(
+            title='child 1 of post 1',
+            date_published=dt.date(2016, 9, 1)
+        )
+        self.child2_of_post1 = AbstractFilterPage(
+            title='child 2 of post 1',
+            date_published=dt.date(2016, 9, 2)
+        )
+        self.child1_of_post2 = AbstractFilterPage(
+            title='child 1 of post 2',
+            date_published=dt.date(2016, 9, 3)
+        )
         helpers.save_new_page(self.child1_of_post1, self.post1)
         helpers.save_new_page(self.child2_of_post1, self.post1)
         helpers.save_new_page(self.child1_of_post2, self.post2)
@@ -79,11 +82,11 @@ class SublandingPageTestCase(ElasticsearchTestsMixin, TestCase):
         The posts should be retrieved in reverse chronological order, and if
         the limit exceeds the total number of posts, all should be retrieved.
         """
-        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
-        self.assertEqual(len(browsefilterable_posts), 3)
-        self.assertEqual(self.child1_of_post1, browsefilterable_posts[2])
-        self.assertEqual(self.child2_of_post1, browsefilterable_posts[1])
-        self.assertEqual(self.child1_of_post2, browsefilterable_posts[0])
+        posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
+        self.assertEqual(len(posts), 3)
+        self.assertEqual(self.child1_of_post1, posts[2])
+        self.assertEqual(self.child2_of_post1, posts[1])
+        self.assertEqual(self.child1_of_post2, posts[0])
 
     def test_get_browsefilterable_posts_with_limit(self):
         """
@@ -92,6 +95,6 @@ class SublandingPageTestCase(ElasticsearchTestsMixin, TestCase):
         specified number of posts, and that the most recent post comes first.
         """
         self.limit = 1
-        browsefilterable_posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
-        self.assertEqual(len(browsefilterable_posts), 1)
-        self.assertEqual(self.child1_of_post2, browsefilterable_posts[0])
+        posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(self.child1_of_post2, posts[0])

--- a/cfgov/v1/tests/templatetags/test_activity_feed.py
+++ b/cfgov/v1/tests/templatetags/test_activity_feed.py
@@ -1,8 +1,6 @@
 import datetime
 from unittest import TestCase
 
-from django.core import management
-
 from v1.models import BlogPage
 from v1.models.base import CFGOVPageCategory
 from v1.templatetags import activity_feed

--- a/cfgov/v1/tests/templatetags/test_base_elements.py
+++ b/cfgov/v1/tests/templatetags/test_base_elements.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from django.template import Context, Template
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 
 
 class TestHeaderFooter(TestCase):

--- a/cfgov/v1/tests/templatetags/test_email_popup.py
+++ b/cfgov/v1/tests/templatetags/test_email_popup.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from django.conf import settings
 from django.template import Context, Template
-from django.test import RequestFactory, SimpleTestCase, override_settings
+from django.test import RequestFactory, override_settings
 
 
 class TestEmailPopupSettings(TestCase):
@@ -13,6 +13,7 @@ class TestEmailPopupSettings(TestCase):
         for k, v in settings.EMAIL_POPUP_URLS.items():
             self.assertIsInstance(k, str)
             self.assertIsInstance(v, list)
+
 
 class TestEmailPopupTag(TestCase):
     def render(self, path):

--- a/cfgov/v1/tests/test_blocks.py
+++ b/cfgov/v1/tests/test_blocks.py
@@ -28,7 +28,7 @@ class TestAbstractFormBlock(TestCase):
         mock_getclass()().process.assert_called_with(True)
 
     def test_get_handler_class_raises_AttributeError_for_unset_handler_meta(self):  # noqa
-        with self.assertRaises(AttributeError) as e:
+        with self.assertRaises(AttributeError):
             self.block.get_handler_class()
 
     @mock.patch('v1.blocks.import_string')
@@ -159,4 +159,3 @@ class RAFToolBlockTestCase(TestCase):
             '<div id="rental-assistance-finder" data-language="en"></div>',
             html
         )
-

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -2,11 +2,10 @@ import json
 from datetime import datetime
 from io import StringIO
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from wagtail.core.models import Site
 
-import dateutil.relativedelta
 from dateutil.relativedelta import relativedelta
 from pytz import timezone
 
@@ -28,7 +27,10 @@ from v1.tests.wagtail_pages.helpers import publish_page
 class FilterablePagesDocumentTest(TestCase):
 
     def test_model_class_added(self):
-        self.assertEqual(FilterablePagesDocument.django.model, AbstractFilterPage)
+        self.assertEqual(
+            FilterablePagesDocument.django.model,
+            AbstractFilterPage
+        )
 
     def test_ignore_signal_default(self):
         self.assertFalse(FilterablePagesDocument.django.ignore_signals)
@@ -66,7 +68,10 @@ class FilterablePagesDocumentTest(TestCase):
         enforcement.statuses.add(status)
         doc = FilterablePagesDocument()
         prepared_data = doc.prepare(enforcement)
-        self.assertEqual(prepared_data['statuses'], ['expired-terminated-dismissed'])
+        self.assertEqual(
+            prepared_data['statuses'],
+            ['expired-terminated-dismissed']
+        )
 
     def test_prepare_content_no_content_defined(self):
         event = EventPage(
@@ -85,10 +90,11 @@ class FilterablePagesDocumentTest(TestCase):
                     'type': 'full_width_text',
                     'value': [
                         {
-                            'type':'content',
-                            'value': 'Blog Text'
-                    }]
-                }
+                            'type': 'content',
+                            'value': 'Blog Text',
+                        },
+                    ],
+                },
             ])
         )
         doc = FilterablePagesDocument()
@@ -124,15 +130,16 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         cls.site = Site.objects.get(is_default_site=True)
 
         content = json.dumps([
-                {
-                    'type': 'full_width_text',
-                    'value': [
-                        {
-                            'type':'content',
-                            'value': 'Foo Test Content'
-                    }]
-                }
-            ])
+            {
+                'type': 'full_width_text',
+                'value': [
+                    {
+                        'type': 'content',
+                        'value': 'Foo Test Content',
+                    },
+                ],
+            },
+        ])
 
         event = EventPage(
             title='Event Test',
@@ -279,6 +286,12 @@ class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
         )
         results = search.search(title="Foo")
         self.assertTrue(results.filter(title=self.blog_title_match).exists())
-        self.assertTrue(results.filter(title=self.blog_content_match.title).exists())
-        self.assertTrue(results.filter(title=self.blog_preview_match.title).exists())
-        self.assertTrue(results.filter(title=self.blog_topic_match.title).exists())
+        self.assertTrue(
+            results.filter(title=self.blog_content_match.title).exists()
+        )
+        self.assertTrue(
+            results.filter(title=self.blog_preview_match.title).exists()
+        )
+        self.assertTrue(
+            results.filter(title=self.blog_topic_match.title).exists()
+        )

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,4 +1,3 @@
-import time
 from datetime import date, datetime
 from io import StringIO
 
@@ -17,7 +16,7 @@ from v1.forms import (
 from v1.models import BlogPage
 from v1.models.base import CFGOVPageCategory
 from v1.models.enforcement_action_page import EnforcementActionPage
-from v1.models.learn_page import AbstractFilterPage, EventPage
+from v1.models.learn_page import EventPage
 from v1.tests.wagtail_pages.helpers import publish_page
 from v1.util.categories import clean_categories
 

--- a/cfgov/v1/tests/test_forms.py
+++ b/cfgov/v1/tests/test_forms.py
@@ -16,7 +16,9 @@ class TestFilterableListForm(TestCase):
 
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('builtins.super')
-    def test_clean_returns_cleaned_data_if_in_future(self, mock_super, mock_init):
+    def test_clean_returns_cleaned_data_if_in_future(
+        self, mock_super, mock_init
+    ):
         mock_init.return_value = None
         from_date = datetime.date(2048, 1, 23)
         to_date = from_date + datetime.timedelta(weeks=52)
@@ -55,7 +57,9 @@ class TestFilterableListForm(TestCase):
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('builtins.super')
     @freeze_time("2017-01-15")
-    def test_clean_uses_earliest_result_if_fromdate_field_is_empty(self, mock_super, mock_init, mock_pub_date):
+    def test_clean_uses_earliest_result_if_fromdate_field_is_empty(
+        self, mock_super, mock_init, mock_pub_date
+    ):
         mock_init.return_value = None
         from_date = None
         to_date = datetime.date(2017, 1, 15)
@@ -75,7 +79,9 @@ class TestFilterableListForm(TestCase):
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('builtins.super')
     @freeze_time("2016-05-15")
-    def test_clean_uses_today_if_todate_field_is_empty(self, mock_super, mock_init):
+    def test_clean_uses_today_if_todate_field_is_empty(
+        self, mock_super, mock_init
+    ):
         mock_init.return_value = None
         from_date = datetime.date(2016, 5, 15)
         to_date = None
@@ -93,13 +99,18 @@ class TestFilterableListForm(TestCase):
 
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('builtins.super')
-    def test_clean_returns_cleaned_data_if_both_date_fields_are_empty(self, mock_super, mock_init):
+    def test_clean_returns_cleaned_data_if_both_date_fields_are_empty(
+        self, mock_super, mock_init
+    ):
         mock_init.return_value = None
         from_date = None
         to_date = None
 
         form = FilterableListForm()
-        mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
+        mock_super().clean.return_value = {
+            'from_date': from_date,
+            'to_date': to_date,
+        }
         form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
         form.data = {}
         form._errors = {}
@@ -108,17 +119,21 @@ class TestFilterableListForm(TestCase):
         assert result['from_date'] == from_date
         assert result['to_date'] == to_date
 
-
     @mock.patch('v1.forms.FilterableListForm.__init__')
     @mock.patch('builtins.super')
     @freeze_time("2000-03-15")
-    def test_clean_switches_date_fields_if_todate_is_less_than_fromdate(self, mock_super, mock_init):
+    def test_clean_switches_date_fields_if_todate_is_less_than_fromdate(
+        self, mock_super, mock_init
+    ):
         mock_init.return_value = None
         to_date = datetime.date(2000, 3, 15)
         from_date = to_date + datetime.timedelta(days=1)
 
         form = FilterableListForm()
-        mock_super().clean.return_value = {'from_date': from_date, 'to_date': to_date}
+        mock_super().clean.return_value = {
+            'from_date': from_date,
+            'to_date': to_date,
+        }
         form.cleaned_data = {'from_date': from_date, 'to_date': to_date}
         form.data = {'from_date': '3/16/2000', 'to_date': '3/15/2000'}
         form._errors = {}

--- a/cfgov/v1/tests/test_social_sharing_image_validation.py
+++ b/cfgov/v1/tests/test_social_sharing_image_validation.py
@@ -17,7 +17,11 @@ class TestSocialSharingImage(TestCase):
         save_new_page(self.page)
 
     def test_validation_error_thrown_if_width_height_too_large(self):
-        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=5000, height=5000)
+        self.page.social_sharing_image = baker.prepare(
+            CFGOVImage,
+            width=5000,
+            height=5000
+        )
         with self.assertRaisesRegex(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'
@@ -25,7 +29,11 @@ class TestSocialSharingImage(TestCase):
             self.page.save()
 
     def test_validation_error_thrown_if_width_too_large(self):
-        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=4097, height=1500)
+        self.page.social_sharing_image = baker.prepare(
+            CFGOVImage,
+            width=4097,
+            height=1500
+        )
         with self.assertRaisesRegex(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'
@@ -33,7 +41,11 @@ class TestSocialSharingImage(TestCase):
             self.page.save()
 
     def test_validation_error_thrown_if_height_too_large(self):
-        self.page.social_sharing_image = baker.prepare(CFGOVImage, width=1500, height=4097)
+        self.page.social_sharing_image = baker.prepare(
+            CFGOVImage,
+            width=1500,
+            height=4097
+        )
         with self.assertRaisesRegex(
             ValidationError,
             'Social sharing image must be less than 4096w x 4096h'

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest import mock
 
 from django.test import (

--- a/cfgov/v1/tests/util/test_events.py
+++ b/cfgov/v1/tests/util/test_events.py
@@ -60,7 +60,10 @@ class EventUtilTestCase(TestCase):
     @override_settings(MAPBOX_ACCESS_TOKEN='test_token')
     def test_get_venue_coords_default_venue_coords_when_empty(self):
         # Should default to DC coords if no city/state provided
-        self.assertEqual(get_venue_coords(city='', state=''), '-77.039628,38.898238')
+        self.assertEqual(
+            get_venue_coords(city='', state=''),
+            '-77.039628,38.898238'
+        )
 
     @override_settings(MAPBOX_ACCESS_TOKEN='test_token')
     @responses.activate

--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -88,13 +88,14 @@ class MigrationsUtilTestCase(TestCase):
         old data, calls the mapper function, and stores new data
         based on the mapper results. """
         # Mock the field mapper migration function. We'll inspect the
-        # call to this and ensure the return value makes it to set_streamfield_data.
+        # call to this and ensure the return value makes it to
+        # set_streamfield_data.
         mapper = mock.Mock(return_value='new text')
 
         migrate_stream_field(self.page, 'body', 'text', mapper)
 
         mapper.assert_called_with(self.page, 'some text')
-        data =self.page.body.raw_data
+        data = self.page.body.raw_data
         self.assertEqual(data[0]['value'], 'new text')
 
     def test_migrate_stream_field_revision(self):
@@ -102,7 +103,8 @@ class MigrationsUtilTestCase(TestCase):
         old data, calls the mapper function, and stores new data
         based on the mapper results. """
         # Mock the field mapper migration function. We'll inspect the
-        # call to this and ensure the return value makes it to set_streamfield_data.
+        # call to this and ensure the return value makes it to
+        # set_streamfield_data.
         mapper = mock.Mock(return_value='new text')
 
         migrate_stream_field(self.revision, 'body', 'text', mapper)
@@ -158,8 +160,10 @@ class MigrationsUtilTestCase(TestCase):
 class ChildStructBlock(blocks.StructBlock):
     text = blocks.CharBlock()
 
+
 class ChildStreamBlock(blocks.StreamBlock):
     text = blocks.CharBlock()
+
 
 class TestStreamBlock(blocks.StreamBlock):
     text = blocks.CharBlock()

--- a/cfgov/v1/tests/util/test_ref.py
+++ b/cfgov/v1/tests/util/test_ref.py
@@ -17,17 +17,23 @@ class TestCategories(TestCase):
 
 
 class TestGetAppropriateCategories(TestCase):
-# Note this test is heavily hard-coded with values from cfgov/v1/util/ref.py
-    def test_non_related_post_category_should_not_return_matches(self):
-        result = get_appropriate_categories(['Administrative adjudication'], 'blog')
+    # This test is heavily hard-coded with values from cfgov/v1/util/ref.py.
+    def test_non_related_post_category_no_matches(self):
+        result = get_appropriate_categories(
+            ['Administrative adjudication'],
+            'blog'
+        )
         self.assertEqual(result, [])
 
-    def test_related_post_category_should_not_return_matches_if_wrong_page_type(self):
+    def test_related_post_category_no_matches_if_wrong_page_type(self):
         result = get_appropriate_categories(['Press Release'], 'blog')
         self.assertEqual(result, [])
 
     def test_should_return_matches_only_for_relevant_page_type(self):
-        result = get_appropriate_categories(['Press Release', 'At the CFPB'], 'blog')
+        result = get_appropriate_categories(
+            ['Press Release', 'At the CFPB'],
+            'blog'
+        )
         self.assertEqual(len(result), 1)
 
     def test_should_return_matches_as_slugs(self):
@@ -35,7 +41,10 @@ class TestGetAppropriateCategories(TestCase):
         self.assertEqual(result, ['press-release'])
 
     def test_should_return_all_matches(self):
-        result = get_appropriate_categories(['Op-Ed', 'Testimony', 'Speech', 'Press Release'], 'newsroom')
+        result = get_appropriate_categories(
+            ['Op-Ed', 'Testimony', 'Speech', 'Press Release'],
+            'newsroom'
+        )
         self.assertEqual(len(result), 4)
 
 
@@ -43,13 +52,23 @@ class TestGetCategoryChildren(TestCase):
     def test_get_children_of_single_category(self):
         self.assertEqual(
             get_category_children(['Amicus Brief']),
-            ['fed-circuit-court', 'fed-district-court', 'state-court', 'us-supreme-court']
+            [
+                'fed-circuit-court',
+                'fed-district-court',
+                'state-court',
+                'us-supreme-court',
+            ]
         )
 
     def test_get_children_of_multiple_categories(self):
         self.assertEqual(
             get_category_children(['Final rule', 'Implementation Resource']),
-            ['compliance-aid', 'final-rule', 'interim-final-rule', 'official-guidance']
+            [
+                'compliance-aid',
+                'final-rule',
+                'interim-final-rule',
+                'official-guidance',
+            ]
         )
 
     def test_get_children_with_invalid_category_raises_keyerror(self):

--- a/cfgov/v1/tests/util/test_util.py
+++ b/cfgov/v1/tests/util/test_util.py
@@ -13,7 +13,9 @@ class TestUtilFunctions(TestCase):
     @mock.patch('__builtin__.isinstance')
     @mock.patch('__builtin__.vars')
     @mock.patch('v1.util.util.StreamValue')
-    def get_streamfields_returns_dict_of_streamfields(self, mock_streamvalueclass, mock_vars, mock_isinstance):
+    def get_streamfields_returns_dict_of_streamfields(
+        self, mock_streamvalueclass, mock_vars, mock_isinstance
+    ):
         page = mock.Mock()
         mock_vars.items.return_value = {'key': 'value'}
         mock_isinstance.return_value = True
@@ -22,19 +24,18 @@ class TestUtilFunctions(TestCase):
 
 
 class TestExtendedStrftime(TestCase):
-
     def test_date_formatted_without_leading_zero_in_day(self):
-        test_date=date(2018, 4, 5)
+        test_date = date(2018, 4, 5)
         formatted_date = util.extended_strftime(test_date, '%b %_d, %Y')
         self.assertEqual(formatted_date, 'Apr 5, 2018')
 
     def test_date_formatted_with_custom_month_abbreviation(self):
-        test_date=date(2018, 9, 5)
+        test_date = date(2018, 9, 5)
         formatted_date = util.extended_strftime(test_date, '%_m %d, %Y')
         self.assertEqual(formatted_date, 'Sept. 05, 2018')
 
     def test_date_formatted_with_default_pattern(self):
-        test_date=date(2018, 9, 5)
+        test_date = date(2018, 9, 5)
         formatted_date = util.extended_strftime(test_date, '%b %d, %Y')
         self.assertEqual(formatted_date, 'Sep 05, 2018')
 
@@ -106,7 +107,7 @@ class TestSecondaryNav(TestCase):
         self.assertEqual(nav[1]['title'], self.browse_page2.title)
         self.assertEqual(nav[1]['children'], [])
 
-    def test_nav_for_child_of_browse_page_includes_only_children_of_parent_browse_page(self):
+    def test_nav_for_child_of_browse_page_includes_only_children_of_parent_browse_page(self):  # noqa: E501
         nav, has_children = util.get_secondary_nav_items(
             self.request, self.child_of_browse_page2
         )
@@ -130,7 +131,7 @@ class TestSecondaryNav(TestCase):
 
         self.assertEqual(has_children, True)
 
-    def test_has_children_is_true_for_browse_page_with_browse_filterable_child(self):
+    def test_has_children_is_true_for_browse_page_with_browse_filterable_child(self):  # noqa: E501
         browse_filterable_page = BrowsePage(title='Non-browse page')
         helpers.publish_page(child=browse_filterable_page)
         browse_filterable_page_child = BrowseFilterablePage(
@@ -145,10 +146,12 @@ class TestSecondaryNav(TestCase):
 
         self.assertEqual(has_children, True)
 
-    def test_has_children_is_false_for_browse_page_with_only_non_browse_children(self):
+    def test_has_children_is_false_for_browse_page_with_only_non_browse_children(self):  # noqa: E501
         browse_page3 = BrowsePage(title='Browse page 3')
         helpers.publish_page(child=browse_page3)
-        child_of_browse_page3 = CFGOVPage(title='Non-browse child of browse page')
+        child_of_browse_page3 = CFGOVPage(
+            title='Non-browse child of browse page'
+        )
         helpers.save_new_page(child_of_browse_page3, browse_page3)
 
         nav, has_children = util.get_secondary_nav_items(

--- a/cfgov/v1/tests/views/test_template_debug.py
+++ b/cfgov/v1/tests/views/test_template_debug.py
@@ -30,8 +30,8 @@ class TemplateDebugViewTests(SimpleTestCase):
                 'text': 'First test case to be rendered',
             },
             'Second': {
-               'url': 'https://example.com/second/',
-               'text': 'Second test case to be rendered',
+                'url': 'https://example.com/second/',
+                'text': 'Second test case to be rendered',
             },
         }
 

--- a/cfgov/v1/tests/wagtail_pages/test_page_states.py
+++ b/cfgov/v1/tests/wagtail_pages/test_page_states.py
@@ -1,14 +1,11 @@
-import os
-
 from django.test import Client, TestCase
 
 from v1.models.landing_page import LandingPage
-from v1.tests.wagtail_pages.helpers import (
-    publish_page, save_new_page, save_page
-)
+from v1.tests.wagtail_pages.helpers import publish_page, save_new_page
 
 
 django_client = Client()
+
 
 class PageStatesTestCase(TestCase):
 


### PR DESCRIPTION
Currently, [for historical reasons](https://github.com/cfpb/consumerfinance.gov/pull/2509), the Python files under v1/tests are excluded from our flake8 linter tests. This commit makes the necessary fixes to get these files to pass the linter, and restores v1/tests to the list of directories that will get checked in future.

## How to test this PR

`tox -e lint`


There are a lot of files changed here; the key one is `.flake8` where you can see the configuration change. The rest of the file changes are just whitespace and code formatting.

## Notes and todos

- [As of last week](https://github.com/psf/black/releases/tag/22.1.0), the [Black](https://black.readthedocs.io/en/stable/) Python auto-formatter is now stable - I know we've discussed this internally a bunch, and it might be a good time to consider adopting it to avoid the need for this kind of linting in future.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)