### PR TITLE
Update Python 2 super() calls to Python 3

### DIFF
--- a/cfgov/agreements/jinja2tags.py
+++ b/cfgov/agreements/jinja2tags.py
@@ -44,7 +44,7 @@ class AgreementsExtension(Extension):
     This will give us an {% agreements_issuer_select %} tag.
     """
     def __init__(self, environment):
-        super(AgreementsExtension, self).__init__(environment)
+        super().__init__(environment)
         self.environment.globals.update({
             'agreements_issuer_select': issuer_select,
         })

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -21,7 +21,7 @@ class TestLoggingHandlers(TestCase):
         Persists previous log configuration and global disable level. These
         then get restored in tearDownClass.
         """
-        super(TestLoggingHandlers, cls).setUpClass()
+        super().setUpClass()
         cls._logging = settings.LOGGING
         cls._logging_disable_level = logging.root.manager.disable
 
@@ -57,7 +57,7 @@ class TestLoggingHandlers(TestCase):
         """Restores regular logging."""
         logging.config.dictConfig(cls._logging)
         logging.disable(cls._logging_disable_level)
-        super(TestLoggingHandlers, cls).tearDownClass()
+        super().tearDownClass()
 
     def test_logger_calls_sqs_queue_post(self, sqs_queue_post):
         self.logger.error('something')

--- a/cfgov/ask_cfpb/models/answer_page.py
+++ b/cfgov/ask_cfpb/models/answer_page.py
@@ -315,7 +315,7 @@ class AnswerPage(CFGOVPage):
         # self.get_meta_description() is not called here because it is called
         # and added to the context by CFGOVPage's get_context() method.
         portal_topic = self.primary_portal_topic or self.portal_topic.first()
-        context = super(AnswerPage, self).get_context(request)
+        context = super().get_context(request)
         context['related_questions'] = self.related_questions.all()
         context['last_edited'] = self.last_edited
         context['portal_page'] = get_portal_or_portal_search_page(
@@ -399,7 +399,7 @@ class AnswerPage(CFGOVPage):
             else:
                 return ("redirected")
         else:
-            return super(AnswerPage, self).status_string
+            return super().status_string
 
     # Returns an image for the page's meta Open Graph tag
     @property

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -174,7 +174,7 @@ class AnswerLandingPage(LandingPage):
         return portal_cards
 
     def get_context(self, request, *args, **kwargs):
-        context = super(AnswerLandingPage, self).get_context(request)
+        context = super().get_context(request)
         context['portal_cards'] = self.get_portal_cards()
         context['about_us'] = get_standard_text(self.language, 'about_us')
         context['disclaimer'] = get_standard_text(self.language, 'disclaimer')
@@ -186,7 +186,7 @@ class SecondaryNavigationJSMixin(object):
 
     @property
     def page_js(self):
-        js = super(SecondaryNavigationJSMixin, self).page_js
+        js = super().page_js
         if self.language == 'en':
             js += ['secondary-navigation.js']
         return js
@@ -295,7 +295,7 @@ class PortalSearchPage(
             activate(self.language)
         else:
             deactivate_all()
-        return super(PortalSearchPage, self).get_context(
+        return super().get_context(
             request, *args, **kwargs)
 
     def get_nav_items(self, request, page):
@@ -601,7 +601,7 @@ class ArticlePage(CFGOVPage):
     objects = CFGOVPageManager()
 
     def get_context(self, request, *args, **kwargs):
-        context = super(ArticlePage, self).get_context(request)
+        context = super().get_context(request)
         context['about_us'] = get_standard_text(self.language, 'about_us')
         return context
 

--- a/cfgov/core/forms.py
+++ b/cfgov/core/forms.py
@@ -17,7 +17,7 @@ class ExternalURLForm(forms.Form):
     signature = forms.CharField(required=False, widget=forms.HiddenInput)
 
     def clean(self):
-        cleaned_data = super(ExternalURLForm, self).clean()
+        cleaned_data = super().clean()
         signer = Signer()
 
         if self.errors:

--- a/cfgov/core/govdelivery.py
+++ b/cfgov/core/govdelivery.py
@@ -66,7 +66,7 @@ class ExceptionMockGovDelivery(MockGovDelivery):
     any method.
     """
     def handle(self, method, *args, **kwargs):
-        super(ExceptionMockGovDelivery, self).handle(method, *args, **kwargs)
+        super().handle(method, *args, **kwargs)
         raise RuntimeError('test GovDelivery exception')
 
 
@@ -77,7 +77,7 @@ class ServerErrorMockGovDelivery(MockGovDelivery):
     an HTTP status code of 500
     """
     def handle(self, method, *args, **kwargs):
-        response = super(ServerErrorMockGovDelivery, self).handle(
+        response = super().handle(
             method,
             *args,
             **kwargs
@@ -107,7 +107,7 @@ class LoggingMockGovDelivery(MockGovDelivery):
             )
         )
 
-        return super(LoggingMockGovDelivery, self).handle(
+        return super().handle(
             method,
             *args,
             **kwargs

--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -8,7 +8,7 @@ from core.utils import slugify_unique
 
 class CoreExtension(Extension):
     def __init__(self, environment):
-        super(CoreExtension, self).__init__(environment)
+        super().__init__(environment)
         self.environment.globals.update({
             'svg_icon': svg_icon,
         })

--- a/cfgov/core/tests/testutils/test_runners.py
+++ b/cfgov/core/tests/testutils/test_runners.py
@@ -25,7 +25,7 @@ class StderrSuppressingStdoutCapturingTestRunner(StdoutCapturingTestRunner):
     """
 
     def get_test_runner_kwargs(self):
-        kwargs = super(StderrSuppressingStdoutCapturingTestRunner, self). \
+        kwargs = super(). \
             get_test_runner_kwargs()
         kwargs['stream'] = StringIO()
         return kwargs

--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -16,7 +16,7 @@ from scripts import initial_data
 
 class TestRunner(DiscoverRunner):
     def setup_test_environment(self, **kwargs):
-        super(TestRunner, self).setup_test_environment(**kwargs)
+        super().setup_test_environment(**kwargs)
 
         # The frontend build generates JavaScript files which are included in
         # Django templates via {% include %} blocks. If these files don't
@@ -43,7 +43,7 @@ class TestRunner(DiscoverRunner):
                     f.write(PLACEHOLDER_STRING)
 
     def teardown_test_environment(self, **kwargs):
-        super(TestRunner, self).teardown_test_environment()
+        super().teardown_test_environment()
 
         # The test settings use a custom MEDIA_ROOT for tests that write files
         # to disk. We want to clean up that location after the tests run.
@@ -53,14 +53,14 @@ class TestRunner(DiscoverRunner):
         # Disable logging below CRITICAL during tests.
         logging.disable(logging.CRITICAL)
 
-        return super(TestRunner, self).run_tests(
+        return super().run_tests(
             test_labels,
             extra_tests,
             **kwargs
         )
 
     def setup_databases(self, **kwargs):
-        dbs = super(TestRunner, self).setup_databases(**kwargs)
+        dbs = super().setup_databases(**kwargs)
 
         # Ensure that certain key data migrations are always run even if
         # tests are being run with most migrations disabled (e.g. using
@@ -113,7 +113,7 @@ class StdoutCapturingTestRunner(TestRunner):
     def run_suite(self, suite, **kwargs):
         captured_stdout = StringIO()
         with redirect_stdout(captured_stdout):
-            return_value = super(StdoutCapturingTestRunner, self).run_suite(
+            return_value = super().run_suite(
                 suite,
                 **kwargs
             )

--- a/cfgov/core/views.py
+++ b/cfgov/core/views.py
@@ -140,10 +140,10 @@ class ExternalURLNoticeView(FormMixin, TemplateView):
     form_class = ExternalURLForm
 
     def dispatch(self, *args, **kwargs):
-        return super(ExternalURLNoticeView, self).dispatch(*args, **kwargs)
+        return super().dispatch(*args, **kwargs)
 
     def get_form_kwargs(self):
-        kwargs = super(ExternalURLNoticeView, self).get_form_kwargs()
+        kwargs = super().get_form_kwargs()
 
         if self.request.method == 'GET':
             kwargs['data'] = self.request.GET
@@ -151,7 +151,7 @@ class ExternalURLNoticeView(FormMixin, TemplateView):
         return kwargs
 
     def get_context_data(self, **kwargs):
-        context = super(ExternalURLNoticeView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         form = self.get_form()
         context['form'] = form
@@ -166,7 +166,7 @@ class ExternalURLNoticeView(FormMixin, TemplateView):
                 'URL invalid, not whitelisted, or signature validation failed'
             )
 
-        return super(ExternalURLNoticeView, self).get(request)
+        return super().get(request)
 
 
 class TranslatedTemplateView(TemplateView):
@@ -178,7 +178,7 @@ class TranslatedTemplateView(TemplateView):
 
     def get_context_data(self, **kwargs):
         activate(self.language)
-        context = super(TranslatedTemplateView, self).get_context_data(
+        context = super().get_context_data(
             **kwargs
         )
         context['current_language'] = get_language()

--- a/cfgov/data_research/blocks.py
+++ b/cfgov/data_research/blocks.py
@@ -68,7 +68,7 @@ class ConferenceRegistrationForm(AbstractFormBlock):
     )
 
     def clean(self, value):
-        cleaned = super(ConferenceRegistrationForm, self).clean(value)
+        cleaned = super().clean(value)
         question = cleaned.get('govdelivery_question_id')
         answer = cleaned.get('govdelivery_answer_id')
 

--- a/cfgov/data_research/forms.py
+++ b/cfgov/data_research/forms.py
@@ -119,10 +119,10 @@ class ConferenceRegistrationForm(forms.Form):
         self.govdelivery_code = kwargs.pop('govdelivery_code')
         self.govdelivery_question_id = kwargs.pop('govdelivery_question_id')
         self.govdelivery_answer_id = kwargs.pop('govdelivery_answer_id')
-        super(ConferenceRegistrationForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def clean(self):
-        cleaned_data = super(ConferenceRegistrationForm, self).clean()
+        cleaned_data = super().clean()
 
         if (
             cleaned_data.get('attendee_type') == self.ATTENDEE_IN_PERSON and

--- a/cfgov/data_research/handlers.py
+++ b/cfgov/data_research/handlers.py
@@ -18,7 +18,7 @@ class ConferenceRegistrationHandler(Handler):
     """
 
     def __init__(self, page, request, block_value, form_cls=None):
-        super(ConferenceRegistrationHandler, self).__init__(page, request)
+        super().__init__(page, request)
         self.govdelivery_code = block_value['govdelivery_code']
         self.govdelivery_question_id = block_value['govdelivery_question_id']
         self.govdelivery_answer_id = block_value['govdelivery_answer_id']

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -375,7 +375,7 @@ class MortgagePerformancePage(BrowsePage):
         return meta
 
     def get_context(self, request, *args, **kwargs):
-        context = super(MortgagePerformancePage, self).get_context(
+        context = super().get_context(
             request, *args, **kwargs)
         context.update(self.get_mortgage_meta())
         if '30-89' in self.url:

--- a/cfgov/data_research/tests/test_handlers.py
+++ b/cfgov/data_research/tests/test_handlers.py
@@ -11,7 +11,7 @@ class MockConferenceRegistrationForm(forms.Form):
         kwargs.pop('govdelivery_code')
         kwargs.pop('govdelivery_question_id')
         kwargs.pop('govdelivery_answer_id')
-        super(MockConferenceRegistrationForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def save(self, commit=False):
         pass

--- a/cfgov/diversity_inclusion/views.py
+++ b/cfgov/diversity_inclusion/views.py
@@ -13,4 +13,4 @@ class GetAssessmentForm(FormView):
         # This method is called when valid form data has been POSTed.
         # It should return an HttpResponse.
         form.send_email()
-        return super(GetAssessmentForm, self).form_valid(form)
+        return super().form_valid(form)

--- a/cfgov/form_explainer/blocks.py
+++ b/cfgov/form_explainer/blocks.py
@@ -12,7 +12,7 @@ class ImageMapCoordinates(blocks.StructBlock):
     height = blocks.FloatBlock(required=True, min_value=0, max_value=100)
 
     def clean(self, value):
-        cleaned = super(ImageMapCoordinates, self).clean(value)
+        cleaned = super().clean(value)
         errors = {}
         if cleaned.get('left') + cleaned.get('width') > 100:
             errors['left'] = errors['width'] = ErrorList([

--- a/cfgov/hmda/models/forms.py
+++ b/cfgov/hmda/models/forms.py
@@ -9,7 +9,7 @@ from hmda.resources.hmda_data_options import (
 class HmdaFilterableForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
-        super(HmdaFilterableForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     geo = forms.ChoiceField(
         required=False,

--- a/cfgov/hmda/models/pages.py
+++ b/cfgov/hmda/models/pages.py
@@ -18,7 +18,7 @@ class HmdaHistoricDataPage(LearnPage):
     template = 'hmda/hmda-explorer.html'
 
     def get_context(self, request, *args, **kwargs):
-        context = super(HmdaHistoricDataPage, self).get_context(
+        context = super().get_context(
             request, *args, **kwargs)
 
         form_data = self.form_data(request.GET)

--- a/cfgov/housing_counselor/views.py
+++ b/cfgov/housing_counselor/views.py
@@ -69,7 +69,7 @@ class HousingCounselorView(TemplateView, HousingCounselorS3URLMixin):
     }
 
     def get_context_data(self, **kwargs):
-        context = super(HousingCounselorView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['mapbox_access_token'] = settings.MAPBOX_ACCESS_TOKEN
 
         zipcode = self.request.GET.get('zipcode')

--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -196,7 +196,7 @@ class JobListingPage(CFGOVPage):
     objects = JobListingPageManager()
 
     def get_context(self, request, *args, **kwargs):
-        context = super(JobListingPage, self).get_context(request)
+        context = super().get_context(request)
 
         try:
             context['about_us'] = ReusableText.objects.get(
@@ -230,4 +230,4 @@ class JobListingPage(CFGOVPage):
 
     @property
     def page_js(self):
-        return super(JobListingPage, self).page_js + ['summary.js']
+        return super().page_js + ['summary.js']

--- a/cfgov/jobmanager/tests/models/test_panels.py
+++ b/cfgov/jobmanager/tests/models/test_panels.py
@@ -29,7 +29,7 @@ class ApplicationLinkTestCaseMixin(object):
 
     @classmethod
     def setUpClass(cls):
-        super(ApplicationLinkTestCaseMixin, cls).setUpClass()
+        super().setUpClass()
         cls.root = Page.objects.get(slug='root')
 
     def setUp(self):
@@ -52,7 +52,7 @@ class USAJobsApplicationLinkTestCase(ApplicationLinkTestCaseMixin, TestCase):
     link_cls = USAJobsApplicationLink
 
     def setUp(self):
-        super(USAJobsApplicationLinkTestCase, self).setUp()
+        super().setUp()
         self.applicant_type = baker.make(ApplicantType)
 
     def test_all_fields_passes_validation(self):

--- a/cfgov/legacy/views/complaint.py
+++ b/cfgov/legacy/views/complaint.py
@@ -17,7 +17,7 @@ class ComplaintLandingView(TemplateView):
     template_name = 'ccdb-complaint/complaint-landing.html'
 
     def get_context_data(self, **kwargs):
-        context = super(ComplaintLandingView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         context.update({
             'technical_issues': flag_enabled('CCDB_TECHNICAL_ISSUES'),
@@ -26,7 +26,7 @@ class ComplaintLandingView(TemplateView):
         return context
 
     def dispatch(self, *args, **kwargs):
-        response = super(ComplaintLandingView, self).dispatch(*args, **kwargs)
+        response = super().dispatch(*args, **kwargs)
         response['Edge-Cache-Tag'] = 'complaints'
         return response
 
@@ -38,7 +38,7 @@ class CCDBSearchView(TemplateView):
     """
 
     def dispatch(self, *args, **kwargs):
-        response = super(CCDBSearchView, self).dispatch(*args, **kwargs)
+        response = super().dispatch(*args, **kwargs)
         response['Edge-Cache-Tag'] = 'complaints'
         return response
 

--- a/cfgov/login/forms.py
+++ b/cfgov/login/forms.py
@@ -22,7 +22,7 @@ class PasswordValidationMixin(object):
     user_attribute = 'user'
 
     def clean(self):
-        cleaned_data = super(PasswordValidationMixin, self).clean()
+        cleaned_data = super().clean()
         user = getattr(self, self.user_attribute)
         key1, key2 = (self.password_key + '1', self.password_key + '2')
         if key1 in cleaned_data and key2 in cleaned_data:
@@ -132,7 +132,7 @@ class LoginForm(AuthenticationForm):
                 return self.cleaned_data
 
     def confirm_login_allowed(self, user):
-        super(LoginForm, self).confirm_login_allowed(user)
+        super().confirm_login_allowed(user)
         now = timezone.now()
 
         lockout_query = user.temporarylockout_set.filter(expires_at__gt=now)
@@ -159,7 +159,7 @@ class UserCreationForm(wagtailforms.UserCreationForm):
             raise ValidationError('This email is already in use.')
 
     def save(self, commit=True):
-        user = super(UserCreationForm, self).save(commit=commit)
+        user = super().save(commit=commit)
 
         if commit:
             send_password_reset_email(user.email)

--- a/cfgov/paying_for_college/models/pages.py
+++ b/cfgov/paying_for_college/models/pages.py
@@ -31,7 +31,7 @@ class PayingForCollegePage(CFGOVPage):
         abstract = True
 
     def get_context(self, request, *args, **kwargs):
-        context = super(PayingForCollegePage, self).get_context(request)
+        context = super().get_context(request)
         context['return_user'] = 'iped' in request.GET and request.GET['iped']
         return context
 

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -120,7 +120,7 @@ def format_constants():
 class BaseTemplateView(TemplateView):
 
     def get_context_data(self, **kwargs):
-        context = super(BaseTemplateView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['url_root'] = DISCLOSURE_ROOT
         context.update(format_constants())
         return context

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -29,7 +29,7 @@ class PrepaidAgreementsExtension(Extension):
     This will give us a {% remove_url_parameter %} tag.
     """
     def __init__(self, environment):
-        super(PrepaidAgreementsExtension, self).__init__(environment)
+        super().__init__(environment)
         self.environment.globals.update({
             'remove_url_parameter': remove_url_parameter
         })

--- a/cfgov/privacy/views.py
+++ b/cfgov/privacy/views.py
@@ -13,7 +13,7 @@ class GetDisclosureConsentForm(FormView):
         # This method is called when valid form data has been POSTed.
         # It should return an HttpResponse.
         form.send_email()
-        return super(GetDisclosureConsentForm, self).form_valid(form)
+        return super().form_valid(form)
 
 
 class GetRecordsAccessForm(FormView):
@@ -25,4 +25,4 @@ class GetRecordsAccessForm(FormView):
         # This method is called when valid form data has been POSTed.
         # It should return an HttpResponse.
         form.send_email()
-        return super(GetRecordsAccessForm, self).form_valid(form)
+        return super().form_valid(form)

--- a/cfgov/regulations3k/blocks.py
+++ b/cfgov/regulations3k/blocks.py
@@ -28,7 +28,7 @@ class RegulationsList(organisms.ModelBlock):
         return qs.live()
 
     def get_queryset(self, value):
-        qs = super(RegulationsList, self).get_queryset(value)
+        qs = super().get_queryset(value)
         future_versions_qs = EffectiveVersion.objects.filter(
             draft=False,
             effective_date__gte=date.today()
@@ -43,7 +43,7 @@ class RegulationsList(organisms.ModelBlock):
         return qs
 
     def get_context(self, value, parent_context=None):
-        context = super(RegulationsList, self).get_context(
+        context = super().get_context(
             value, parent_context=parent_context
         )
         context['regulations'] = self.get_queryset(value)

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -36,7 +36,7 @@ class CopyButtonHelper(TreeButtonHelper):
         ph = self.permission_helper
         pk = getattr(obj, self.opts.pk.attname)
 
-        btns = super(CopyButtonHelper, self).get_buttons_for_obj(
+        btns = super().get_buttons_for_obj(
             obj,
             exclude=exclude,
             classnames_add=classnames_add,

--- a/cfgov/regulations3k/jinja2tags.py
+++ b/cfgov/regulations3k/jinja2tags.py
@@ -44,7 +44,7 @@ def regs_hide_on_mobile(text):
 class RegulationsExtension(Extension):
 
     def __init__(self, environment):
-        super(RegulationsExtension, self).__init__(environment)
+        super().__init__(environment)
 
         self.environment.globals.update({
             'routablepageurl': jinja2.contextfunction(routablepageurl),

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -131,7 +131,7 @@ class EffectiveVersion(models.Model):
         return 'Previous version'
 
     def validate_unique(self, exclude=None):
-        super(EffectiveVersion, self).validate_unique(exclude=exclude)
+        super().validate_unique(exclude=exclude)
 
         # Enforce some uniqueness on the effective-date. It will need to be
         # unique within a part, so if this part has a date the same as this
@@ -317,7 +317,7 @@ class Section(models.Model):
 
     def save(self, **kwargs):
         self.sortable_label = '-'.join(sortable_label(self.label))
-        super(Section, self).save(**kwargs)
+        super().save(**kwargs)
 
     @cached_property
     def part(self):

--- a/cfgov/teachers_digital_platform/fields.py
+++ b/cfgov/teachers_digital_platform/fields.py
@@ -6,4 +6,4 @@ from mptt.models import TreeManyToManyField
 class ParentalTreeManyToManyField(ParentalManyToManyField, TreeManyToManyField):  # noqa: E501
     def formfield(self, **kwargs):
         kwargs.setdefault('form_class', TreeNodeMultipleChoiceField)
-        return super(TreeManyToManyField, self).formfield(**kwargs)
+        return super().formfield(**kwargs)

--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -91,7 +91,7 @@ class ActivityIndexPage(CFGOVPage):
     @classmethod
     def can_create_at(cls, parent):
         # You can only create one of these!
-        return super(ActivityIndexPage, cls).can_create_at(parent) \
+        return super().can_create_at(parent) \
             and not cls.objects.exists()
 
     def get_template(self, request):
@@ -212,7 +212,7 @@ class ActivityIndexPage(CFGOVPage):
         if not self.activity_setups:
             self.activity_setups = get_activity_setup()
         context_update = self.dsl_search(request, *args, **kwargs)
-        context = super(ActivityIndexPage, self).get_context(request)
+        context = super().get_context(request)
         context.update(context_update)
         return context
 

--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -28,7 +28,7 @@ from v1.models import HomePage
 class ActivityIndexPageTests(WagtailPageTests):
     @classmethod
     def setUpClass(self):
-        super(ActivityIndexPageTests, self).setUpClass()
+        super().setUpClass()
 
     def test_can_create_an_activity_page_under_activity_index_page(self):
         self.assertCanCreateAt(ActivityIndexPage, ActivityPage)
@@ -284,7 +284,7 @@ class TestActivityIndexPageSearch(TestCase):
     fixtures = ['tdp_initial_data']
 
     def setUp(self):
-        # super(TestActivityIndexPageSearch, self).setUp()
+        # super().setUp()
         self.root_page = HomePage.objects.get(slug='cfgov')
         self.root_page.save_revision().publish()
         self.site = Site.objects.get(is_default_site=True)

--- a/cfgov/teachers_digital_platform/tests/models/test_activity_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_page.py
@@ -19,7 +19,7 @@ class TestActivityPage(TestCase):
     fixtures = ['tdp_initial_data']
 
     def setUp(self):
-        super(TestActivityPage, self).setUp()
+        super().setUp()
         self.ROOT_PAGE = HomePage.objects.get(slug='cfgov')
         self.ROOT_PAGE.save_revision().publish()
 

--- a/cfgov/teachers_digital_platform/tests/test_views.py
+++ b/cfgov/teachers_digital_platform/tests/test_views.py
@@ -18,7 +18,7 @@ _time = 1623518461
 class TestSurveyWizard(TestCase):
 
     def setUp(self):
-        super(TestSurveyWizard, self).setUp()
+        super().setUp()
 
         self.factory = RequestFactory()
 

--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -39,7 +39,7 @@ class Hyperlink(blocks.StructBlock):
 
     def __init__(self, required=True):
         self.is_required = required
-        super(Hyperlink, self).__init__()
+        super().__init__()
 
     @property
     def required(self):
@@ -48,7 +48,7 @@ class Hyperlink(blocks.StructBlock):
     def clean(self, data):
         error_dict = {}
 
-        data = super(Hyperlink, self).clean(data)
+        data = super().clean(data)
 
         if self.is_required:
             if not data['text']:
@@ -110,7 +110,7 @@ class ImageBasic(blocks.StructBlock):
 
     def __init__(self, required=True):
         self.is_required = required
-        super(ImageBasic, self).__init__()
+        super().__init__()
 
     @property
     def required(self):
@@ -119,7 +119,7 @@ class ImageBasic(blocks.StructBlock):
     def clean(self, data):
         error_dict = {}
 
-        data = super(ImageBasic, self).clean(data)
+        data = super().clean(data)
 
         if not self.required and not data['upload']:
             return data

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -48,7 +48,7 @@ class TextIntroduction(blocks.StructBlock):
     )
 
     def clean(self, value):
-        cleaned = super(TextIntroduction, self).clean(value)
+        cleaned = super().clean(value)
 
         # Eyebrow requires a heading.
         if cleaned.get('eyebrow') and not cleaned.get('heading'):
@@ -220,7 +220,7 @@ class ContactEmail(blocks.StructBlock):
     )
 
     def clean(self, value):
-        cleaned = super(ContactEmail, self).clean(value)
+        cleaned = super().clean(value)
 
         if not cleaned.get('emails'):
             raise StructBlockValidationError(
@@ -380,7 +380,7 @@ class RSSFeed(blocks.StaticBlock):
         )
 
     def get_context(self, value, parent_context=None):
-        context = super(RSSFeed, self).get_context(
+        context = super().get_context(
             value,
             parent_context=parent_context
         )

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -119,7 +119,7 @@ class InfoUnitGroup(blocks.StructBlock):
     ])
 
     def clean(self, value):
-        cleaned = super(InfoUnitGroup, self).clean(value)
+        cleaned = super().clean(value)
 
         # If 25/75, info units must have images.
         if cleaned.get('format') == '25-75':
@@ -280,7 +280,7 @@ class RelatedPosts(blocks.StructBlock):
     )
 
     def get_context(self, value, parent_context=None):
-        context = super(RelatedPosts, self).get_context(
+        context = super().get_context(
             value,
             parent_context=parent_context
         )
@@ -839,7 +839,7 @@ class FilterableList(BaseExpandable):
             return []
 
     def get_context(self, value, parent_context=None):
-        context = super(FilterableList, self).get_context(
+        context = super().get_context(
             value,
             parent_context=parent_context
         )

--- a/cfgov/v1/atomic_elements/tables.py
+++ b/cfgov/v1/atomic_elements/tables.py
@@ -33,7 +33,7 @@ class AtomicTableBlock(TableBlock):
         return forms.CharField(widget=widget, **self.field_options)
 
     def to_python(self, value):
-        new_value = super(AtomicTableBlock, self).to_python(value)
+        new_value = super().to_python(value)
         if new_value:
             new_value['has_data'] = self.get_has_data(new_value)
         return new_value

--- a/cfgov/v1/blocks.py
+++ b/cfgov/v1/blocks.py
@@ -64,7 +64,7 @@ class AnchorLink(blocks.StructBlock):
                 return get_unique_id('anchor_' + slugify(string) + suffix)
 
         data['link_id'] = format_id(data['link_id'])
-        data = super(AnchorLink, self).clean(data)
+        data = super().clean(data)
         return data
 
     class Meta:
@@ -173,7 +173,7 @@ class PlaceholderFieldBlock(blocks.FieldBlock):
     placeholder, for use in a custom form_template.
     """
     def __init__(self, *args, **kwargs):
-        super(PlaceholderFieldBlock, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.placeholder = kwargs.pop('placeholder', None)
 
     def render_form(self, *args, **kwargs):

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -59,7 +59,7 @@ class FilterableDateField(forms.DateField):
         kwargs.setdefault('widget', widgets.DateInput(
             attrs=self.default_widget_attrs
         ))
-        super(FilterableDateField, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class FilterableListForm(forms.Form):
@@ -134,7 +134,7 @@ class FilterableListForm(forms.Form):
         # provided.
         self.cache_key_prefix = kwargs.pop('cache_key_prefix', hash(self))
 
-        super(FilterableListForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         clean_categories(selected_categories=self.data.get('categories'))
 
@@ -271,7 +271,7 @@ class FilterableListForm(forms.Form):
         self.fields['language'].choices = language_options
 
     def clean(self):
-        cleaned_data = super(FilterableListForm, self).clean()
+        cleaned_data = super().clean()
         if self.errors.get('from_date') or self.errors.get('to_date'):
             return cleaned_data
         else:
@@ -410,7 +410,7 @@ class FeedbackForm(forms.ModelForm):
         fields = ['is_helpful', 'comment', 'language']
 
     def __init__(self, *args, **kwargs):
-        super(FeedbackForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields['is_helpful'].required = True
 
 
@@ -421,7 +421,7 @@ class ReferredFeedbackForm(forms.ModelForm):
         fields = ['is_helpful', 'referrer', 'comment', 'language']
 
     def __init__(self, *args, **kwargs):
-        super(ReferredFeedbackForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields['comment'].required = True
 
 
@@ -438,7 +438,7 @@ class SuggestionFeedbackForm(forms.ModelForm):
                   'language']
 
     def __init__(self, *args, **kwargs):
-        super(SuggestionFeedbackForm, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.fields['comment'].required = True
 
 

--- a/cfgov/v1/handlers/blocks/feedback.py
+++ b/cfgov/v1/handlers/blocks/feedback.py
@@ -36,7 +36,7 @@ class FeedbackHandler(Handler):
                  page,
                  request,
                  block_value):
-        super(FeedbackHandler, self).__init__(page, request)
+        super().__init__(page, request)
         self.block_value = block_value
 
     def sanitize_referrer(self):

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -150,7 +150,7 @@ def search_gov_affiliate(context):
 
 class V1Extension(Extension):
     def __init__(self, environment):
-        super(V1Extension, self).__init__(environment)
+        super().__init__(environment)
 
         self.environment.globals.update({
             'category_label': ref.category_label,

--- a/cfgov/v1/jinja2tags/datetimes.py
+++ b/cfgov/v1/jinja2tags/datetimes.py
@@ -18,7 +18,7 @@ def get_date_string(date, format="%Y-%m-%d", tz='America/New_York'):
 
 class DatetimesExtension(Extension):
     def __init__(self, environment):
-        super(DatetimesExtension, self).__init__(environment)
+        super().__init__(environment)
         self.environment.globals.update({
             'date_formatter': date_formatter,
             'localtime': template_localtime,

--- a/cfgov/v1/management/commands/_utils.py
+++ b/cfgov/v1/management/commands/_utils.py
@@ -8,7 +8,7 @@ import input
 
 class WagtailClient(object):
     def __init__(self, *args, **kwargs):
-        super(WagtailClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.client = Client()
 
     def login(self):

--- a/cfgov/v1/management/commands/makemessages.py
+++ b/cfgov/v1/management/commands/makemessages.py
@@ -40,7 +40,7 @@ class Command(makemessages.Command):
         # The rest of trans_real's regular expressions should match conventions
         # used in both Django and Jinja2 templates.
         # Call makemessages
-        super(Command, self).handle(*args, **options)
+        super().handle(*args, **options)
 
         # Restore just the Django-matching regular expressions
         trans_real.endblock_re = django_endblock_re

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -191,7 +191,7 @@ class CFGOVPage(Page):
     ]
 
     def clean(self):
-        super(CFGOVPage, self).clean()
+        super().clean()
         validate_social_sharing_image(self.social_sharing_image)
 
     def get_authors(self):
@@ -298,7 +298,7 @@ class CFGOVPage(Page):
         return ''
 
     def get_context(self, request, *args, **kwargs):
-        context = super(CFGOVPage, self).get_context(request, *args, **kwargs)
+        context = super().get_context(request, *args, **kwargs)
 
         for hook in hooks.get_hooks('cfgovpage_context_handlers'):
             hook(self, request, context, *args, **kwargs)
@@ -331,7 +331,7 @@ class CFGOVPage(Page):
         # Force the page's language on the request
         translation.activate(self.language)
         request.LANGUAGE_CODE = translation.get_language()
-        return super(CFGOVPage, self).serve(request, *args, **kwargs)
+        return super().serve(request, *args, **kwargs)
 
     def _return_bad_post_response(self, request):
         if request.is_ajax():

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -35,7 +35,7 @@ class BlogPage(AbstractFilterPage):
     ]
 
     def get_context(self, request, *args, **kwargs):
-        context = super(BlogPage, self).get_context(request, *args, **kwargs)
+        context = super().get_context(request, *args, **kwargs)
 
         context['rss_feed'] = get_appropriate_rss_feed_url_for_page(
             self,

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -78,7 +78,7 @@ class BrowseFilterablePage(FilterableListMixin, CFGOVPage):
     @property
     def page_js(self):
         return (
-            super(BrowseFilterablePage, self).page_js
+            super().page_js
             + ['secondary-navigation.js']
         )
 

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -91,11 +91,11 @@ class BrowsePage(CFGOVPage):
     @property
     def page_js(self):
         return (
-            super(BrowsePage, self).page_js + ['secondary-navigation.js']
+            super().page_js + ['secondary-navigation.js']
         )
 
     def get_context(self, request, *args, **kwargs):
-        context = super(BrowsePage, self).get_context(request, *args, **kwargs)
+        context = super().get_context(request, *args, **kwargs)
         context.update({
             'get_secondary_nav_items': get_secondary_nav_items
         })

--- a/cfgov/v1/models/enforcement_action_page.py
+++ b/cfgov/v1/models/enforcement_action_page.py
@@ -283,7 +283,7 @@ class EnforcementActionPage(AbstractFilterPage):
     ]
 
     def get_context(self, request):
-        context = super(EnforcementActionPage, self).get_context(request)
+        context = super().get_context(request)
         dispositions = self.enforcement_dispositions.all()
 
         context.update({

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -82,7 +82,7 @@ class HomePage(CFGOVPage):
     objects = PageManager()
 
     def get_context(self, request):
-        context = super(HomePage, self).get_context(request)
+        context = super().get_context(request)
 
         context.update({
             'info_units': [

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -30,7 +30,7 @@ class CFGOVImage(PlaceholderRenditionMixin, AbstractImage):
         if self.file.name.endswith('.gif'):
             return self.get_mock_rendition(rendition_filter)
         else:
-            return super(CFGOVImage, self).get_rendition(rendition_filter)
+            return super().get_rendition(rendition_filter)
 
     def get_mock_rendition(self, rendition_filter):
         """Create a mock rendition object that wraps the original image.

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -103,7 +103,7 @@ class AbstractFilterPage(CFGOVPage):
     # Returns an image for the page's meta Open Graph tag
     @property
     def meta_image(self):
-        parent_meta = super(AbstractFilterPage, self).meta_image
+        parent_meta = super().meta_image
         return parent_meta or self.preview_image
 
 
@@ -399,9 +399,9 @@ class EventPage(AbstractFilterPage):
             (self.live_stream_date and self.event_state == 'present')
             or (self.archive_video_id and self.event_state == 'past')
         ):
-            return super(EventPage, self).page_js + ['video-player.js']
+            return super().page_js + ['video-player.js']
 
-        return super(EventPage, self).page_js
+        return super().page_js
 
     def location_image_url(self, scale='2', size='276x155', zoom='12'):
         if not self.venue_coords:
@@ -420,7 +420,7 @@ class EventPage(AbstractFilterPage):
         return static_map_image_url
 
     def clean(self):
-        super(EventPage, self).clean()
+        super().clean()
         if self.venue_image_type == 'image' and not self.venue_image:
             raise ValidationError({
                 'venue_image': 'Required if "Venue image type" is "Image".'
@@ -433,10 +433,10 @@ class EventPage(AbstractFilterPage):
 
     def save(self, *args, **kwargs):
         self.venue_coords = get_venue_coords(self.venue_city, self.venue_state)
-        return super(EventPage, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)
 
     def get_context(self, request):
-        context = super(EventPage, self).get_context(request)
+        context = super().get_context(request)
         context['event_state'] = self.event_state
         return context
 

--- a/cfgov/v1/tests/atomic_elements/organisms/test_model_blocks.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_model_blocks.py
@@ -7,7 +7,7 @@ from v1.atomic_elements.organisms import ModelBlock
 class UserModelMixin(object):
     @classmethod
     def setUpClass(cls):
-        super(UserModelMixin, cls).setUpClass()
+        super().setUpClass()
         usernames = ['chico', 'harpo', 'groucho']
         first_names = ['leonard', 'arthur', 'julius']
 

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -31,7 +31,7 @@ class TestCFGOVPage(TestCase):
     @mock.patch('builtins.super')
     def test_serve_calls_super_on_non_ajax_request(self, mock_super):
         self.page.serve(self.request)
-        mock_super.assert_called_with(CFGOVPage, self.page)
+        mock_super.assert_called_once()
         mock_super().serve.assert_called_with(self.request)
 
     @mock.patch('v1.models.base.CFGOVPage.serve_post')

--- a/cfgov/v1/tests/models/test_page_settings.py
+++ b/cfgov/v1/tests/models/test_page_settings.py
@@ -11,7 +11,7 @@ class PageSettingsOrderTestCaseMeta(type):
                 if issubclass(model, CFGOVPage):
                     cls.add_test(dct, model)
 
-        return super(PageSettingsOrderTestCaseMeta, cls).__new__(
+        return super().__new__(
             cls, name, parent, dct
         )
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -178,7 +178,7 @@ class PermissionCheckingMenuItem(MenuItem):
 
     def __init__(self, *args, **kwargs):
         self.permission = kwargs.pop('permission')
-        super(PermissionCheckingMenuItem, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def is_shown(self, request):
         return request.user.has_perm(self.permission)

--- a/cfgov/wellbeing/forms.py
+++ b/cfgov/wellbeing/forms.py
@@ -60,7 +60,7 @@ class ResultsForm(forms.Form):
     )
 
     def clean(self):
-        cleaned_data = super(ResultsForm, self).clean()
+        cleaned_data = super().clean()
 
         if self._errors:
             return

--- a/cfgov/wellbeing/views.py
+++ b/cfgov/wellbeing/views.py
@@ -159,7 +159,7 @@ class ResultsView(TranslatedTemplateView):
     }
 
     def get_context_data(self, **kwargs):
-        context = super(ResultsView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
 
         context.update({
             'avg_score': FWBScore.avg(),


### PR DESCRIPTION
In Python 2, it was necessary to specify the super type. This is no longer necessary in Python 3, but we have numerous examples of the old approach that were never migrated. This commit does so.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)