### PR TITLE
Add troubleshooting around gettext and dates

### DIFF
--- a/docs/translation.md
+++ b/docs/translation.md
@@ -138,3 +138,13 @@ mystring = gettext_noop("Hello World!")
 ```jinja
 {{ _(mystring) }}
 ```
+
+### Do ensure gettext is relatively recent
+
+Django's `makemessages` and `compilemessages` management commands invoke GNU gettext to generate the message files. gettext versions below 0.20 had an issue where they will bring creation dates forward from the text `.po` file into the binary `.mo` file. This can break our pull request check to ensure that translations have been updated. To check the version of gettext Django will use, run:
+
+```shell
+gettext -V
+```
+
+Our CentOS 7 Docker container unfortunately uses an older version of gettext. If the `validate-translations` check on pull requests fails, please try to run `makemessages` and `compilemessages` [in a local virtualenv](https://cfpb.github.io/consumerfinance.gov/installation/#set-up-the-consumerfinancegov-virtualenv).


### PR DESCRIPTION
This adds a quick bit of troubleshooting help to our translation documentation around the version of gettext that Django invokes.

gettext below 0.20 [had an issue where a `POT-Creation-Date` field in the `.po` file would continue through into the `.mo` file](https://savannah.gnu.org/bugs/?59658#comment0). Django updates that date string every time `makemessages` is run. This will fail our validate-migrations check.

The fix is to ensure a version of gettext > 0.20.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
