### PR TITLE
Bump the ES_JAVA_OPTS config to 512m

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
             - 127.0.0.1:9300:9300
         environment:
             discovery.type: single-node
-            ES_JAVA_OPTS: "-Xms128m -Xmx128m"
+            ES_JAVA_OPTS: "-Xms512m -Xmx512m"
     kibana:
         image: docker.elastic.co/kibana/kibana:7.16.0
         depends_on:


### PR DESCRIPTION
The current config of 128m doesn't allow indexing of our
current consumer complaint data, which is needed
for data products development.

We could probably return to the smaller value once
we have more robust dev and staging environments available
that include kibana and complete indexes.
