### PR TITLE
Direct CCDB landing page to Wagtail

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -30,7 +30,7 @@ from core.views import (
 from housing_counselor.views import (
     HousingCounselorPDFView, HousingCounselorView
 )
-from legacy.views.complaint import CCDBSearchView, ComplaintLandingView
+from legacy.views.complaint import CCDBSearchView
 from regulations3k.views import redirect_eregs
 from v1.views.documents import DocumentServeView
 
@@ -269,12 +269,6 @@ urlpatterns = [
     re_path(
         r'^consumer-tools/retirement/',
         include('retirement_api.urls', namespace='retirement_api')
-    ),
-
-    re_path(
-        r'^data-research/consumer-complaints/$',
-        ComplaintLandingView.as_view(),
-        name='complaint-landing'
     ),
 
     # CCDB5-API

--- a/cfgov/legacy/tests/views/test_complaint.py
+++ b/cfgov/legacy/tests/views/test_complaint.py
@@ -5,26 +5,7 @@ from django.urls import reverse
 class ComplaintLandingViewTests(TestCase):
 
     def setUp(self):
-        self.landing_url = reverse("complaint-landing")
         self.search_url = reverse("complaint-search")
-
-    @override_settings(
-        FLAGS={"CCDB_TECHNICAL_ISSUES": [("boolean", False)]})
-    def test_no_banner_when_flag_disabled(self):
-        response = self.client.get(self.landing_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "m-notification_explanation")
-
-    @override_settings(
-        FLAGS={"CCDB_TECHNICAL_ISSUES": [("boolean", True)]})
-    def test_banner_when_flag_enabled(self):
-        response = self.client.get(self.landing_url)
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "m-notification_explanation")
-
-    def test_landing_page_cache_tag(self):
-        response = self.client.get(self.landing_url)
-        self.assertTrue(response.has_header("Edge-Cache-Tag"))
 
     def test_search_page_cache_tag(self):
         response = self.client.get(self.search_url)

--- a/cfgov/legacy/tests/views/test_complaint.py
+++ b/cfgov/legacy/tests/views/test_complaint.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 

--- a/test/cypress/integration/data-research/consumer-complaints/consumer-complaints-helpers.js
+++ b/test/cypress/integration/data-research/consumer-complaints/consumer-complaints-helpers.js
@@ -1,7 +1,7 @@
 export class ConsumerComplaints {
 
   click( name ) {
-    cy.get( '.a-btn' ).contains( name ).click();
+    cy.get( '.m-list_link' ).contains( name ).click();
   }
 
   clickTab( name ) {
@@ -14,23 +14,6 @@ export class ConsumerComplaints {
 
   clickButton( name ) {
     cy.get( '.a-btn' ).contains( name ).click();
-  }
-
-  clickTile( name ) {
-    const tile = name.toUpperCase();
-    return cy.get( `.tile-${ tile }` ).click();
-  }
-
-  checkState( name ) {
-    return cy.get( `.highcharts-name-${ name }`.toLowerCase() );
-  }
-
-  checkChart( name ) {
-    return cy.get( '.highcharts-tracker' ).should( 'contain', name );
-  }
-
-  checkLegend( name ) {
-    return cy.get( `.highcharts-legend-${ name }` );
   }
 
   enter( term ) {

--- a/test/cypress/integration/data-research/consumer-complaints/consumer-complaints.js
+++ b/test/cypress/integration/data-research/consumer-complaints/consumer-complaints.js
@@ -1,4 +1,4 @@
-import { ConsumerComplaints } from './consumer-complaints-helpers';
+/* import { ConsumerComplaints } from './consumer-complaints-helpers';
 
 const page = new ConsumerComplaints();
 
@@ -46,4 +46,4 @@ describe( 'Consumer Complaint Database', () => {
     cy.url().should( 'include', 'download-the-data' );
   } );
 
-} );
+} ); */

--- a/test/cypress/integration/data-research/consumer-complaints/consumer-complaints.js
+++ b/test/cypress/integration/data-research/consumer-complaints/consumer-complaints.js
@@ -1,35 +1,14 @@
 import { ConsumerComplaints } from './consumer-complaints-helpers';
 
 const page = new ConsumerComplaints();
-const states = [ 'AK', 'AL', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
-  'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN',
-  'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK',
-  'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY' ];
 
 describe( 'Consumer Complaint Database', () => {
   beforeEach( () => {
     cy.visit( '/data-research/consumer-complaints/' );
   } );
 
-  it( 'should display chart with complaints for all 50 states', () => {
-    page.clickButton( 'Complaints' );
-    page.checkLegend( 'description' ).should( 'contain', 'Complaints' );
-    cy.get( '.cfpb-chart' ).should( 'be.visible' );
-    states.forEach( name => {
-      page.checkChart( name ).should( 'be.visible' );
-    } );
-    page.clickButton( 'Complaints per 1,000' );
-    page.checkLegend( 'description' ).should( 'contain', 'Complaints per 1,000' );
-    page.checkLegend( 'dates' ).should( 'be.visible' );
-    states.forEach( name => {
-      page.checkState( name ).should( 'be.visible' );
-    } );
-    page.clickTile( 'DC' );
-    cy.url().should( 'include', 'state=DC' );
-  } );
-
   it( 'should limit results by a date range', () => {
-    page.click( 'View complaint data' );
+    page.click( 'Explore data and trends' );
     page.clickDateRange( '3m' );
     cy.url().should( 'include', 'dateRange=3m' );
     page.clickDateRange( '6m' );
@@ -43,7 +22,7 @@ describe( 'Consumer Complaint Database', () => {
   } );
 
   it( 'should limit results by search query', () => {
-    page.click( 'View complaint data' );
+    page.click( 'Read complaints' );
     page.clickTab( 'trends' );
     cy.url().should( 'include', 'tab=Trends' );
     page.enter( 'money' );
@@ -53,7 +32,7 @@ describe( 'Consumer Complaint Database', () => {
   } );
 
   it( 'should search based on multiple terms', () => {
-    page.click( 'View complaint data' );
+    page.click( 'Explore data and trends' );
     page.clickTab( 'list' );
     cy.url().should( 'include', 'tab=List' );
     page.enter( 'loan sold' );
@@ -63,13 +42,8 @@ describe( 'Consumer Complaint Database', () => {
   } );
 
   it( 'should display Download the data', () => {
-    page.click( 'Download options and API' );
+    page.click( 'Download complaint data' );
     cy.url().should( 'include', 'download-the-data' );
-  } );
-
-  it( 'should display Consumer Response annual report', () => {
-    page.click( 'Read our annual report' );
-    cy.url().should( 'include', 'consumer-response-annual-report' );
   } );
 
 } );


### PR DESCRIPTION
We're getting rid of the custom CCDB landing page template and using a standard Wagtail page instead. This is the first part of that work: removing the routing that points the CCDB landing page URL to the custom template and updating functional tests to match. There will be follow-up work to clean up the old template detritus later.

---

## Removals

- Custom routing that directs `/data-research/consumer-complaints/` to the custom CCDB landing page template
- Unnecessary functional tests now that the CCDB landing page will be just a bunch of standard links on a standard page

## Changes

- Functional test selectors to get new button names

## How to test this PR

1. Create a new page in Wagtail under "Data & Research" with the slug `consumer-complaints`
2. Visit `/data-research/consumer-complaints/` and make sure it resolves to that new Wagtail page instead of the old custom template
3. Note that consumer complaints functional tests fail for the moment. They should start working again once the new Wagtail CCDB landing page is published.

## Notes and todos

- Make sure functional tests work once the new CCDB landing page is published
- Clean up the old template detritus, including:
    - Delete the template itself
    - Recreate the CCDB outage banners in Wagtail's banner manager
    - Re-enable functional tests

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
