### PR TITLE
More Alpine Refinements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.8-alpine as base
 
+# cfgov-dev is used for local development, as well as a base for frontend and prod.
 FROM base AS cfgov-dev
 
 # Ensure that the environment uses UTF-8 encoding by default
@@ -17,9 +18,11 @@ WORKDIR ${APP_HOME}
 
 # Install common OS packages
 RUN apk update --no-cache && apk upgrade --no-cache
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev postgresql-dev
-RUN apk add --no-cache --virtual .backend-deps postgresql curl bash
-RUN apk add --no-cache --virtual .frontend-deps nodejs yarn zlib-dev jpeg-dev
+# .build-deps are required to build and test the application (pip, tox, etc.)
+RUN apk add --no-cache --virtual .build-deps gcc gettext git libffi-dev musl-dev postgresql-dev
+# .backend-deps and .frontend-deps are required to run the application
+RUN apk add --no-cache --virtual .backend-deps bash curl postgresql
+RUN apk add --no-cache --virtual .frontend-deps jpeg-dev nodejs yarn zlib-dev
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 
 # Disables pip cache. Reduces build time, and suppresses warnings when run as non-root.
@@ -29,9 +32,6 @@ ENV PIP_NO_CACHE_DIR true
 # Install python requirements
 COPY requirements requirements
 RUN pip install -r requirements/local.txt -r requirements/deployment.txt
-
-# Remove build dependencies for smaller image
-RUN apk del .build-deps
 
 EXPOSE 8000
 
@@ -112,6 +112,9 @@ COPY --from=cfgov-build --chown=apache:apache ${CFGOV_PATH}/static.in ${CFGOV_PA
 
 RUN ln -s /usr/lib/apache2 cfgov/apache/modules
 RUN chown -R apache:apache ${APP_HOME} /usr/share/apache2 /var/run/apache2 /var/log/apache2
+
+# Remove build dependencies for smaller image
+RUN apk del .build-deps
 
 USER apache
 


### PR DESCRIPTION
* Add `gettext` and `git` to `.build-deps` for tox in local dev.
* Moved `apk del .build-deps` to prod stage so that tox could install requirements in local dev.