### PR TITLE
Catch errors from badly formatted date strings in regulation versions

### DIFF
--- a/cfgov/regulations3k/tests/test_pages.py
+++ b/cfgov/regulations3k/tests/test_pages.py
@@ -87,3 +87,11 @@ class PagesRegulations3kTestCase(TestCase):
         self.assertEqual(
             response.get('location'),
             '/reg-landing/1002/interp-2/')
+
+    def test_invalid_effective_date(self):
+        # Try to fetch a date string that's incorrectly formatted.
+        # It should 404.
+        response = self.client.get(
+            '/reg-landing/1002/2014-18-01/'
+        )
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
We’ve been seeing attempts to access regulation versions with the format YEAR-DAY-MONTH. This isn’t a valid date string, and raises a `ValidationError`, which we don’t catch, so the user sees a 500. This change catches that `ValidationError` and raises a 404.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
