### PR TITLE
Pin Jinja 2.11's MarkupSafe dependency

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -46,3 +46,6 @@ wagtailmedia==0.6.0
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.1/owning_a_home_api-0.17.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
 https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.4/crtool-2.1.4-py3-none-any.whl
+
+# Temporarily pin Jinja 2.11's MarkupSafe dependency.
+MarkupSafe==2.0.1


### PR DESCRIPTION
A new release of MarkupSafe is incompatible with how Jinja 2.11 uses it, however Jinja doesn't include an upper bound on its pin and pulls it in anyway. This change pins the last working version until we can either upgrade Jinja to > 3, or there's an upstream patch release.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
