### PR TITLE
Make apache /f/ rewriting more accurate

### DIFF
--- a/cfgov/apache/conf.d/uploads.conf
+++ b/cfgov/apache/conf.d/uploads.conf
@@ -1,7 +1,7 @@
 # If $APACHE_UPLOADS_F_ALIAS is a local directory, alias /f/ to it.
 RewriteCond %{ENV:APACHE_UPLOADS_F_ALIAS} -d
-RewriteRule /f/(.+) ${APACHE_UPLOADS_F_ALIAS}$1 [L]
+RewriteRule ^/f/(.+) ${APACHE_UPLOADS_F_ALIAS}$1 [L]
 
 # If $APACHE_UPLOADS_F_ALIAS is a URL, redirect /f/ to it.
 RewriteCond %{ENV:APACHE_UPLOADS_F_ALIAS} ^http
-RewriteRule /f/(.+) ${APACHE_UPLOADS_F_ALIAS}$1 [R,L]
+RewriteRule ^/f/(.+) ${APACHE_UPLOADS_F_ALIAS}$1 [R,L]


### PR DESCRIPTION
Fixes the bug @chosak found in https://github.local/CFGOV/platform/issues/4338

File uploading should still work as expected locally, in dev servers, and in staging.