### PR TITLE
Border above mega-menu button not properly showing (mobile)

### DIFF
--- a/cfgov/unprocessed/css/organisms/header.less
+++ b/cfgov/unprocessed/css/organisms/header.less
@@ -116,7 +116,7 @@
         // Hide Global Header Call to Action.
         // Adjust Mobile Megamenu margin
         .respond-to-max( @bp-sm-max, {
-            margin-top: -6px;
+            margin-top: -5.5px;
             > .wrapper {
                 > .m-global-header-cta {
                     display: none;


### PR DESCRIPTION
## Changes

-Resolved border not showing properly on mobile mega-menu button

## How to test this PR

1. Open consumerfinance.gov on mobile and note the border above the mega-menu button

## Screenshots

Android:

![image](https://user-images.githubusercontent.com/85513449/157335921-54280d82-57cc-49a5-8aef-874aa694849e.png)

iOS:

![image](https://user-images.githubusercontent.com/85513449/157335946-e12e369d-c64c-47af-b81b-d380d1eb87d6.png)

Resolves platform issue 4331