### PR TITLE
Deprecate unnecessary custom page managers

### DIFF
--- a/cfgov/ask_cfpb/models/answer_page.py
+++ b/cfgov/ask_cfpb/models/answer_page.py
@@ -22,7 +22,7 @@ from wagtailautocomplete.edit_handlers import AutocompletePanel
 from ask_cfpb.models import blocks as ask_blocks
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
-from v1.models import CFGOVPage, CFGOVPageManager, PortalCategory, PortalTopic
+from v1.models import CFGOVPage, PortalCategory, PortalTopic
 from v1.models.snippets import RelatedResource, ReusableText
 
 
@@ -316,8 +316,6 @@ class AnswerPage(CFGOVPage):
     )
 
     template = "ask-cfpb/answer-page.html"
-
-    objects = CFGOVPageManager()
 
     def get_sibling_url(self):
         if self.answer_base:

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -32,7 +32,6 @@ from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
 from v1.models import (
     CFGOVPage,
-    CFGOVPageManager,
     LandingPage,
     PortalCategory,
     PortalTopic,
@@ -151,8 +150,6 @@ class AnswerLandingPage(LandingPage):
 
     template = "ask-cfpb/landing-page.html"
 
-    objects = CFGOVPageManager()
-
     def get_portal_cards(self):
         """Return an array of dictionaries used to populate portal cards."""
         portal_cards = []
@@ -214,7 +211,6 @@ class PortalSearchPage(
     A routable page type for Ask CFPB portal search ("see-all") pages.
     """
 
-    objects = CFGOVPageManager()
     portal_topic = models.ForeignKey(
         PortalTopic,
         blank=True,
@@ -401,8 +397,6 @@ class PortalSearchPage(
 
 
 class AnswerResultsPage(CFGOVPage):
-
-    objects = CFGOVPageManager()
     answers = []
 
     edit_handler = TabbedInterface(
@@ -436,8 +430,6 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
     """A routable page for serving Answers by tag"""
 
     template = "ask-cfpb/answer-search-results.html"
-
-    objects = CFGOVPageManager()
 
     def get_context(self, request, *args, **kwargs):
         if self.language != "en":
@@ -648,8 +640,6 @@ class ArticlePage(CFGOVPage):
     )
 
     template = "ask-cfpb/article-page.html"
-
-    objects = CFGOVPageManager()
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -2,8 +2,6 @@ import logging
 
 from django.db import models
 
-from wagtail.core.models import PageManager
-
 from dateutil import parser
 
 from v1.models import BrowsePage
@@ -381,7 +379,6 @@ class MortgagePerformancePage(BrowsePage):
     and related data visualizations.
     """
 
-    objects = PageManager()
     template = "browse-basic/index.html"
 
     def get_mortgage_meta(self):

--- a/cfgov/form_explainer/models.py
+++ b/cfgov/form_explainer/models.py
@@ -10,7 +10,7 @@ from wagtail.search import index
 from form_explainer.blocks import Explainer
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
-from v1.models.base import CFGOVPage, CFGOVPageManager
+from v1.models.base import CFGOVPage
 
 
 class FormExplainerContent(StreamBlock):
@@ -56,7 +56,5 @@ class FormExplainerPage(CFGOVPage):
     )
 
     template = "form-explainer/index.html"
-
-    objects = CFGOVPageManager()
 
     search_fields = CFGOVPage.search_fields + [index.SearchField("header")]

--- a/cfgov/hmda/models/pages.py
+++ b/cfgov/hmda/models/pages.py
@@ -1,5 +1,3 @@
-from wagtail.core.models import PageManager
-
 from hmda.models.forms import HmdaFilterableForm
 from hmda.resources.hmda_data_options import (
     HMDA_FIELD_DESC_OPTIONS,
@@ -16,7 +14,6 @@ class HmdaHistoricDataPage(LearnPage):
     containing HMDA data.
     """
 
-    objects = PageManager()
     template = "hmda/hmda-explorer.html"
 
     def get_context(self, request, *args, **kwargs):

--- a/cfgov/paying_for_college/models/pages.py
+++ b/cfgov/paying_for_college/models/pages.py
@@ -7,7 +7,7 @@ from wagtail.core import blocks
 from wagtail.core.fields import StreamField
 
 from v1.atomic_elements import molecules, organisms
-from v1.models import CFGOVPage, CFGOVPageManager
+from v1.models import CFGOVPage
 
 
 class PayingForCollegePage(CFGOVPage):
@@ -33,7 +33,6 @@ class PayingForCollegePage(CFGOVPage):
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )
-    objects = CFGOVPageManager()
 
     class Meta:
         abstract = True
@@ -80,7 +79,6 @@ class CollegeCostsPage(PayingForCollegePage):
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )
-    objects = CFGOVPageManager()
     content = StreamField(PayingForCollegeContent, blank=True)
     template = "paying-for-college/college-costs.html"
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -22,7 +22,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtailsharing.models import ShareableRoutablePageMixin
 
 import requests
@@ -36,7 +35,7 @@ from regulations3k.forms import SearchForm
 from regulations3k.models import Part, Section, label_re_str
 from regulations3k.resolver import get_contents_resolver, get_url_resolver
 from v1.atomic_elements import molecules, organisms
-from v1.models import CFGOVPage, CFGOVPageManager
+from v1.models import CFGOVPage
 
 
 logger = logging.getLogger(__name__)
@@ -44,8 +43,6 @@ logger = logging.getLogger(__name__)
 
 class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
     """A page for the custom search interface for regulations."""
-
-    objects = PageManager()
 
     parent_page_types = ["regulations3k.RegulationLandingPage"]
     subpage_types = []
@@ -197,7 +194,6 @@ class RegulationLandingPage(ShareableRoutablePageMixin, CFGOVPage):
         ]
     )
 
-    objects = CFGOVPageManager()
     subpage_types = ["regulations3k.RegulationPage", "RegulationsSearchPage"]
     template = "regulations3k/landing-page.html"
 
@@ -235,7 +231,6 @@ class RegulationPage(
 ):
     """A routable page for serving an eregulations page by Section ID."""
 
-    objects = PageManager()
     parent_page_types = ["regulations3k.RegulationLandingPage"]
     subpage_types = []
 

--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -31,7 +31,7 @@ from teachers_digital_platform.models.django import (
 from teachers_digital_platform.models.pages import ActivityPage
 from teachers_digital_platform.molecules import TdpSearchHeroImage
 from v1.atomic_elements import molecules
-from v1.models import CFGOVPage, CFGOVPageManager
+from v1.models import CFGOVPage
 
 
 # facet name, (facet class, is-nested)
@@ -71,8 +71,6 @@ class ActivityIndexPage(CFGOVPage):
     """A model for the Activity Search page."""
 
     subpage_types = ["teachers_digital_platform.ActivityPage"]
-
-    objects = CFGOVPageManager()
 
     header = StreamField(
         [

--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -19,7 +19,7 @@ from modelcluster.fields import ParentalKey, ParentalManyToManyField
 
 from teachers_digital_platform.fields import ParentalTreeManyToManyField
 from teachers_digital_platform.models.django import ActivityTopic
-from v1.models import CFGOVPage, CFGOVPageManager
+from v1.models import CFGOVPage
 
 
 class ActivityPageActivityDocuments(Orderable):
@@ -62,7 +62,6 @@ class ActivityPage(CFGOVPage):
     # Allow Activity pages to exist under the ActivityIndexPage or the Trash
     parent_page_types = ["ActivityIndexPage", "v1.HomePage"]
     subpage_types = []
-    objects = CFGOVPageManager()
 
     date = models.DateField("Updated", default=timezone.now)
     summary = models.TextField("Summary", blank=False)

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -2,11 +2,9 @@
 from django.conf import settings
 
 from v1.models.base import (
-    BaseCFGOVPageManager,
     CFGOVAuthoredPages,
     CFGOVPage,
     CFGOVPageCategory,
-    CFGOVPageManager,
     CFGOVTaggedPages,
     FailedLoginAttempt,
     PasswordHistoryItem,

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -20,7 +20,7 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import hooks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import Page, PageManager, PageQuerySet, Site
+from wagtail.core.models import Page, Site
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
@@ -64,14 +64,6 @@ class CFGOVOwnedPages(ItemBase):
         CFGOVContentOwner, related_name="owned_pages", on_delete=models.CASCADE
     )
     content_object = ParentalKey("CFGOVPage")
-
-
-class BaseCFGOVPageManager(PageManager):
-    def get_queryset(self):
-        return PageQuerySet(self.model).order_by("path")
-
-
-CFGOVPageManager = BaseCFGOVPageManager.from_queryset(PageQuerySet)
 
 
 class CFGOVPage(Page):
@@ -158,8 +150,6 @@ class CFGOVPage(Page):
 
     # This is used solely for subclassing pages we want to make at the CFPB.
     is_creatable = False
-
-    objects = CFGOVPageManager()
 
     search_fields = Page.search_fields + [
         index.SearchField("sidefoot"),

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -1,13 +1,11 @@
 from wagtail.admin.edit_handlers import StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.search import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import organisms, schema
 from v1.feeds import get_appropriate_rss_feed_url_for_page
-from v1.models.base import CFGOVPageManager
 from v1.models.learn_page import AbstractFilterPage
 
 
@@ -30,7 +28,6 @@ class BlogPage(AbstractFilterPage):
     )
     template = "blog/blog_page.html"
 
-    objects = PageManager()
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField("content")
     ]
@@ -61,7 +58,7 @@ class LegacyBlogPage(AbstractFilterPage):
             ),
         ]
     )
-    objects = CFGOVPageManager()
+
     edit_handler = AbstractFilterPage.generate_edit_handler(
         content_panel=StreamFieldPanel("content")
     )

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -8,7 +8,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.search import index
 
 from v1 import blocks as v1_blocks
@@ -74,8 +73,6 @@ class BrowseFilterablePage(FilterableListMixin, CFGOVPage):
 
     template = "browse-filterable/index.html"
 
-    objects = PageManager()
-
     search_fields = CFGOVPage.search_fields + [
         index.SearchField("content"),
         index.SearchField("header"),
@@ -88,7 +85,6 @@ class BrowseFilterablePage(FilterableListMixin, CFGOVPage):
 
 class EnforcementActionsFilterPage(BrowseFilterablePage):
     template = "browse-filterable/index.html"
-    objects = PageManager()
 
     @staticmethod
     def get_form_class():
@@ -108,8 +104,6 @@ class EnforcementActionsFilterPage(BrowseFilterablePage):
 class EventArchivePage(BrowseFilterablePage):
     template = "browse-filterable/index.html"
 
-    objects = PageManager()
-
     @staticmethod
     def get_model_class():
         return EventPage
@@ -128,5 +122,3 @@ class EventArchivePage(BrowseFilterablePage):
 class NewsroomLandingPage(CategoryFilterableMixin, BrowseFilterablePage):
     template = "newsroom/index.html"
     filterable_categories = ["Newsroom"]
-
-    objects = PageManager()

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -8,7 +8,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.search import index
 
 from data_research.blocks import (
@@ -91,8 +90,6 @@ class BrowsePage(CFGOVPage):
     )
 
     template = "browse-basic/index.html"
-
-    objects = PageManager()
 
     search_fields = CFGOVPage.search_fields + [
         index.SearchField("content"),

--- a/cfgov/v1/models/campaign_page.py
+++ b/cfgov/v1/models/campaign_page.py
@@ -5,7 +5,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage
@@ -51,5 +50,3 @@ class CampaignPage(CFGOVPage):
 
     # Sets page to only be createable as the child of the homepage
     parent_page_types = ["v1.HomePage"]
-
-    objects = PageManager()

--- a/cfgov/v1/models/enforcement_action_page.py
+++ b/cfgov/v1/models/enforcement_action_page.py
@@ -9,7 +9,7 @@ from wagtail.admin.edit_handlers import (
     TabbedInterface,
 )
 from wagtail.core.fields import StreamField
-from wagtail.core.models import Page, PageManager
+from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
@@ -291,8 +291,6 @@ class EnforcementActionPage(AbstractFilterPage):
     )
 
     template = "enforcement-action/index.html"
-
-    objects = PageManager()
 
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField("content")

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -11,7 +11,7 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import Orderable, PageManager
+from wagtail.core.models import Orderable
 from wagtail.images import get_image_model_string
 from wagtail.images.edit_handlers import ImageChooserPanel
 
@@ -109,8 +109,6 @@ class HomePage(CFGOVPage):
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )
-
-    objects = PageManager()
 
     def get_context(self, request):
         context = super().get_context(request)

--- a/cfgov/v1/models/landing_page.py
+++ b/cfgov/v1/models/landing_page.py
@@ -4,7 +4,6 @@ from wagtail.admin.edit_handlers import (
     TabbedInterface,
 )
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.search import index
 
 from v1 import blocks as v1_blocks
@@ -46,8 +45,6 @@ class LandingPage(CFGOVPage):
     )
 
     template = "landing-page/index.html"
-
-    objects = PageManager()
 
     search_fields = CFGOVPage.search_fields + [
         index.SearchField("content"),

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -19,7 +19,7 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import blocks
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.core.models import Page, PageManager
+from wagtail.core.models import Page
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
@@ -28,7 +28,7 @@ from localflavor.us.models import USStateField
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import molecules, organisms
-from v1.models.base import CFGOVPage, CFGOVPageManager
+from v1.models.base import CFGOVPage
 from v1.util.events import get_venue_coords
 
 
@@ -101,8 +101,6 @@ class AbstractFilterPage(CFGOVPage):
     # This page class cannot be created.
     is_creatable = False
 
-    objects = CFGOVPageManager()
-
     search_fields = CFGOVPage.search_fields + [index.SearchField("header")]
 
     @classmethod
@@ -156,8 +154,6 @@ class LearnPage(AbstractFilterPage):
     )
     template = "learn-page/index.html"
 
-    objects = PageManager()
-
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField("content")
     ]
@@ -183,8 +179,6 @@ class DocumentDetailPage(AbstractFilterPage):
     )
     template = "document-detail/index.html"
 
-    objects = PageManager()
-
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField("content")
     ]
@@ -205,8 +199,6 @@ class AgendaItemBlock(blocks.StructBlock):
             required=False,
         )
     )
-
-    objects = PageManager()
 
     class Meta:
         icon = "date"
@@ -346,8 +338,6 @@ class EventPage(AbstractFilterPage):
 
     # Agenda content fields
     agenda_items = StreamField([("item", AgendaItemBlock())], blank=True)
-
-    objects = CFGOVPageManager()
 
     search_fields = AbstractFilterPage.search_fields + [
         index.SearchField("body"),

--- a/cfgov/v1/models/newsroom_page.py
+++ b/cfgov/v1/models/newsroom_page.py
@@ -1,12 +1,9 @@
-from v1.models.base import CFGOVPageManager
 from v1.models.blog_page import BlogPage, LegacyBlogPage
 
 
 class NewsroomPage(BlogPage):
     template = "newsroom/newsroom-page.html"
-    objects = CFGOVPageManager()
 
 
 class LegacyNewsroomPage(LegacyBlogPage):
     template = "newsroom/newsroom-page.html"
-    objects = CFGOVPageManager()

--- a/cfgov/v1/models/story_page.py
+++ b/cfgov/v1/models/story_page.py
@@ -5,7 +5,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage
@@ -47,5 +46,3 @@ class StoryPage(CFGOVPage):
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )
-
-    objects = PageManager()

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -5,7 +5,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.search import index
 
 from v1 import blocks as v1_blocks
@@ -61,8 +60,6 @@ class SublandingFilterablePage(FilterableListMixin, CFGOVPage):
 
     template = "sublanding-page/index.html"
 
-    objects = PageManager()
-
     search_fields = CFGOVPage.search_fields + [
         index.SearchField("content"),
         index.SearchField("header"),
@@ -73,5 +70,3 @@ class ActivityLogPage(CategoryFilterableMixin, SublandingFilterablePage):
     template = "activity-log/index.html"
     filterable_categories = ("Blog", "Newsroom", "Research Report")
     filterable_per_page_limit = 100
-
-    objects = PageManager()

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -8,7 +8,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.core.models import PageManager
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.search import index
 
@@ -119,8 +118,6 @@ class SublandingPage(CFGOVPage):
     )
 
     template = "sublanding-page/index.html"
-
-    objects = PageManager()
 
     search_fields = CFGOVPage.search_fields + [
         index.SearchField("content"),


### PR DESCRIPTION
This commit deprecates the custom `v1.models.base.CFGOVPageManager` class, which was set as the default manager on CFGOVPages. This class was introduced back when CFGOVPage QuerySets needed [custom behavior around the sharing of drafts](https://github.com/cfpb/consumerfinance.gov/commit/968e4e76641138040870c0df5e345450c05d22bd), but this functionality was removed long ago. Currently the CFGOVPageManager is exactly the same as the base Wagtail PageManager, so it can be removed.

Additionally, this commit removes the now-unnecessary definition of page managers on almost all of our page models. In the past, due to some behavior in Django < 1.10, page models [had to explicitly specify their manager class](https://docs.wagtail.org/en/latest/releases/1.6.1.html#multi-level-inheritance-and-custom-managers). On our current version of Django, page model subclasses automatically inherit the proper manager from their parent, [even if not explicitly specified](https://docs.djangoproject.com/en/3.2/topics/db/managers/#custom-managers-and-model-inheritance).

For example, after this change:

```
>>> from v1.models import CFGOVPage, LearnPage
>>> CFGOVPage.objects
<django.db.models.manager.BasePageManagerFromPageQuerySet object at 0x104431a90>
>>> LearnPage.objects
<django.db.models.manager.BasePageManagerFromPageQuerySet object at 0x1044319a0>
```

Note that both of these page classes properly inherit the base Wagtail PageManager, even though they no longer specify a manager themselves.

After this change, our codebase only has a single custom page manager, which has been defined to support [custom QuerySet behavior](https://github.com/cfpb/consumerfinance.gov/blob/54dddc061b5f843a575a6887bb412a4033de8365/cfgov/jobmanager/models/pages.py#L32-L44).

## How to test this PR

All unit tests continue to pass properly.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)