### PR TITLE
Restore home page flag changes from #6933

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -613,11 +613,9 @@ FLAGS = {
     # Supports testing of a new 2021 version of the website home page.
     # Enable by appending ?home_page_2021=True to home page URLs.
     "HOME_PAGE_2021": [
-        ("environment is not", "production", True),
         ("parameter", "home_page_2021"),
     ],
     "HOME_PAGE_2021_MINIMAL": [
-        ("environment is not", "production", True),
         ("parameter", "home_page_2021_minimal"),
     ],
     # Whether robots.txt should block all robots, except for Search.gov.


### PR DESCRIPTION
This change restores the removal of “environment is not” “production” flag conditions for the home page, from 8a25df0.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
