### PR TITLE
Trim copy task hack, put in place to solve former relative reference

### DIFF
--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -31,26 +31,10 @@ gulp.task( 'copy:root', () => {
   return stream;
 } );
 
-gulp.task( 'copy:icons:main', () => {
+gulp.task( 'copy:icons', () => {
   const stream = _genericCopy(
     iconSrc,
     `${ paths.processed }/icons/`
-  );
-  return stream;
-} );
-
-gulp.task( 'copy:icons:oah', () => {
-  const stream = _genericCopy(
-    iconSrc,
-    `${ paths.processed }/apps/owning-a-home/icons/`
-  );
-  return stream;
-} );
-
-gulp.task( 'copy:icons:r3k', () => {
-  const stream = _genericCopy(
-    iconSrc,
-    `${ paths.processed }/apps/regulations3k/icons/`
   );
   return stream;
 } );
@@ -62,14 +46,6 @@ gulp.task( 'copy:lightbox2', () => {
   );
   return stream;
 } );
-
-gulp.task( 'copy:icons',
-  gulp.parallel(
-    'copy:icons:main',
-    'copy:icons:oah',
-    'copy:icons:r3k'
-  )
-);
 
 gulp.task( 'copy',
   gulp.parallel(


### PR DESCRIPTION
Background: https://github.com/cfpb/consumerfinance.gov/pull/4119

The relative reference problem has since been removed from the design-system, so this hack is no longer needed.

Testing:
 - collectstatic should run without erroring

