### PR TITLE
File a Complaint: Remove "File a Complaint" link from /complaint

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -15,12 +15,14 @@
 
 
 {% macro render( language='en' ) %}
-    {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
-    {# TODO: Padding should be on link, not CTA itself #}
+    {% if request.path != '/complaint/' %}
+        {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
+        {# TODO: Padding should be on link, not CTA itself #}
     <div class="m-global-header-cta">
         <a href="{{ complaint_link }}">
             {{ svg_icon('complaint') }}
             {{ _('Submit a Complaint') }}
         </a>
     </div>
+    {% endif %}
 {% endmacro %}

--- a/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-header-cta.html
@@ -15,7 +15,7 @@
 
 
 {% macro render( language='en' ) %}
-    {% if request.path != '/complaint/' %}
+    {% if request.path != '/complaint/' and request.path != '/es/enviar-una-queja/' %}
         {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
         {# TODO: Padding should be on link, not CTA itself #}
     <div class="m-global-header-cta">


### PR DESCRIPTION
The `/complaint/` page has a link at the top to itself. This causes some users to click through, expecting to see a different page, and becoming confused.

This PR adds a conditional in jinja to suppress the Complaint link at the top of the page **only** when viewing the `/complaint/` url.

## Additions
- Add conditional to `global-header-cta.html`

## How to test this PR
1. Pull it down and get it running.
2. Make sure the Complaint link at the top of the page doesn't appear on `/complaint/` but does appear on other pages.


## Screenshots
<img width="1570" alt="Screen Shot 2022-03-16 at 11 57 45 AM" src="https://user-images.githubusercontent.com/1490703/158633426-3a95e96f-718f-44a9-a932-ecfb98c7d94c.png">


## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

