### PR TITLE
Blog Filter Test Fix

### DIFF
--- a/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
+++ b/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
@@ -25,8 +25,9 @@ describe( 'Filter Blog Posts based on content', () => {
         'contain', title.get( 0 ).innerText
       );
       // And the page url should contain "title=" followed by the title
+      plus_title = title.get( 0 ).innerText.split( ' ' ).join( '+' );
       cy.url().should(
-        'include', 'title=' + title.get( 0 ).innerText
+        'include', 'title=' + plus_title
       );
     } );
   } );
@@ -101,8 +102,6 @@ describe( 'Filter Blog Posts based on content', () => {
         'from_date=' + date.get( 0 ).getAttribute( 'datetime' ).split( 'T' )[
           0
         ] );
-      // When I paginate to the last page of results
-      page.lastResults();
       // Then I should see only results dated that year or later
       blog.lastResultHeader().should(
         'contain', date.get( 0 ).getAttribute( 'datetime' ).split( '-' )[ 0 ]
@@ -427,7 +426,8 @@ describe( 'Filter Blog Posts based on content', () => {
           'contain', category.get( 0 ).innerText.split( '\n' ).pop().trim()
         );
         // And the page url should contain "title=" title
-        cy.url().should( 'include', 'title=' + title.get( 0 ).innerText );
+        plus_title = title.get( 0 ).innerText.split( ' ' ).join( '+' );
+        cy.url().should( 'include', 'title=' + plus_title );
         // And the page url should contain "categories=" category
         cy.url().should(
           'include',
@@ -463,7 +463,8 @@ describe( 'Filter Blog Posts based on content', () => {
           blog.resultsContent().should( 'contain', label.get( 0 ).innerText );
         } );
         // And the page url should contain "title=" title
-        cy.url().should( 'include', 'title=' + title.get( 0 ).innerText );
+        plus_title = title.get( 0 ).innerText.split( ' ' ).join( '+' );
+        cy.url().should( 'include', 'title=' + plus_title );
         // And the page url should contain "topics=" topic
         cy.url().should(
           'include',
@@ -499,7 +500,8 @@ describe( 'Filter Blog Posts based on content', () => {
         );
         blog.resultsContent().should( 'contain', title.get( 0 ).innerText );
         // And the page url should contain "title=loans"
-        cy.url().should( 'include', 'title=' + title.get( 0 ).innerText );
+        plus_title = title.get( 0 ).innerText.split( ' ' ).join( '+' );
+        cy.url().should( 'include', 'title=' + plus_title );
         // And the page url should contain "from_date=2020-01-01"
         cy.url().should(
           'include',


### PR DESCRIPTION
New changes to the blog filter tests so they pass on staging.

---



## Removals

- Removed one line that was not needed for unit testing and causing failures on stage testing  


## Changes

- URL Title comparison will now add "+" as the separators instead of spaces that were being used before


## How to test this PR

1.Once this code has been merged we can rerun the Jenkins Cypress test and hopefully the results will be positive

2. It is also important to make sure these changes didn't break testing for thee GitHub Actions as well which will be tested by the PR's checks anyway


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
