### PR TITLE
Don't try to flake Python files in cfgov/f

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -26,6 +26,7 @@ exclude =
     venv,
 
     # And directories in cfgov that don't have python files to lint
+    cfgov/f,
     cfgov/jinja2,
     cfgov/static_built,
     cfgov/templates,


### PR DESCRIPTION
The site MEDIA_ROOT is set to `cfgov/f` when running locally. If you sync your local media with the production site,
you may end up with some Python files in there, [for example](https://files.consumerfinance.gov/f/documents/NFWBS_PUF_2016_read_in_PY27.py).

We shouldn't try to run our Python linter on such files.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)