### PR TITLE
Add sync_database_storage management command

### DIFF
--- a/cfgov/v1/management/commands/_sync_storage_base.py
+++ b/cfgov/v1/management/commands/_sync_storage_base.py
@@ -1,0 +1,55 @@
+import os
+
+import requests
+import requests.exceptions
+
+
+class SyncStorageCommandMixin:
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "base_url", help="ex: https://files.consumerfinance.gov/f/"
+        )
+        parser.add_argument("dest_dir", help="ex: ./cfgov/f/")
+
+    def handle(self, *args, **options):
+        self.base_url = options["base_url"]
+        self.dest_dir = options["dest_dir"]
+
+        for subdir in self.get_storage_directories():
+            directory = os.path.join(self.dest_dir, subdir)
+            if not os.path.exists(directory):
+                os.makedirs(directory)
+
+        queryset = self.get_queryset()
+        count = queryset.count()
+
+        for i, instance in enumerate(queryset):
+            log_prefix = "%d/%d (%d) " % (i + 1, count, instance.pk)
+            self.handle_instance(instance, log_prefix)
+
+    def get_storage_subdirectories():
+        raise NotImplementedError
+
+    def get_queryset():
+        raise NotImplementedError
+
+    def handle_instance(self, instance, log_prefix):
+        self.stdout.write(log_prefix, ending="")
+        self.save(instance.file.name)
+
+    def save(self, path):
+        url = self.base_url + path
+        filename = self.dest_dir + path
+
+        self.stdout.write("Saving %s to %s\n" % (url, filename))
+
+        response = requests.get(url, stream=True)
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.stderr.write(str(e))
+        else:
+            with open(filename, "wb") as f:
+                for block in response.iter_content(1024):
+                    f.write(block)

--- a/cfgov/v1/management/commands/sync_document_storage.py
+++ b/cfgov/v1/management/commands/sync_document_storage.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from wagtail.documents import get_document_model
+
+from ._sync_storage_base import SyncStorageCommandMixin
+
+
+class Command(SyncStorageCommandMixin, BaseCommand):
+    def get_storage_directories(self):
+        return ["documents"]
+
+    def get_queryset(self):
+        return get_document_model().objects.all()

--- a/cfgov/v1/management/commands/sync_image_storage.py
+++ b/cfgov/v1/management/commands/sync_image_storage.py
@@ -1,62 +1,28 @@
-import os
-
 from django.core.management.base import BaseCommand
 
 from wagtail.images import get_image_model
 
-import requests
-import requests.exceptions
+from ._sync_storage_base import SyncStorageCommandMixin
 
 
-class Command(BaseCommand):
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "base_url", help="ex: https://files.consumerfinance.gov/f/"
-        )
-        parser.add_argument("dest_dir", help="ex: ./cfgov/f/")
+class Command(SyncStorageCommandMixin, BaseCommand):
+    def get_storage_directories(self):
+        return ["images", "original_images"]
 
-    def handle(self, *args, **options):
-        base_url = options["base_url"]
-        dest_dir = options["dest_dir"]
+    def get_queryset(self):
+        return get_image_model().objects.all()
 
-        for subdir in ("images", "original_images"):
-            directory = os.path.join(dest_dir, subdir)
-            if not os.path.exists(directory):
-                os.makedirs(directory)
+    def handle_instance(self, instance, log_prefix):
+        super().handle_instance(instance, log_prefix)
 
-        images = get_image_model().objects.all()
-        image_count = images.count()
+        renditions = instance.renditions.all()
+        rendition_count = renditions.count()
 
-        for i, image in enumerate(images):
-            image_prefix = "%d/%d (%d) " % (i + 1, image_count, image.pk)
-            self.stdout.write(image_prefix, ending="")
-            self.save(base_url, dest_dir, image.file.name)
-
-            renditions = image.renditions.all()
-            rendition_count = renditions.count()
-
-            for j, rendition in enumerate(renditions):
-                rendition_prefix = "%d/%d (%d) " % (
-                    j + 1,
-                    rendition_count,
-                    rendition.pk,
-                )
-                self.stdout.write(image_prefix + rendition_prefix, ending="")
-                self.save(base_url, dest_dir, rendition.file.name)
-
-    def save(self, base_url, dest_dir, path):
-        url = base_url + path
-        filename = dest_dir + path
-
-        self.stdout.write("Saving %s to %s\n" % (url, filename))
-
-        response = requests.get(url, stream=True)
-
-        try:
-            response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            self.stderr.write(str(e))
-        else:
-            with open(filename, "wb") as f:
-                for block in response.iter_content(1024):
-                    f.write(block)
+        for j, rendition in enumerate(renditions):
+            rendition_prefix = "%d/%d (%d) " % (
+                j + 1,
+                rendition_count,
+                rendition.pk,
+            )
+            self.stdout.write(log_prefix + rendition_prefix, ending="")
+            self.save(rendition.file.name)

--- a/cfgov/v1/tests/management/commands/test_sync_storage.py
+++ b/cfgov/v1/tests/management/commands/test_sync_storage.py
@@ -1,0 +1,72 @@
+import os.path
+import re
+import tempfile
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from wagtail.documents import get_document_model
+from wagtail.documents.tests.utils import get_test_document_file
+from wagtail.images import get_image_model
+from wagtail.images.tests.utils import get_test_image_file
+
+import responses
+
+
+class SyncStorageTestMixin:
+    def setUp(self):
+        self.fake_storage = "https://example-cfpbtest.gov/files/"
+        responses.add(responses.GET, re.compile(self.fake_storage + r".*"))
+
+        self.tempdir = tempfile.TemporaryDirectory()
+
+    @responses.activate
+    def test_sync(self):
+        out = StringIO()
+
+        call_command(
+            self.sync_command,
+            self.fake_storage,
+            self.tempdir.name + "/",
+            stdout=out,
+        )
+
+        for instance in self.model_cls.objects.all():
+            synced_filename = os.path.join(
+                self.tempdir.name, instance.file.name
+            )
+            self.assertTrue(os.path.exists(synced_filename))
+
+
+class SyncDocumentStorageTests(SyncStorageTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create some test documents in the database.
+        Document = get_document_model()
+
+        for _ in range(3):
+            document = Document(title="test")
+            document.file.save("testing.txt", get_test_document_file())
+
+        self.model_cls = Document
+        self.sync_command = "sync_document_storage"
+
+
+class SyncImageStorageTests(SyncStorageTestMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+
+        # Create some test images in the database.
+        Image = get_image_model()
+
+        for _ in range(3):
+            image = Image.objects.create(
+                title="testing",
+                file=get_test_image_file(),
+            )
+            image.get_rendition("original")
+
+        self.model_cls = Image
+        self.sync_command = "sync_image_storage"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -354,26 +354,32 @@ Once complete, our `runserver.sh` script will bring up the site at
 
 ## Additional setup
 
-### Sync local image storage (optional)
+### Sync local image and document storage (optional)
 
-If using a database dump, pages will contain links to images that exist in
-the database but don't exist on your local disk. This will cause broken or
-missing images when browsing the site locally.
+If using a database dump, pages will contain links to images or documents
+that exist in the database but don't exist on your local disk.
+This will cause broken or missing images or links when browsing the site locally.
 
-For example, in production images are stored on S3, but when running locally
-they are stored on disk.
+This is because in production images and documents are stored on S3,
+but when running locally they are stored on disk.
 
-This project includes a Django management command that can be used to download
-any remote images referenced in the database so that they can be served when
+This project includes two Django management commands that can be used to download
+any remote images or documents referenced in the database so that they can be served when
 running locally.
+
+This command downloads all remote images (and image renditions) referenced in the
+database, retrieving them from the specified URL and storing them in the
+specified local directory:
 
 ```sh
 cfgov/manage.py sync_image_storage https://files.consumerfinance.gov/f/ ./cfgov/f/
 ```
 
-This downloads all remote images (and image renditions) referenced in the
-database, retrieving them from the specified URL and storing them in the
-specified local directory.
+This command does the same, but for documents:
+
+```sh
+cfgov/manage.py sync_document_storage https://files.consumerfinance.gov/f/ ./cfgov/f/
+```
 
 ### Install GNU gettext for Django translation support (optional)
 


### PR DESCRIPTION
This commit adds a new management command to the v1 app: `sync_database_storage`. Like the existing `sync_image_storage` command, this new command can be used to sync Wagtail media from a remote S3 storage to a local disk for use during development.

As part of this work I've factored out common functionality from these two commands into a base `SyncStorageCommandMixin` class.

## How to test this PR

To test, the command can be run like this, assuming you have a copy of the production database:

```
cfgov/manage.py sync_document_storage https://files.consumerfinance.gov/f/ ./cfgov/f/
```

This will (after a long time) download all documents from remote S3 storage, making them available when you run a server locally.

## Screenshots

New documentation change (compare with [existing content](https://cfpb.github.io/consumerfinance.gov/installation/#sync-local-image-storage-optional))

![image](https://user-images.githubusercontent.com/654645/158451746-40b54094-aeec-482b-9057-b9d5af2fb49f.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)