### PR TITLE
Remove unused EMAIL_SUBJECT_PREFIX env variable

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -37,7 +37,6 @@ export WAGTAIL_SHARING_HOSTNAME=content.localhost
 #export ENABLE_POST_PREVIEW_CACHE=1
 #export EMAIL_HOST=<email_server_hostname>
 #export ADMIN_EMAILS=<comma_delimited_list_of_emails>
-#export EMAIL_SUBJECT_PREFIX=<email_subject_prefix>
 #export WAGTAILADMIN_NOTIFICATION_FROM_EMAIL=<wagtail_notification_from_email>
 #export LOGIN_FAIL_TIME_PERIOD=<time_between_failed_attempts>
 #export LOGIN_FAILS_ALLOWED=<number_of_fails_allowed_before_lockout>


### PR DESCRIPTION
The `EMAIL_SUBJECT_PREFIX` environment variable [has not been used](https://github.com/cfpb/consumerfinance.gov/search?q=email_subject_prefix) in the cf.gov codebase [since 2017](https://github.com/cfpb/consumerfinance.gov/commit/bc32dde75d1ac41b806b53d58c20ca7c4d56aa1f).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)