### PR TITLE
Use Python 3.8 in GitHub Actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.backend == 'true'
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install dependencies
         if: steps.filter.outputs.backend == 'true'
@@ -106,7 +106,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.backend == 'true'
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install dependencies
         if: steps.filter.outputs.backend == 'true'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/setup-python@v2.2.2
         if: steps.filter.outputs.frontend == 'true'
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install dependencies
         if: steps.filter.outputs.frontend == 'true'


### PR DESCRIPTION
Swaps out Python 3.6 -> 3.8 in all GitHub Action workflows. 