### PR TITLE
Bump curriculum-review-tool version to 2.1.7

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -45,7 +45,7 @@ wagtailmedia==0.9.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.2/owning_a_home_api-0.17.2-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.6/crtool-2.1.6-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.7/crtool-2.1.7-py3-none-any.whl
 
 # Temporarily pin Jinja 2.11's MarkupSafe dependency.
 MarkupSafe==2.0.1


### PR DESCRIPTION
Updates the CRC to contain https://github.com/cfpb/curriculum-review-tool/pull/426, which should eliminate some false-positive Checkmarx flaggings.

---

## Changes

Several string constants used in the UI are turned into React components to allow the same inline markup, but without the dangerouslySetInnerHTML prop. The resulting markup in the app should be identical.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
