### PR TITLE
Add images report

### DIFF
--- a/cfgov/v1/templates/v1/images_report.html
+++ b/cfgov/v1/templates/v1/images_report.html
@@ -15,13 +15,13 @@
             <thead>
                 <tr>
                     <th>
-                        ID
-                    </th>
-                    <th>
                         Title
                     </th>
                     <th>
                         File
+                    </th>
+                    <th>
+                        Size (bytes)
                     </th>
                     <th>
                         Collection
@@ -41,15 +41,15 @@
                 {% for image in object_list %}
                     <tr>
                         <td>
-                            {{ image.id }}
-                        </td>
-                        <td>
                             {{ image.title }}
                         </td>
                         <td>
-                            <a href="https://www.consumerfinance.gov{{ image.url }}">
-                                {{ image.filename }}
+                            <a href="{{ image.url }}">
+                                {{ image.url }}
                             </a>
+                        </td>
+                        <td>
+                            {{ image.file_size }}
                         </td>
                         <td>
                             {{ image.collection }}

--- a/cfgov/v1/templates/v1/images_report.html
+++ b/cfgov/v1/templates/v1/images_report.html
@@ -1,0 +1,73 @@
+{% extends 'wagtailadmin/reports/base_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block actions %}
+    {% if view.list_export %}
+        <div class="actionbutton">
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block results %}
+    {% if object_list %}
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th>
+                        ID
+                    </th>
+                    <th>
+                        Title
+                    </th>
+                    <th>
+                        File
+                    </th>
+                    <th>
+                        Collection
+                    </th>
+                    <th>
+                        Tags
+                    </th>
+                    <th>
+                        Uploaded on
+                    </th>
+                    <th>
+                        Uploaded by
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for image in object_list %}
+                    <tr>
+                        <td>
+                            {{ image.id }}
+                        </td>
+                        <td>
+                            {{ image.title }}
+                        </td>
+                        <td>
+                            <a href="https://www.consumerfinance.gov{{ image.url }}">
+                                {{ image.filename }}
+                            </a>
+                        </td>
+                        <td>
+                            {{ image.collection }}
+                        </td>
+                        <td>
+                            {{ image.tags.names|join:", " }}
+                        </td>
+                        <td>
+                            {{ image.created_at }}
+                        </td>
+                        <td>
+                            {{ image.uploaded_by_user }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>There are no images in the image library.</p>
+    {% endif %}
+{% endblock %}

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -2,6 +2,7 @@ from datetime import date
 
 from wagtail.admin.views.reports import PageReportView, ReportView
 from wagtail.documents.models import Document
+from wagtail.images.models import Image
 
 from v1.models import CFGOVPage
 
@@ -106,3 +107,43 @@ class DocumentsReportView(ReportView):
 
     def get_queryset(self):
         return Document.objects.all().order_by("-id").prefetch_related("tags")
+
+
+class ImagesReportView(ReportView):
+    header_icon = "image"
+    title = "All images"
+
+    list_export = [
+        "id",
+        "title",
+        "filename",
+        "url",
+        "collection",
+        "tags.names",
+        "created_at",
+        "uploaded_by_user",
+    ]
+    export_headings = {
+        "id": "ID",
+        "title": "Title",
+        "filename": "File",
+        "url": "URL",
+        "collection": "Collection",
+        "tags.names": "Tags",
+        "created_at": "Uploaded on",
+        "uploaded_by_user": "Uploaded by",
+    }
+
+    custom_field_preprocess = {
+        "tags.names": {"csv": process_tags},
+        "url": {"csv": construct_absolute_url},
+    }
+
+    template_name = "v1/images_report.html"
+
+    def get_filename(self):
+        """Get a better filename than the default 'spreadsheet-export'."""
+        return f"all-cfgov-images-{date.today()}"
+
+    def get_queryset(self):
+        return Image.objects.all().order_by("-id").prefetch_related("tags")

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -37,7 +37,7 @@ from v1.template_debug import (
     video_player_test_cases,
 )
 from v1.util import util
-from v1.views.reports import DocumentsReportView, PageMetadataReportView
+from v1.views.reports import DocumentsReportView, ImagesReportView, PageMetadataReportView
 
 
 try:
@@ -286,6 +286,27 @@ def register_documents_report_url():
             r"^reports/documents/$",
             DocumentsReportView.as_view(),
             name="documents_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_images_report_menu_item():
+    return MenuItem(
+        "Images",
+        reverse("images_report"),
+        classnames="icon icon-" + ImagesReportView.header_icon,
+        order=700,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_images_report_url():
+    return [
+        re_path(
+            r"^reports/images/$",
+            ImagesReportView.as_view(),
+            name="images_report",
         ),
     ]
 


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
Adds a report with details of all the images managed in Wagtail. 

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- An images report using [Wagtail's standard reports interface](https://docs.wagtail.org/en/stable/extending/adding_reports.html)


## How to test this PR

1. Load the latest dump of production data
2. Go to `/admin/reports/images/`, where you should see a list of all the images managed in Wagtail
3. Hit the download CSV button on that list to make sure the CSV download works and all the data looks good in the CSV


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance