### PR TITLE
Properly set job listing schema for hourly salary

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
@@ -233,7 +233,7 @@
                 "@type": "QuantitativeValue",
                 "minValue": "{{ page.salary_min }}",
                 "maxValue": "{{ page.salary_max }}",
-                "unitText": "YEAR"
+                "unitText": "{{ "HOUR" if page.salary_is_hourly else "YEAR" }}"
             }
         },
         "description": "{{ page.description }}",


### PR DESCRIPTION
#6989 added the ability to specify an hourly salary for job postings. JobListingPages include JSON schema which also needs to be updated appropriately:

https://developers.google.com/search/docs/advanced/structured-data/job-posting

This change modifies the JSON schema to indicate that a posting has an hourly wage instead of an annual one.

## Screenshots

Schema for annual salary:

![image](https://user-images.githubusercontent.com/654645/161599164-315c471f-289d-4232-9b8d-be9b5c58e69c.png)

Schema for hourly salary:

![image](https://user-images.githubusercontent.com/654645/161599272-2a41e737-0e7d-4327-868e-787298d6c99d.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)