### PR TITLE
Bump coverage version to 6.3.2

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,4 @@
-coverage==4.5.1
+coverage==6.3.2
 diff_cover==5.1.2
 pluggy==0.13.1
 tox==3.19.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-coverage==4.5.1
+coverage==6.3.2
 diff_cover==5.1.2
 django-sslserver==0.20
 freezegun==0.3.12


### PR DESCRIPTION
This commit bumps the version of the Python `coverage` package from 4.5.1 to 6.3.2. See the `coverage` changelog [here](https://coverage.readthedocs.io/en/6.3.2/changes.html).

In my experience the newer version gives much more accurate coverage reporting. See for an example a recent PR coverage check like [this](https://github.com/cfpb/consumerfinance.gov/runs/5979266809?check_suite_focus=true).

This fails coverage reporting these lines:

```
cfgov/v1/tests/test_documents.py (78.6%): Missing lines 325,328,338-340,346
```

but an inspection of those lines shows that some of them are comments and some can't possibly be getting skipped:

https://github.com/cfpb/consumerfinance.gov/blob/aa3557fe249a4368e575e95ca18393903f072f36/cfgov/v1/tests/test_documents.py#L325-L346

The 6.x version of coverage properly measures coverage on this change.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)