### PR TITLE
Resolve 'getFiles' to absolute paths and adjust string replacement logic

### DIFF
--- a/esbuild/copy.js
+++ b/esbuild/copy.js
@@ -1,20 +1,20 @@
 const { mkdir, copyFile } = require( 'fs' ).promises;
-const { dirname } = require( 'path' );
+const { dirname, resolve } = require( 'path' );
 const { getFiles, copyAll } = require( './utils.js' );
 const { unprocessed, modules } = require( '../config/environment.js' ).paths;
 
 module.exports = async function( baseConfig ) {
-  const files = await getFiles( unprocessed );
-  const staticFiles = files.filter( v => !v.match( /.js$|.less$|.css$/ ) );
+  const resolvedBase = resolve( unprocessed );
+  const files = await getFiles( resolvedBase );
 
-  const inDirs = [ ...new Set( staticFiles.map( v => dirname( v ) ) ) ];
+  const staticFiles = files.filter( v => !v.match( /^\.|\.js$|\.less$|\.css$/ ) );
+  const inDirs = [
+    ...new Set( staticFiles.map( v => dirname( v ) ) )
+  ];
   const outDirs = [
-    ...inDirs.map( v => v.replace( unprocessed, baseConfig.outdir ) ),
+    ...inDirs.map( v => v.replace( resolvedBase, baseConfig.outdir ) ),
     // Create specific icon directory
-    `${ baseConfig.outdir }/icons`,
-    // Hande prebuilt lightbox dep
-    ...[ '', '/images', '/js', '/css' ]
-      .map( v => `${ baseConfig.outdir }/lightbox2${ v }` )
+    `${ baseConfig.outdir }/icons`
   ];
 
   // Make output directories
@@ -22,7 +22,7 @@ module.exports = async function( baseConfig ) {
 
   // Copy files to output directories
   staticFiles.forEach( f => copyFile(
-    f, f.replace( unprocessed, baseConfig.outdir )
+    f, f.replace( resolvedBase, baseConfig.outdir )
   ) );
 
   // Handle files that live at the root of the site

--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -38,9 +38,11 @@ async function getFiles( dir ) {
  * @returns {array} Array of promises for each copied file
  **/
 async function copyAll( from, to ) {
-  const files = await getFiles( from );
+  const rFrom = resolve( from );
+  const rTo = resolve( to );
+  const files = await getFiles( rFrom );
   return files.map( f => copyFile(
-    f, f.replace( from, to )
+    f, f.replace( rFrom, rTo )
   ) );
 }
 

--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -18,7 +18,6 @@ const blocklist = [
   'node_modules', 'npm-packages-offline-cache', '.yarnrc', 'yarn.lock',
   'browserslist', 'package.json', 'config.json', '.gitkeep', 'root'
 ];
-const rDir = resolve( '.' );
 
 /**
  * @param {string} dir Current directory to walk
@@ -31,7 +30,6 @@ async function getFiles( dir ) {
     return dirent.isDirectory() ? getFiles( res ) : res;
   } ) );
   return files.flat().filter( v => v )
-    .map( v => v.replace( rDir, '.' ) );
 }
 
 /**

--- a/esbuild/utils.js
+++ b/esbuild/utils.js
@@ -29,7 +29,7 @@ async function getFiles( dir ) {
     const res = resolve( dir, dirent.name );
     return dirent.isDirectory() ? getFiles( res ) : res;
   } ) );
-  return files.flat().filter( v => v )
+  return files.flat().filter( v => v );
 }
 
 /**


### PR DESCRIPTION
In some Unix environments, the current way files were resolved was not correct.

This updated logic will work in all cases.