### PR TITLE
Add build scripts JS to linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "enforce": "enforce-node-version",
     "preinstall": "node scripts/preinstall.js",
     "postinstall": "yarn enforce && node scripts/yarn/apps-install && ./scripts/check-npm-cache.sh",
-    "lint": "eslint --ignore-pattern node_modules './cfgov/unprocessed/**/*.js' './test/**/*.js'",
+    "lint": "eslint --ignore-pattern node_modules './{cfgov/unprocessed,config,esbuild,scripts,test}/**/*.js'",
     "jest": "jest",
     "test": "yarn lint && yarn jest",
     "snyk": "snyk test",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,6 +1,7 @@
-if (process.env.npm_execpath.indexOf('yarn') === -1) {
-  console.error('\x1b[41m', 'You must use Yarn to install dependencies:');
-  console.error('\x1b[41m', '  $ yarn install');
-  console.error('\x1b[40m');
-  process.exit(1);
+// eslint-disable-next-line no-process-env
+if ( process.env.npm_execpath.indexOf( 'yarn' ) === -1 ) {
+  console.error( '\x1b[41m', 'You must use Yarn to install dependencies:' );
+  console.error( '\x1b[41m', '  $ yarn install' );
+  console.error( '\x1b[40m' );
+  process.exit( 1 );
 }


### PR DESCRIPTION
## Changes

- Add build scripts JS to linting


## How to test this PR

1. `yarn lint` should show no errors and should include build script JS in warnings.
