### PR TITLE
Raise Ask search limit to 75 characters

### DIFF
--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -132,8 +132,8 @@ class AnswerPageSearchTest(TestCase):
 
     @mock.patch.object(AnswerPageDocument, "search")
     def test_ask_search_autocomplete_honors_max_chars(self, mock_search):
-        valid_term = "This search has 75 characters, the upper limit we have "
-        "set for Ask searches"
+        valid_term = "Years, days, makes no difference to me babe "
+        "You look exactly the same to me"
         overage = " This is overage text that should not appear in the query"
         too_long_term = valid_term + overage
         self.client.get(

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -132,7 +132,8 @@ class AnswerPageSearchTest(TestCase):
 
     @mock.patch.object(AnswerPageDocument, "search")
     def test_ask_search_autocomplete_honors_max_chars(self, mock_search):
-        valid_term = "You saw the masterpiece, she looks a lot like you!"
+        valid_term = "This search has 75 characters, the upper limit we have "
+        "set for Ask searches"
         overage = " This is overage text that should not appear in the query"
         too_long_term = valid_term + overage
         self.client.get(

--- a/cfgov/search/models.py
+++ b/cfgov/search/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 
 
-AUTOCOMPLETE_MAX_CHARS = 50
+AUTOCOMPLETE_MAX_CHARS = 75
 
 
 class Synonym(models.Model):


### PR DESCRIPTION
Now that there's no longer an Ask search field on the submit a complaint page, we can loosen the character limit on searches a little. See GHE/CFGOV/platform/issues/4399 for more details.

---

## Changes

- Raise the character limit of Ask searches from 50 to 75 chracters
- Update the unit test for the new higher limit

## How to test this PR

1. Visit a page with the Ask search on it, like `/ask-cfpb/`
2. Inspect the source on the search field. It should have a `maxlength="75"` set.
3. Try typing in a long search. When you hit 75 characters, you should get an error message that says "Searches are limited to 75 characters."

## Notes and todos

- Note that the unit tests in `test_search.py` that use `mock_search.called_with()` aren't working as intended right now—they'll always pass regardless of the input. We're fixing that separately; see GHE/CFGOV/platform/issues/4390 for more details.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets