### PR TITLE
fix improperly formatted string in pfc disclosures

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3345,7 +3345,7 @@
   if (document.body.parentElement.className.indexOf('no-js') === -1) {
     !function() {
       var s = [
-        '{{ static('apps/paying-for-college/js/disclosures/index.js') }}'
+        "{{ static('apps/paying-for-college/js/disclosures/index.js') }}"
       ];
       jsl(s);
     }()


### PR DESCRIPTION
Fix for pfc disclosures not working correctly in staging. Not sure why this wasn't broken before.


## Changes

- Changed string formatting


## How to test this PR

1. Ensure all tests still pass


## Checklist

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)