### PR TITLE
Better regex for targeting hidden files (to ignore)

### DIFF
--- a/esbuild/copy.js
+++ b/esbuild/copy.js
@@ -7,10 +7,12 @@ module.exports = async function( baseConfig ) {
   const resolvedBase = resolve( unprocessed );
   const files = await getFiles( resolvedBase );
 
-  const staticFiles = files.filter( v => !v.match( /^\.|\.js$|\.less$|\.css$/ ) );
+  const staticFiles = files.filter( v => !v.match( /\/\.[-.\w]*$|\.js$|\.less$|\.css$/i ) );
+
   const inDirs = [
     ...new Set( staticFiles.map( v => dirname( v ) ) )
   ];
+
   const outDirs = [
     ...inDirs.map( v => v.replace( resolvedBase, baseConfig.outdir ) ),
     // Create specific icon directory


### PR DESCRIPTION
If returning absolute paths, the current regex attempting to target hidden files won't work. This fixes that.

Also causes makes the regex case-insensitive, which it should be.