### PR TITLE
Add final prefix replacement

### DIFF
--- a/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
+++ b/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
@@ -62,8 +62,8 @@ def import_agreements_data(agreements_data):
         )
         created_time = created_time.replace(tzinfo=pytz.timezone("EST"))
 
-        product_id = item["product_id"].replace("PRODUCT-", "").replace(
-            "AGMNT-", ""
+        product_id = (
+            item["product_id"].replace("PRODUCT-", "").replace("AGMNT-", "")
         )
         product = PrepaidProduct.objects.get(pk=product_id)
         url = S3_PATH + item["agreements_files_location"]

--- a/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
+++ b/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
@@ -62,7 +62,9 @@ def import_agreements_data(agreements_data):
         )
         created_time = created_time.replace(tzinfo=pytz.timezone("EST"))
 
-        product_id = item["product_id"].replace("PRODUCT-", "").replace("AGMNT-", "")
+        product_id = item["product_id"].replace("PRODUCT-", "").replace(
+            "AGMNT-", ""
+        )
         product = PrepaidProduct.objects.get(pk=product_id)
         url = S3_PATH + item["agreements_files_location"]
 

--- a/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
+++ b/cfgov/prepaid_agreements/scripts/import_prepaid_agreements_data.py
@@ -62,7 +62,7 @@ def import_agreements_data(agreements_data):
         )
         created_time = created_time.replace(tzinfo=pytz.timezone("EST"))
 
-        product_id = item["product_id"].replace("PRODUCT-", "")
+        product_id = item["product_id"].replace("PRODUCT-", "").replace("AGMNT-", "")
         product = PrepaidProduct.objects.get(pk=product_id)
         url = S3_PATH + item["agreements_files_location"]
 


### PR DESCRIPTION
Missed one AGMNT- prefix replacement in the previous fix for this script.


## Additions

- Added an additional replace command from "AGMNT-" to ""


## How to test this PR

1. Ensure cf.gov-prepaid-agreements-data-load-and-write-csv Jenkins job passes

## Checklist

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
