### PR TITLE
Ask CFPB: restore related resourcees

### DIFF
--- a/cfgov/jinja2/v1/ask-cfpb/answer-page.html
+++ b/cfgov/jinja2/v1/ask-cfpb/answer-page.html
@@ -76,6 +76,17 @@
                 </button>
             </div>
 
+            {% if page.related_resource and page.related_resource.trans_text(page.language) | striptags %}
+            <div class="block next-steps">
+                <div class="o-well">
+                    <h2>
+                        {{ page.related_resource.trans_title(page.language) | safe }}
+                    </h2>
+                    {{ page.related_resource.trans_text(page.language) | safe }}
+                </div>
+            </div>
+            {% endif %}
+
             <div class="block related-questions">
                 <h2>{{ _('Don\'t see what you\'re looking for?') }}</h2>
                 {% if related_questions %}


### PR DESCRIPTION
Reverses https://github.com/cfpb/consumerfinance.gov/pull/5391, which removed the next steps / related resources section from the Ask answer template. Stakeholders plan to test the use of related resources on top-performing Ask pages.

## Additions

- Code to output related resources on Ask answer page template

## How to test this PR

1. Check out branch
2. Create a `Related resource` snippet with both English and Spanish content
3. Add the related resource to both an English and Spanish Ask question
4. Verify that the related resource's English fields are displayed on the English page and its Spanish fields are displayed on the Spanish page


## Screenshots
### Related resource
<img width="890" alt="Screen Shot 2022-04-19 at 9 57 48 AM" src="https://user-images.githubusercontent.com/778171/164056528-94708467-896e-4961-865e-0fe5e368cec1.png">



### English answer page
<img width="806" alt="Screen Shot 2022-04-19 at 10 00 22 AM" src="https://user-images.githubusercontent.com/778171/164056867-f684793a-e272-4761-b573-5edf6555d212.png">


### Spanish answer page
<img width="802" alt="Screen Shot 2022-04-19 at 10 00 57 AM" src="https://user-images.githubusercontent.com/778171/164056889-c8fda251-e43d-47dc-b476-4181dbdc6437.png">



## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)


