### PR TITLE
Fix some linter warnings

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -21,8 +21,8 @@ if ( printPageLink ) {
 }
 
 let map;
-let marker_array = [];
-let zip_marker = null;
+let markerArray = [];
+let zipMarker = null;
 let markerDomCache = {};
 
 /**
@@ -96,12 +96,12 @@ function queryMarkerDom( num ) {
 function updateMap( data ) {
   // reset the map
   markerDomCache = {};
-  for ( let i = 0; i < marker_array.length; i++ ) {
-    map.removeLayer( marker_array[i] );
+  for ( let i = 0; i < markerArray.length; i++ ) {
+    map.removeLayer( markerArray[i] );
   }
-  marker_array = [];
-  if ( zip_marker !== null ) {
-    map.removeLayer( zip_marker );
+  markerArray = [];
+  if ( zipMarker !== null ) {
+    map.removeLayer( zipMarker );
   }
   map.setZoom( 2 );
   map.setView( [ 40, -80 ] );
@@ -121,7 +121,7 @@ function updateMap( data ) {
     let ymax = -Infinity;
     let ymin = Infinity;
 
-    zip_marker = window.L.circle( ziplatlng, 3 ).addTo( map );
+    zipMarker = window.L.circle( ziplatlng, 3 ).addTo( map );
 
     data.counseling_agencies.forEach( ( val, i ) => {
       const lat = val.agc_ADDR_LATITUDE;
@@ -149,7 +149,7 @@ function updateMap( data ) {
         position,
         { icon: icon }
       ).addTo( map );
-      marker_array[i] = marker;
+      markerArray[i] = marker;
 
       marker.on( 'click', function() {
         const resultEntryDom = queryMarkerDom( number );

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -296,7 +296,8 @@ function placeBenefitsText() {
   benefitsTop = parseInt( $selectedBar.css( 'top' ), 10 );
   benefitsTop -= $( '#benefits-text' ).height() + 10;
   benefitsLeft = parseInt( $selectedBar.css( 'left' ), 10 );
-  benefitsLeft -= $( '#benefits-text' ).width() / 2 - graphSettings.barWidth / 2;
+  benefitsLeft -= ( $( '#benefits-text' ).width() / 2 ) -
+                  ( graphSettings.barWidth / 2 );
   $( '#benefits-text' ).css( 'top', benefitsTop );
   $( '#benefits-text' ).css( 'left', benefitsLeft );
 
@@ -306,8 +307,8 @@ function placeBenefitsText() {
   fullAgeTop = parseInt( $fullAgeBar.css( 'top' ), 10 );
   fullAgeTop -= $fullAgeBenefits.height() + 10;
   fullAgeLeft = parseInt( $fullAgeBar.css( 'left' ), 10 );
-  fullAgeLeft -= $fullAgeBenefits.width() / 2 -
-    graphSettings.barWidth / 2;
+  fullAgeLeft -= ( $fullAgeBenefits.width() / 2 ) -
+                 ( graphSettings.barWidth / 2 );
   $fullAgeBenefits.css( 'top', fullAgeTop );
   $fullAgeBenefits.css( 'left', fullAgeLeft );
 

--- a/cfgov/unprocessed/apps/retirement/js/views/next-steps-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/next-steps-view.js
@@ -3,17 +3,11 @@ import isElementInView from '../utils/is-element-in-view';
 // TODO: remove jquery.
 import $ from 'jquery';
 
-let currentAge = 0;
-let fullAge = 0;
-
-function init( ageRightNow, fullRetirementAge ) {
-  currentAge = ageRightNow;
-  fullAge = fullRetirementAge;
-
-  limitAgeSelector( currentAge );
+function init( ageRightNow = 0, fullRetirementAge = 0 ) {
+  limitAgeSelector( ageRightNow );
 
   $( '#retirement-age-selector' ).change( function() {
-    chooseClaimingAge();
+    chooseClaimingAge( fullRetirementAge );
   } );
 
   $( '#age-selector-response .helpful-btn' ).click( function() {
@@ -21,10 +15,12 @@ function init( ageRightNow, fullRetirementAge ) {
   } );
 }
 
-/* This function updates the text in Step 3
-    based on the user's chosen retirement age
-    @param {number} fullAge   The user's full retirement age */
-function chooseClaimingAge() {
+/**
+ * This function updates the text in Step 3
+ * based on the user's chosen retirement age
+ * @param {number} fullAge   The user's full retirement age
+ */
+function chooseClaimingAge( fullAge ) {
 
   if ( $( '#retirement-age-selector' ).find(
     'option:selected'

--- a/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
@@ -39,8 +39,8 @@ function toolTipper( elem ) {
 
   $ttc.show();
   const newTop = $elem.offset().top + $elem.outerHeight() + 10;
-  newLeft = $elem.offset().left + $elem.outerWidth() / 2 -
-            $ttc.outerWidth( true ) / 2;
+  newLeft = $elem.offset().left + ( $elem.outerWidth() / 2 ) -
+            ( $ttc.outerWidth( true ) / 2 );
   $ttc.css( { top: newTop, left: newLeft } );
 
   // check offset again, properly set tips to point to the element clicked
@@ -54,11 +54,11 @@ function toolTipper( elem ) {
     $ttc.css( 'left', pagePadding );
     innerTip.css(
       'left',
-      elemCenter - innerTip.outerWidth() / 2 - pagePadding
+      elemCenter - ( innerTip.outerWidth() / 2 ) - pagePadding
     );
     outerTip.css(
       'left',
-      elemCenter - outerTip.outerWidth() / 2 - pagePadding
+      elemCenter - ( outerTip.outerWidth() / 2 ) - pagePadding
     );
   }
 

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -50,7 +50,9 @@ function censusAPI( data, ruralCounties ) {
 
         if ( addressUtils.isRural( fips, ruralCounties ) ) {
           result.type = 'rural';
-        } else if ( addressUtils.isRuralCensus( censusUC.features, censusUA.features ) ) {
+        } else if (
+          addressUtils.isRuralCensus( censusUC.features, censusUA.features )
+        ) {
           result.type = 'rural';
         } else {
           result.type = 'notRural';
@@ -82,7 +84,7 @@ function processAddresses( addresses ) {
 
   getRuralCounties( DT.getEl( '#year' ).value )
     .then( function( ruralCounties ) {
-      addresses.forEach( function( address, index ) {
+      addresses.forEach( function( address ) {
 
         if ( addressUtils.isDup( address, processed ) ) {
           // setup the result to render
@@ -105,8 +107,8 @@ function processAddresses( addresses ) {
 
 // On submit of address entered manually.
 const addressFormDom = document.querySelector( '#geocode' );
-addressFormDom.addEventListener( 'submit', function( e ) {
-  e.preventDefault();
+addressFormDom.addEventListener( 'submit', function( evt ) {
+  evt.preventDefault();
 
   window.location.hash = 'rural-or-underserved';
   const addresses = [];
@@ -387,19 +389,18 @@ function generateCSV() {
   function _loopHandler( element ) {
     const isHidden = DT.hasClass( DT.getParentEls( '.js-table' ), 'u-hidden' );
 
-    // add a data row, if table isn't hidden (!)
-    if ( isHidden === false ) {
+    /* Add a data row, if table isn't hidden (!)
+       and map cols have colspan and we don't want those. */
+    if ( isHidden === false && element.getAttribute( 'colspan' ) === null ) {
+      const CSVLabel = element.textContent.replace( 'Show map', '' );
 
-      // map cols have colspan and we don't want those
-      if ( element.getAttribute( 'colspan' ) === null ) {
-        const CSVLabel = element.textContent.replace( 'Show map', '' );
-        theCSV += '"' + CSVLabel + '"'; // put the content in first
+      // Put the content in first.
+      theCSV += '"' + CSVLabel + '"';
 
-        if ( element.matches( ':last-child' ) ) {
-          theCSV = theCSV + ',' + monthIndex + '/' + day + '/' + year + '\n';
-        } else {
-          theCSV += ',';
-        }
+      if ( element.matches( ':last-child' ) ) {
+        theCSV = theCSV + ',' + monthIndex + '/' + day + '/' + year + '\n';
+      } else {
+        theCSV += ',';
       }
     }
   }

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/show-map.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/show-map.js
@@ -5,11 +5,6 @@ const MAPBOX_CSS_URL = 'https://api.mapbox.com/mapbox.js/v3.3.1/mapbox.css';
 const mapboxAccessToken = 'pk.eyJ1IjoiY2ZwYiIsImEiOiJodmtiSk5zIn0.VkCynzmVYcLBxbyHzlvaQw';
 const mapIdString = 'mapbox://styles/mapbox/streets-v11';
 
-let map;
-const marker_array = [];
-const zip_marker = null;
-const markerDomCache = {};
-
 /**
  * Dynamically add mapbox CSS to document head.
  */

--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-analytics.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-analytics.js
@@ -269,8 +269,8 @@ const handleSurveySwitchGradeClick = event => {
     return;
   }
   const action = link.textContent.trim();
-  const grade_level = link.getAttribute( 'data-tdp_grade_level' );
-  const label = 'Switch grades from ' + grade_level;
+  const gradeLevel = link.getAttribute( 'data-tdp_grade_level' );
+  const label = 'Switch grades from ' + gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -286,8 +286,8 @@ const handleSurveyPrivacyModalClick = event => {
     return;
   }
   const action = link.textContent.trim();
-  const grade_level = link.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = link.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -303,8 +303,8 @@ const handleSurveyLetsDoThisClick = event => {
     return;
   }
   const action = link.textContent.trim();
-  const grade_level = link.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = link.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -321,11 +321,11 @@ const handleSurveyChoiceChange = event => {
   }
   const action = 'Radio Button Clicked';
   const wrapper = closest( radio, 'div.wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const parent_fieldset = closest( radio, 'fieldset' );
-  const question = queryOne( 'legend.tdp-question-legend', parent_fieldset );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const parentFieldset = closest( radio, 'fieldset' );
+  const question = queryOne( 'legend.tdp-question-legend', parentFieldset );
   const answer = queryOne( 'label', radio.parentElement );
-  const label = grade_level + ': ' + question.textContent.trim() + ' (' + answer.textContent.trim() + ')';
+  const label = gradeLevel + ': ' + question.textContent.trim() + ' (' + answer.textContent.trim() + ')';
   return sendSurveyEvent( action, label );
 };
 
@@ -342,10 +342,10 @@ const handleSurveyErrorNoticeClick = event => {
   }
   const action = 'Anchor: Missed Question';
   const wrapper = closest( link, 'div.wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
   const section = Number( queryOne( 'div[data-page-idx]', wrapper ).getAttribute( 'data-page-idx' ) ) + 1;
   const question = link.textContent.trim();
-  const label = grade_level + ': Section ' + section + ' | ' + question;
+  const label = gradeLevel + ': Section ' + section + ' | ' + question;
   return sendSurveyEvent( action, label );
 };
 
@@ -362,13 +362,13 @@ const handleSurveyRestartModalClick = event => {
   if ( link && link.getAttribute( 'data-open-modal' ) === 'modal-restart' ) {
     const wrapper = closest( link, 'div.wrapper.tdp-survey' );
     const section = Number( queryOne( 'div[data-page-idx]', wrapper ).getAttribute( 'data-page-idx' ) ) + 1;
-    const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-    label = grade_level + ': Section ' + section;
+    const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+    label = gradeLevel + ': Section ' + section;
   } else if ( link && link.getAttribute( 'data-open-modal' ) === 'modal-reset' ) {
     const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
     const section = 'Results page';
-    const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-    label = grade_level + ': ' + section;
+    const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+    label = gradeLevel + ': ' + section;
   } else {
     return;
   }
@@ -391,9 +391,9 @@ const handleSurveyExpandableClick = event => {
   const state = getExpandableState( expandable ) === 'expand' ? 'Expand' : 'Collapse';
   const action = `Survey Progress Dropdown: ${ state }`;
   const wrapper = closest( expandable, 'div.wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
   const section = Number( queryOne( 'div[data-page-idx]', wrapper ).getAttribute( 'data-page-idx' ) ) + 1;
-  const label = grade_level + ': Section ' + section;
+  const label = gradeLevel + ': Section ' + section;
   return sendSurveyEvent( action, label );
 };
 
@@ -410,9 +410,9 @@ const handleSurveySectionClick = event => {
   }
   const action = 'Edit';
   const wrapper = closest( link, 'div.wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
   const section = queryOne( '.tdp-survey-section__title', link ).textContent.replace( '(complete)', '' ).trim();
-  const label = grade_level + ': ' + section;
+  const label = gradeLevel + ': ' + section;
   return sendSurveyEvent( action, label );
 };
 
@@ -432,9 +432,9 @@ const handleSurveySubmitClick = event => {
     return;
   }
   const wrapper = closest( link, 'div.wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
   const section = Number( queryOne( 'div[data-page-idx]', wrapper ).getAttribute( 'data-page-idx' ) ) + 1;
-  const label = grade_level + ': Section ' + section;
+  const label = gradeLevel + ': Section ' + section;
   return sendSurveyEvent( action, label );
 };
 
@@ -452,11 +452,11 @@ const handleSurveyResultsExpandableClick = event => {
   }
   const state = getExpandableState( expandable ) === 'expand' ? 'Expand' : 'Collapse';
   const wrapper = closest( expandable, 'div.content_wrapper.tdp-survey' );
-  const page_type = queryOne( '.tdp-survey-results--shared', wrapper ) ? 'View' : 'Results';
-  const action = `${ page_type } Dropdown: ${ state }`;
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const pageType = queryOne( '.tdp-survey-results--shared', wrapper ) ? 'View' : 'Results';
+  const action = `${ pageType } Dropdown: ${ state }`;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
   const text = queryOne( '.o-expandable_label', expandable ).textContent.trim();
-  const label = grade_level + ': ' + text;
+  const label = gradeLevel + ': ' + text;
 
   return sendSurveyEvent( action, label );
 };
@@ -489,11 +489,11 @@ const handleSurveyResultsModalClick = event => {
   if ( !link || !link.getAttribute( 'data-open-modal' ) ) {
     return;
   }
-  const modal_id = link.getAttribute( 'data-open-modal' );
-  const action = modal_id === 'modal-print' ? 'Results Print' : 'Results Share';
+  const modalId = link.getAttribute( 'data-open-modal' );
+  const action = modalId === 'modal-print' ? 'Results Print' : 'Results Share';
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -505,16 +505,16 @@ const handleSurveyResultsModalClick = event => {
  * @returns {object} Event data
  */
 const handleSurveyResultsModalClose = ( modal, opener ) => {
-  const modal_id = modal.getAttribute( 'id' );
+  const modalId = modal.getAttribute( 'id' );
   const wrapper = closest( modal, 'div.content_wrapper.tdp-survey' );
   const valid_ids = [ 'modal-print', 'modal-share-url' ];
-  if ( !valid_ids.includes( modal_id ) || !wrapper ) {
+  if ( !valid_ids.includes( modalId ) || !wrapper ) {
     return;
   }
-  const action = modal_id === 'modal-print' ? 'Print: Close' : 'Share: Close';
+  const action = modalId === 'modal-print' ? 'Print: Close' : 'Share: Close';
 
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
 
   return sendSurveyEvent( action, label );
 };
@@ -532,10 +532,10 @@ const handleSurveyResultsSavePdfClick = event => {
     return;
   }
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const page_type = queryOne( '.tdp-survey-results--shared', wrapper ) ? 'View' : 'Results';
-  const action = `${ page_type } Save PDF`;
-  const label = grade_level;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const pageType = queryOne( '.tdp-survey-results--shared', wrapper ) ? 'View' : 'Results';
+  const action = `${ pageType } Save PDF`;
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -551,12 +551,12 @@ const handleSurveyResultsGetLinkClick = event => {
   if ( !link || !link.classList.contains( 'a-btn' ) ) {
     return;
   }
-  const text_field = queryOne( '#modal-share-url input#modal-share-url-initials-input' );
+  const textField = queryOne( '#modal-share-url input#modal-share-url-initials-input' );
   const action = 'Share: Get Link';
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const initials = text_field.value ? 'With initials' : 'No initials';
-  const label = grade_level + ': ' + initials;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const initials = textField.value ? 'With initials' : 'No initials';
+  const label = gradeLevel + ': ' + initials;
   return sendSurveyEvent( action, label );
 };
 
@@ -574,8 +574,8 @@ const handleSurveyResultsCopyLinkClick = event => {
 
   const action = 'Share: Copy Link';
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 
@@ -591,12 +591,12 @@ const handleSurveyResultsPrintClick = event => {
   if ( !link || !link.classList.contains( 'a-btn' ) ) {
     return;
   }
-  const text_field = queryOne( '#modal-print input#modal-print-initials-input' );
+  const textField = queryOne( '#modal-print input#modal-print-initials-input' );
   const action = 'Print: Get Link';
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const initials = text_field.value ? 'With initials' : 'No initials';
-  const label = grade_level + ': ' + initials;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const initials = textField.value ? 'With initials' : 'No initials';
+  const label = gradeLevel + ': ' + initials;
   return sendSurveyEvent( action, label );
 };
 
@@ -613,13 +613,13 @@ const surveyResultsPageLoad = () => {
   const subtotals = JSON.parse( el.dataset.subtotals );
 
   const wrapper = closest( el, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
 
   const queue = subtotals.map( ( total, idx ) => [
-    `Results: ${ grade_level }`, `Part ${ idx + 1 } total: ${ total }`
+    `Results: ${ gradeLevel }`, `Part ${ idx + 1 } total: ${ total }`
   ] );
   queue.push( [
-    `Results: ${ grade_level }`, `Overall score: ${ score }`
+    `Results: ${ gradeLevel }`, `Overall score: ${ score }`
   ] );
 
   queue.forEach( args => sendSurveyEvent( args[0], args[1] ) );
@@ -642,8 +642,8 @@ const handleSurveyViewPrintClick = event => {
 
   const action = 'View Print';
   const wrapper = closest( link, 'div.content_wrapper.tdp-survey' );
-  const grade_level = wrapper.getAttribute( 'data-tdp_grade_level' );
-  const label = grade_level;
+  const gradeLevel = wrapper.getAttribute( 'data-tdp_grade_level' );
+  const label = gradeLevel;
   return sendSurveyEvent( action, label );
 };
 

--- a/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
+++ b/test/cypress/integration/components/filterable-lists/filter-blog-posts.js
@@ -7,7 +7,6 @@ import { Pagination } from '../pagination/pagination-helpers';
 
 const blog = new FilterableListControl();
 const filter = new Filter();
-const page = new Pagination();
 
 describe( 'Filter Blog Posts based on content', () => {
   beforeEach( () => {


### PR DESCRIPTION
## Changes

- Convert snake_case variables to camelCase for some variables.
- Remove unused variables.
- Convert `e` variable to `evt`.
- Add parentheses around math.


## How to test this PR

1. Apps find a housing counselor, retirement, and rural or underserved should work as before.
