### PR TITLE
Use unused error argument in error message

### DIFF
--- a/cfgov/unprocessed/js/modules/util/behavior.js
+++ b/cfgov/unprocessed/js/modules/util/behavior.js
@@ -43,7 +43,7 @@ function _findElements( behaviorSelector, baseElement ) {
   try {
     behaviorElements = baseElement.querySelectorAll( behaviorSelector );
   } catch ( error ) {
-    const msg = behaviorSelector + ' not found in DOM!';
+    const msg = `${ behaviorSelector } not found in DOM! ${ error }`;
     throw new Error( msg );
   }
 


### PR DESCRIPTION
## Changes

- Use unused `error` argument in error message.


## How to test this PR

1. The mega menu should show up in legacy browsers (e.g. Chrome 65).
