### PR TITLE
Update newrelic_alerts.py to point to incident ID instead of violation ID

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -47,10 +47,10 @@ class NewRelicAlertViolations:
         this method are automatically added to known_violations."""
         violations = []
         for violation in self.get_current_violations():
-            if violation["id"] in self.known_violations:
+            if violation["links"]["incident_id"] in self.known_violations:
                 continue
 
-            self.known_violations.append(violation["id"])
+            self.known_violations.append(violation["links"]["incident_id"])
             violations.append(violation)
 
         return violations

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -76,13 +76,13 @@ class NewRelicAlertViolations:
         ).format(account_number=self.account_number)
         body = (
             "New Relic {product}, {name}, {label} "
-            "({priority}, opened {opened}, violation id {id})."
-            "View incidents: {link}"
+            "({priority}, opened {opened}, incident ID {id})."
+            " View incidents: {link}"
         ).format(
             product=violation["entity"]["product"],
             label=violation["label"],
             name=violation["entity"]["name"],
-            id=violation["id"],
+            id=violation["links"]["incident_id"],
             priority=violation["priority"],
             opened=opened_str,
             link=incidents_link,

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -47,10 +47,10 @@ class NewRelicAlertViolations:
         this method are automatically added to known_violations."""
         violations = []
         for violation in self.get_current_violations():
-            if violation["links"]["incident_id"] in self.known_violations:
+            if violation["id"] in self.known_violations:
                 continue
 
-            self.known_violations.append(violation["links"]["incident_id"])
+            self.known_violations.append(violation["id"])
             violations.append(violation)
 
         return violations
@@ -76,13 +76,13 @@ class NewRelicAlertViolations:
         ).format(account_number=self.account_number)
         body = (
             "New Relic {product}, {name}, {label} "
-            "({priority}, opened {opened}, incident ID {id})."
+            "({priority}, opened {opened}, incident ID {incident_id})."
             " View incidents: {link}"
         ).format(
             product=violation["entity"]["product"],
             label=violation["label"],
             name=violation["entity"]["name"],
-            id=violation["links"]["incident_id"],
+            incident_id=violation["links"]["incident_id"],
             priority=violation["priority"],
             opened=opened_str,
             link=incidents_link,

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -24,7 +24,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "type": "Monitor",
                     },
                     "links": {
-                        "incident_id": 12345678
+                        "incident_id": 12345678,
                     },
                     "label": "This test opened just now",
                     "policy_name": "cf.gov unit tests",
@@ -39,7 +39,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "type": "Application",
                     },
                     "links": {
-                        "incident_id": 23456781
+                        "incident_id": 23456781,
                     },
                     "label": "This test opened 2 min ago",
                     "policy_name": "cf.gov unit tests",
@@ -54,7 +54,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "type": "Application",
                     },
                     "links": {
-                        "incident_id": 34567812
+                        "incident_id": 34567812,
                     },
                     "label": "This is a different application",
                     "policy_name": "other unit tests",

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -23,6 +23,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Synthetic",
                         "type": "Monitor",
                     },
+                    "id": 12345678,
                     "links": {
                         "incident_id": 12345678,
                     },
@@ -38,6 +39,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Apm",
                         "type": "Application",
                     },
+                    "id": 23456781,
                     "links": {
                         "incident_id": 23456781,
                     },
@@ -53,6 +55,7 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Apm",
                         "type": "Application",
                     },
+                    "id": 34567812,
                     "links": {
                         "incident_id": 34567812,
                     },

--- a/cfgov/alerts/tests/test_newrelic_alerts.py
+++ b/cfgov/alerts/tests/test_newrelic_alerts.py
@@ -23,7 +23,9 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Synthetic",
                         "type": "Monitor",
                     },
-                    "id": 12345678,
+                    "links": {
+                        "incident_id": 12345678
+                    },
                     "label": "This test opened just now",
                     "policy_name": "cf.gov unit tests",
                     "priority": "Critical",
@@ -36,7 +38,9 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Apm",
                         "type": "Application",
                     },
-                    "id": 23456781,
+                    "links": {
+                        "incident_id": 23456781
+                    },
                     "label": "This test opened 2 min ago",
                     "policy_name": "cf.gov unit tests",
                     "priority": "Critical",
@@ -49,7 +53,9 @@ class TestNewRelicAlertViolations(unittest.TestCase):
                         "product": "Apm",
                         "type": "Application",
                     },
-                    "id": 34567812,
+                    "links": {
+                        "incident_id": 34567812
+                    },
                     "label": "This is a different application",
                     "policy_name": "other unit tests",
                     "priority": "Critical",


### PR DESCRIPTION
Check out one of our New Relic alerts in GHE and see that the violation ID shown doesn't show up in the incidents ID column, so it can be annoying to find the incident referenced in a particular alert. This PR changes the violation ID to the incident ID and does some minor formatting fixes.

## Changes

- Changes the New Relic alert violation ID to the incident ID.
-  Minor formatting fixes to add a leading space before the visit link and to capital ID.


## How to test this PR

1. Not sure how to test. Probably just merge and wait till the next alert?