### PR TITLE
Remove extra arguments for custom font files

### DIFF
--- a/docker/deployable-zipfile/_build.sh
+++ b/docker/deployable-zipfile/_build.sh
@@ -36,10 +36,6 @@ build_args=(
     "$build_artifact_name"
 )
 
-if [ -d "$webfonts_path" ]; then
-    build_args+=("--extra-static" "$webfonts_path")
-fi
-
 # Build the deployable zipfile.
 "$cfgov_refresh_volume/cfgov/deployable_zipfile/create.py" "${build_args[@]}"
 


### PR DESCRIPTION
In #7025 added our private font files to this repository, I missed this part of the build script that would add extra arguments for our webfonts path.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
