### PR TITLE
Move webfonts path to build_args

### DIFF
--- a/docker/deployable-zipfile/_build.sh
+++ b/docker/deployable-zipfile/_build.sh
@@ -7,7 +7,7 @@ set -e
 set -x
 
 # Set GIT_COMMITTER_NAME to enable us to `pip -e` from git URLs
-# git < 2.6.5 requires either these variables to be set or the user to exist 
+# git < 2.6.5 requires either these variables to be set or the user to exist
 # in passwd file.
 export GIT_COMMITTER_NAME="cf.gov build user"
 export GIT_COMMITTER_EMAIL="tech@cfpb.gov"
@@ -34,6 +34,7 @@ build_args=(
     "$cfgov_refresh_volume/cfgov"
     "$cfgov_refresh_volume/requirements/deployment.txt"
     "$build_artifact_name"
+    "--extra-static" "$webfonts_path"
 )
 
 # Build the deployable zipfile.


### PR DESCRIPTION
This change partially reverts #7039, which removed the `static.in` directory from our build entirely. This restores it but ensures that it is always included in our `build_args`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)