### PR TITLE
Simple-chart label positioning

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -118,7 +118,10 @@ function makeChartOptions( data, dataAttributes ) {
     };
   }
 
-  if ( projectedMonths ) defaultObj = addProjectedMonths( defaultObj, projectedMonths );
+  if ( projectedMonths > 0 ) {
+    defaultObj = addProjectedMonths( defaultObj, projectedMonths );
+    defaultObj.legend.y = -10;
+  }
 
   alignMargin( defaultObj, chartType );
 
@@ -147,8 +150,8 @@ function addProjectedMonths( chartObject, numMonths ) {
     label: {
       text: `Values after ${ projectedDate.humanFriendly } are projected`,
       rotation: 0,
-      x: -300,
-      y: -20
+      x: -260,
+      y: -10
     }
   } ];
 


### PR DESCRIPTION
## Changes

- Changed the positioning of the projected value label when there is a projected value present in the chart


## How to test this PR

1. Pull PR
2. `yarn build`
3. Go to http://localhost:8000/admin/pages/4481/edit/
4. Add Simple-Chart block, add projected months value
5. Preview and see new label positioning


## Screenshots

With projected months:
![image](https://user-images.githubusercontent.com/85513449/166312942-d2fe0267-8b24-47c8-842d-9d5983f58f2a.png)

With projected months:
![image](https://user-images.githubusercontent.com/85513449/166312966-c899fc7d-5e1c-4dc0-af7e-cd50e6c6a517.png)

Without projected months:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/85513449/166313099-227f9082-6480-4336-8804-9990d4c6fd05.png">
