### PR TITLE
remove broken admin simple-chart-css reference

### DIFF
--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -5,11 +5,9 @@ from urllib.parse import urlencode
 from django.apps import apps
 from django.db.models import Q
 from django.forms.utils import ErrorList
-from django.templatetags.static import static
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from wagtail.core import blocks, hooks
+from wagtail.core import blocks
 from wagtail.core.blocks.struct_block import StructBlockValidationError
 from wagtail.core.models import Page
 from wagtail.images import blocks as images_blocks
@@ -25,14 +23,6 @@ from v1.atomic_elements import atoms, molecules
 # maintain import structure across the project
 from v1.atomic_elements.tables import AtomicTableBlock
 from v1.util import ref
-
-
-@hooks.register("insert_editor_css")
-def editor_css():
-    return format_html(
-        '<link rel="stylesheet" href="{}">',
-        static("cfgov/templates/wagtailadmin/css/simple-chart-admin.css"),
-    )
 
 
 class AskSearch(blocks.StructBlock):


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/7030 added some simple-chart admin css, but did so in two ways, [the first way](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/v1/wagtail_hooks.py#L133) works fine, and the second way (removed in this PR) is both broken and unnecessary. Thus, I'm removing it!