### PR TITLE
Added Helm CronJob Template with clearsession job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ LABEL maintainer="tech@cfpb.gov"
 ENV PYTHONUNBUFFERED 1
 
 ENV APP_HOME /src/consumerfinance.gov
+ENV CFGOV_PATH ${APP_HOME}
+ENV CFGOV_CURRENT ${APP_HOME}
+ENV PYTHONPATH ${APP_HOME}/cfgov
+
+# Django Settings
+ENV DJANGO_SETTINGS_MODULE cfgov.settings.local
+# ENV DJANGO_STATIC_ROOT ${STATIC_PATH}
+ENV ALLOWED_HOSTS '["*"]'
+
 RUN mkdir -p ${APP_HOME}
 WORKDIR ${APP_HOME}
 

--- a/helm/cfgov/templates/cronjob.yaml
+++ b/helm/cfgov/templates/cronjob.yaml
@@ -1,0 +1,55 @@
+{{- range .Values.cronJobs }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "cfgov.fullname" $  | lower }}-cronjob-{{ .name | lower }}
+  labels:
+    {{- include "cfgov.labels" $ | nindent 4 }}
+spec:
+  schedule: {{ .schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          securityContext:
+            {{- toYaml $.Values.securityContext | nindent 12 }}
+          containers:
+            - name: {{ $.Chart.Name | lower }}-cronjob-{{ .name | lower }}
+              image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ $.Values.image.pullPolicy }}
+              command:
+                {{- range .command }}
+                - {{ . | quote }}
+                {{- end }}
+              args:
+                {{- range .args }}
+                - {{ . | quote }}
+                {{- end }}
+              env:
+                {{- if $.Values.postgresql.enabled }}
+                - name: DATABASE_URL
+                  {{- if $.Values.postgresql.nameOverride }}
+                  value: "postgres://{{ $.Values.postgresql.postgresqlUsername }}:{{ $.Values.postgresql.postgresqlPassword }}@{{ $.Values.postgresql.nameOverride }}-postgresql/{{ $.Values.postgresql.postgresqlDatabase }}"
+                  {{- else if $.Values.postgresql.fullnameOverride }}
+                  value: "postgres://{{ $.Values.postgresql.postgresqlUsername }}:{{ $.Values.postgresql.postgresqlPassword }}@{{ $.Values.postgresql.fullNameOverride }}/{{ $.Values.postgresql.postgresqlDatabase }}"
+                  {{- else }}
+                  value: "postgres://{{ $.Values.postgresql.postgresqlUsername }}:{{ $.Values.postgresql.postgresqlPassword }}@{{ include "cfgov.fullname" $ }}-postgresql/{{ $.Values.postgresql.postgresqlDatabase }}"
+                  {{- end }}
+                {{- end }}
+                {{- if $.Values.elasticsearch.enabled }}
+                - name: ES_HOST
+                  {{- if $.Values.elasticsearch.nameOverride }}
+                  value: "{{ $.Values.elasticsearch.nameOverride }}-master"
+                  {{- else if $.Values.elasticsearch.fullnameOverride }}
+                  value: {{ $.Values.elasticsearch.fullnameOverride | quote }}
+                  {{- else }}
+                  value: elasticsearch-master
+                  {{- end }}
+                {{- end }}
+                {{- range $.Values.extraEnvs }}
+                - name: {{ .name }}
+                  value: {{ .value | quote }}
+                {{- end }}
+          restartPolicy: {{ .restartPolicy }}
+  {{- end }}

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -170,6 +170,16 @@ docs:
 
 importDbPath: ""
 
+cronJobs:
+  - name: "clearSessions"
+    schedule: "@weekly"
+    command:
+      - "django-admin"
+    args:
+      - "clearsessions"
+    restartPolicy: OnFailure
+
+
 postgresql:
   enabled: false
 

--- a/helm/overrides/local.yaml
+++ b/helm/overrides/local.yaml
@@ -37,3 +37,12 @@ extraEnvs:
     value: "${DJANGO_ADMIN_USERNAME}"
   - name: DJANGO_ADMIN_PASSWORD
     value: "${DJANGO_ADMIN_PASSWORD}"
+
+cronJobs:
+  - name: "clearSessions"
+    schedule: "@daily"
+    command:
+      - "django-admin"
+    args:
+      - "clearsessions"
+    restartPolicy: OnFailure


### PR DESCRIPTION
* Adds `cronjob.yaml` as a cronJob template to have as a simple feature for adding cronJobs
  * Define jobs in `values.yaml` under `cronJobs`. 
* Adds `clearsessions` job that runs weekly on production, daily on local.

To make a new job, its just adding a new item to the `cronJobs` array:

```
- name: "clearSessions"
  schedule: "@daily"
  command:
    - "django-admin"
  args:
    - "clearsessions"
  restartPolicy: OnFailure
```

Further improvements that could be made:
  * Add option to define image for the cronjob instead of just using the overall image for cfgov