### PR TITLE
Fix temp directory path in unittests

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -1,4 +1,5 @@
 import datetime
+import tempfile
 from unittest import mock
 
 from django.apps import apps
@@ -54,6 +55,8 @@ from v1.util.migrations import (
     set_streamfield_data,
 )
 
+
+TEMPDIR = tempfile.gettempdir()
 
 now = timezone.now()
 
@@ -130,7 +133,7 @@ class ExportAskDataTests(TestCase, WagtailTestUtils):
             export_questions()
         self.assertEqual(mock_output.call_count, 1)
         m.assert_called_once_with(
-            "/tmp/{}".format(slug), "w", encoding="windows-1252"
+            f"{TEMPDIR}/{slug}", "w", encoding="windows-1252"
         )
 
     @mock.patch("ask_cfpb.scripts.export_ask_data.assemble_output")


### PR DESCRIPTION
#7060 introduced Bandit and made some changes to satisfy its checks. One of those changes was to use `tempfile.gettempdir()` rather than a hard-coded `/tmp` in Ask CFPB exports.

This had the effect of breaking our unittests when the `TMPDIR` envvar isn’t set to `/tmp` itself, because we hard-coded that path in the unit tests, as [@chosak noted](https://github.com/cfpb/consumerfinance.gov/pull/7060#issuecomment-1130320885).

This change fixes that by reusing the value of `tempfile.gettempdir()` for that test.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)