### PR TITLE
Updates pfc css to import only references to the design-system 

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/main.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/main.less
@@ -6,13 +6,7 @@
 // Project-specific Less rules go after the imports.
 
 // Import Design System components.
-@import (reference) "cfpb-core.less";
-@import (reference) "cfpb-buttons.less";
-@import (reference) "cfpb-forms.less";
-@import (reference) "cfpb-grid.less";
-@import (reference) "cfpb-icons.less";
-@import (less) "cfpb-layout.less";
-@import (reference) "cfpb-typography.less";
+@import (reference) "../../../css/main.less";
 
 // Import the brand color palette.
 @import (less) "brand-palette.less";


### PR DESCRIPTION
Shrinks pfc's `main.css` file by ~37kb with no downsides.

Testing:
 - Pull & build
 - All pfc pages should look identical to prod