### PR TITLE
Fix "filter_children" feature of filterable lists

### DIFF
--- a/cfgov/core/testutils/test_cases.py
+++ b/cfgov/core/testutils/test_cases.py
@@ -1,0 +1,56 @@
+from django.test import TestCase
+
+from wagtail.core.models import Page, Site
+
+
+class WagtailPageTreeTestCase(TestCase):
+    """Mixin that creates a Wagtail page tree for tests.
+
+    Test cases that inherit from this should define a get_page_tree()
+    classmethod which returns a tree of pages as a nested list:
+
+    [
+        ParentPage,
+        [
+            ChildPage,
+            ChildPage,
+            [
+                GrandchildPage,
+                GrandchildPage,
+            ],
+        ],
+    ]
+
+    Pages returned from that method get added as children of the Wagtail
+    default site root for the duration of the test case.
+
+    The class variable `page_tree` can also be used by tests to reference
+    pages that were added to the tree.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.get(is_default_site=True)
+
+        cls.page_tree = cls._build_page_tree(
+            site.root_page, cls.get_page_tree()
+        )
+
+    @classmethod
+    def _build_page_tree(cls, root, page_tree):
+        tree = []
+        parent = root
+
+        for node in page_tree:
+            if isinstance(node, Page):
+                root.add_child(instance=node)
+                tree.append(node)
+                parent = node
+            else:
+                tree.extend(cls._build_page_tree(parent, node))
+
+        return tree
+
+    @classmethod
+    def get_page_tree(cls):
+        raise NotImplementedError

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -871,7 +871,6 @@ class FilterableList(BaseExpandable):
         help_text="Add links to post preview images and"
         " headings in filterable list results",
     )
-
     filter_children = blocks.BooleanBlock(
         default=True,
         required=False,

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -41,7 +41,7 @@ class FilterablePagesDocument(Document):
     model_class = fields.KeywordField()
     content = fields.TextField()
     preview_description = fields.TextField()
-    path = fields.TextField()
+    path = fields.KeywordField()
     depth = fields.IntegerField()
 
     def get_queryset(self):
@@ -115,10 +115,16 @@ class FilterablePagesDocument(Document):
 
 
 class FilterablePagesDocumentSearch:
-    def __init__(self, prefix="/"):
-        self.prefix = prefix
-        self.document = FilterablePagesDocument()
-        self.search_obj = self.document.search().filter("prefix", url=prefix)
+    def __init__(self, root_page, children_only=True):
+        search = FilterablePagesDocument.search()
+        search = search.filter("prefix", path=root_page.path)
+
+        if children_only:
+            search = search.filter("term", depth=root_page.depth + 1)
+        else:
+            search = search.filter("range", depth={"gt": root_page.depth})
+
+        self.search_obj = search
 
     def filter_topics(self, topics=None):
         if topics is None:

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -19,7 +19,11 @@ from v1.models.browse_filterable_page import (
 from v1.models.browse_page import BrowsePage
 from v1.models.caching import CDNHistory
 from v1.models.campaign_page import CampaignPage
-from v1.models.enforcement_action_page import EnforcementActionPage
+from v1.models.enforcement_action_page import (
+    EnforcementActionPage,
+    EnforcementActionProduct,
+    EnforcementActionStatus,
+)
 from v1.models.feedback import Feedback
 from v1.models.home_page import HomePage
 from v1.models.images import CFGOVImage, CFGOVRendition

--- a/cfgov/v1/tests/models/test_browse_filterable_page.py
+++ b/cfgov/v1/tests/models/test_browse_filterable_page.py
@@ -1,3 +1,4 @@
+import json
 from io import StringIO
 
 from django.test import TestCase
@@ -24,7 +25,20 @@ class EventArchivePageTestCase(TestCase):
 
 class TestNewsroomLandingPage(ElasticsearchTestsMixin, TestCase):
     def setUp(self):
-        self.newsroom_page = NewsroomLandingPage(title="News", slug="newsroom")
+        self.newsroom_page = NewsroomLandingPage(
+            title="News",
+            slug="newsroom",
+            content=json.dumps(
+                [
+                    {
+                        "type": "filter_controls",
+                        "value": {
+                            "filter_children": False,
+                        },
+                    },
+                ]
+            ),
+        )
         self.about_us_page = LandingPage(title="About us", slug="about-us")
         self.site_root = Site.objects.get(is_default_site=True).root_page
         self.site_root.add_child(instance=self.about_us_page)

--- a/cfgov/v1/tests/models/test_filterable_list_mixins.py
+++ b/cfgov/v1/tests/models/test_filterable_list_mixins.py
@@ -1,15 +1,13 @@
+import json
 from io import StringIO
 from unittest import mock
 
 from django.test import RequestFactory, TestCase, override_settings
 
-from wagtail.core.blocks import StreamValue
 from wagtail.core.models import Page, Site
 
-from scripts._atomic_helpers import filter_controls
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
-from v1.models import BlogPage
-from v1.models.browse_filterable_page import BrowseFilterablePage
+from v1.models import BlogPage, BrowseFilterablePage
 from v1.models.filterable_list_mixins import FilterableListMixin
 
 
@@ -51,13 +49,6 @@ class TestFilterableListMixin(TestCase):
         mock_form = mock.Mock()
         self.mixin.process_form(mock_request, mock_form)
         assert mock_form.is_valid.called
-
-    def test_filterable_pages_not_in_site_returns_no_pages(self):
-        class MockPageInDefaultSite(FilterableListMixin):
-            def get_site(self):
-                return None
-
-        self.assertIsNone(MockPageInDefaultSite().get_filterable_search())
 
     # FilterableListMixin.set_do_not_index tests
     def test_do_not_index_is_false_by_default(self):
@@ -145,54 +136,6 @@ class FilterableRoutesTestCase(ElasticsearchTestsMixin, TestCase):
         )
         self.assertEqual(response["Edge-Control"], "cache-maxage=10m")
 
-
-class FilterableListRelationsTestCase(ElasticsearchTestsMixin, TestCase):
-    def setUp(self):
-        self.filter_controls = filter_controls
-
-        self.filterable_page = BrowseFilterablePage(title="Blog", slug="test")
-        self.root = Site.objects.get(is_default_site=True).root_page
-        self.root.add_child(instance=self.filterable_page)
-        self.filterable_page.save_revision().publish()
-
-        self.set_filterable_controls(filter_controls)
-
-        self.child_page = BlogPage(title="Child test page", live=True)
-        self.sibling_page = BlogPage(title="Sibling test page", live=True)
-        self.archived_sibling_page = BlogPage(
-            title="Archive test page", live=True, is_archived="yes"
-        )
-        self.filterable_page.add_child(instance=self.child_page)
-        self.filterable_page.get_parent().add_child(instance=self.sibling_page)
-        self.filterable_page.get_parent().add_child(
-            instance=self.archived_sibling_page
-        )
-
-        self.rebuild_elasticsearch_index("v1", stdout=StringIO())
-
-    def set_filterable_controls(self, value):
-        self.filterable_page.content = StreamValue(
-            self.filterable_page.content.stream_block, [value], True
-        )
-        self.filterable_page.save()
-
-    def test_get_filterable_children_pages(self):
-        filter_controls["value"]["filter_children"] = True
-        self.set_filterable_controls(self.filter_controls)
-
-        filterable_search = self.filterable_page.get_filterable_search()
-        qs = filterable_search.search()
-        self.assertEqual(qs.count(), 1)
-        self.assertEqual(qs[0].pk, self.child_page.pk)
-        self.assertEqual("/test/", self.filterable_page.get_filterable_root())
-
-    def test_get_filterable_root_site_wide(self):
-        filter_controls["value"]["filter_children"] = False
-        self.set_filterable_controls(self.filter_controls)
-
-        root = self.filterable_page.get_filterable_root()
-        self.assertEqual("/", root)
-
     def test_cache_tag_applied(self):
         response = self.client.get(self.filterable_page.url)
         self.assertEqual(
@@ -204,3 +147,100 @@ class FilterableListRelationsTestCase(ElasticsearchTestsMixin, TestCase):
         self.assertEqual(
             response.get("Edge-Cache-Tag"), self.filterable_page.slug
         )
+
+
+class MockSearch:
+    def __init__(self, search_root, children_only):
+        self.search_root = search_root
+        self.children_only = children_only
+
+
+@mock.patch(
+    "v1.models.BrowseFilterablePage.get_search_class", return_value=MockSearch
+)
+class FilterableListSearchTestCase(TestCase):
+    def test_no_filterable_list_block_defaults(self, _):
+        page = BrowseFilterablePage(title="test")
+
+        search = page.get_filterable_search()
+        self.assertEqual(search.search_root, page)
+        self.assertEqual(search.children_only, True)
+
+    def test_search_default_children_only(self, _):
+        page = BrowseFilterablePage(
+            title="test",
+            content=json.dumps(
+                [
+                    {"type": "filter_controls", "value": {}},
+                ]
+            ),
+        )
+
+        search = page.get_filterable_search()
+        self.assertEqual(search.search_root, page)
+        self.assertEqual(search.children_only, True)
+
+    def test_search_children_only_true(self, _):
+        page = BrowseFilterablePage(
+            title="test",
+            content=json.dumps(
+                [
+                    {
+                        "type": "filter_controls",
+                        "value": {
+                            "filter_children": True,
+                        },
+                    },
+                ]
+            ),
+        )
+
+        search = page.get_filterable_search()
+        self.assertEqual(search.search_root, page)
+        self.assertEqual(search.children_only, True)
+
+    def test_search_children_only_false_uses_default_site_if_not_in_site(
+        self, _
+    ):
+        page = BrowseFilterablePage(
+            title="test",
+            content=json.dumps(
+                [
+                    {
+                        "type": "filter_controls",
+                        "value": {
+                            "filter_children": False,
+                        },
+                    },
+                ]
+            ),
+        )
+
+        search = page.get_filterable_search()
+        self.assertEqual(
+            search.search_root,
+            Site.objects.get(is_default_site=True).root_page,
+        )
+        self.assertEqual(search.children_only, False)
+
+    def test_search_children_only_false_uses_site_root(self, _):
+        page = BrowseFilterablePage(
+            title="test",
+            content=json.dumps(
+                [
+                    {
+                        "type": "filter_controls",
+                        "value": {
+                            "filter_children": False,
+                        },
+                    },
+                ]
+            ),
+        )
+
+        Page.objects.get(pk=1).add_child(instance=page)
+        Site.objects.create(root_page=page)
+
+        search = page.get_filterable_search()
+        self.assertEqual(search.search_root.specific, page)
+        self.assertEqual(search.children_only, False)

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -1,15 +1,15 @@
 import json
-from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
-from wagtail.core.models import Site
+from wagtail.core.models import Page, Site
 
 from dateutil.relativedelta import relativedelta
-from pytz import timezone
 
+from core.testutils.test_cases import WagtailPageTreeTestCase
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
 from v1.documents import (
     EnforcementActionFilterablePagesDocumentSearch,
@@ -17,15 +17,17 @@ from v1.documents import (
     FilterablePagesDocument,
     FilterablePagesDocumentSearch,
 )
-from v1.models.base import CFGOVPageCategory
-from v1.models.blog_page import BlogPage
-from v1.models.enforcement_action_page import (
+from v1.models import (
+    AbstractFilterPage,
+    BlogPage,
+    CFGOVPageCategory,
+    DocumentDetailPage,
     EnforcementActionPage,
     EnforcementActionProduct,
     EnforcementActionStatus,
+    EventPage,
+    SublandingFilterablePage,
 )
-from v1.models.learn_page import AbstractFilterPage, EventPage
-from v1.tests.wagtail_pages.helpers import publish_page
 
 
 class FilterablePagesDocumentTest(TestCase):
@@ -66,9 +68,7 @@ class FilterablePagesDocumentTest(TestCase):
         )
 
     def test_get_queryset(self):
-        test_event = EventPage(
-            title="Testing", start_dt=datetime.now(timezone("UTC"))
-        )
+        test_event = EventPage(title="Testing", start_dt=timezone.now())
         qs = FilterablePagesDocument().get_queryset()
         self.assertFalse(qs.filter(title=test_event.title).exists())
 
@@ -76,7 +76,7 @@ class FilterablePagesDocumentTest(TestCase):
         enforcement = EnforcementActionPage(
             title="Great Test Page",
             preview_description="This is a great test page.",
-            initial_filing_date=datetime.now(timezone("UTC")),
+            initial_filing_date=timezone.now(),
         )
         status = EnforcementActionStatus(status="expired-terminated-dismissed")
         enforcement.statuses.add(status)
@@ -87,9 +87,7 @@ class FilterablePagesDocumentTest(TestCase):
         )
 
     def test_prepare_content_no_content_defined(self):
-        event = EventPage(
-            title="Event Test", start_dt=datetime.now(timezone("UTC"))
-        )
+        event = EventPage(title="Event Test", start_dt=timezone.now())
         doc = FilterablePagesDocument()
         prepared_data = doc.prepare(event)
         self.assertIsNone(prepared_data["content"])
@@ -125,7 +123,7 @@ class FilterablePagesDocumentTest(TestCase):
         enforcement = EnforcementActionPage(
             title="Great Test Page",
             preview_description="This is a great test page.",
-            initial_filing_date=datetime.now(timezone("UTC")),
+            initial_filing_date=timezone.now(),
         )
         product = EnforcementActionProduct(product="Fair Lending")
         enforcement.products.add(product)
@@ -134,169 +132,309 @@ class FilterablePagesDocumentTest(TestCase):
         self.assertEqual(prepared_data["products"], ["Fair Lending"])
 
 
-class FilterablePagesDocumentSearchTest(ElasticsearchTestsMixin, TestCase):
+class ElasticsearchWagtailPageTreeTestCase(
+    ElasticsearchTestsMixin, WagtailPageTreeTestCase
+):
+    """Test case that creates and indexes a Wagtail page tree."""
+
     @classmethod
     def setUpTestData(cls):
-        cls.site = Site.objects.get(is_default_site=True)
+        super().setUpTestData()
+        cls.rebuild_elasticsearch_index("v1", stdout=StringIO())
 
-        content = json.dumps(
-            [
-                {
-                    "type": "full_width_text",
-                    "value": [
-                        {
-                            "type": "content",
-                            "value": "Foo Test Content",
-                        },
-                    ],
-                },
-            ]
+
+class FilterableSearchTests(ElasticsearchWagtailPageTreeTestCase):
+    @classmethod
+    def get_page_tree(cls):
+        return [
+            (
+                SublandingFilterablePage(title="search1"),
+                [
+                    DocumentDetailPage(title="child1"),
+                    DocumentDetailPage(title="child2"),
+                    (
+                        SublandingFilterablePage(title="search2"),
+                        [
+                            DocumentDetailPage(title="nested child1"),
+                            DocumentDetailPage(title="nested child2"),
+                        ],
+                    ),
+                ],
+            )
+        ]
+
+    def test_search_from_root(self):
+        # By default search only returns AbstractFilterPages
+        # that are direct children of the specified root.
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        self.assertEqual(search.count(), 2)
+
+    def test_search_children_only(self):
+        # Setting children_only to False returns all AbstractFilterablePages
+        # that live anywhere underneath the specified root.
+        search = FilterablePagesDocumentSearch(
+            self.page_tree[0], children_only=False
         )
+        self.assertEqual(search.count(), 4)
 
-        event = EventPage(
-            title="Event Test",
-            start_dt=datetime(2021, 2, 16, tzinfo=timezone("UTC")),
-            end_dt=datetime(2021, 2, 16, tzinfo=timezone("UTC")),
+    def test_search_from_other_page(self):
+        # Search works starting from some other page in the tree.
+        page = Page.objects.get(slug="search2")
+        search = FilterablePagesDocumentSearch(page)
+        self.assertEqual(search.count(), 2)
+
+    def test_search_by_title(self):
+        search = FilterablePagesDocumentSearch(
+            self.page_tree[0], children_only=False
         )
-        event.tags.add("test-topic")
-        event.categories.add(CFGOVPageCategory(name="test-category"))
-        event.language = "es"
-        publish_page(event)
-        enforcement = EnforcementActionPage(
-            title="Great Test Page",
-            preview_description="This is a great test page.",
-            initial_filing_date=datetime.now(timezone("UTC")),
-        )
-        status = EnforcementActionStatus(status="expired-terminated-dismissed")
-        enforcement.statuses.add(status)
-        product = EnforcementActionProduct(product="Debt Collection")
-        enforcement.products.add(product)
-        publish_page(enforcement)
-        blog = BlogPage(title="Blog Page")
-        publish_page(blog)
+        self.assertEqual(search.search(title="child").count(), 4)
+        self.assertEqual(search.search(title="child1").count(), 2)
+        self.assertEqual(search.search(title="child3").count(), 0)
 
-        blog_title_match = BlogPage(title="Foo Bar")
-        publish_page(blog_title_match)
+    def test_get_raw_results(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        results = search.get_raw_results()
+        self.assertEqual(len(results.hits), 2)
 
-        blog_preview_match = BlogPage(
-            title="Random Title", preview_description="Foo blog"
-        )
-        publish_page(blog_preview_match)
+    # Mocking is necessary here because unfortunately it's not currently
+    # possible to use override_settings with DED autosync. See
+    # https://github.com/django-es/django-elasticsearch-dsl/issues/322.
+    @patch(
+        "django_elasticsearch_dsl.apps.DEDConfig.autosync_enabled",
+        return_value=True,
+    )
+    def test_index_updates_automatically(self, _):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        self.assertEqual(search.search(title="foo").count(), 0)
+        indexed_page = Page.objects.get(slug="child1")
+        indexed_page.title = "child1 foo"
+        indexed_page.save_revision().publish()
+        self.assertEqual(search.search(title="foo").count(), 1)
 
-        blog_content_match = BlogPage(title="Some Title", content=content)
-        publish_page(blog_content_match)
 
-        blog_topic_match = BlogPage(title="Another Blog Post")
-        blog_topic_match.tags.add("Foo Tag")
-        publish_page(blog_topic_match)
+class FilterableSearchFilteringTests(
+    ElasticsearchTestsMixin, WagtailPageTreeTestCase
+):
+    @classmethod
+    def get_page_tree(cls):
+        cls.today = timezone.now().date()
+        cls.yesterday = cls.today - relativedelta(days=1)
 
-        cls.event = event
-        cls.enforcement = enforcement
-        cls.blog = blog
-        cls.blog_title_match = blog_title_match
-        cls.blog_preview_match = blog_preview_match
-        cls.blog_content_match = blog_content_match
-        cls.blog_topic_match = blog_topic_match
+        return [
+            (
+                SublandingFilterablePage(title="search"),
+                [
+                    BlogPage(
+                        title="en",
+                        language="en",
+                        date_published=cls.today,
+                    ),
+                    BlogPage(
+                        title="es",
+                        language="es",
+                        date_published=cls.yesterday,
+                    ),
+                    BlogPage(
+                        title="archived",
+                        language="en",
+                        date_published=cls.yesterday,
+                        is_archived="yes",
+                    ),
+                ],
+            ),
+        ]
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # Page tags and categories can't be set at creation time, so they need
+        # to be added after the page tree has been created.
+        def add_tag_and_category_to_page(page_slug, name):
+            page = BlogPage.objects.get(slug=page_slug)
+            page.tags.add(name)
+            page.categories.add(CFGOVPageCategory(name=name))
+            page.save()
+
+        add_tag_and_category_to_page("en", "foo")
+        add_tag_and_category_to_page("es", "bar")
 
         cls.rebuild_elasticsearch_index("v1", stdout=StringIO())
 
-    def test_search_event_all_fields(self):
-        to_date_dt = datetime(2021, 3, 16)
-        to_date = datetime.date(to_date_dt)
-        from_date_dt = datetime(2021, 1, 16)
-        from_date = datetime.date(from_date_dt)
+    def test_no_filters(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        self.assertEqual(search.count(), 3)
 
-        search = EventFilterablePagesDocumentSearch(prefix="/")
-        search.filter(
-            topics=["test-topic"],
-            categories=["test-category"],
-            language=["es"],
-            to_date=to_date,
-            from_date=from_date,
-            archived=["no"],
-        )
-        results = search.search(title="Event Test")
-        self.assertTrue(results.filter(title=self.event.title).exists())
+        search.filter()
+        self.assertEqual(search.count(), 3)
 
-    def test_search_blog_dates(self):
-        to_date_dt = datetime.today() + relativedelta(months=1)
-        to_date = datetime.date(to_date_dt)
-        from_date_dt = datetime.today() - relativedelta(months=1)
-        from_date = datetime.date(from_date_dt)
+    def test_filter_by_language(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        self.assertEqual(search.count(), 3)
 
-        search = FilterablePagesDocumentSearch(prefix="/")
-        search.filter(
-            topics=[],
-            categories=[],
-            language=[],
-            to_date=to_date,
-            from_date=from_date,
-            archived=None,
-        )
-        results = search.search(title=None)
-        self.assertTrue(results.filter(title=self.blog.title).exists())
+        search.filter_language(["es"])
+        self.assertEqual(search.count(), 1)
 
-    def test_search_enforcement_actions(self):
-        to_date_dt = datetime.today() + relativedelta(months=1)
-        to_date = datetime.date(to_date_dt)
-        from_date_dt = datetime.today() - relativedelta(months=1)
-        from_date = datetime.date(from_date_dt)
+    def test_filter_by_date(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter_date(from_date=self.today, to_date=self.today)
+        self.assertEqual(search.count(), 1)
 
-        search = EnforcementActionFilterablePagesDocumentSearch(prefix="/")
-        search.filter(
-            topics=[],
-            categories=[],
-            language=[],
-            to_date=to_date,
-            from_date=from_date,
-            statuses=["expired-terminated-dismissed"],
-            products=["Debt Collection"],
-            archived=None,
-        )
-        results = search.search(title=None)
-        self.assertTrue(results.filter(title=self.enforcement.title).exists())
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter_date(from_date=self.yesterday, to_date=self.yesterday)
+        self.assertEqual(search.count(), 2)
 
-    def test_search_enforcement_actions_no_statuses(self):
-        to_date_dt = datetime.today() + relativedelta(months=1)
-        to_date = datetime.date(to_date_dt)
-        from_date_dt = datetime.today() - relativedelta(months=1)
-        from_date = datetime.date(from_date_dt)
+    def test_filter_by_topics(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter_topics(["foo"])
+        self.assertEqual(search.count(), 1)
 
-        search = EnforcementActionFilterablePagesDocumentSearch(prefix="/")
-        search.filter(
-            topics=[],
-            categories=[],
-            language=[],
-            to_date=to_date,
-            from_date=from_date,
-            statuses=[],
-            products=[],
-            archived=None,
-        )
-        results = search.search(title=None)
-        self.assertTrue(results.filter(title=self.enforcement.title).exists())
+    def test_filter_by_categories(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter_categories(["bar"])
+        self.assertEqual(search.count(), 1)
 
-    def test_search_title_uses_multimatch(self):
-        search = FilterablePagesDocumentSearch(prefix="/")
-        search.filter(
-            topics=[],
-            categories=[],
-            language=[],
-            to_date=None,
-            from_date=None,
-            archived=None,
+    def test_filter_by_archived(self):
+        search = FilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter_archived(["yes"])
+        self.assertEqual(search.count(), 1)
+
+
+class EnforcementActionFilterableSearchFilteringTests(
+    ElasticsearchTestsMixin, WagtailPageTreeTestCase
+):
+    @classmethod
+    def get_page_tree(cls):
+        cls.today = timezone.now().date()
+        cls.yesterday = cls.today - relativedelta(days=1)
+
+        return [
+            (
+                SublandingFilterablePage(title="search1"),
+                [
+                    EnforcementActionPage(
+                        title="child1", initial_filing_date=cls.yesterday
+                    ),
+                    EnforcementActionPage(
+                        title="child2", initial_filing_date=cls.today
+                    ),
+                    DocumentDetailPage(title="should be ignored"),
+                ],
+            ),
+        ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Page status and products can't be set at creation time, so they need
+        # to be added after the page tree has been created.
+        page = EnforcementActionPage.objects.get(slug="child1")
+        status = EnforcementActionStatus(status="expired-terminated-dismissed")
+        page.statuses.add(status)
+        product = EnforcementActionProduct(product="Debt Collection")
+        page.products.add(product)
+        page.save()
+
+        cls.rebuild_elasticsearch_index("v1", stdout=StringIO())
+
+    def test_no_filters(self):
+        search = EnforcementActionFilterablePagesDocumentSearch(
+            self.page_tree[0]
         )
-        results = search.search(title="Foo")
-        self.assertTrue(results.filter(title=self.blog_title_match).exists())
-        self.assertTrue(
-            results.filter(title=self.blog_content_match.title).exists()
+        search.filter()
+        results = search.search()
+
+        # The EA search default filter behavior excludes pages that are not of
+        # type EnforcementActionPage.
+        self.assertEqual(results.count(), 2)
+
+        # Results should be ordered by most recent initial filing date.
+        self.assertEqual(results[0].title, "child2")
+        self.assertEqual(results[1].title, "child1")
+
+    def test_filter_by_status(self):
+        search = EnforcementActionFilterablePagesDocumentSearch(
+            self.page_tree[0]
         )
-        self.assertTrue(
-            results.filter(title=self.blog_preview_match.title).exists()
+        search.filter(statuses=["expired-terminated-dismissed"])
+        self.assertEqual(search.count(), 1)
+
+    def test_filter_by_product(self):
+        search = EnforcementActionFilterablePagesDocumentSearch(
+            self.page_tree[0]
         )
-        self.assertTrue(
-            results.filter(title=self.blog_topic_match.title).exists()
+
+        search.filter(products=["Debt Collection"])
+        self.assertEqual(search.count(), 1)
+
+    def test_filter_by_date(self):
+        search = EnforcementActionFilterablePagesDocumentSearch(
+            self.page_tree[0]
         )
+        search.filter(from_date=self.today, to_date=self.today)
+        self.assertEqual(search.count(), 1)
+
+        search = EnforcementActionFilterablePagesDocumentSearch(
+            self.page_tree[0]
+        )
+        search.filter(from_date=self.yesterday, to_date=self.yesterday)
+        self.assertEqual(search.count(), 1)
+
+
+class EventFilterableSearchFilteringTests(
+    ElasticsearchWagtailPageTreeTestCase
+):
+    @classmethod
+    def get_page_tree(cls):
+        cls.now = timezone.now()
+        cls.one_hour_ago = cls.now - relativedelta(hours=1)
+        cls.one_day_ago = cls.now - relativedelta(days=1)
+
+        return [
+            (
+                SublandingFilterablePage(title="search1"),
+                [
+                    EventPage(
+                        title="child1",
+                        start_dt=cls.one_day_ago,
+                        end_dt=cls.one_hour_ago,
+                    ),
+                    EventPage(
+                        title="child2",
+                        start_dt=cls.one_hour_ago,
+                        end_dt=cls.now,
+                    ),
+                    DocumentDetailPage(title="should be ignored"),
+                ],
+            ),
+        ]
+
+    def test_no_filters(self):
+        search = EventFilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter()
+        results = search.search()
+
+        # The event search default filter behavior excludes pages that are not
+        # of type EventPage.
+        self.assertEqual(results.count(), 2)
+
+    def test_filter_by_date(self):
+        search = EventFilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter(from_date=self.one_day_ago, to_date=self.one_day_ago)
+        self.assertEqual(search.count(), 0)
+
+        search = EventFilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter(from_date=self.one_day_ago, to_date=self.one_hour_ago)
+        self.assertEqual(search.count(), 1)
+
+        search = EventFilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter(from_date=self.one_day_ago, to_date=self.now)
+        self.assertEqual(search.count(), 2)
+
+        search = EventFilterablePagesDocumentSearch(self.page_tree[0])
+        search.filter(from_date=self.one_hour_ago, to_date=self.now)
+        self.assertEqual(search.count(), 1)
 
 
 class TestThatWagtailPageSignalsUpdateIndex(ElasticsearchTestsMixin, TestCase):
@@ -316,7 +454,7 @@ class TestThatWagtailPageSignalsUpdateIndex(ElasticsearchTestsMixin, TestCase):
         parent.add_child(instance=blog3)
 
         self.rebuild_elasticsearch_index("v1", stdout=StringIO())
-        search = FilterablePagesDocumentSearch(prefix="/parent/")
+        search = FilterablePagesDocumentSearch(parent)
 
         # Initially a search at the root should return 3 results.
         results = search.search(title="foo")

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -3,6 +3,8 @@ from io import StringIO
 
 from django.test import TestCase, override_settings
 
+from wagtail.core.models import Site
+
 from pytz import timezone
 
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
@@ -16,10 +18,12 @@ from v1.forms import (
     EventArchiveFilterForm,
     FilterableListForm,
 )
-from v1.models import BlogPage
-from v1.models.base import CFGOVPageCategory
-from v1.models.enforcement_action_page import EnforcementActionPage
-from v1.models.learn_page import EventPage
+from v1.models import (
+    BlogPage,
+    CFGOVPageCategory,
+    EnforcementActionPage,
+    EventPage,
+)
 from v1.tests.wagtail_pages.helpers import publish_page
 from v1.util.categories import clean_categories
 
@@ -59,8 +63,9 @@ class TestFilterableListForm(ElasticsearchTestsMixin, TestCase):
         self.rebuild_elasticsearch_index("v1", stdout=StringIO())
 
     def setUpFilterableForm(self, data=None, filterable_categories=None):
+        site_root = Site.objects.get(is_default_site=True).root_page
         form = FilterableListForm(
-            filterable_search=FilterablePagesDocumentSearch(prefix="/"),
+            filterable_search=FilterablePagesDocumentSearch(site_root),
             wagtail_block=None,
             filterable_categories=filterable_categories,
         )
@@ -184,6 +189,7 @@ class TestFilterableListFormArchive(ElasticsearchTestsMixin, TestCase):
         cls.page1 = BlogPage(title="test page", is_archived="yes")
         cls.page2 = BlogPage(title="another test page")
         cls.page3 = BlogPage(title="never-archived page", is_archived="never")
+
         publish_page(cls.page1)
         publish_page(cls.page2)
         publish_page(cls.page3)
@@ -191,8 +197,9 @@ class TestFilterableListFormArchive(ElasticsearchTestsMixin, TestCase):
         cls.rebuild_elasticsearch_index("v1", stdout=StringIO())
 
     def get_filtered_pages(self, data):
+        site_root = Site.objects.get(is_default_site=True).root_page
         form = FilterableListForm(
-            filterable_search=FilterablePagesDocumentSearch(prefix="/"),
+            filterable_search=FilterablePagesDocumentSearch(site_root),
             wagtail_block=None,
             filterable_categories=None,
             data=data,
@@ -230,8 +237,9 @@ class TestEventArchiveFilterForm(ElasticsearchTestsMixin, TestCase):
         cls.event = event
 
     def test_event_archive_elasticsearch(self):
+        site_root = Site.objects.get(is_default_site=True).root_page
         form = EventArchiveFilterForm(
-            filterable_search=EventFilterablePagesDocumentSearch(prefix="/"),
+            filterable_search=EventFilterablePagesDocumentSearch(site_root),
             wagtail_block=None,
             filterable_categories=None,
         )
@@ -252,9 +260,10 @@ class TestEnforcementActionsFilterForm(ElasticsearchTestsMixin, TestCase):
         cls.rebuild_elasticsearch_index("v1", stdout=StringIO())
 
     def test_enforcement_action_elasticsearch(self):
+        site_root = Site.objects.get(is_default_site=True).root_page
         form = EnforcementActionsFilterForm(
             filterable_search=EnforcementActionFilterablePagesDocumentSearch(
-                prefix="/"
+                site_root
             ),
             wagtail_block=None,
             filterable_categories=None,


### PR DESCRIPTION
The FilterableList organism has a configuration option named "filter_children" with help text "If checked this list will only filter its child pages."

Prior to the 2021 migration of filterable lists to Elasticsearch (specifically #6044), this selection would mean that a filterable
list page would only return pages that were direct children of itself. After the migration, grandchildren and other descendants were included.

This change reverts back to the previous behavior, meaning filterable lists work in two modes:

1. Filter direct children only (the default)
2. Filter every filterable page on the site (enabled by unchecking that checkbox when creating a filterable list)

We don't currently have any pages that need to filter an entire subtree. There are currently 3 pages on the site that use this second approach:

https://www.consumerfinance.gov/activity-log/
https://www.consumerfinance.gov/about-us/newsroom/
https://www.consumerfinance.gov/data-research/research-hub/

This fixes internal platform#4147.

## How to test this PR

To test, verify that these three pages still work as expected locally:

http://localhost:8000/activity-log/
http://localhost:8000/about-us/newsroom/
http://localhost:8000/data-research/research-hub/

And other pages that have this checkbox checked also work properly:

http://localhost:8000/about-us/blog/

Also verify that event pages work properly:

http://localhost:8000/about-us/events/
http://localhost:8000/about-us/events/archive-past-events/

Note that this change does include a modification to the Elasticsearch index so you will need to rebuild your index (e.g. via refresh-data.sh) before testing locally.

## Notes and todos

Additionally this will need a production reindex when this launches.