### PR TITLE
Fix deployable zipfile extraction

### DIFF
--- a/cfgov/deployable_zipfile/create.py
+++ b/cfgov/deployable_zipfile/create.py
@@ -62,7 +62,6 @@ def create_zipfile(
     requirements_file,
     zipfile_basename,
     extra_static,
-    extra_python,
 ):
     with temp_directory() as temp_dir:
         # Bootstrap wheels get stored in the zip under /bootstrap_wheels/.
@@ -73,8 +72,6 @@ def create_zipfile(
         wheel_dir = os.path.join(temp_dir, "wheels")
 
         wheel_executables = [sys.executable]
-        if extra_python:
-            wheel_executables.append(extra_python)
 
         for wheel_executable in wheel_executables:
             save_wheels(
@@ -148,10 +145,6 @@ if __name__ == "__main__":  # pragma: no cover
         "--extra-static",
         action="append",
         help="Optionally include additional static file directories",
-    )
-    parser.add_argument(
-        "--extra-python",
-        help="Optionally build wheels for a second Python version",
     )
 
     args = parser.parse_args()

--- a/cfgov/deployable_zipfile/install_wheels.py
+++ b/cfgov/deployable_zipfile/install_wheels.py
@@ -3,32 +3,11 @@ import os
 import subprocess  # nosec
 import sys
 
-from pip._internal.exceptions import InstallationError
-from pip._internal.req.constructors import install_req_from_line
-from pip._internal.req.req_set import RequirementSet
-
-
-def get_supported_wheels(wheel_directory):
-    requirement_set = RequirementSet()
-    for f in os.listdir(wheel_directory):
-        wheel_filename = os.path.join(wheel_directory, f)
-
-        requirement = install_req_from_line(wheel_filename)
-        requirement.is_direct = True
-
-        try:
-            requirement_set.add_requirement(requirement)
-        except InstallationError:
-            # This deliberately filters out incompatible requirements.
-            pass
-
-    return sorted(
-        req.link.path for req in requirement_set.requirements.values()
-    )
-
 
 def install_wheels(wheel_directory):
-    supported_wheel_filenames = get_supported_wheels(wheel_directory)
+    wheel_filenames = sorted(
+        os.path.join(wheel_directory, f) for f in os.listdir(wheel_directory)
+    )
 
     subprocess.check_call(  # nosec
         [
@@ -38,7 +17,7 @@ def install_wheels(wheel_directory):
             "install",
             "--no-deps",
         ]
-        + supported_wheel_filenames
+        + wheel_filenames
     )
 
 

--- a/cfgov/deployable_zipfile/tests/test_create.py
+++ b/cfgov/deployable_zipfile/tests/test_create.py
@@ -61,13 +61,12 @@ class TestCreateDeployableZip(TestCase):
             self.requirements_file,
             zipfile_basename,
             extra_static=[self.extra_static],
-            extra_python="python4",
         )
 
         # save_wheels should be called three times; once for the bootstrap
         # wheels (pip, setuptools), and once per Python version for the
         # requirements file.
-        self.assertEqual(save_wheels.call_count, 3)
+        self.assertEqual(save_wheels.call_count, 2)
 
         self.assertEqual(zipfile_filename, "%s.zip" % zipfile_basename)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,5 +4,5 @@ freezegun==1.2.1
 github3.py==0.9.6  # TODO: Remove once GitHub notifications are deprecated, or update cfgov.alerts
 model-bakery==1.5.0
 moto==3.1.7
-pip==22.0.4
+pip
 responses==0.20.0


### PR DESCRIPTION
This PR fixes our deployable zipfile extraction. Previously our zipfile extraction supported multiple Python versions (intended for 2 and 3), and used an internal pip `RequirementSet` to ensure the wheel files for the target Python were installed. [pip recently moved the function we used](https://github.com/pypa/pip/commit/d673aa14284788ea12a789b34846353b7cb3d46f), which makes it harder to call that function in isolation.

This PR removes the use of pip's internals and multiple Python version support entirely. It also unpins pip in our test requirements, as we install the latest pip when deploying and should test against that.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
