### PR TITLE
Fix new redirect path

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -7,7 +7,7 @@ Redirect permanent /es/obtener-respuestas/c/comprar-un-vehiculo/879/pase-5-horas
 Redirect permanent /es/obtener-respuestas/c/comprar-un-vehiculo/1175/acabo-de-empezar-un-nuevo-negocio-e-intente-obtener-un-prestamo-vehicular-para-mi-empresa-creo-que-el-prestamista-o-el-concesionario-me-discrimino-y-a-mi-empresa-tambien-cuales-son-los-derechos-que-me-otorga-la-ley.html /es/obtener-respuestas/que-debo-hacer-si-creo-que-un-prestamista-o-un-concesionario-discrimino-en-mi-contra-cuando-solicite-un-prestamo-para-auto-por-ejemplo-al-negar-mi-solicitud-o-al-cobrarme-una-tasa-de-interes-mas-alta-es-1171/
 
 # Redirects intended to catch sub-pages
-Redirect permanent /innovation/ /competition-innovation/
+Redirect permanent /rules-policy/innovation/ /rules-policy/competition-innovation/
 Redirect permanent /policy-compliance/amicus/ /compliance/amicus/
 Redirect permanent /policy-compliance/enforcement/ /enforcement/
 Redirect permanent /policy-compliance/rulemaking/ /rules-policy/


### PR DESCRIPTION
The path set in the previous PR https://github.com/cfpb/consumerfinance.gov/pull/7077 is incorrect -- the path should be /rules-policy/innovation/, rather than just /innovation/. This PR corrects the previous.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Changes

- Modified line in redirects.conf


## How to test this PR

1. localhost
2. Navigate to /rules-policy/innovation
3. Confirm that you are properly redirected to /rules-policy/competition-innovation


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
