### PR TITLE
Broken jinja made only a single media_css file get included on a page

### DIFF
--- a/cfgov/jinja2/v1/_layouts/base.html
+++ b/cfgov/jinja2/v1/_layouts/base.html
@@ -116,7 +116,7 @@
     <link rel="stylesheet" href="{{ static('css/main.css') }}">
       {% if page and page.media_css %}
         {% for css in page.media_css %}
-          <link rel="stylesheet" href="{{ static('css/on-demand/' + css) }}" );
+          <link rel="stylesheet" href="{{ static('css/on-demand/' + css) }}" />
         {% endfor %}
       {% endif %}
     {% endblock css %}

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -606,7 +606,17 @@ class TestCFGOVPageMediaCSSProperty(TestCase):
         self.assertEqual(CFGOVPage().streamfield_media("css"), [])
 
     def test_page_pulls_in_child_block_media(self):
-        page = CFGOVPage()
+        page = BrowsePage()
+        page.content = blocks.StreamValue(
+            page.content.stream_block,
+            [
+                {
+                    "type": "simple_chart",
+                    "value": {},
+                }
+            ],
+            True,
+        )
         page.sidefoot = blocks.StreamValue(
             page.sidefoot.stream_block,
             [
@@ -618,7 +628,9 @@ class TestCFGOVPageMediaCSSProperty(TestCase):
             True,
         )
 
-        self.assertEqual(page.media_css, ["sidebar-contact-info.css"])
+        self.assertEqual(
+            page.media_css, ["sidebar-contact-info.css", "simple-chart.css"]
+        )
 
     def test_doesnt_pull_in_media_for_nonexistent_child_blocks(self):
         page = BrowsePage()


### PR DESCRIPTION
This is a bug!

@brandon-rusk can test via his cct/simple-chart setup