### PR TITLE
Fix smoke tests after #7077

### DIFF
--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -88,7 +88,7 @@ APPS = [
     "/about-us/careers/",
     "/about-us/careers/current-openings/",
     "/about-us/doing-business-with-us/",
-    "/rules-policy/innovation/",
+    "/rules-policy/competition-innovation/",
     "/activity-log/",
     "/ask-cfpb/",
     "/your-story/",


### PR DESCRIPTION
#7077 added a redirect for /rules-policy/innovation/ to /rules-policy/competition-innovation/. This quick change fixes the smoke test for /rules-policy/innovation/.

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
