### PR TITLE
updated css and javascript to improve display of TOC 

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -12,6 +12,8 @@ let offsets = [];
 let primaryOffsets = [];
 let set = 0;
 let lastTargetIndex;
+let screenX = window.innerWidth || document.documentElement.clientWidth || doc.getElementsByTagName('body')[0].clientWidth;
+let screenY = window.innerHeight|| document.documentElement.clientHeight|| doc.getElementsByTagName('body')[0].clientHeight;
 
 (function(){
   for(let i=0; i<headers.length; i++){
@@ -22,6 +24,13 @@ let lastTargetIndex;
 
 document.querySelector('.o-footer').classList.add( 'report-global-footer' );
 
+function scrunchIfNeeded() {
+  if (screenX < 900) {
+      sidenav.classList.add ( 'scrunch' );
+  } else {
+    sidenav.classList.remove ( 'scrunch' );
+  }
+}
 
 function stickIfNeeded() {
   if ( window.scrollY > top ) {
@@ -64,7 +73,6 @@ function hightlightTOC() {
   }
 }
 
-
 function onScroll() {
   stickIfNeeded();
   hightlightTOC();
@@ -72,3 +80,5 @@ function onScroll() {
 
 window.addEventListener( 'scroll', onScroll );
 onScroll();
+scrunchIfNeeded();
+

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -79,6 +79,7 @@ function onScroll() {
 }
 
 window.addEventListener( 'scroll', onScroll );
+window.addEventListener( 'resize', scrunchIfNeeded );
 onScroll();
 scrunchIfNeeded();
 

--- a/cfgov/unprocessed/css/on-demand/reports-sidenav.less
+++ b/cfgov/unprocessed/css/on-demand/reports-sidenav.less
@@ -19,15 +19,21 @@
   }
 }
 
+.scrunch{
+  width: 100% !important;
+}
+
 .o-report-sidenav {
   &.sticky {
     position: fixed;
+    width: 230px !important;
     top: 0;
-    width: 240px;
   }
   display: block;
   overflow-y: scroll;
-  height: 100%;
+  width: 230px;
+  background-color: white;
+
   .o-secondary-navigation_list__parents > li > a {
     padding-left: unit( 30px / @base-font-size-px, em );
     text-indent: unit( -18px / @base-font-size-px, em );

--- a/cfgov/unprocessed/css/on-demand/reports-sidenav.less
+++ b/cfgov/unprocessed/css/on-demand/reports-sidenav.less
@@ -1,4 +1,6 @@
 @import (reference) '../main.less';
+@nonMobileResize:   ~"only screen and (min-width: 900px) and (max-width: 1049px)";
+
 
 .research-report {
   max-width: unit( (670 + 30) / 16, em );
@@ -26,12 +28,17 @@
 .o-report-sidenav {
   &.sticky {
     position: fixed;
-    width: 230px !important;
     top: 0;
   }
   display: block;
   overflow-y: scroll;
-  width: 230px;
+  @media (min-width: 1050px) {
+    width: 230px !important;
+  }
+  @media @nonMobileResize {
+    width: 180px !important;
+  } 
+
   background-color: white;
 
   .o-secondary-navigation_list__parents > li > a {


### PR DESCRIPTION
There were issues with the TOC "bleeding" over its border on screen re-sizing and scrolling.  I re-tooled some of the css and javscript to stop the bleed.

## Additions

- added to the css and js


## How to test this PR

1. clone branch
2. fire up a Fig Content Page in wagtail admin
3. go hog wild with resizing the browser window and scrolling


## Notes and todos

- the table of contents disappears behind the bottom nav pane of the CFPB gov page


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android
