### PR TITLE
Override highcharts hidden legend hover color

### DIFF
--- a/cfgov/unprocessed/css/on-demand/simple-chart.less
+++ b/cfgov/unprocessed/css/on-demand/simple-chart.less
@@ -251,3 +251,7 @@
     padding-top: unit( 15 / @size-vi, em );
   }
 }
+
+.highcharts-legend-item-hidden * {
+  fill: unset !important;
+}

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
@@ -33,6 +33,9 @@ const styles = {
       color: '#5a5d61',
       fontFamily: '"AvenirNextLTW01-Regular", Arial, sans-serif',
       fontSize: 16
+    },
+    itemHoverStyle: {
+      color: '#000 !important'
     }
   },
   plotOptions: {

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
@@ -34,6 +34,9 @@ const styles = {
       fontFamily: '"AvenirNextLTW01-Regular", Arial, sans-serif',
       fontSize: 16
     },
+    itemHiddenStyle: {
+      color: '#ccc !important'
+    },
     itemHoverStyle: {
       color: '#000 !important'
     }


### PR DESCRIPTION
Highcharts includes a [CSS rule](https://github.com/highcharts/highcharts/blob/9d0110b6ae677708989e3a908ebaef56c43834ac/css/highcharts.scss#L441-L445) that sets the color of hidden legend
elements using an !important attribute. This prevents our hover color
from showing when a legend  item is hidden. We can unset it in our
stylesheet.

| hover state | non-hover state |
|--------|-------|
| <img width="723" alt="image" src="https://user-images.githubusercontent.com/1060248/171266766-7e0fc95b-a43b-4c51-abed-c194aee6f9cd.png"> | <img width="723" alt="image" src="https://user-images.githubusercontent.com/1060248/171266890-e48ec2f9-6ec7-4951-a853-71bdee6ec31b.png"> |

## To-do

- This causes hidden legend items to appear colored when not hovered because the `#ccc` color is now `unset`. It should be set to gray again. I'm not sure where/how to do this.