### PR TITLE
Fixed Indentation of Child Section Headers in FIG-toc

### DIFF
--- a/cfgov/unprocessed/css/on-demand/reports-sidenav.less
+++ b/cfgov/unprocessed/css/on-demand/reports-sidenav.less
@@ -1,22 +1,8 @@
 @import (reference) '../main.less';
 
-.research-report {
-  max-width: unit( (670 + 30) / 16, em );
-
-  .lead-paragraph, .author-names {
-    margin: 30px 0 30px 0;
-  }
-
-  .appendix-header {
-    margin: 0.83em 0;
-  }
-
-  .report-header > a {
-    color: black;
-    &:visited {
-      color: black;
-    }
-  }
+.m-nav-link{
+  padding-left: 1.875em;
+  text-indent: -1.9em;
 }
 
 .o-report-sidenav {
@@ -54,6 +40,26 @@
         padding-top: 0.5em;
         padding-bottom: 0.5em;
       }
+    }
+  }
+}
+
+
+.research-report {
+  max-width: unit( (670 + 30) / 16, em );
+
+  .lead-paragraph, .author-names {
+    margin: 30px 0 30px 0;
+  }
+
+  .appendix-header {
+    margin: 0.83em 0;
+  }
+
+  .report-header > a {
+    color: black;
+    &:visited {
+      color: black;
     }
   }
 }


### PR DESCRIPTION
Added CSS styling to fix the indentation of child section headers in FIG-toc.  

---

## Changes

- alphabetized classes in `reports-sidenav.html`


## How to test this PR

1. clone branch
2. fire up a FIG Content Page in wagtail admin
3. make sections/sub-sections
4. change browser display 


## Screenshots

| before | after |
|-|-|
| ![Screen Shot 2022-06-02 at 9 06 22 AM](https://user-images.githubusercontent.com/43133807/171635955-ef6cc4af-a081-48d2-bab1-c953c08716e9.png) | ![Screen Shot 2022-06-02 at 9 13 53 AM](https://user-images.githubusercontent.com/43133807/171637299-8692a3af-d786-43e1-a848-d9c0a48d8de7.png) |

## Notes and todos

- not sure if `.m-nav-link` is used elsewhere


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android