### PR TITLE
Add formatter to y-xis to properly display number types

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
@@ -93,16 +93,14 @@ const styles = {
         fontSize: '16px'
       },
       formatter: function() {
-        // If chart data is above 1 billion return "B" in y-axis
+        /* If chart data is above 1 billion return "B" in y-axis.
+         If chart data is above 1 million return "M" in y-axis.
+         If chart data is above 1 thousand return "K" in y-axis */
         if ( this.value >= 1000000000 ) {
           return this.value / 1000000000 + 'B';
-        }
-        // If chart data is above 1 million return "M" in y-axis
-        else if ( this.value >= 1000000 ) {
+        } else if ( this.value >= 1000000 ) {
           return this.value / 1000000 + 'M';
-        }
-        // If chart data is above 1 thousand return "K" in y-axis
-        else if ( this.value >= 1000 ) {
+        } else if ( this.value >= 1000 ) {
           return this.value / 1000 + 'K';
         }
         return this.value;

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/common-styles.js
@@ -91,6 +91,21 @@ const styles = {
       style: {
         color: '#5a5d61',
         fontSize: '16px'
+      },
+      formatter: function() {
+        // If chart data is above 1 billion return "B" in y-axis
+        if ( this.value >= 1000000000 ) {
+          return this.value / 1000000000 + 'B';
+        }
+        // If chart data is above 1 million return "M" in y-axis
+        else if ( this.value >= 1000000 ) {
+          return this.value / 1000000 + 'M';
+        }
+        // If chart data is above 1 thousand return "K" in y-axis
+        else if ( this.value >= 1000 ) {
+          return this.value / 1000 + 'K';
+        }
+        return this.value;
       }
     }
   },


### PR DESCRIPTION
## Changes

-Added y-xis label formatter to ensure charts properly display number types


## Screenshots

Before:

<img width="709" alt="image" src="https://user-images.githubusercontent.com/85513449/172210778-de33401d-8632-41a3-8e78-74639e9e035a.png">

<img width="717" alt="image" src="https://user-images.githubusercontent.com/85513449/172210815-d4e964d0-51a0-4ba8-927f-48a509712bec.png">


After:

<img width="722" alt="image" src="https://user-images.githubusercontent.com/85513449/172210312-7eefa3ae-3de8-41e4-97ad-1999d0afadb7.png">

<img width="711" alt="image" src="https://user-images.githubusercontent.com/85513449/172210601-c47bdaf4-2d6d-4e1a-9278-2a0164ccdd3b.png">