### PR TITLE
Bump curriculum-review-tool version to 2.1.8

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -39,7 +39,7 @@ wagtailmedia==0.9.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.3/owning_a_home_api-0.17.3-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.7/crtool-2.1.7-py3-none-any.whl
+https://github.com/cfpb/curriculum-review-tool/releases/download/2.1.8/crtool-2.1.8-py3-none-any.whl
 
 # Temporarily pin Jinja 2.11's MarkupSafe dependency.
 MarkupSafe==2.0.1


### PR DESCRIPTION
Updates the CRT to contain https://github.com/cfpb/curriculum-review-tool/pull/430, to limit title to 150 characters.

## Changes

- Validate title and pub_date string len directly instead of the combined JSON input size.
- Refactors views to use return-early for easier reading.
- Eliminates pass_code input handling as this is no longer used.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)