### PR TITLE
Remove utf8 param from search base URL

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/global-search.html
+++ b/cfgov/jinja2/v1/_includes/molecules/global-search.html
@@ -17,8 +17,7 @@
 {%- set search_url_base = "https://search.consumerfinance.gov/search" -%}
 {%- set search_url = (
     search_url_base
-    ~ "?utf8=✓"
-    ~ "&affiliate=" ~ search_gov_affiliate()
+    ~ "?affiliate=" ~ search_gov_affiliate()
     ~ "&query="
 ) -%}
 


### PR DESCRIPTION
This changes removes the `utf8=✓` parameter from our search base URL. This will remove that parameter from our no-JS fallback link used by IE that links directly to the search.gov search page for CFPB. Its removal shouldn't impact JS-enabled search as there is a hidden input that adds the parameter on lines [55-57](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/molecules/global-search.html#L56-L58). 

In IE, with this parameter, we're seeing 400 Bad Request errors on following the link that appear down to the UTF-8 `✓` character. This is an attempt to solve that issue.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
