### PR TITLE
FIG: Show a link to print the page

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
@@ -16,6 +16,11 @@
       <div class="eyebrow">{{ page.eyebrow }}</div>
       <h1>{{ page.page_header }}</h1>
       <div class="lead-paragraph">{{ page.subheader }}</div>
+      <a class="a-link a-link__jump" href="javascript:window.print()">
+          <span class="a-link_text">
+		  Print this page
+          </span>
+      </a>
     </div>
 
     {% for block in page.content %}

--- a/cfgov/unprocessed/css/on-demand/reports-sidenav.less
+++ b/cfgov/unprocessed/css/on-demand/reports-sidenav.less
@@ -84,3 +84,9 @@
   position: relative;
   z-index: 1;
 }
+
+.respond-to-print({
+  .o-report-sidenav {
+    display: none;
+  }
+});


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->

This is a very basic proof of concept for printing the page using `window.print()` and using CSS to conditionally hide (or show) features differently from when the page is in the browser.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- Add a link beneath the header that brings up the browser's print function for the page
- Add CSS that hides the table of contents, since the TOC links won't work anyway


## How to test this PR

1. Run this branch
2. Make and publish a FIG content page (it won't work if you use Preview)
3. Click the "print this page" link
    - See that it brings up the print window
    - See that the print preview adheres to CFPB's [guidelines](https://cfpb.github.io/design-system/guidelines/print-styles) for printed pages: minimal header and footer, reasonable line lengths, the URL at the bottom of the page, explicitly printed URLs, and no web-only features like the TOC.


## Screenshots
![Screen Shot 2022-06-07 at 6 09 04 PM](https://user-images.githubusercontent.com/4295388/172491397-556934fb-89ec-4c7a-a0dd-06d886a8d2a2.png)


## Notes and todos

- We'll refine the style for the printed page, as well as the link on the page.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
