### PR TITLE
Handle fig sidenav sizing in css and clean up/document js

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -1,82 +1,68 @@
-/* eslint-disable */
+/* eslint-disable complexity, no-undefined */
 /* ==========================================================================
    Scripts for Report Sidenav organism
    ========================================================================== */
 
-const sidenav = document.querySelector( '.o-report-sidenav' );
-const tocHeaders = document.querySelectorAll( '.o-report-sidenav .m-nav-link' );
-const top = sidenav.offsetTop;
-const headerOffset = 224
-const headers = document.querySelectorAll( '.content_main .report-header' )
-let offsets = [];
-let primaryOffsets = [];
-let set = 0;
+const main = document.querySelector( 'main' );
+const sidenav = main.querySelector( '.o-report-sidenav' );
+const tocHeaders = sidenav.querySelectorAll( '.m-nav-link' );
+const headerOffset = main.offsetTop - 10;
+const headers = main.querySelectorAll( 'h2.report-header, h3.report-header' );
+
+const offsets = [];
+const primaryOffsets = [];
 let lastTargetIndex;
 
-(function(){
-  for(let i=0; i<headers.length; i++){
-    offsets.push(headers[i].offsetTop + headerOffset)
-    primaryOffsets.push(headers[i].tagName === 'H2')
+// Initialize offsets for calculating what to highlight
+( function() {
+  for ( let i = 0; i < headers.length; i++ ) {
+    offsets.push( headers[i].offsetTop + headerOffset );
+    primaryOffsets.push( headers[i].tagName === 'H2' );
   }
-})();
+} )();
 
-document.querySelector('.o-footer').classList.add( 'report-global-footer' );
+// Keep sidenav content from clipping into footer
+document.querySelector( '.o-footer' ).classList.add( 'report-global-footer' );
 
-function scrunchIfNeeded() {
-  let screenX = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-  if (screenX < 900) {
-      sidenav.classList.add( 'scrunch' );
-  } else {
-    sidenav.classList.remove( 'scrunch' );
+// Set sidebar height on parent of sticky sidenav
+sidenav.parentElement.style.height = main.clientHeight + 'px';
+
+/**
+ * Gets the node in the sidenav that wraps the section and subsections
+ * @param {number} index from which to search for the parent
+ * @returns {object} The parent node of the section
+ **/
+function getParentHeader( index ) {
+  for ( let i = index; i >= 0; i-- ) {
+    if ( primaryOffsets[i] ) return tocHeaders[i].parentNode;
   }
+  return null;
 }
 
-function stickIfNeeded() {
-  if ( window.scrollY > top ) {
-    if ( !set ) {
-      sidenav.classList.add( 'sticky' );
-      set = 1;
-    }
-  } else if ( set ) {
-    sidenav.classList.remove( 'sticky' );
-    set = 0;
-  }
-}
-
-function getParentHeader(index){
-  for(let i=index; i>=0; i--){
-    if(primaryOffsets[i]) return tocHeaders[i].parentNode
-  }
-}
-
+/**
+ * Highlights the appropriate sidenav header and reveals children on scroll
+ **/
 function hightlightTOC() {
   const sY = window.scrollY;
   const len = offsets.length;
 
   for ( let i = 0; i <= len; i++ ) {
     if ( i === len || sY < offsets[i] ) {
-      let hl = i ? i - 1 : i;
+      const hl = i ? i - 1 : i;
       if ( hl === lastTargetIndex ) return;
-      if ( lastTargetIndex !== undefined ){
+
+      if ( lastTargetIndex !== undefined ) {
         tocHeaders[lastTargetIndex].classList.remove( 'm-nav-link__current' );
-        getParentHeader(lastTargetIndex).classList.remove('parent-header')
+        getParentHeader( lastTargetIndex ).classList.remove( 'parent-header' );
       }
 
       tocHeaders[hl].classList.add( 'm-nav-link__current' );
-      getParentHeader(hl).classList.add( 'parent-header' );
+      getParentHeader( hl ).classList.add( 'parent-header' );
       lastTargetIndex = hl;
       return;
     }
   }
 }
 
-function onScroll() {
-  stickIfNeeded();
-  hightlightTOC();
-}
-
-window.addEventListener( 'scroll', onScroll );
-window.addEventListener( 'resize', scrunchIfNeeded );
-onScroll();
-scrunchIfNeeded();
-
+window.addEventListener( 'scroll', hightlightTOC );
+hightlightTOC();

--- a/cfgov/unprocessed/css/on-demand/reports-sidenav.less
+++ b/cfgov/unprocessed/css/on-demand/reports-sidenav.less
@@ -1,37 +1,26 @@
 @import (reference) '../main.less';
-@nonMobileResize:   ~"only screen and (min-width: 900px) and (max-width: 1049px)";
-
-.m-nav-link{
-  padding-left: unit( 40px / @base-font-size-px, em );
-  text-indent: unit( -30px / @base-font-size-px, em );
-}
-
-.scrunch{
-  width: 100%;
-}
 
 .o-report-sidenav {
-  &.sticky {
-    position: fixed;
-    top: 0;
-  }
+  position: sticky;
+  top: 0;
   display: block;
   overflow-y: scroll;
-  @media (min-width: 1050px) {
-    width: 230px;
+
+  .m-nav-link{
+    padding-left: unit( 40px / @base-font-size-px, em );
+    text-indent: unit( -30px / @base-font-size-px, em );
   }
-  @media @nonMobileResize {
-    width: 180px;
-  } 
-  background-color: white;
+
 
   .o-secondary-navigation_list__parents > li > a {
     padding-left: unit( 30px / @base-font-size-px, em );
     text-indent: unit( -18px / @base-font-size-px, em );
   }
+
   h3 {
     padding-left: unit( 19px / @size-iii, em );
   }
+
   h4 {
     padding-left: unit( 19px / @size-iv, em );
   }
@@ -39,9 +28,11 @@
   .o-report-sidenav__appendix > li > a {
     text-indent: unit( -20px / @base-font-size-px, em );
   }
+
   .o-secondary-navigation_list__children {
     display: none;
   }
+
   .parent-header {
     .o-secondary-navigation_list__children  {
       display: block;


### PR DESCRIPTION
As a follow-on to https://github.com/cfpb/consumerfinance.gov/pull/7087, this addresses the underlying clipping issue in a simpler way. Namely, instead of using `position: fixed` and adding a class with js + setting the width as a percentage of the body (which `position: fixed` forces you to do), this uses `position: sticky` (relatively new but supported in all browsers we serve js), which just requires the parent element to have a `height` set. Doing this also allowed me to remove the `scrunch` logic.

Also included in this PR:
 - reenable eslint on the js file and add docstrings
 - fixed a bug where sub-headers weren't properly being shown/hidden if a level-3 header was present
 - updated the `headerOffset` and keyed it off the `main` tag's `offsetTop` so it will always be correct.
 
 Testing:
 - Pull and `yarn build`
 - Spin up a `Fig content page`
 - Everything should appear correct at all non-mobile sizes
 
<img width="1249" alt="Screen Shot 2022-06-08 at 9 11 43 PM" src="https://user-images.githubusercontent.com/1558033/172743388-c6067acf-a9e5-4b05-9ab0-528e50eabd5e.png">
