### PR TITLE
Remove outdated docs from Expandable template

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/expandable.html
+++ b/cfgov/jinja2/v1/_includes/organisms/expandable.html
@@ -13,8 +13,6 @@
    value.label:           Label you want on the Expandable.
                           Default is an empty string.
 
-   value.paragraph:       Intro paragraph text.
-
    value.content:         Main content of the expandable.
 
    value.is_bordered:     Whether the Expandable has a bottom border or not.


### PR DESCRIPTION
The template for the Expandable module mentions a "paragraph" variable, but this is unused.

Any paragraph in an expandable is now part of its regular content:

https://github.com/cfpb/consumerfinance.gov/blob/ec8a43459910ef3bca6d53ed10b7b3b41d2fb7d5/cfgov/v1/atomic_elements/organisms.py#L634

This help text was left behind in [this commit](
https://github.com/cfpb/consumerfinance.gov/commit/9de95a6798923e3253c550bd1c4ab5d88ff0e709) from 2016, but can be removed.