### PR TITLE
Update Cypress action and add admin username/password

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -9,6 +9,8 @@ jobs:
     env:
       DATABASE_URL: postgres://cfpb:cfpb@localhost/cfgov
       MAPBOX_ACCESS_TOKEN:  ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+      DJANGO_ADMIN_USERNAME: admin
+      DJANGO_ADMIN_PASSWORD: admin
 
     services:
       elasticsearch:
@@ -49,12 +51,8 @@ jobs:
     - name: Set up initial data
       run: ./refresh-data.sh test.sql.gz
 
-
-    # - name: Run server
-    #   run: python cfgov/manage.py runserver
-
     - name: Run Cypress
-      uses: cypress-io/github-action@v2
+      uses: cypress-io/github-action@v4
       env:
           MAPBOX_ACCESS_TOKEN:  ${{ secrets.MAPBOX_ACCESS_TOKEN }}
       with:


### PR DESCRIPTION
This PR is a quick fix for failures we've just started seeing with the Cypress tests in GHA.

First it updates the Cypress action to the latest version.

Second, it adds the `DJANGO_ADMIN_USERNAME` and `DJANGO_ADMIN_PASSWORD` variables to the action so that they are defined our [our `initial_data` script](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/scripts/initial_data.py#L22-L23). I'm unsure at this point why this was working previously, and why it stopped working. But this should get our functional tests back to passing in GitHub.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
