### PR TITLE
Removes 'startOnTick' for datetime simple charts

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/datetime-styles.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/datetime-styles.js
@@ -14,7 +14,6 @@ const datetime = {
   xAxis: {
     ...styles.xAxis,
     type: 'datetime',
-    startOnTick: true,
     labels: {
       ...styles.xAxis.labels
     },


### PR DESCRIPTION
This allows them to start on the first instance of data, meaning data will extend all the way to the left of the chart.
<img width="729" alt="Screen Shot 2022-06-15 at 4 19 49 PM" src="https://user-images.githubusercontent.com/1558033/173919849-4b9cd2ef-bf8a-4574-ab98-1c98aff0b5e5.png">

Testing:

 - Pull and build
 - Data should extend the full width of the chart on load.
 - Play with the rangeSelector buttons, data should continue to fill the chart (even/especially on 'All')
 - Data display and interaction is still correct