### PR TITLE
Switches mega-menu selection line to be relative to the bottom

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -836,7 +836,7 @@ body {
         &:after {
           position: absolute;
           left: 0;
-          top: unit( 46px / @base-font-size-px, em );
+          bottom: 0;
           content: '';
           background: transparent;
           width: 100%;
@@ -844,8 +844,6 @@ body {
         }
 
         &:hover {
-          padding-bottom: ( @grid_gutter-width / 2) - 6px;
-          border-bottom: 6px solid transparent;
           cursor: pointer;
 
           // Change hover border color.


### PR DESCRIPTION
Currently, if the user has their font size set to "Very large" in their browser's settings, the mega menu looks p bad:
<img width="1278" alt="Screen Shot 2022-06-15 at 4 45 00 PM" src="https://user-images.githubusercontent.com/1558033/173928520-895fc8af-6bbf-4a01-8dd3-fb5735afc32c.png">

This fixes that to now look passable:
<img width="1339" alt="Screen Shot 2022-06-15 at 5 01 01 PM" src="https://user-images.githubusercontent.com/1558033/173929074-a19eb70b-37b4-4ef7-819e-38ef892eef22.png">

Testing:
- Pull and build
- With no settings changes (eg, font size Medium in settings) the mega menu should appear identical to prod.
- Change font size to Very large in settings. Mega menu selection line should look like the second screenshot