### PR TITLE
Correcting wildcard redirects

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -7,11 +7,12 @@ Redirect permanent /es/obtener-respuestas/c/comprar-un-vehiculo/879/pase-5-horas
 Redirect permanent /es/obtener-respuestas/c/comprar-un-vehiculo/1175/acabo-de-empezar-un-nuevo-negocio-e-intente-obtener-un-prestamo-vehicular-para-mi-empresa-creo-que-el-prestamista-o-el-concesionario-me-discrimino-y-a-mi-empresa-tambien-cuales-son-los-derechos-que-me-otorga-la-ley.html /es/obtener-respuestas/que-debo-hacer-si-creo-que-un-prestamista-o-un-concesionario-discrimino-en-mi-contra-cuando-solicite-un-prestamo-para-auto-por-ejemplo-al-negar-mi-solicitud-o-al-cobrarme-una-tasa-de-interes-mas-alta-es-1171/
 
 # Redirects intended to catch sub-pages
-Redirect permanent /rules-policy/innovation/ /rules-policy/competition-innovation/
-Redirect permanent /policy-compliance/amicus/ /compliance/amicus/
-Redirect permanent /policy-compliance/enforcement/ /enforcement/
-Redirect permanent /policy-compliance/rulemaking/ /rules-policy/
-Redirect permanent /policy-compliance/guidance/ /compliance/
+RedirectMatch permanent ^/practitioner-resources/(.*)  /consumer-tools/educator-tools/$1
+RedirectMatch permanent ^/rules-policy/innovation/(.*)  /rules-policy/competition-innovation/$1
+RedirectMatch permanent ^/policy-compliance/amicus/(.*) /compliance/amicus/$1
+RedirectMatch permanent ^/policy-compliance/enforcement/(.*)  /enforcement/$1
+RedirectMatch permanent ^/policy-compliance/rulemaking/(.*)  /rules-policy/$1
+RedirectMatch permanent ^/policy-compliance/guidance/(.*)  /compliance/$1
 
 # These URLs 404 and always will-- let's send 410 Gone instead
 Redirect gone /static/colorbox


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
Some of the newer redirects intended to be wildcards in `redirects.conf` weren't formatted properly. This PR properly formats them and adds an additional wildcard redirect requested by an internal content team.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- Redirect from `/practitioner-resources/*` to `/consumer-tools/educator-tools/*`


## Changes

- Correcting formatting on other wildcard redirects in the "Redirects intended to catch sub-pages" subsection of `redirects.conf`


## How to test this PR

1. localhost
2. Confirm that instances of /practitioner-resources/ redirect to /consumer-tools/educator-tools/ regardless of full URL string or subpage chosen 

## Notes and todos

- Wildcard redirects are more desired by stakeholders than I'd realized when first converting a large chunk of our redirects to Wagtail. I'm contemplating whether it may make sense to go all the way in the _other_ direction, i.e. moving all redirects into this file instead, so that we have maximum control. It's a single file in the repo, which should make maintenance easier for content-management team members less comfortable in general using Github.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
