### PR TITLE
Don't require a simple-chart download source if the data source will suffice

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/simple-chart.html
+++ b/cfgov/jinja2/v1/_includes/organisms/simple-chart.html
@@ -9,11 +9,11 @@
    Create a chart organism with data
 
    ========================================================================== #}
-{% macro make_download_name(download_source, download_text) -%}
-  {% if download_text %}
-    {{download_text}}
-  {% else %}
+{% macro make_download_href(download_source, data_source) -%}
+  {% if download_source %}
     {{download_source}}
+  {% else %}
+    {{data_source}}
   {% endif %}
 {%- endmacro %}
 
@@ -59,16 +59,14 @@
          >
     </div>
     <div class="o-simple-chart_tilemap_legend"></div>
-    {% set download_source = value.download_file %}
-
     <p class="m-chart-footnote block__sub block__border-top block short-desc">
         {% if value.source_credits %}<strong>Source:</strong> {{value.source_credits}}<br>{% endif %}
         {% if value.date_published %}<strong>Date Published:</strong> {{value.date_published}}<br>{% endif %}
-        {% if download_source %}
+        {% if value.download_text %}
           <strong>Download:</strong>
           <a class="icon-link icon-link__download"
-             href="{{ download_source }}">
-            <span class="icon-link_text">{{make_download_name(download_source, value.download_text)}}</span></a><br>
+             href="{{make_download_href(value.download_file, data_location)}}">
+            <span class="icon-link_text">{{value.download_text}}</span></a><br>
         {% endif %}
         {% if value.notes%}<strong>Notes:</strong> {{value.notes}}{% endif %}
     </p>


### PR DESCRIPTION
This changes the logic of the `download_source`, `download_text` a bit in simple-chart, so that a `download_source` is only required if it's different that the `data_source` (which is used by default instead).

To do this, without adding more logic than this change is worth, I made the presence of the download link key off the presence of `download_text`, meaning you'll need to provide that for the download link to display (before, if you provided a `download_source` and no `download_text`, it would just use the `download_source`. This behavior isn't really worth preserving).

Testing:

 - Pull
 - Remove a simple-chart's `download_source` in wagtail and note that it uses the `data_source`
 - Remove that chart's `download_text` and note that the download link won't appear, whether there's a `download_source` or not

Something to note: if a `download_source` is NOT provided, `download_text` is provided, and the `data_source` is just some JSON, the download link will be created with a nonsense href. I may push up a commit which prevents this if I feel it's worth the complexity.