### PR TITLE
Add report view for email signups

### DIFF
--- a/cfgov/v1/templates/v1/_list_page_emailsignups.html
+++ b/cfgov/v1/templates/v1/_list_page_emailsignups.html
@@ -1,0 +1,19 @@
+{% extends 'wagtailadmin/reports/listing/_list_page_report.html' %}
+
+{% block extra_columns %}
+    <th>URL</th>
+    <th>Email signup</th>
+{% endblock %}
+
+{% block extra_page_data %}
+    <td valign="top">
+        {{ page.url }}
+    </td>
+    <td valign="top">
+        {{ page.email_signup_value }}
+
+        <ul class="actions">
+            <li><a  class="button button-secondary button-small" href="{% url "wagtailsnippets:edit" app_label="v1" model_name="emailsignup" pk=page.email_signup_value %}" title="Edit">Edit</a></li>
+        </ul>
+    </td>
+{% endblock %}

--- a/cfgov/v1/templates/v1/page_emailsignups_report.html
+++ b/cfgov/v1/templates/v1/page_emailsignups_report.html
@@ -1,0 +1,18 @@
+{% extends 'wagtailadmin/reports/base_page_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block actions %}
+    {% if view.list_export %}
+        <div class="actionbutton">
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block listing %}
+    {% include 'v1/_list_page_emailsignups.html' %}
+{% endblock %}
+
+{% block no_results %}
+    <p>No pages with email signups.</p>
+{% endblock %}

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -1,10 +1,15 @@
 from datetime import date
 
+from django.db.models import Case, IntegerField, Value, When
+
 from wagtail.admin.views.reports import PageReportView, ReportView
+from wagtail.core.fields import StreamField
+from wagtail.core.models import get_page_models
 from wagtail.documents.models import Document
 from wagtail.images import get_image_model
 
 from v1.models import CFGOVPage
+from v1.query import StreamBlockPageQuerySet
 
 
 def process_categories(queryset):
@@ -151,3 +156,93 @@ class ImagesReportView(ReportView):
             .order_by("-created_at")
             .prefetch_related("tags")
         )
+
+
+class EmailSignupReportView(PageReportView):
+    header_icon = "mail"
+    title = "Pages with email signups"
+
+    list_export = PageReportView.list_export + [
+        "url",
+        "email_signup_value",
+    ]
+    export_headings = dict(
+        [
+            ("url", "URL"),
+            ("email_signup_value", "Email Signup"),
+        ],
+        **PageReportView.export_headings,
+    )
+
+    custom_field_preprocess = {
+        "categories.all": {
+            "csv": process_categories,
+            "xlsx": process_categories,
+        }
+    }
+
+    template_name = "v1/page_emailsignups_report.html"
+
+    def get_filename(self):
+        return generate_filename("pages_with_email_signups")
+
+    def get_models_with_block(self, target_block):
+        for page_cls in get_page_models():
+            if page_cls._meta.abstract:
+                continue
+
+            for field in page_cls._meta.get_fields(include_parents=False):
+                if not isinstance(field, StreamField):
+                    continue
+
+                yield page_cls, field.name
+
+    def get_queryset(self):
+        # We're diving deep into Django's ORM here.
+
+        # We're going to be getting individual querysets for each model with an
+        # email_signup block in its streamfields. We'll select only the pk and
+        # annotate with the email_signup block's value. Annotating after
+        # values() will add the annotation to the resulting values dict.
+        querysets = [
+            (
+                StreamBlockPageQuerySet(model)
+                .live()
+                .block_in_field("email_signup", field)
+                .values("pk")
+                .annotate_block_in("email_signup", field)
+            )
+            for model, field in self.get_models_with_block("email_signups")
+        ]
+
+        # Then we're going to union those to get one big queryset with all page
+        # pks and their email_signup block values.
+        qs = querysets[0].union(*querysets[1:])
+
+        # Unfortunately, we need to evaluate this queryset now. We can't do the
+        # email_signup_value annotation on our final queryset unless we do.
+        page_pks_and_email_signup_values = list(qs)
+
+        # We're going to pull out the page pks, for use in filter() in our
+        # final queryset.
+        page_pks = [d["pk"] for d in page_pks_and_email_signup_values]
+
+        # Next we're going to construct a list of SQL WHEN statements for use
+        # in our annotation on the final queryset. This will express the list
+        # of page pks and email_signup_values in SQL form and allow us to
+        # attached the email_signup_value as an annotation on the new queryset.
+        email_signup_value_whens = [
+            When(pk=d["pk"], then=Value(d["email_signup_value"]))
+            for d in page_pks_and_email_signup_values
+        ]
+
+        # Now we construct our final queryset. This will be for any CFGOVPage
+        # object with a pk in our list of page_pks, and then we'll annotate
+        # that queryset with our email_signup_value_whens.
+        page_qs = CFGOVPage.objects.filter(pk__in=page_pks).annotate(
+            email_signup_value=Case(
+                *email_signup_value_whens, output_field=IntegerField()
+            )
+        )
+
+        return page_qs

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -189,7 +189,7 @@ class EmailSignupReportView(PageReportView):
     def get_models_with_block(self, target_block):
         for page_cls in get_page_models():
             if page_cls._meta.abstract:
-                continue
+                continue  # pragma: no cover
 
             for field in page_cls._meta.get_fields(include_parents=False):
                 if not isinstance(field, StreamField):

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -43,6 +43,7 @@ from v1.template_debug import (
 )
 from v1.views.reports import (
     DocumentsReportView,
+    EmailSignupReportView,
     ImagesReportView,
     PageMetadataReportView,
 )
@@ -289,6 +290,27 @@ def register_images_report_url():
             r"^reports/images/$",
             ImagesReportView.as_view(),
             name="images_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_page_emailsignups_report_menu_item():
+    return MenuItem(
+        "Page Email Signups",
+        reverse("page_emailsignups_report"),
+        classnames="icon icon-" + EmailSignupReportView.header_icon,
+        order=700,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_page_emailsignups_report_url():
+    return [
+        re_path(
+            r"^reports/page-emailsignups/$",
+            EmailSignupReportView.as_view(),
+            name="page_emailsignups_report",
         ),
     ]
 


### PR DESCRIPTION
This change adds a Wagtail report for pages with email signup blocks. The report view will show page metadata (title, updated date, type, status, URL) along with the email signup ID and an edit button linking to that email signup. The report is downloadable in CSV form as well.

Right now as a report view, there's no way to filter/search for specific pages or sign-ups. But I believe the basic outline of how to query for email signups could be ported to the email signup snippet view itself at a later date to make management of specific signups a little easier still.

There's some Django ORM wizardry that makes this possible in only 2 queries. I've tried to richly-comment that code in `get_queryset` on the `EmailSignupReportView` class, but please let me know if there's anything more that should be added.

## How to test this PR

1. Download the latest data with `./refresh-data.sh`
2. Pull this branch
3. Visit the report at http://localhost:8000/admin/reports/page-emailsignups/

## Screenshots
![image](https://user-images.githubusercontent.com/10562538/176215993-a354276e-971f-4108-af86-646c5a0c42d1.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
