### PR TITLE
Fix the current job openings table timezone handling

### DIFF
--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.safestring import mark_safe
@@ -16,6 +17,7 @@ from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.core.fields import RichTextField
 from wagtail.core.models import PageManager, PageQuerySet
 
+import pytz
 from modelcluster.fields import ParentalManyToManyField
 
 from jobmanager.models.django import (
@@ -31,7 +33,9 @@ from v1.models.snippets import ReusableText
 
 class JobListingPageQuerySet(PageQuerySet):
     def open(self):
-        today = timezone.now().date()
+        today = timezone.localtime(
+            timezone=pytz.timezone(settings.TIME_ZONE)
+        ).date()
 
         return (
             self.filter(live=True)

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.conf import settings
 from django.http import HttpRequest
 from django.test import TestCase
 from django.urls import reverse
@@ -7,6 +8,8 @@ from django.utils import timezone
 
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
+
+import pytz
 
 from jobmanager.models.django import (
     Grade,
@@ -23,7 +26,10 @@ from v1.models.snippets import ReusableText
 class JobListingPageQuerySetTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        today = timezone.now().date()
+        today = timezone.localtime(
+            timezone=pytz.timezone(settings.TIME_ZONE)
+        ).date()
+
         root_page = Site.objects.get(is_default_site=True).root_page
         division = JobCategory.objects.create(job_category="Division")
 


### PR DESCRIPTION
This change fixes some weirdness in our [“Current openings” table](http://localhost:8000/about-us/careers/current-openings/) that lists CFPB’s current job openings. Those job openings are typically set to unpublish at midnight on their closing date (so, a job listing that closes on June 28 will unpublish at 00:00 June 29). This happens in our configured `TIME_ZONE`, which is `America/New_York`.

The `JobListingPageQuerySet` has an `open()` method that returns listing pages that are “open” for applications. This method uses [Django’s `timezone.now().date`](https://docs.djangoproject.com/en/3.2/ref/utils/#django.utils.timezone.now) to determine whether the job is open or closed. `timezone.now()`, per the Django docs, returns a datetime object in UTC.

This means the “Current openings” table could be 4/5 hours ahead of a job actually opening or closing, as the job opening/closing happens with Wagtail’s scheduled publishing in Eastern time, but the current openings checks the date against UTC.

This change fixes that by using Django’s [`timezone.localtime()`](https://docs.djangoproject.com/en/3.2/ref/utils/#django.utils.timezone.localtime), with the `settings.TIME_ZONE` explicitly. This should ensure the “Current openings” table is not out of sync with jobs pages that are published/unpublished.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
