### PR TITLE
Deprecate duplicate CFGOVPage.parent() method

### DIFF
--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -130,7 +130,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 "label": hit.title,
                 "snippet": snippet,
                 "url": "{}{}/{}/#{}".format(
-                    self.parent().url,
+                    self.get_parent().specific.url,
                     hit.part,
                     hit.section_label.lower(),
                     hit.paragraph_id,

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -345,13 +345,6 @@ class CFGOVPage(Page):
         request.LANGUAGE_CODE = translation.get_language()
         return super().serve(request, *args, **kwargs)
 
-    class Meta:
-        app_label = "v1"
-
-    def parent(self):
-        parent = self.get_ancestors(inclusive=False).reverse()[0].specific
-        return parent
-
     def streamfield_media(self, media_type):
         media = []
 

--- a/cfgov/v1/tests/management/commands/test_archive_events.py
+++ b/cfgov/v1/tests/management/commands/test_archive_events.py
@@ -104,8 +104,13 @@ class TestArchiveEvents(TestCase):
         single_day_event_page.refresh_from_db()
         multi_day_event_page.refresh_from_db()
 
-        self.assertEqual(single_day_event_page.parent(), archive_page)
-        self.assertEqual(multi_day_event_page.parent(), archive_page)
+        self.assertEqual(
+            single_day_event_page.get_parent(update=True).specific,
+            archive_page,
+        )
+        self.assertEqual(
+            multi_day_event_page.get_parent(update=True).specific, archive_page
+        )
 
     @freeze_time("2020-02-02")
     def test_append_date_to_duplicate_slug(self):


### PR DESCRIPTION
The `CFGOVPage.parent()` method duplicates functionality already available via the base treebeard [`Node.get_parent()`](https://django-treebeard.readthedocs.io/en/latest/api.html#treebeard.models.Node.get_parent) method.

This commit also removes an unnecessary `app_label` on v1.CFGOVPage.

## How to test this PR

Unit tests continue to pass.

For the iRegs change, run a local server and visit a page like [this](http://localhost:8000/rules-policy/regulations/search-regulations/results/?regs=1002&q=housing) to confirm that search results URLs are constructed properly.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)