### PR TITLE
Fix broken get_parent() in post preview template

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/post-preview-snapshot.html
+++ b/cfgov/jinja2/v1/_includes/organisms/post-preview-snapshot.html
@@ -25,8 +25,8 @@
 {% for post in posts %}
     {{ post_preview.render(
         post,
-        controls=none, 
-        url=pageurl(post.parent()),
+        controls=none,
+        url=pageurl(post.get_parent().specific),
         post_date_description=value.post_date_description
     ) }}
 {% endfor %}


### PR DESCRIPTION
#7128 tried removing a custom `parent()` method in favor of using Wagtail's built-in `get_parent()`, but missed this one reference.

Thanks to @willbarton (and our acceptance tests!) for the catch.

## How to test this PR

To test, run a local server and visit:

http://localhost:8000/compliance/amicus/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)