### PR TITLE
SimpleChart: Change `getProjectedDate` to `convertEpochToDateString` to better target its intention

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -13,7 +13,7 @@ import defaultLine from './line-styles.js';
 import tilemapChart from './tilemap-chart.js';
 import { alignMargin, extractSeries, formatSeries, makeFormatter, overrideStyles } from './utils.js';
 import { initFilters } from './data-filters.js';
-import { getProjectedDate } from './utils';
+import { convertEpochToDateString } from './utils';
 
 accessibility( Highcharts );
 
@@ -170,7 +170,10 @@ function addProjectedMonths( chartObject, numMonths ) {
 
   // Convert lastChartDate from months to milliseconds for Epoch format
   const convertedProjectedDate = lastChartDate - ( numMonths * 30 * msInDay );
-  const projectedDate = getProjectedDate( convertedProjectedDate );
+  const projectedDate = {
+    humanFriendly: convertEpochToDateString( convertedProjectedDate ),
+    timestamp: convertedProjectedDate
+  };
 
   /* Add a vertical line and some explanatory text at the starting
      point of the projected data */

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/utils.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/utils.js
@@ -159,10 +159,14 @@ function extractSeries( rawData, { series, xAxisSource, chartType } ) {
   return null;
 }
 
-// Converts to human readable date from Epoch format
-function getProjectedDate( date ) {
+/**
+ * Converts to human readable date from Epoch format.
+ * @param {number} date - UNIX timestamp (seconds since Epoch).
+ * @returns {string|null} Human readable date string,
+ *   or null if supplied timestamp is invalid.
+ */
+function convertEpochToDateString( date ) {
   let humanFriendly = null;
-  let timestamp = null;
   let month = null;
   let year = null;
   const months = [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ];
@@ -174,13 +178,9 @@ function getProjectedDate( date ) {
     year = new Date( date ).getUTCFullYear();
 
     humanFriendly = month + ' ' + year;
-    timestamp = date;
   }
 
-  return {
-    humanFriendly: humanFriendly,
-    timestamp: timestamp
-  };
+  return humanFriendly;
 }
 
 
@@ -190,5 +190,5 @@ export {
   makeFormatter,
   overrideStyles,
   extractSeries,
-  getProjectedDate
+  convertEpochToDateString
 };


### PR DESCRIPTION
## Changes

- Change `getProjectedDate` to `convertEpochToDateString` to better describe what it does, and only return one string value, not an object.


## How to test this PR

1. SimpleChart functionality should be unchanged.