### PR TITLE
Maintain the visual hierarchy of FIG info unit headings

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
@@ -14,7 +14,7 @@
     .h2();
   }
 
-  h4 {
+  :not(.m-info-unit_heading-text) > h4 {
     .h3();
   }
 


### PR DESCRIPTION
Commit that I failed to push up to https://github.com/cfpb/consumerfinance.gov/pull/7146.