### PR TITLE
FIG: Don't include a trailing dot in section IDs

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
@@ -17,7 +17,7 @@
 {% set block_class = block_types[block_type].class | default('o-fig_section') %}
 
 {% if block_type in ['Fig_Section', 'Fig_Subsection'] %}
-    {% set header = value.section_id + " " + value.header %}
+    {% set header = value.section_id + ". " + value.header %}
 {% else %}
     {% set header = value.header %}
 {% endif %}

--- a/cfgov/filing_instruction_guide/models.py
+++ b/cfgov/filing_instruction_guide/models.py
@@ -101,14 +101,14 @@ class FIGContentPage(CFGOVPage):
                 ind += 1
                 sub_ind = 0
                 sub3_ind = 0
-                id = f"{ind}."
+                id = f"{ind}"
             if sec_type == "Fig_Subsection":
                 sub_ind += 1
                 sub3_ind = 0
-                id = f"{ind}.{sub_ind}."
+                id = f"{ind}.{sub_ind}"
             if sec_type == "Fig_Level_3_Subsection":
                 sub3_ind += 1
-                id = f"{ind}.{sub_ind}.{sub3_ind}."
+                id = f"{ind}.{sub_ind}.{sub3_ind}"
             section.value["section_id"] = id
 
     base_form_class = FIGPageForm

--- a/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
+++ b/cfgov/jinja2/v1/_includes/organisms/sidenav-toc.html
@@ -31,7 +31,7 @@
                  o-secondary-navigation_list__parents">
        {%- for item in toc_headers %}
            <li class="m-list_item">
-             {{ nav_link.render(item.id + " " + item.header, "#" + item.id, true) }}
+             {{ nav_link.render(item.id + ". " + item.header, "#" + item.id, true) }}
 	   {% if item.children %}
              <ul class="m-list
                         m-list__unstyled
@@ -39,7 +39,7 @@
                         o-secondary-navigation_list__children">
 	     {%- for child in item.children %}
                <li class="m-list_item">
-                 {{ nav_link.render(child.id + " " + child.header, "#" + child.id, false) }}
+                 {{ nav_link.render(child.id + ". " + child.header, "#" + child.id, false) }}
                </li>
 	     {%- endfor %}
              </ul>


### PR DESCRIPTION
Previously, a section ID for a part of a FIG document would be something like `3.1.2.` (including the trailing dot). Now, the section ID for the same section would be `3.1.2` (without a trailing dot).

With this PR, an anchor link to an individual section of the FIG won't include a trailing dot (which was weird), but the body of the page will still have the dot in headers and the table of contents. Now, the dot is added by the Jinja template.


## How to test this PR

1. Make a FIG Content page
2. Add a few sections at different levels
3. View or preview the page
4. See that the section headers (in both the table of contents and the main body of the page) still have a dot after the section ID
5. Click a TOC link or section header, see that the anchor ID in the URL does not have a dot at the end


## Screenshots

![Screen Shot 2022-07-12 at 3 01 39 PM](https://user-images.githubusercontent.com/4295388/178573656-82dc28dc-beb2-43ae-8c19-cebc90fd080f.png)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance