### PR TITLE
Only show fahc map if a valid zipcode has been entered

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -176,14 +176,16 @@
                                 {% endif %}
 
                             </div>
-                            <div class="hud-search-container_map">
-                                <!-- Mapbox map is ignored during voiceover navigation
-                                     as set by aria-hidden. -->
-                                <div id="hud_hca_api_map_container"
-                                     aria-hidden="true">
-                                    <div id="hud_hca_api_map_canvas"></div>
-                                </div><!-- end .hud_hca_api_map -->
-                            </div>
+                            {% if zipcode and zipcode_valid %}
+                              <div class="hud-search-container_map">
+                                  <!-- Mapbox map is ignored during voiceover navigation
+                                       as set by aria-hidden. -->
+                                  <div id="hud_hca_api_map_container"
+                                       aria-hidden="true">
+                                      <div id="hud_hca_api_map_canvas"></div>
+                                  </div><!-- end .hud_hca_api_map -->
+                              </div>
+                            {% endif %}
                         </section>
 
                     </div>

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -10,6 +10,10 @@
   height: 320px;
 }
 
+#hud_hca_api_query {
+  max-width: unit( 480px / @base-font-size-px, em );
+}
+
 .respond-to-min( @bp-med-min, {
   .hud-search-container {
     display: flex;

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.less
@@ -73,7 +73,7 @@
     }
   }
 
-  #hud_hca_api_map_container,
+  .hud-search-container_map,
   #hud_print-page-link {
     display: none;
   }

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -12,7 +12,7 @@ HUD Counselors by zip code. See hud_api_replace for more details on the
 API queries. -wernerc */
 
 // Set up print results list button functionality, if it exists.
-const printPageLink = document.querySelector( '#hud_print-page-link' );
+const printPageLink = document.getElementById( 'hud_print-page-link' );
 if ( printPageLink ) {
   printPageLink.addEventListener( 'click', evt => {
     evt.preventDefault();
@@ -64,7 +64,7 @@ function initializeMap() {
   );
 
   if ( showMap ) {
-    const fcm = document.querySelector( '#hud_search_container' );
+    const fcm = document.getElementById( 'hud_search_container' );
     fcm.classList.remove( 'no-js' );
     window.L.mapbox.accessToken = mapboxAccessToken;
     map = window.L.mapbox.map( 'hud_hca_api_map_container' )
@@ -85,10 +85,10 @@ function initializeMap() {
  * @returns {HTMLNode} The DOM node of the result item.
  */
 function queryMarkerDom( num ) {
-  const selector = '#hud-result-' + Number.parseInt( num, 10 );
+  const selector = 'hud-result-' + Number.parseInt( num, 10 );
   let cachedItem = markerDomCache[selector];
   if ( typeof cachedItem === 'undefined' ) {
-    cachedItem = document.querySelector( selector );
+    cachedItem = document.getElementById( selector );
     markerDomCache[selector] = cachedItem;
   }
 

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -85,11 +85,11 @@ function initializeMap() {
  * @returns {HTMLNode} The DOM node of the result item.
  */
 function queryMarkerDom( num ) {
-  const selector = 'hud-result-' + Number.parseInt( num, 10 );
-  let cachedItem = markerDomCache[selector];
+  const id = 'hud-result-' + Number.parseInt( num, 10 );
+  let cachedItem = markerDomCache[id];
   if ( typeof cachedItem === 'undefined' ) {
-    cachedItem = document.getElementById( selector );
-    markerDomCache[selector] = cachedItem;
+    cachedItem = document.getElementById( id );
+    markerDomCache[id] = cachedItem;
   }
 
   return cachedItem;

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -59,15 +59,21 @@ function scriptLoaded( evt ) {
  * Set access map options and create map.
  */
 function initializeMap() {
-  const fcm = document.querySelector( '#hud_search_container' );
-  fcm.classList.remove( 'no-js' );
-  window.L.mapbox.accessToken = mapboxAccessToken;
-  map = window.L.mapbox.map( 'hud_hca_api_map_container' )
-    .setView( [ 40, -80 ], 2 )
-    .addLayer( window.L.mapbox.styleLayer( 'mapbox://styles/mapbox/streets-v11' ) );
+  const showMap = Boolean(
+    document.getElementById( 'hud_hca_api_map_container' )
+  );
 
-  if ( hudData.counseling_agencies ) {
-    updateMap( hudData );
+  if ( showMap ) {
+    const fcm = document.querySelector( '#hud_search_container' );
+    fcm.classList.remove( 'no-js' );
+    window.L.mapbox.accessToken = mapboxAccessToken;
+    map = window.L.mapbox.map( 'hud_hca_api_map_container' )
+      .setView( [ 40, -80 ], 2 )
+      .addLayer( window.L.mapbox.styleLayer( 'mapbox://styles/mapbox/streets-v11' ) );
+
+    if ( hudData.counseling_agencies ) {
+      updateMap( hudData );
+    }
   }
 }
 


### PR DESCRIPTION
Currently, we load the mapbox map on the find-a-housing-counselor page before a search has been performed. This is unnecessary and possibly distracting, as the only reason to show the map is to display the results of a search for housing counselors.

This change makes keeps the map element out of the page unless there is a valid zipcode and adds a check for this element in the JS before attempting to initialize the map.

There's also a small CSS tweak to keep everything consistent across JS/no-js views

Update: also clamps the input to 30em (480px).

default page:
<img width="1230" alt="Screen Shot 2022-07-13 at 11 46 23 AM" src="https://user-images.githubusercontent.com/1558033/178777282-c4151f57-f34c-4402-8378-09c6f8d0f40a.png">


valid zip:
<img width="1206" alt="Screen Shot 2022-07-13 at 10 43 23 AM" src="https://user-images.githubusercontent.com/1558033/178765371-05f28d76-5081-4689-891a-ccebba09c20e.png">

invalid zip:
<img width="1209" alt="Screen Shot 2022-07-13 at 11 49 29 AM" src="https://user-images.githubusercontent.com/1558033/178777363-52c1d08b-d952-4103-a002-1c6989eb48f2.png">


## Testing

- Pull and build
- visit [fahc page](http://localhost:8000/find-a-housing-counselor/) and note appearance. Check requests to mapbox don't exist (other than pulling in the api js/css).
- Make a search, note appearance.