### PR TITLE
Set font-smoothing to anti-aliased

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -153,3 +153,7 @@
 }
 
 @horizontal-rule: @gray-40;
+
+body {
+  -webkit-font-smoothing: antialiased;
+}


### PR DESCRIPTION
This syncs font appearance between MacOS and mobile/windows/linux.

## Testing:
 - Pull and build
 - Open localhost:8000 in one tab and https://www.consumerfinance.gov/ in another
 - Note the sharper lines in localhost
 - From an internal phone or citrix session, compare dev5 (where this branch is deployed) to https://www.consumerfinance.gov/. They should appear identical. This shows that this change is bringing webkit browsers on MacOS in line with how everyone else already experiences the site.