### PR TITLE
Add a `wait` to email signup functional test

### DIFF
--- a/test/cypress/integration/components/email-signup/email-signup.js
+++ b/test/cypress/integration/components/email-signup/email-signup.js
@@ -8,6 +8,8 @@ describe( 'Email Sign Up', () => {
     page.open();
     // Act
     page.signUp( 'testing@cfpb.gov' );
+    // Let the request process
+    cy.wait( 500 );
     // Assert
     page.successNotification().should( 'exist' );
     page.successNotification().contains( 'Your submission was successfully received.' );


### PR DESCRIPTION
This small change adds a `wait` to our email signup tests between the signup submission and checking for the success notification. Previously, we were seeing occasional failures to find the success notification, and observing the results in Cypress, it seems to be because Cypress gets to the success check before the success notification has rendered.

This wait seems to fix it against staging, which is the only place I was able to reproduce the issue with any regularity.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
