### PR TITLE
Add additional documentation around Helm and AWS CLI

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -128,3 +128,26 @@ The main container should be created, and skip migrations
 (assuming a user was created `SELECT COUNT(*) FROM auth_user`).
 The main container should now be loaded with Postgres and ElasticSearch with
 your manually loaded data.
+
+# AWS CLI
+To use the AWS CLI, the chart must be deployed with `$HOME/.aws` mounted,
+or with keys and tokens passed in via environment variables or mounted in
+the correct files within `/root/.aws` for `local` image, or `/var/www/.aws`
+for the `prod` image. You can also mount the secrets to a different path
+and set `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` variables,
+pointing to the appropriate files. More info on AWS CLI Environment
+Variables can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
+
+Currently, `local.yaml` override will mount your `.aws` directory to the
+containers for local development. This directory is mounted to
+`/var/run/secrets/.aws`, then `AWS_CONFIG_FILE` and
+`AWS_SHARED_CREDENTIALS_FILE` are set to the appropriate files within that
+directory. To make use of AWS CLI in the containers locally, you will need
+to run your `gimme-aws-creds` in your local terminal to get valid credentials
+locally. AWS CLI will then work within the containers.
+
+## TODO
+In production, an AWS Service Account is used, and its credentials are
+mounted within the containers to `/var/run/secrets/.aws`, then
+`AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` are set to the appropriate
+files within that directory.

--- a/helm/overrides/local.yaml
+++ b/helm/overrides/local.yaml
@@ -33,7 +33,7 @@ volumes:
       hostPath:
         path: ${HOME}/.aws
         type: Directory
-    mountPath: /root/.aws
+    mountPath: /var/run/secrets/.aws
 
 importDbPath: "${CFGOV_PROD_DB_LOCATION}"
 
@@ -42,6 +42,10 @@ extraEnvs:
     value: "${DJANGO_ADMIN_USERNAME}"
   - name: DJANGO_ADMIN_PASSWORD
     value: "${DJANGO_ADMIN_PASSWORD}"
+  - name: AWS_CONFIG_FILE
+    value: /var/run/secrets/.aws/config
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: /var/run/secrets/.aws/credentials
 
 cronJobs:
   - name: "publish-scheduled-pages"


### PR DESCRIPTION
Adds additional documentation on how we mount and use AWS credentials for AWS CLI.

Also moved mounting of `.aws` to `/var/run/secrets/.aws`, and sets the appropriate environment variables accordingly. This will help to prevent issues with using different users within the container (local vs local-prod,  root vs apache, etc). 


## How to test this PR

1. Run `./build-images.sh && ./helm-install.sh` to deploy the chart. 
2. Get valid credentials locally using your `gimme-aws-creds` per usual.
3. `exec` into the cfgov pod/container and use `aws`, or create a cronjob/job that uses `aws`. 


## Screenshots


## Notes and todos

- We still will need to implement a way to mount in an AWS Service Account credentials set. 
