### PR TITLE
Further improvements to Elasticsearch Environment Variables template

### DIFF
--- a/helm/cfgov/templates/_helpers.tpl
+++ b/helm/cfgov/templates/_helpers.tpl
@@ -113,14 +113,11 @@ Elasticsearch Environment Vars
 {{- else }}
   value: "{{ include "elasticsearch.uname" .Subcharts.elasticsearch | trunc 63 | trimSuffix "-" }}"
 {{- end }}
-- name: ES_PORT
-  value: "{{ default "9200" .Values.elasticsearch.httpPort }}"
 {{- else }}
-- name: ES_HOST
   value: "{{ default "elasticsearch-master" .Values.elasticsearch.externalHostname }}"
+{{- end }}
 - name: ES_PORT
   value: "{{ default "9200" .Values.elasticsearch.httpPort }}"
-{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/cfgov/templates/cronjob.yaml
+++ b/helm/cfgov/templates/cronjob.yaml
@@ -40,16 +40,7 @@ spec:
                 {{- end }}
               env:
                 {{- include "cfgov.postgresEnv" $ | nindent 16}}
-                {{- if $.Values.elasticsearch.enabled }}
-                - name: ES_HOST
-                  {{- if $.Values.elasticsearch.nameOverride }}
-                  value: "{{ $.Values.elasticsearch.nameOverride }}-master"
-                  {{- else if $.Values.elasticsearch.fullnameOverride }}
-                  value: {{ $.Values.elasticsearch.fullnameOverride | quote }}
-                  {{- else }}
-                  value: elasticsearch-master
-                  {{- end }}
-                {{- end }}
+                {{- include "cfgov.elasticsearchEnv" $ | nindent 16 }}
                 {{- range $.Values.extraEnvs }}
                 - name: {{ .name }}
                   value: {{ .value | quote }}


### PR DESCRIPTION
* Further improves upon the `cfgov.elasticsearchEnv` helper template
* Use `cfgov.elasticsearchEnv` helper template in `cronjob.yaml` template.