### PR TITLE
Remove unneeded svg width to fix mobile wrap

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -435,7 +435,6 @@ body {
         display: inline;
         color: @pacific;
         margin-right: 10px;
-        width: 100%;
       }
     }
   }


### PR DESCRIPTION
At mobile, there is an unsightly wrapping of the first item in the mega-menu, see below:
<img width="492" alt="Screen Shot 2022-08-11 at 8 57 45 AM" src="https://user-images.githubusercontent.com/1558033/184138912-2a513d13-a0db-4c45-a2e7-9d5dfde60682.png">

This fixes it to now appear as:
<img width="488" alt="Screen Shot 2022-08-11 at 8 57 35 AM" src="https://user-images.githubusercontent.com/1558033/184138961-fadcbf01-82af-4f6b-bf5f-eb338b46d595.png">

There should be no other major differences to the megamenu at any screen size.