### PR TITLE
Remove direct RPM install from NodeSource

### DIFF
--- a/docker/deployable-zipfile/Dockerfile
+++ b/docker/deployable-zipfile/Dockerfile
@@ -24,7 +24,6 @@ RUN mkdir -p ${HOME} && chmod 777 ${HOME}
 # Python 3 to be enabled at login.
 RUN yum -y update && \
     yum install -y centos-release-scl && \
-    rpm -i https://rpm.nodesource.com/pub_16.x/el/7/x86_64/nodejs-16.13.1-1nodesource.x86_64.rpm && \
     curl -sL https://rpm.nodesource.com/setup_16.x | bash - && \
     curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     yum install -y rh-python38 gcc git nodejs yarn && \


### PR DESCRIPTION
It looks like there’s an upstream issue with `nodejs-16.13.1-1nodesource.x86_64.rpm` at NodeSource. Installing this RPM directly results in a “Package does not match intended download” error from rpm.

It’s [not just us having the issue](https://github.com/nodesource/distributions/issues/1432), and from the directory listing, that file was updated yesterday.

Removing the direct install, which was added in #6747 mitigates the issue, and I don’t see a return of that error message without it that #6747 intended to fix.

## How to test this PR

`docker/deployable-zipfile/build.sh` should successfully build the deployable zip file.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
