### PR TITLE
added beforeEach hook to FIG tests to test page response

### DIFF
--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -9,6 +9,15 @@ skipOn( 'staging', () => {
 
     describe( 'FIG table of contents', () => {
 
+      // putting a request in a beforeEach hook will cause the rest of the
+      // spec to be skipped if the response is not ok.
+      beforeEach( () => {
+        cy.request( {
+          url: '/compliance/compliance-resources/small-business-lending/1071-filing-instruction-guide/',
+          failOnStatusCode: true
+        } )
+      } );
+
       context( 'Desktop experience', () => {
 
         const desktops = [

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -11,7 +11,7 @@ skipOn( 'staging', () => {
 
       // putting a request in a beforeEach hook will cause the rest of the
       // spec to be skipped if the response is not ok.
-      beforeEach( () => {
+      before( () => {
         cy.request( {
           url: '/compliance/compliance-resources/small-business-lending/1071-filing-instruction-guide/',
           failOnStatusCode: true


### PR DESCRIPTION
Added a beforeEach hook to the FIG cypress test file which tests the page response. If the status is not 2xx or 3xx, the beforeEach hook will fail, causing the remaining tests to be skipped, but the first test will show a failure.


## Additions

- Added beforeEach hook in filing-instruction-guide.cy.js

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)