### PR TITLE
add README.md to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@
 !initial-data.sh
 !jest.config.js
 !package.json
+!README.md
 !refresh-data.sh
 !yarn.lock
 


### PR DESCRIPTION
added `README.md` to `.dockerignore` as a means to test if `.dockerignore` is the culprit behind issues in the images created in the docker image compose workflow. 

