### PR TITLE
Don't add bullet to 'reached maximum of five selections' note

### DIFF
--- a/cfgov/unprocessed/css/molecules/multiselect.less
+++ b/cfgov/unprocessed/css/molecules/multiselect.less
@@ -79,6 +79,7 @@ select.o-multiselect {
 
     &.u-max-selections:after {
       content: 'Reached maximum of five selections';
+      list-style: none;
     }
   }
 


### PR DESCRIPTION
Closes https://github.local/CFGOV/platform/issues/4366

Testing:
 - pull and build
 - go to localhost:8000/about-us/blog/
 - select five items in one of the limited fields
 - note no bullet in message (in SS below)
<img width="288" alt="Screen Shot 2022-08-24 at 11 41 51 AM" src="https://user-images.githubusercontent.com/1558033/186462384-6d2494a2-95e9-45c2-bc88-ee54ae01e16b.png">
