### PR TITLE
Add GitSHA image tagging

### DIFF
--- a/.github/workflows/publish_cfgov.yml
+++ b/.github/workflows/publish_cfgov.yml
@@ -46,6 +46,8 @@ jobs:
           echo VERSION=$VERSION
           SHA=${{ github.sha }}
           if [ ! -z $GITHUB_HEAD_REF ]; then
+            # This is done to get the branch commit SHA, not the PR merge SHA.
+            # We do this for better traceability and image:tag match up
             echo "PR Build, pop commit SHA..."
             SHA=$(git --no-pager log -n 2 --pretty="%H" | sed -n '2 p')
           fi

--- a/.github/workflows/publish_cfgov.yml
+++ b/.github/workflows/publish_cfgov.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build Root Docker Image
-        run: docker build . --file Dockerfile --tag $(echo "${{ github.repository }}" | sed -e 's,.*/\(.*\),\1,') --label "runnumber=${GITHUB_RUN_ID}" --label "GitSHA=${{ github.sha }}" --build-arg "FRONTEND_TARGET=production"
+        run: docker build . --file Dockerfile --tag $(echo "${{ github.repository }}" | sed -e 's,.*/\(.*\),\1,') --label "runnumber=${GITHUB_RUN_ID}" --build-arg "FRONTEND_TARGET=production"
 
       - name: GitHub Container Registry Login
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
@@ -42,5 +42,11 @@ jobs:
           [ "$VERSION" == "master" ] || [ "$VERSION" == "main" ] && VERSION=latest
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
+          SHA=${{ github.sha }}
+          if [ ! -z $GITHUB_HEAD_REF ]; then
+            SHA=$(git --no-pager log -n 3 --pretty="format:%H" | sed -n '3 p')
+          fi
+          docker tag $IMAGE_NAME $IMAGE_ID:${{ github.sha }}
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:${{ github.sha }}
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish_cfgov.yml
+++ b/.github/workflows/publish_cfgov.yml
@@ -19,6 +19,8 @@ jobs:
       DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
 
       - name: Build Root Docker Image
         run: docker build . --file Dockerfile --tag $(echo "${{ github.repository }}" | sed -e 's,.*/\(.*\),\1,') --label "runnumber=${GITHUB_RUN_ID}" --build-arg "FRONTEND_TARGET=production"
@@ -44,9 +46,11 @@ jobs:
           echo VERSION=$VERSION
           SHA=${{ github.sha }}
           if [ ! -z $GITHUB_HEAD_REF ]; then
-            SHA=$(git --no-pager log -n 3 --pretty="format:%H" | sed -n '3 p')
+            echo "PR Build, pop commit SHA..."
+            SHA=$(git --no-pager log -n 2 --pretty="%H" | sed -n '2 p')
           fi
-          docker tag $IMAGE_NAME $IMAGE_ID:${{ github.sha }}
+          echo "GitSHA: ${SHA}"
+          docker tag $IMAGE_NAME $IMAGE_ID:${SHA}
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:${{ github.sha }}
+          docker push $IMAGE_ID:${SHA}
           docker push $IMAGE_ID:$VERSION

--- a/helm-install.sh
+++ b/helm-install.sh
@@ -67,6 +67,7 @@ if [ ! -d ./helm/cfgov/charts ]; then
   echo "Building dependency charts..."
   helm repo add bitnami https://charts.bitnami.com/bitnami
   helm repo add elastic https://helm.elastic.co/
+  helm repo add opensearch https://opensearch-project.github.io/helm-charts/
   helm repo update
   helm dependency build ./helm/cfgov
 else

--- a/helm/cfgov/templates/NOTES.txt
+++ b/helm/cfgov/templates/NOTES.txt
@@ -5,6 +5,8 @@
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- else if .Values.mapping.enabled }}
+  https://{{ include "cfgov.fqdn" . }}/
 {{- else if contains "NodePort" .Values.service.type }}
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "cfgov.fullname" . }})
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")


### PR DESCRIPTION
Adds GitSHA tagging to Docker tags pushed to GHCR.
Canonical tags are still in place (`pr-#`, `latest`, `release`). 