### PR TITLE
ESLint: Prefer double quotes in JSX

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -744,7 +744,7 @@ rules:
   # Enforce whether double or single quotes should be used in JSX attributes.
   jsx-quotes:
     - 2
-    - prefer-single
+    - prefer-double
 
   # Enforce spacing between keys and values in object literal properties.
   key-spacing:


### PR DESCRIPTION
JSX looks like HTML and we double-quote attributes in HTML, so it seems like we should double-quote them in JSX as well.

## Changes

- Prefer double quotes in JSX


## How to test this PR

1. `yarn lint` should show no errors.
