### PR TITLE
External DB support, support for any db username with db dumps

### DIFF
--- a/helm/cfgov/templates/_helpers.tpl
+++ b/helm/cfgov/templates/_helpers.tpl
@@ -99,6 +99,35 @@ Postgres Environment Vars
   value: "{{ include "postgresql.database" .Subcharts.postgresql | default "postgres" }}"
 - name: PGPORT
   value: "{{ include "postgresql.service.port" .Subcharts.postgresql }}"
+{{- else }}
+{{- if .Values.postgresql.auth.createSecret -}}
+- name: PGUSER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cfgov.fullname" . }}-postgres
+      key: username
+- name: PGPASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cfgov.fullname" . }}-postgres
+      key: password
+- name: PGDATABASE
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "cfgov.fullname" . }}-postgres
+      key: database
+{{- else }}
+- name: PGUSER
+  value: "{{ .Values.postgresql.auth.username | default "postgres" }}"
+- name: PGPASSWORD
+  value: {{ .Values.postgresql.auth.password | quote }}
+- name: PGDATABASE
+  value: "{{ .Values.postgresql.auth.database | default "postgres" }}"
+{{- end }}
+- name: PGHOST
+  value: {{ .Values.postgresql.external.host | quote }}
+- name: PGPORT
+  value: "{{ .Values.postgresql.external.port | default "5432" }}"
 {{- end }}
 {{- end }}
 

--- a/helm/cfgov/templates/postgres-secret.yaml
+++ b/helm/cfgov/templates/postgres-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.postgresql.auth.createSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cfgov.fullname" . }}-postgres
+  labels:
+    {{- include "cfgov.labels" . | nindent 4 }}
+data:
+  username: {{ .Values.postgresql.auth.username | b64enc }}
+  password: {{ .Values.postgresql.auth.password | b64enc }}
+  database: {{ .Values.postgresql.auth.database | b64enc }}
+{{- end }}

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -227,9 +227,17 @@ cronJobs:
     suspend: true
 
 
-
+# Postgres Values
 postgresql:
-  enabled: false
+  enabled: false  # Deploy child chart, if false, uses external host and port
+  auth:
+    # username: ""  # Used for both chart and external db's
+    # password: ""  # Used for both chart and external db's
+    # database: ""  # Used for both chart and external db's
+    createSecret: true  # Only valid when using external database
+  external:
+    host: ""
+    port: ""
   service:
     type: ClusterIP
 

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -56,6 +56,7 @@ refresh_data() {
     echo 'Importing refresh db'
     gunzip < "$refresh_dump_name" | cfgov/manage.py dbshell > /dev/null
     SCHEMA="$(gunzip -c $refresh_dump_name | grep -m 1 'CREATE SCHEMA' | sed 's/CREATE SCHEMA \(.*\);$/\1/')"
+    PGUSER="${PGUSER:-cfpb}"
     if [ "${PGUSER}" != "${SCHEMA}" ]; then
       echo "Adjusting schema name to match username..."
       echo "DROP SCHEMA IF EXISTS \"${PGUSER}\" CASCADE; \


### PR DESCRIPTION
### Findings
Some interesting finds with this one. When I am using a database where `PGUSER` does not match the dump files schema (the username from the dump), things don't work out so well. After the dump file is ingested, migrations apply to `public` schema, and not the dump username schema. After doing some research, Django doesn't have a great way to support having a different schema. There is an `OPTIONS` key that you can set, but found it to be more problematic with how we are ingesting the dump file that has the schema name hard coded. 

Instead, I have modified `refresh-data.sh` to do a quick lightweight check to get the schema name from the dump file, and check to see if it matches `PGUSER`. If not, it will delete `PGUSER` schema (since this is a dump ingestion, this is what happens with the dump too), and then `ALTER SCHEMA` to rename the detected dump schema, to `PGUSER`. 

Seemingly, Django will look for a schema with the `PGUSER` name, and use that, if not, it uses `public`. I never found any great documentation that explains this behavior, and just happened to figure it out via trial and error.


### Changes
* Adds support for external DBs in the Helm chart (only supported the child chart before).
* Adjusts `refresh-data.sh` to alter the schema name to match `PGUSER`, if different than the schema used in the dump file.