### PR TITLE
Fix CronJob name when longer than 52 char

### DIFF
--- a/helm/cfgov/templates/cronjob.yaml
+++ b/helm/cfgov/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "cfgov.fullname" $ | lower }}-cronjob-{{ .name | lower }}
+  name: {{ printf "%s-%s" (include "cfgov.fullname" $) .name | trunc 52 | trimSuffix "-" | lower }}
   labels:
     {{- include "cfgov.labels" $ | nindent 4 }}
 spec:
@@ -16,7 +16,7 @@ spec:
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
           containers:
-            - name: {{ $.Chart.Name | lower }}-cronjob-{{ .name | lower }}
+            - name: {{ printf "%s-%s" $.Chart.Name .name | lower }}
               {{- if .image }}
               image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"
               imagePullPolicy: {{ default "IfNotPresent" .image.pullPolicy }}


### PR DESCRIPTION
This truncates the generated CronJob name to 52 characters to adhere to the naming limitation for CronJobs. Also removes the redundant "cronjob" part of the name.

> When creating the manifest for a CronJob resource, make sure the name you provide is a valid [DNS subdomain name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names#dns-subdomain-names). The name must be no longer than 52 characters. This is because the CronJob controller will automatically append 11 characters to the job name provided and there is a constraint that the maximum length of a Job name is no more than 63 characters.
