### PR TITLE
CronJob History Limits

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -268,20 +268,22 @@ locally. AWS CLI will then work within the containers.
 
 ## Testing
 
-To run tests in helm use `helm test <deployment_name>`. 
+To run tests in helm use `helm test <release_name>`.
 
-To create a test from a `pod.yaml`, add
-```
-metadata:
-  name: <test_name>
-  label: <test_label>
-  annotations:    
-    "helm.sh/hook": test
-``` 
+To add new tests, follow the template provided by Helm in the
+[Example Test Section](https://helm.sh/docs/topics/chart_tests/#example-test)
+of the [Helm Chart Tests](https://helm.sh/docs/topics/chart_tests/)
+documentation.
 
-To exclude certain tests from running use `helm test --filter strings name=<test_name>`.  Additionally you can disable tests from within in the `values.yaml` but **only** for tests that the charts have added (i.e. the ElasticSearch Chart and Postgres Chart). You will need to look up that chart's respective documentation for how to do that.  
+To exclude certain tests from running use
+`helm test --filter strings name=<test_name>`. However, you can disable tests
+from within in the `values.yaml` but **only** for tests that the charts have
+added (i.e. the ElasticSearch Chart and Postgres Chart). You will need to
+look up that chart's respective documentation for how to do that.
 
-More can be found on helm testing [here](https://helm.sh/docs/topics/chart_tests/) or by running `helm test --help`. 
+More can be found on Helm Chart Tests
+[here](https://helm.sh/docs/topics/chart_tests/) or by running
+`helm test --help`.
 
 
 ## TODO

--- a/helm/README.md
+++ b/helm/README.md
@@ -171,6 +171,8 @@ for a cronJob object.
   image:  # ONLY define if different from cfgov_python
     repository: cfogv_python  # default is the chart image repository
     tag: ""  # default is the chart image tag
+  successfulJobsHistoryLimit: 1  # default
+  failedJobsHistoryLimit: 1  # default
   schedule: "@daily"  # default
   suspend: false  # default
   restartPolicy: OnFailure  # default

--- a/helm/cfgov/templates/cronjob.yaml
+++ b/helm/cfgov/templates/cronjob.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   suspend: {{ default false .suspend }}
   schedule: {{ default "@daily" .schedule | quote }}
+  successfulJobsHistoryLimit: {{ default 1 .successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -183,6 +183,8 @@ cronJobs:
 #      repository: "busybox"
 #      tag: "latest"
 #    schedule: "@daily"  # default
+#    successfulJobsHistoryLimit: 1
+#    failedJobsHistoryLimit: 1
 #    suspend: false  # default
 #    restartPolicy: OnFailure  # default
 #    command:

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -204,17 +204,17 @@ cronJobs:
     args:
       - "clearsessions"
   - name: "publish-scheduled-pages"
-    schedule: '* * * * *' # every minute
+    schedule: '* * * * *'  # every minute
     command:
       - "django-admin"
     args:
       - "publish_scheduled_pages"
-  - name: "archive-wagtail-events" #archive cfpb events posted on https://www.consumerfinance.gov/about-us/events/
-    schedule: '23 * * * *' 
+  - name: "archive-wagtail-events"  # archive cfpb events posted on https://www.consumerfinance.gov/about-us/events/
+    schedule: '23 * * * *'
     command:
       - "django-admin"
     args:
-      - "archive_events" #function found in cfgov/v1/management/commands/archive_events.py
+      - "archive_events"  # function found in cfgov/v1/management/commands/archive_events.py
   - name: "elasticsearch-Rebuild-Index"
     schedule: "@daily"
     command:


### PR DESCRIPTION
This adds the `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` options to the `cronjob.yaml` template.
Also sets the default value for both of these, to `1`. This helps to keep from having 3 successful pods for each cronjob sitting there. 