### PR TITLE
Switch to mapping for CronJobs

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -147,14 +147,14 @@ TODO: Add Table with commonly overridden values.
 To make a new
 [Kubernetes CronJob](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/)
 based on our [CronJob template](cfgov/templates/cronjob.yaml),
-add a new item to the cronJobs array in
+add a new item to the cronJobs mapping in
 [`cfgov/values.yaml`](cfgov/values.yaml).
 
 For example, our Django
 `clearsessions` management command runs in a cron job defined like this:
 
 ```yaml
-- name: "clearSessions"
+clear-sessions:
   schedule: "@daily"
   command:
     - "django-admin"
@@ -166,7 +166,8 @@ The following shows the all the available values and default values
 for a cronJob object.
 
 ```yaml
-- name: ""  # There is no default for name, this is required
+example-job-name:  # There is no default for name, this is required
+  enabled: true  # default is true. If false, will not create the CronJob resource
   includeEnv: true  # includes the same volumes and environment variables as the main application container
   image:  # ONLY define if different from cfgov_python
     repository: cfogv_python  # default is the chart image repository

--- a/helm/cfgov/templates/cronjob.yaml
+++ b/helm/cfgov/templates/cronjob.yaml
@@ -1,16 +1,17 @@
-{{- range .Values.cronJobs }}
+{{- range $jobName, $values := .Values.cronJobs }}
+{{- if or $values.enabled (not (hasKey $values "enabled")) }}
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ printf "%s-%s" (include "cfgov.fullname" $) .name | trunc 52 | trimSuffix "-" | lower }}
+  name: {{ printf "%s-%s" (include "cfgov.fullname" $) $jobName | trunc 52 | trimSuffix "-" | lower }}
   labels:
     {{- include "cfgov.labels" $ | nindent 4 }}
 spec:
-  suspend: {{ default false .suspend }}
-  schedule: {{ default "@daily" .schedule | quote }}
-  successfulJobsHistoryLimit: {{ default 1 .successfulJobsHistoryLimit }}
-  failedJobsHistoryLimit: {{ default 1 .failedJobsHistoryLimit }}
+  suspend: {{ default false $values.suspend }}
+  schedule: {{ default "@daily" $values.schedule | quote }}
+  successfulJobsHistoryLimit: {{ default 1 $values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ default 1 $values.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:
@@ -18,24 +19,24 @@ spec:
           securityContext:
             {{- toYaml $.Values.securityContext | nindent 12 }}
           containers:
-            - name: {{ printf "%s-%s" $.Chart.Name .name | lower }}
-              {{- if .image }}
-              image: "{{ .image.repository }}:{{ .image.tag | default "latest" }}"
-              imagePullPolicy: {{ default "IfNotPresent" .image.pullPolicy }}
+            - name: {{ printf "%s-%s" $.Chart.Name $jobName | lower }}
+              {{- if $values.image }}
+              image: "{{ $values.image.repository }}:{{ $values.image.tag | default $.Chart.AppVersion }}"
+              imagePullPolicy: {{ default "IfNotPresent" $values.image.pullPolicy }}
               {{- else }}
               image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
               imagePullPolicy: {{ $.Values.image.pullPolicy }}
               {{- end }}
               command:
-                {{- range .command }}
+                {{- range $values.command }}
                 - {{ . | quote }}
                 {{- end }}
               args:
-                {{- range .args }}
+                {{- range $values.args }}
                 - {{ . | quote }}
                 {{- end }}
               volumeMounts:
-                {{- if or .includeEnv (not (hasKey . "includeEnv")) }}
+                {{- if or $values.includeEnv (not (hasKey $values "includeEnv")) }}
                 # Add in main container volumes
                 {{- range $.Values.volumes }}
                 - mountPath: {{ .mountPath }}
@@ -43,12 +44,12 @@ spec:
                 {{- end }}
                 {{- end }}
                 # Add in the cronjob volumes
-                {{- range .volumes }}
+                {{- range $values.volumes }}
                 - mountPath: {{ .mountPath }}
                   name: {{ .name }}
                 {{- end }}
               env:
-                {{- if or .includeEnv (not (hasKey . "includeEnv")) }}
+                {{- if or $values.includeEnv (not (hasKey $values "includeEnv")) }}
                 {{- include "cfgov.postgresEnv" $ | nindent 16 }}
                 {{- include "cfgov.searchEnv" $ | nindent 16 }}
                 {{- range $.Values.extraEnvs }}
@@ -56,13 +57,13 @@ spec:
                   value: {{ .value | quote }}
                 {{- end }}
                 {{- end }}
-                {{- range .env }}
+                {{- range $values.env }}
                 - name: {{ .name }}
                   value: {{ .value | quote }}
                 {{- end }}
-          restartPolicy: {{ default "OnFailure" .restartPolicy }}
+          restartPolicy: {{ default "OnFailure" $values.restartPolicy }}
           volumes:
-            {{- if or .includeEnv (not (hasKey . "includeEnv")) }}
+            {{- if or $values.includeEnv (not (hasKey $values "includeEnv")) }}
             # Add in main container volumes
             {{- range $.Values.volumes }}
             - name: {{ .name }}
@@ -70,8 +71,9 @@ spec:
             {{- end }}
             {{- end }}
             # Add in cronjob volumes
-            {{- range .volumes }}
+            {{- range $values.volumes }}
             - name: {{ .name }}
               {{- toYaml .volume | nindent 14 }}
             {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -177,14 +177,15 @@ docs:
 importDbPath: ""
 
 cronJobs:
-#  - name: "example"
+#  example-job:
+#    enabled: true  # default is true. If false, will not create the CronJob resource
 #    includeEnv: true  # includes the same volumes and environment variables as the main application container
 #    image:  # ONLY if different from chart image, default is chart image
 #      repository: "busybox"
 #      tag: "latest"
 #    schedule: "@daily"  # default
-#    successfulJobsHistoryLimit: 1
-#    failedJobsHistoryLimit: 1
+#    successfulJobsHistoryLimit: 1  # default
+#    failedJobsHistoryLimit: 1  # default
 #    suspend: false  # default
 #    restartPolicy: OnFailure  # default
 #    command:
@@ -197,26 +198,39 @@ cronJobs:
 #      - name: A_CRONJOB_ENV
 #        value: "A_CRONJOB_ENV_VALUE"
 
-  - name: "clearSessions"
-    schedule: "@weekly"
-    command:
-      - "django-admin"
-    args:
-      - "clearsessions"
-  - name: "publish-scheduled-pages"
-    schedule: '* * * * *'  # every minute
-    command:
-      - "django-admin"
-    args:
-      - "publish_scheduled_pages"
-  - name: "archive-wagtail-events"  # archive cfpb events posted on https://www.consumerfinance.gov/about-us/events/
+  archive-wagtail-events: # archive cfpb events posted on https://www.consumerfinance.gov/about-us/events/
     schedule: '23 * * * *'
     command:
       - "django-admin"
     args:
       - "archive_events"  # function found in cfgov/v1/management/commands/archive_events.py
-  - name: "elasticsearch-Rebuild-Index"
-    schedule: "@daily"
+
+  clear-sessions:
+    schedule: "@weekly"
+    command:
+      - "django-admin"
+    args:
+      - "clearsessions"
+
+  dump-db:
+    command:
+      - "bash"
+    args:
+      - "-c"
+      - >-
+        pg_dump --no-owner --no-privileges | \
+        gzip > test.sql.gz | \
+        aws s3 cp test.sql.gz s3://$S3_BUCKET/
+    suspend: true
+
+  publish-scheduled-pages:
+    schedule: '* * * * *'  # every minute
+    command:
+      - "django-admin"
+    args:
+      - "publish_scheduled_pages"
+
+  rebuild-search-index:
     command:
       - "bash"
     args:
@@ -224,14 +238,6 @@ cronJobs:
       - >-
         django-admin opensearch index --force rebuild &&
         django-admin opensearch document --force --refresh index
-    suspend: true
-  - name: "dump-Postgres-DB"
-    schedule: "@daily"
-    command:
-      - "bash"
-    args:
-      - "-c"
-      - "pg_dump --no-owner --no-privileges | gzip > test.sql.gz"
     suspend: true
 
 

--- a/helm/overrides/local-dev.yaml
+++ b/helm/overrides/local-dev.yaml
@@ -49,47 +49,17 @@ volumes:
     mountPath: /var/run/secrets/.aws
 
 cronJobs:
-  - name: "publish-scheduled-pages"
-    schedule: '@hourly'
-    command:
-      - "django-admin"
-    args:
-      - "publish_scheduled_pages"
+  archive-wagtail-events:
     suspend: true
 
-  - name: "archive-wagtail-events"
-    schedule: '23 * * * *'
-    command:
-      - "django-admin"
-    args:
-      - "archive_events"
+  clear-sessions:
     suspend: true
 
-  - name: "clearSessions"
-    schedule: "@daily"
-    command:
-      - "django-admin"
-    args:
-      - "clearsessions"
-
-  - name: "elasticsearch-Rebuild-Index"
-    schedule: "@daily"
-    command:
-      - "bash"
-    args:
-      - "-c"
-      - >-
-        django-admin opensearch index --force rebuild &&
-        django-admin opensearch document --force --refresh index
-
-  - name: "dump-Postgres-DB"
-    schedule: "@daily"
-    command:
-      - "bash"
-    args:
-      - "-c"
-      # supply the desired s3 bucket you wish to test with
-      - "pg_dump --no-owner --no-privileges | gzip > test.gz | aws s3 cp test.gz s3://$S3_BUCKET/"
-    restartPolicy: OnFailure
+  dump-db:
     suspend: true
 
+  publish-scheduled-pages:
+    suspend: true
+
+  rebuild-search-index:
+    suspend: true


### PR DESCRIPTION
We used to use an array to define CronJobs. This had limitations, especially in regards to override files. This PR swaps out the array, for mappings.

Array
```YAML
cronJobs:
  - name: job-a
    command: blah
  - name: job-b
    command: blah-b
```

Mapping
```YAML
cronJobs:
  job-a:
    command: blah
  job-b:
    command: blah-b
```

To override `job-a` before, you would have to redefine all CronJobs within the override file, or use `--set`, and select the job based on integer index. This is unreliable and can lead to problems, as well as being a pain to use. Now, to override `job-a`, you can just override the specific values of `cronJobs.job-a`, and no longer will you have to redefine the entire CronJobs list. 

In this example, we want to override `job-a` command.

Old override (using example from above), having to redefine the entire CronJobs list, because Helm doesn't merge arrays
```YAML
cronJobs:
  - name: job-a
    command: blah-new
  - name: job-b
    command: blah-b
```

Using `--set` targeting index, which Helm will fail to set properly if not using an override file with `cronJobs` defined. Helm, for some reason, cannot override the default array via `--set` when using an index.
```Bash
--set cronJobs[0].command=blah-new  # this also fails if not providing an override file with cronJobs
```

New override, Helm merges mappings much better
```YAML
cronJobs:
  job-a:
    command: blah-new
```

Using `--set` targeting the mapping
```Bash
--set cronJobs.job-a.command=blah-new  # can be used with or without an override file with cronJobs
```