### PR TITLE
Always source .env in docker (if it exists)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -f '.env' ] && [ -d /var/run/secrets/kubernetes.io ]; then
+if [ -f '.env' ]; then
   . '.env'
 fi
 


### PR DESCRIPTION
Fixes a bug where `.env` was sometimes not sourced