### PR TITLE
Always source .env

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -f '.env' ] && [ -d /var/run/secrets/kubernetes.io ]; then
+if [ -f '.env' ]; then
   . '.env'
 fi
 


### PR DESCRIPTION
Fixes an issue where `.env` doesn't get sourced on application start. We used to only force sourcing `.env` with `docker-entrypoint.sh` in Kubrenetes, but there is no reason we can't just always do it. 