### PR TITLE
Clean up Wagtail reports

### DIFF
--- a/cfgov/search/wagtail_hooks.py
+++ b/cfgov/search/wagtail_hooks.py
@@ -21,11 +21,10 @@ def register_external_links_url():
     ]
 
 
-@hooks.register("register_admin_menu_item")
+@hooks.register("register_reports_menu_item")
 def register_external_links_menu():
     return MenuItem(
-        "External links",
+        "External Links",
         reverse("external-links"),
         classnames="icon icon-link",
-        order=10000,
     )

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -72,7 +72,7 @@ def generate_filename(type):
 
 class PageMetadataReportView(PageReportView):
     header_icon = "doc-empty-inverse"
-    title = "Metadata for live pages"
+    title = "Page Metadata (for Live Pages)"
 
     list_export = PageReportView.list_export + [
         "url",
@@ -118,7 +118,7 @@ class PageMetadataReportView(PageReportView):
 
 class DocumentsReportView(ReportView):
     header_icon = "doc-full"
-    title = "All documents"
+    title = "Documents"
 
     list_export = [
         "id",
@@ -157,7 +157,7 @@ class DocumentsReportView(ReportView):
 
 class ImagesReportView(ReportView):
     header_icon = "image"
-    title = "All images"
+    title = "Images"
 
     list_export = [
         "title",
@@ -197,8 +197,8 @@ class ImagesReportView(ReportView):
 
 
 class EnforcementActionsReportView(ReportView):
-    header_icon = "doc-full"
-    title = "Enforcement actions report"
+    header_icon = "form"
+    title = "Enforcement Actions"
 
     list_export = [
         "title",
@@ -243,7 +243,7 @@ class EnforcementActionsReportView(ReportView):
 
 class AskReportView(ReportView):
     header_icon = "help"
-    title = "Ask CFPB report"
+    title = "Ask CFPB"
 
     list_export = [
         "answer_base",

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from django.conf import settings
 from django.contrib import admin
@@ -288,20 +289,15 @@ def register_ask_report_url():
 
 
 @hooks.register("construct_reports_menu")
+# Alphabetizie and title case report menu items
 def clean_up_report_menu_items(request, report_menu_items):
-    item_labels = []
-    for item in report_menu_items:
-        if item.label == "Site history":
-            item.label = "Site History"
-        if item.label == "Workflow tasks":
-            item.label = "Workflow Tasks"
-        item_labels.append(item.label)
-    item_labels.sort()
-    for index, label in enumerate(item_labels):
-        menu_item = next(
-            (item for item in report_menu_items if item.label == label), None
-        )
-        menu_item.order = index
+    cfpb_re = r"CFPB"
+    report_menu_items.sort(key=lambda item: item.label)
+    for index, item in enumerate(report_menu_items):
+        item.label = item.label.title()
+        if re.search(cfpb_re, item.label, re.IGNORECASE):
+            item.label = re.sub(cfpb_re, "CFPB", item.label, 0, re.IGNORECASE)
+        item.order = index
 
 
 def get_resource_tags():

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -193,7 +193,6 @@ def register_page_metadata_report_menu_item():
         "Page Metadata",
         reverse("page_metadata_report"),
         classnames="icon icon-" + PageMetadataReportView.header_icon,
-        order=700,
     )
 
 
@@ -214,7 +213,6 @@ def register_documents_report_menu_item():
         "Documents",
         reverse("documents_report"),
         classnames="icon icon-" + DocumentsReportView.header_icon,
-        order=700,
     )
 
 
@@ -235,7 +233,6 @@ def register_enforcements_actions_report_menu_item():
         "Enforcement Actions",
         reverse("enforcement_report"),
         classnames="icon icon-" + EnforcementActionsReportView.header_icon,
-        order=700,
     )
 
 
@@ -256,7 +253,6 @@ def register_images_report_menu_item():
         "Images",
         reverse("images_report"),
         classnames="icon icon-" + ImagesReportView.header_icon,
-        order=700,
     )
 
 
@@ -277,7 +273,6 @@ def register_ask_report_menu_item():
         "Ask CFPB",
         reverse("ask_report"),
         classnames="icon icon-" + AskReportView.header_icon,
-        order=700,
     )
 
 
@@ -290,6 +285,23 @@ def register_ask_report_url():
             name="ask_report",
         ),
     ]
+
+
+@hooks.register("construct_reports_menu")
+def clean_up_report_menu_items(request, report_menu_items):
+    item_labels = []
+    for item in report_menu_items:
+        if item.label == "Site history":
+            item.label = "Site History"
+        if item.label == "Workflow tasks":
+            item.label = "Workflow Tasks"
+        item_labels.append(item.label)
+    item_labels.sort()
+    for index, label in enumerate(item_labels):
+        menu_item = next(
+            (item for item in report_menu_items if item.label == label), None
+        )
+        menu_item.order = index
 
 
 def get_resource_tags():

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -197,7 +197,8 @@ export class AdminPage {
   }
 
   openExternalLinks() {
-    this.openNavigationTab( 'External links' );
+    this.openNavigationTab( 'Reports' );
+    this.selectSubMenu( 'External Links' );
   }
 
   searchExternalLink( link ) {


### PR DESCRIPTION
We've added a lot of Wagtail reports in the last year or so, but we haven't done much to keep the reports and the reports menu consistent and organized. This PR cleans up reports by doing a few things:

- Alphabetizes and title cases items in the reports menu
- Gives each report a unique icon for easier scanning
- Makes report titles more consistent
- Moves the external link search into the reports menu (the link search tool is still the same, this just moves it's menu item into the reports menu rather than hanging out at the bottom of the main menu)

---

## Additions

- `construct_reports_menu` Wagtail hook to keep items in the reports menu title cased and alphabetized no matter where they come from

## Removals

- `order` attribute from all of our custom reports since order is now handled automatically in `construct_reports_menu`

## Changes

- Minor updates to report titles and icons
- Wagtail admin functional test that checks the external link search to find the link in a submenu instead of the top-level menu

## How to test this PR

1. Open up the reports menu in the Wagtail admin
2. Confirm the menu items in there look like the screenshot: alphabetized, title cased, and with unique icons
3. Make sure the report menu items still take you to the right reports (including the external links item, which should still take you to the old external link search tool instead of a proper Wagtail report)

## Screenshots

![reports-menu](https://user-images.githubusercontent.com/1862695/189425622-633c66df-9de0-43b8-92d4-4c1691201447.png)

## Notes and todos

- We added the Ask CFPB report in #7212, which means the old "Export Ask data" item can be removed now. That will be done in a subsequent PR.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets