### PR TITLE
Remove additional redundant title check in filter-blog-posts functional test

### DIFF
--- a/test/cypress/integration/components/filterable-lists/filter-blog-posts.cy.js
+++ b/test/cypress/integration/components/filterable-lists/filter-blog-posts.cy.js
@@ -417,9 +417,6 @@ describe( 'Filter Blog Posts based on content', () => {
         blog.resultsHeaderContent().should(
           'contain', category.get( 0 ).innerText.split( '\n' ).pop().trim()
         );
-        // And the page url should contain "title=" title
-        const plusTitle = title.get( 0 ).innerText.split( ' ' ).join( '+' );
-        cy.url().should( 'include', 'title=' + plusTitle );
         // And the page url should contain "categories=" category
         cy.url().should(
           'include',
@@ -453,9 +450,6 @@ describe( 'Filter Blog Posts based on content', () => {
           ).toLowerCase() ).then( label => {
           blog.resultsContent().should( 'contain', label.get( 0 ).innerText );
         } );
-        // And the page url should contain "title=" title
-        const plusTitle = title.get( 0 ).innerText.split( ' ' ).join( '+' );
-        cy.url().should( 'include', 'title=' + plusTitle );
         // And the page url should contain "topics=" topic
         cy.url().should(
           'include',
@@ -490,9 +484,6 @@ describe( 'Filter Blog Posts based on content', () => {
           date.get( 0 ).getAttribute( 'datetime' ).split( '-' )[0]
         );
         blog.resultsContent().should( 'contain', title.get( 0 ).innerText );
-        // And the page url should contain "title=loans"
-        const plusTitle = title.get( 0 ).innerText.split( ' ' ).join( '+' );
-        cy.url().should( 'include', 'title=' + plusTitle );
         // And the page url should contain "from_date=2020-01-01"
         cy.url().should(
           'include',


### PR DESCRIPTION
This change removes some additional checks for the `title` parameter in the URL after the `title` field is checked in the filterable list controls. The `title` parameter check was failing occasionally due to URL-encoding of the title. The title parameter check seems redundant given that we’re checking the title field of the control after applying the filters.

This is a follow-up to #7234, which removed one of these checks but not all.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)