### PR TITLE
Temporarily skip the mortgage performance tests on staging

### DIFF
--- a/test/cypress/integration/data-research/mortgage-performance-trends/mortgage-performance-trends.cy.js
+++ b/test/cypress/integration/data-research/mortgage-performance-trends/mortgage-performance-trends.cy.js
@@ -1,23 +1,28 @@
 import { MortgagePerformanceTrends } from './mortgage-performance-trends-helpers.cy.js';
+import { skipOn } from '@cypress/skip-test';
 
 const trends = new MortgagePerformanceTrends();
 
-describe( 'Mortgage Performance Trends', () => {
+skipOn( 'staging', () => {
 
-  it( 'should display delinquency trends chart for a given state', () => {
-    trends.open();
-    trends.selectLocationType( 'State' );
-    trends.selectStateForDelinquencyTrends( 'Virginia' );
-  } );
+  describe( 'Mortgage Performance Trends', () => {
 
-  it( 'should display delinquency rates by month for a given state', () => {
-    trends.open();
-    trends.selectStateForDelinquencyRatesPerMonth( 'Virginia' );
-    trends.selectMonth( 'January' );
-    trends.selectYear( '2017' );
-    trends.mapTitle().should( 'contain', 'Virginia' );
-    trends.mapTitle().should( 'contain', 'January' );
-    trends.mapTitle().should( 'contain', '2017' );
+    it( 'should display delinquency trends chart for a given state', () => {
+      trends.open();
+      trends.selectLocationType( 'State' );
+      trends.selectStateForDelinquencyTrends( 'Virginia' );
+    } );
+
+    it( 'should display delinquency rates by month for a given state', () => {
+      trends.open();
+      trends.selectStateForDelinquencyRatesPerMonth( 'Virginia' );
+      trends.selectMonth( 'January' );
+      trends.selectYear( '2017' );
+      trends.mapTitle().should( 'contain', 'Virginia' );
+      trends.mapTitle().should( 'contain', 'January' );
+      trends.mapTitle().should( 'contain', '2017' );
+    } );
+
   } );
 
 } );


### PR DESCRIPTION
This small change temporarily disables our mortgage performance tests on staging while we try to troubleshoot the strange intermittent failures we’re seeing on Jenkins.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
