### PR TITLE
Add release labels for EKS CI/CD

### DIFF
--- a/.github/workflows/helm_lint.yml
+++ b/.github/workflows/helm_lint.yml
@@ -31,15 +31,6 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
 
-      - name: Set up Helm chart dependencies
-        id: helm-chart-dependencies
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add elastic https://helm.elastic.co/
-          helm repo add opensearch https://opensearch-project.github.io/helm-charts/
-          helm repo update
-          helm dependency update ./helm/cfgov
-
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,3 +2,7 @@ helm-extra-args: --timeout 600s
 chart-dirs:
   - helm/
 target-branch: main
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami
+  - elastic=https://helm.elastic.co/
+  - opensearch=https://opensearch-project.github.io/helm-charts/

--- a/helm-install.sh
+++ b/helm-install.sh
@@ -39,7 +39,7 @@ else
 fi
 
 ## Set release name
-RELEASE=${RELEASE:-cfgov}
+export RELEASE=${RELEASE:-cfgov}
 
 # Setup
 ## Get absolute path to helm-install.sh
@@ -49,7 +49,7 @@ realpath() {
 ## Get Project Dir path containing helm-install.sh
 export PROJECT_DIR="$(dirname "$(realpath "$0")")"
 ## Set Default Args
-DEFAULT_ARGS="${PROJECT_DIR}/helm/overrides/local-dev.yaml ${PROJECT_DIR}/helm/overrides/dev-vars.yaml ${PROJECT_DIR}/helm/overrides/services.yaml"
+DEFAULT_ARGS="${PROJECT_DIR}/helm/overrides/local-dev.yaml ${PROJECT_DIR}/helm/overrides/dev-vars.yaml ${PROJECT_DIR}/helm/overrides/services.yaml ${PROJECT_DIR}/helm/overrides/required.yaml"
 ## Source .env, if it exists
 if [ -f .env ]; then
   source .env
@@ -81,7 +81,7 @@ fi
 if [ $# -eq 0 ]; then
   ARGS=${DEFAULT_ARGS}
 else
-  ARGS=$@
+  ARGS="$@ ${PROJECT_DIR}/helm/overrides/required.yaml"
 fi
 
 ## Separate --set from files, substitute Environment Variables in override files
@@ -106,9 +106,6 @@ done
 ## Install/Upgrade cfgov release
 helm upgrade --install ${WAIT_OPT} \
   "${RELEASE}" ${NAMESPACE_OPT} ${OVERRIDES} ${IMAGE} ${TAG} \
-  --set ingress.hosts[0].host="${RELEASE}.localhost" \
-  --set elasticsearch.clusterName="${RELEASE}-elasticsearch" ${ES_TEST_OVERRIDE} \
-  --set kibana.elasticsearchHosts="http://${RELEASE}-elasticsearch-master:9200" \
   ${PROJECT_DIR}/helm/cfgov
 
 # Add these in for local SSL.

--- a/helm/cfgov/Chart.yaml
+++ b/helm/cfgov/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: cfgov
 description: A Helm chart for Kubernetes
+icon: https://www.consumerfinance.gov/static/icon.svg
 
 maintainers:
   - name: cfpb
@@ -19,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/cfgov/templates/_helpers.tpl
+++ b/helm/cfgov/templates/_helpers.tpl
@@ -40,6 +40,22 @@ helm.sh/chart: {{ include "cfgov.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+release.cfpb.gov/product: {{ .Chart.Name }}
+{{- if or (eq .Release.Name .Chart.Name) (eq .Release.Name "edge") }}
+release.cfpb.gov/auto-delete: "false"
+{{- else }}
+release.cfpb.gov/auto-delete: {{ .Values.release.autoDelete | quote }}
+{{- end }}
+release.cfpb.gov/auto-upgrade: {{ .Values.release.autoUpgrade | quote }}
+{{- if .Values.release.branch }}
+release.cfpb.gov/branch: {{ .Values.release.branch | quote }}
+{{- end }}
+{{- if .Values.release.owner }}
+release.cfpb.gov/owner: {{ .Values.release.owner | quote }}
+{{- end }}
+{{- if .Values.release.gitSHA }}
+release.cfpb.gov/git-sha: {{ .Values.release.gitSHA  | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/helm/cfgov/values.yaml
+++ b/helm/cfgov/values.yaml
@@ -2,6 +2,14 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Release metadata
+release:
+  autoDelete: true  # Auto delete release based off branch
+  autoUpgrade: true  # Autoupgrade release based off branch
+  branch: ""  # Ref this is deployed from (ex "<branch-name>" to track a branch, "release" to track release)
+  owner: ""  # Recognizable owner name (user/service account/etc)
+  gitSHA: ""  # Git commit SHA
+
 replicaCount: 1
 
 image:

--- a/helm/overrides/required.yaml
+++ b/helm/overrides/required.yaml
@@ -1,0 +1,29 @@
+# These values are required, and always included by helm-install.sh
+# Some of these values, are needed to set certain values needed between
+# Sibling charts from the Parent chart (cfgov).
+#
+# Everything can also be overridden explicitly with --set
+
+elasticsearch:
+  # using release name to always get unique naming,
+  # as elasticsearch chart breaks convention
+  clusterName: "${RELEASE}-elasticsearch"
+
+kibana:
+  # match the generated elasticsearch cluster name,
+  # overridable with --set kibana.elasticsearchHosts, which is useful
+  # when using an external ElasticSearch host and not the Child chart
+  elasticsearchHosts: "http://${RELEASE}-elasticsearch-master:9200"
+
+# ingress is only used for local deployments
+ingress:
+  hosts:
+    - host: ${RELEASE}.localhost  # overridable with --set ingress.hosts[0].host
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+
+release:
+  branch: ${RELEASE_BRANCH}
+  owner: ${RELEASE_OWNER}
+  gitSHA: ${GitSHA}


### PR DESCRIPTION
Adds the following labels:
* `release.cfpb.gov/product` - Set to `.Chart.Name`, used for identifying what product the release is associated with.
* `release.cfpb.gov/auto-delete` - Used by the CI/CD pipeline to know what releases it should delete, based off `branch` label
* `release.cfpb.gov/auto-upgrade` - Used by the CI/CD pipeline to know what releases it should upgrade, based off `branch` label
* `release.cfpb.gov/branch` - Used by the CI/CD pipeline to know what git ref the release is associated with, to know what to upgrade when an update comes through for the specified seed. `<branch>` for a branch, `release` for release.
* `release.cfpb.gov/git-sha` - Just another place to store what Git commit SHA this is associated with for all deployed resources
* `release.cfpb.gov/owner` - Just something to attach a name to (user/service account/etc) for ownership/POC of the release.

Moves some stuff into a `required.yaml` override.
Updates `helm-install.sh` to always include `required.yaml` override.
Uses `ct.yaml` for dependency repos for Helm linting
Adds icon to Chart.yaml