### PR TITLE
Add fallback for querying document body

### DIFF
--- a/cfgov/unprocessed/js/modules/util/breakpoint-state.js
+++ b/cfgov/unprocessed/js/modules/util/breakpoint-state.js
@@ -8,7 +8,8 @@ import varsBreakpoints from '@cfpb/cfpb-core/src/vars-breakpoints';
  * @returns {number} The base font size set on the body element.
  */
 function _getBodyBaseFontSize() {
-  let fontSize = getComputedStyle( document.body ).fontSize;
+  const docBody = document.body || document.querySelector('body');
+  let fontSize = window.getComputedStyle( docBody ).fontSize;
   fontSize = fontSize === '' ? -1 : fontSize;
   return parseFloat( fontSize );
 }


### PR DESCRIPTION
## Changes

- On the `getComputedStyle` call, add a fallback for querying `document.body` that uses a regular query selector.


## How to test this PR

1. See background in https://[GHE]/CFGOV/platform/issues/4476, we should probably just deploy this and see if it helps, if you'll think it's worthwhile.