### PR TITLE
Allow global search button to adapt to translations

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -288,6 +288,14 @@
         border-bottom-left-radius: 0;
         padding-left: 1em;
         white-space: nowrap;
+
+        // Chinese and Korean have slightly larger characters in Avenir,
+        // so we need a slightly smaller line-height to keep the button
+        // the correct height
+        [lang="zh-Hant"] &,
+        [lang="ko"] & {
+          line-height: 1.2;
+        }
       }
     }
   }

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -288,17 +288,12 @@
       button {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
+        // Some languages, like Chinese and Korean, have slightly larger
+        // x-heights, so we need to constrain the height to make sure the
+        // button is never taller than the input
+        max-height: unit(35px / @base-font-size-px, em);
         padding-left: 1em;
         white-space: nowrap;
-
-        // Some languages have slightly larger characters in Avenir, so we need
-        // a slightly smaller line-height to keep the button the correct height
-        [lang="ko"] &,
-        [lang="ru"] &,
-        [lang="vi"] &,
-        [lang="zh-Hant"] & {
-          line-height: 1.2;
-        }
       }
     }
   }

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -289,11 +289,12 @@
         padding-left: 1em;
         white-space: nowrap;
 
-        // Chinese and Korean have slightly larger characters in Avenir,
-        // so we need a slightly smaller line-height to keep the button
-        // the correct height
-        [lang="zh-Hant"] &,
-        [lang="ko"] & {
+        // Some languages have slightly larger characters in Avenir, so we need
+        // a slightly smaller line-height to keep the button the correct height
+        [lang="ko"] &,
+        [lang="ru"] &,
+        [lang="vi"] &,
+        [lang="zh-Hant"] & {
           line-height: 1.2;
         }
       }

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -277,11 +277,13 @@
 
     .o-form__input-w-btn_input-container {
       flex: 0 1 75%;
+      width: initial;
     }
 
     .o-form__input-w-btn_btn-container {
       border-left: 0;
       flex: 1 1 25%;
+      width: initial;
 
       button {
         border-top-left-radius: 0;

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -277,8 +277,8 @@
 
     .o-form__input-w-btn_input-container {
       display: flex;
-      flex: 0 1 75%;
       width: initial;
+      flex: 0 1 75%;
 
       // Characters in some languages, like Chinese, have a larger x-height,
       // which will make the button taller than the input. Fix that by making
@@ -292,14 +292,14 @@
     }
 
     .o-form__input-w-btn_btn-container {
+      width: initial;
       border-left: 0;
       flex: 1 1 25%;
-      width: initial;
 
       button {
+        padding-left: 1em;
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
-        padding-left: 1em;
         white-space: nowrap;
       }
     }

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -1,4 +1,3 @@
-
 // TODO: Move the theme variables to /enhancements/ for CF.
 /* topdoc
   name: Theme variables
@@ -17,8 +16,8 @@
     - cf-core
 */
 
-@margin__em: unit( @grid_gutter-width / @base-font-size-px, em );
-@margin_half__em: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
+@margin__em: unit(@grid_gutter-width / @base-font-size-px, em);
+@margin_half__em: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
 @mobile_trigger_ht__px: 54px;
 
 /* topdoc
@@ -93,6 +92,7 @@
 .m-global-search {
 
   &_trigger {
+
     // Hide search unless we have JavaScript (JS).
     html.no-js & {
       display: none;
@@ -107,210 +107,211 @@
     box-sizing: border-box;
     border-left: 1px solid transparent;
 
-    .respond-to-max( @bp-xs-max, {
+    .respond-to-max(@bp-xs-max, {
       font-size: 18px;
-    } );
+    });
 
-    &:focus {
-      outline: 1px dotted @black;
+  &:focus {
+    outline: 1px dotted @black;
+  }
+
+  &-open-label {
+    vertical-align: text-top;
+  }
+
+  &-close-label {
+    display: none;
+  }
+
+  // Hover state for desktop.
+  &:hover {
+    color: @gray-90;
+  }
+}
+
+&_content {
+  position: absolute;
+  left: 0;
+
+  &-form {
+    position: absolute;
+    width: 100%;
+  }
+
+  &.u-invisible {
+    overflow-x: hidden;
+  }
+
+  &[aria-expanded="true"] &-form {
+    display: block;
+  }
+
+}
+
+// Up to desktops.
+.respond-to-max(@bp-sm-max, {
+
+  &_fallback {
+    margin: @margin_half__em;
+  }
+
+  &_trigger {
+    padding-top: 5px;
+    height: @mobile_trigger_ht__px;
+    min-width: @mobile_trigger_ht__px;
+
+    &[aria-expanded="true"] {
+      background: @gray-10;
+      border-left: 1px solid @gray-40;
+
+      .m-global-search_trigger-open-label {
+        display: none;
+      }
+
+      .m-global-search_trigger-close-label {
+        display: block;
+      }
     }
 
-    &-open-label {
-      vertical-align: text-top;
-    }
+    // Hover state for (x) close button.
+    @media (hover: hover) {
+      &:hover {
+        color: @black;
+        border-left: 1px solid @gray-40;
 
-    &-close-label {
-      display: none;
-    }
-
-    // Hover state for desktop.
-    &:hover {
-      color: @gray-90;
+        // Important needed to override background color in expanded state.
+        background: @gray-20  !important;
+      }
     }
   }
 
   &_content {
-    position: absolute;
-    left: 0;
+    width: 100%;
 
     &-form {
-      position: absolute;
+      .u-drop-shadow-after();
+
+      box-sizing: border-box;
       width: 100%;
-    }
+      padding: @margin__em @margin_half__em @margin_half__em;
 
-    &.u-invisible {
-      overflow-x: hidden;
-    }
+      left: 0;
+      z-index: 10;
 
-    &[aria-expanded="true"] &-form {
-      display: block;
-    }
-
-  }
-
-  // Up to desktops.
-  .respond-to-max( @bp-sm-max, {
-
-    &_fallback {
-      margin: @margin_half__em;
-    }
-
-    &_trigger{
-      padding-top: 5px;
-      height: @mobile_trigger_ht__px;
-      min-width: @mobile_trigger_ht__px;
-
-      &[aria-expanded="true"] {
-        background: @gray-10;
-        border-left: 1px solid @gray-40;
-
-        .m-global-search_trigger-open-label {
-          display: none;
-        }
-
-        .m-global-search_trigger-close-label {
-          display: block;
-        }
-      }
-
-      // Hover state for (x) close button.
-      @media (hover: hover) {
-        &:hover {
-          color: @black;
-          border-left: 1px solid @gray-40;
-
-          // Important needed to override background color in expanded state.
-          background: @gray-20 !important;
-        }
-      }
-    }
-
-    &_content {
-      width: 100%;
-
-      &-form {
-        .u-drop-shadow-after();
-
-        box-sizing: border-box;
-        width: 100%;
-        padding: @margin__em
-        @margin_half__em
-        @margin_half__em;
-
-        left: 0;
-        z-index: 10;
-
-        background-color: @gray-5;
-        border-top: 1px solid @gray-40;
-        border-bottom: 1px solid @gray-40;
-      }
-    }
-  } );
-
-  // Tablet size only.
-  .respond-to-range( @bp-sm-min, @bp-sm-max, {
-    &_trigger {
-      // Min-width sets open/close states to same size.
-      min-width: 110px;
-
-      padding-left: unit( @grid_gutter-width / 2 / 18px, em );
-      padding-right: unit( @grid_gutter-width / 2 / 18px, em );
-    }
-
-  } );
-
-  // Tablet and above
-  .respond-to-min( @bp-sm-min, {
-
-    // Override for the .m-btn-inside-input class from the design system.
-    // This is needed because we do not have an icon inside the input
-    // at the desktop size (there is an icon at the mobile size).
-    .m-btn-inside-input .a-text-input {
-      padding-right: unit( 14px / @base-font-size-px, em );
-    }
-
-  } );
-
-  // Desktop and above
-  .respond-to-min( @bp-med-min, {
-
-    // Center on the call to action (CTA) divider to right of search.
-    padding-top: 6px;
-    padding-bottom: 5px;
-    // Match CTA offset from divider.
-    padding-right: @margin_half__em;
-    position: relative;
-
-    overflow: hidden;
-
-    &_trigger {
-      // Match height of input with button.
-      padding: 8px 0;
-
-      &[aria-expanded="true"] {
-        .u-invisible();
-      }
-    }
-
-    &_trigger {
-      float: right;
-    }
-
-    &_content {
-      right: @margin_half__em;
-      width: auto;
-      // Add margin so that the focus rectangle is not cropped by
-      // the hidden overflow of the search container element.
-      margin-left: 3px;
-    }
-  } );
-
-  // Mobile size.
-  .respond-to-min( 480px, {
-    &_content-form {
-      // Attach button to input.
-      .o-form__input-w-btn_input-container {
-        width: 75%;
-
-        [lang="es"] & {
-          width: 70%;
-        }
-      }
-      .o-form__input-w-btn_btn-container {
-        width: 25%;
-        border-left: 0;
-
-        button {
-          border-top-left-radius: 0;
-          border-bottom-left-radius: 0;
-        }
-
-        [lang="es"] & {
-          width: 30%;
-        }
-      }
-    }
-  } );
-
-  // Hide on print.
-  .respond-to-print( {
-    & {
-      // Important needed to override JS display settings.
-      display: none !important;
-    }
-  } );
-
-  // Hide fallback by default.
-  &_fallback {
-    display: none;
-    padding: 8px;
-    padding-right: 0;
-
-    // Only show fallback if JavaScript (JS) is not enabled.
-    .no-js & {
-      display: block;
+      background-color: @gray-5;
+      border-top: 1px solid @gray-40;
+      border-bottom: 1px solid @gray-40;
     }
   }
+});
+
+// Tablet size only.
+.respond-to-range(@bp-sm-min, @bp-sm-max, {
+  &_trigger {
+    // Min-width sets open/close states to same size.
+    min-width: 110px;
+
+    padding-left: unit(@grid_gutter-width / 2 / 18px, em);
+    padding-right: unit(@grid_gutter-width / 2 / 18px, em);
+  }
+
+});
+
+// Tablet and above
+.respond-to-min(@bp-sm-min, {
+
+  // Override for the .m-btn-inside-input class from the design system.
+  // This is needed because we do not have an icon inside the input
+  // at the desktop size (there is an icon at the mobile size).
+  .m-btn-inside-input .a-text-input {
+    padding-right: unit(14px / @base-font-size-px, em);
+  }
+
+});
+
+// Desktop and above
+.respond-to-min(@bp-med-min, {
+
+  // Center on the call to action (CTA) divider to right of search.
+  padding-top: 6px;
+  padding-bottom: 5px;
+  // Match CTA offset from divider.
+  padding-right: @margin_half__em;
+  position: relative;
+
+  overflow: hidden;
+
+  &_trigger {
+    // Match height of input with button.
+    padding: 8px 0;
+
+    &[aria-expanded="true"] {
+      .u-invisible();
+    }
+  }
+
+  &_trigger {
+    float: right;
+  }
+
+  &_content {
+    right: @margin_half__em;
+    width: auto;
+    // Add margin so that the focus rectangle is not cropped by
+    // the hidden overflow of the search container element.
+    margin-left: 3px;
+  }
+});
+
+// Mobile size.
+.respond-to-min(480px, {
+  &_content-form {
+
+    // The "search" button needs to be more flexible than in our usual
+    // input-w-btn element to accommodate longer translations of "search",
+    // so we'll make it flexbox
+    .o-form__input-w-btn {
+      display: flex;
+      padding-right: 0.25em;
+    }
+
+    .o-form__input-w-btn_input-container {
+      flex: 0 1 75%;
+    }
+
+    .o-form__input-w-btn_btn-container {
+      border-left: 0;
+      flex: 1 1 25%;
+
+      button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        padding-left: 1em;
+        white-space: nowrap;
+      }
+    }
+  }
+});
+
+// Hide on print.
+.respond-to-print({
+  & {
+    // Important needed to override JS display settings.
+    display: none !important;
+  }
+});
+
+// Hide fallback by default.
+&_fallback {
+  display: none;
+  padding: 8px;
+  padding-right: 0;
+
+  // Only show fallback if JavaScript (JS) is not enabled.
+  .no-js & {
+    display: block;
+  }
+}
 }
 
 /* topdoc

--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -276,8 +276,19 @@
     }
 
     .o-form__input-w-btn_input-container {
+      display: flex;
       flex: 0 1 75%;
       width: initial;
+
+      // Characters in some languages, like Chinese, have a larger x-height,
+      // which will make the button taller than the input. Fix that by making
+      // the input elements flex and stretch to fit the full height of the
+      // container (i.e. match the button height)
+      .m-btn-inside-input {
+        display: flex;
+        align-items: stretch;
+        flex-basis: 100%;
+      }
     }
 
     .o-form__input-w-btn_btn-container {
@@ -288,10 +299,6 @@
       button {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
-        // Some languages, like Chinese and Korean, have slightly larger
-        // x-heights, so we need to constrain the height to make sure the
-        // button is never taller than the input
-        max-height: unit(35px / @base-font-size-px, em);
         padding-left: 1em;
         white-space: nowrap;
       }


### PR DESCRIPTION
Currently the "Search" button in our global search doesn't handle some translations well:

- In [Vietnamese](https://www.consumerfinance.gov/language/vi/), "search" translates into two words, "tìm kiếm," which causes the button text to wrap into two linens (see GHE/CFGOV/platform/issues/4195 for that bug report)
- In [Chinese](https://www.consumerfinance.gov/language/zh/) and [Korean](https://www.consumerfinance.gov/language/ko/), the slightly larger x-heights of characters cause the button to extend a little below the bottom of the adjoining text input

These changes fix those issues by having the global search form use a `flexbox` layout to allow the text input and button to grow a little to fit translations while still mostly maintaining the 75/25 input/button split of the [text input with a button pattern](https://cfpb.github.io/design-system/components/text-inputs#text-input-with-a-button).

---

## Removals

- The bit of CSS that set the input/button split to 70/30 instead of 75/25 for Spanish. Not sure why that was there in the first place, but it seems more maintainable to keep all languages the same, and I didn't see a design or UX reason to keep the Spanish button wider.

## Changes

- Global search form now uses `flexbox` for much of its layout, both to allow the button to grow horizontally if it needs to fit longer text and to allow the text input to grow vertically to match the heigh of the button.
- The search button text is now `nowrap` to make sure it doesn't split in Vietnamese, where "search" is two words.
- A bunch of whitespace fixes caught by the linter

## How to test this PR

1. Check out the global search in every language in the header to make sure it looks good
2. If you're feeling ambitious, check out the same thing in multiple browsers (I tested in the usual suspects in Sauce Labs, and everything was looking good to me with the exception of Edge weirdness noted below)

## Screenshots

The search button is now just slightly larger in English and smaller in Spanish (because these changes remove the special 70/30 split we were setting for Spanish):

![search-button-comparison-vertical](https://user-images.githubusercontent.com/1862695/191986330-c630454f-e8fc-4ca7-a464-17aabcedf13d.png)

And the search button will always be the same height as the text input in all languages:

![search-button-comparison-horizontal](https://user-images.githubusercontent.com/1862695/191986454-f4ec1e78-f420-4022-8a7a-5d1e9b410352.png)

## Notes and todos

- Testing on localhost in Edge in Sauce Labs was giving me some issues—sometimes Edge wouldn't load any of our CSS. Since that also happened on `main`, I'm assuming it's a weird Edge/Sauce Labs testing issue. I'll confirm everything looks OK on Edge when this is in production.
- It might make sense to bring this `flexbox` approach to the [text input with a button pattern](https://cfpb.github.io/design-system/components/text-inputs#text-input-with-a-button) in the Design System. In theory we could see these same issues on any instance of that pattern for translated text. In practice, though, the global search is the only instance I know of that's translated into a bunch of languages, so I think fixing that here makes sense for now.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets

### Front-end testing

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android