### PR TITLE
Fix alignment on blank regulation landing pages

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/main.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/main.less
@@ -6,6 +6,7 @@
 
 @import (reference) '../../../css/main.less';
 @import (less) './reg-listing.less';
+@import (less) './reg-landing-page.less';
 @import (less) './reg-navigation.less';
 @import (less) './reg-pagination.less';
 @import (less) './reg-search.less';

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-landing-page.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-landing-page.less
@@ -1,0 +1,13 @@
+/* ==========================================================================
+   Regulations 3000
+   Regulations landing page
+   ========================================================================== */
+
+// Helper class to correct regs3k notifications alignment
+.block__flush-regs3k {
+  margin-top: -30px;
+
+  .block__flush-bottom+& {
+    margin-top: 30px;
+  }
+}

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -11,6 +11,7 @@
     box-sizing: border-box;
     padding-left: (@i * 2em);
   }
+
   .generateLevel(@n, (@i + 1));
 }
 
@@ -21,6 +22,7 @@
 .regdown-form_extend {
   font-size: 0;
   position: relative;
+
   span {
     border-top: 1px solid @black;
     content: '';
@@ -33,15 +35,10 @@
 }
 
 .regulation-meta {
-  margin-bottom: unit( 25px / @base-font-size-px, rem );
+  margin-bottom: unit(25px / @base-font-size-px, rem);
 
   .a-date {
-    margin-bottom: unit( 8px / @base-font-size-px, rem );
+    margin-bottom: unit(8px / @base-font-size-px, rem);
     white-space: normal;
   }
-}
-
-// Helper class to correct regs3k notifications alignment
-.block__flush-regs3k {
-  margin-top: -30px;
 }


### PR DESCRIPTION
Regulation landing pages (like [Reg F's](https://www.consumerfinance.gov/rules-policy/regulations/1006/)) are meant to have a lead paragraph that briefly introduces the regulation. Sometimes when we add a new regulation to iRegs, though, we have to temporarily put up a blank landing page while the landing page content—including the lead paragraph—is still being written ("temporarily" can sometimes be months,  however). But the landing page template wasn't designed with the no-lead-paragraph case in mind, so some elements were squished together on regs landing pages without a lead paragraph (see GHE/CFGOV/platform/issues/4162 and GHE/CFGOV/platform/issues/4138 for examples). This change makes sure that regs landing page elements are always properly spaced regardless of whether the page has a lead paragraph or not.

---

## Additions

- A little CSS to handle lead paragraph-less regs landing pages

## Changes

- Re-organized the iRegs LESS a little to pull styles specific to landing pages into their own file
- Couple of fixes caught by the linter

## How to test this PR

1. Delete all the content from an existing regulation landing page
2. Confirm that there's 30 px of space between the landing page heading, the not-current-version notification, and the list of links on the blank landing page
3. Confirm that no spacing has changed on regulation landing pages that do have content

## Screenshots

Landing page state | Current | New
---- | ---- | ----
Current version | ![current-old](https://user-images.githubusercontent.com/1862695/192024453-7c0bd539-c69a-44c5-bb8f-4e2ea12f9ab3.png) | ![current-new](https://user-images.githubusercontent.com/1862695/192024480-4782276d-2db9-4d60-b24e-ba0900b6529f.png)
Previous/future version | ![previous-old](https://user-images.githubusercontent.com/1862695/192024512-b77903d5-eca6-43fd-8c78-0a480ce1e53c.png) | ![previous-new](https://user-images.githubusercontent.com/1862695/192024540-7c90af77-ae31-42b2-9db9-63f19e7df22a.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)