### PR TITLE
Remove crtool dependency and routing. Also institute redirect

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -414,6 +414,7 @@ RedirectMatch permanent (?i)^/money([\-]?)as([\-]?)you([\-]?)grow(.*) /consumer-
 
 # Youth Financial Education
 RedirectMatch permanent (?i)^/youth-financial-education([/]?)$ /consumer-tools/educator-tools/youth-financial-education/
+RedirectMatch permanent (?i)^(/consumer-tools/educator-tools/youth-financial-education/curriculum-review/).+ $1
 
 # Adult Financial Education
 RedirectMatch permanent (?i)^/adult-financial-education([/]?)$ /consumer-tools/educator-tools/adult-financial-education/

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -107,7 +107,6 @@ INSTALLED_APPS = (
     # Satellites
     "complaint_search",
     "countylimits",
-    "crtool",
     "mptt",
     "ratechecker",
     "rest_framework",

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -417,10 +417,6 @@ urlpatterns = [
         include("teachers_digital_platform.urls"),
     ),
     re_path(
-        r"^consumer-tools/educator-tools/youth-financial-education/curriculum-review/",  # noqa: B950
-        include("crtool.urls"),
-    ),
-    re_path(
         r"^regulations3k-service-worker.js$",
         TemplateView.as_view(
             template_name="regulations3k/regulations3k-service-worker.js",

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -39,7 +39,6 @@ wagtailmedia==0.9.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.3/owning_a_home_api-0.17.3-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
-https://github.com/cfpb/curriculum-review-tool/releases/download/2.2.0/crtool-2.2.0-py3-none-any.whl
 
 # Temporarily pin Jinja 2.11's MarkupSafe dependency.
 MarkupSafe==2.0.1


### PR DESCRIPTION
The Curriculum Review Tool has been deprecated and its repo archived. Links to the tool have already been removed from the curriculum review homepage.

This PR removes our inclusion of the tool in the codebase and adds an Apache redirect for all former crtool subpages.