### PR TITLE
Work around a linting bug

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -269,7 +269,7 @@
 
     // The "search" button needs to be more flexible than in our usual
     // input-w-btn element to accommodate longer translations of "search",
-    // so we'll make it flexbox
+    // so we will make it flexbox
     .o-form__input-w-btn {
       display: flex;
       padding-right: 0.25em;


### PR DESCRIPTION
stylelint is flagging this apostrophe in a LESS comment as an "unclosed string" 😆 . It's a stylelint bug, but we'll work around it to get our tests passing. Contractions begone!

---

## Changes

- No more contractions

## How to test this PR

1. All the front-end linting should pass

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)