### PR TITLE
Prevent possible divide-by-zero error in hero

### DIFF
--- a/cfgov/jinja2/v1/_includes/molecules/hero.html
+++ b/cfgov/jinja2/v1/_includes/molecules/hero.html
@@ -89,7 +89,7 @@
                 border-bottom: 0 !important;
             {% endif -%}
         }
-    {% if img %}
+    {% if img and img.width %}
         .m-hero_image {
             background-image: url('{{ sm_img.url }}');
             filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(


### PR DESCRIPTION
In the course of working on getting Cypress tests running in an EKS environment, we discovered there's a possible divide-by-zero error lurking in the hero template. If a hero has an image set in Wagtail but the image file itself is missing, `img.width` and `sm_img.width` will come back as `0`, causing a 500 error and preventing the page from rendering. Up until now this has been masked by using placekitten locally to plop in a placeholder image, but EKS uses production settings *and* doesn't have any image files loaded, so any page with a hero in that environment will 500. There's also a small chance this could pop up in production if something goes wrong with the image file, so best to pop in a quick check for `img.width` to make sure we're never dividing by zero.

---

## Additions

- Check that `img.width` is truthy before trying to divide by it

## How to test this PR

1. Disable placekitten locally by commenting out [lines 111–112 in `cfgov/cfgov/settings/local.py`](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/cfgov/settings/local.py#L111-L112)
2. Load the test database with `./refresh-data.sh test.sql.gz`
3. On `main`, visit a page with a hero image, like /ask-cfpb/; you'll get a divide-by-zero server error
4. Switch to this branch and refresh the page; the page should render without a hero image or any of the hero CSS

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)