### PR TITLE
Fix a reference to the FAFSA website, which has moved.

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3207,7 +3207,7 @@
                                          your college</a>
                                     </p>
                                     <div>
-                                        <a href="https://fafsa.ed.gov/"
+                                        <a href="https://studentaid.gov/h/apply-for-aid/fafsa"
                                         target="_blank" rel="noopener noreferrer">FAFSA&reg;</a>
                                         <p>Apply for federal, state, and school
                                             financial aid.</p>


### PR DESCRIPTION
The EFIP tool's last page has links to federal help sites for students, and the FAFSA website has moved.
This was missed in #7282.

## Changes
- One hyperlink in disclosure.html
