### PR TITLE
Moves login-associated type conversion to where settings are defined

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -416,9 +416,11 @@ CFPB_COMMON_PASSWORD_RULES = [
 ]
 # cfpb_common login rules
 # in seconds
-LOGIN_FAIL_TIME_PERIOD = os.environ.get("LOGIN_FAIL_TIME_PERIOD", 120 * 60)
+LOGIN_FAIL_TIME_PERIOD = int(
+    os.environ.get("LOGIN_FAIL_TIME_PERIOD", 120 * 60)
+)
 # number of failed attempts
-LOGIN_FAILS_ALLOWED = os.environ.get("LOGIN_FAILS_ALLOWED", 5)
+LOGIN_FAILS_ALLOWED = int(os.environ.get("LOGIN_FAILS_ALLOWED", 5))
 LOGIN_REDIRECT_URL = "/admin/"
 LOGIN_URL = "/login/"
 

--- a/cfgov/login/forms.py
+++ b/cfgov/login/forms.py
@@ -84,8 +84,8 @@ class LoginForm(AuthenticationForm):
                 now = time.time()
                 fa.failed(now)
                 # Defaults to a 2 hour lockout for a user
-                time_period = now - int(settings.LOGIN_FAIL_TIME_PERIOD)
-                attempts_allowed = int(settings.LOGIN_FAILS_ALLOWED)
+                time_period = now - settings.LOGIN_FAIL_TIME_PERIOD
+                attempts_allowed = settings.LOGIN_FAILS_ALLOWED
                 attempts_used = len(fa.failed_attempts.split(","))
 
                 if fa.too_many_attempts(attempts_allowed, time_period):


### PR DESCRIPTION
In `cfgov/login/forms.py` the `LOGIN_FAIL_TIME_PERIOD` wasn't cast to an `int` everywhere it was used. This does the casting where the setting is defined instead (and does the same for `LOGIN_FAILS_ALLOWED`).