### PR TITLE
Improve handling of FIG viewport resizing

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation-fig.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation-fig.html
@@ -20,7 +20,8 @@
 <nav class="o-fig_sidebar o-secondary-navigation"
     aria-label="{{ _('Table of contents') }}">
     {% set sec_nav_settings_label = _("Table of contents") %}
-    {% set sec_nav_settings_label = sec_nav_settings_label + " (" + _(version_status) + ")" %}
+    {% set version_label = " (" + _(version_status) + ")" if version_status else '' %}
+    {% set sec_nav_settings_label = sec_nav_settings_label + version_label %}
     {% set sec_nav_settings = {
         'label': sec_nav_settings_label,
         'is_midtone': true,

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -1,3 +1,6 @@
+/* istanbul ignore file */
+/* Cypress tests cover all the UI interactions on this page. */
+
 import varsBreakpoints from '@cfpb/cfpb-core/src/vars-breakpoints';
 
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
@@ -29,7 +32,6 @@ const handleMobileNav = event => {
  */
 const init = () => {
   /* Only proceed if IntersectionObserver is supported (everything except IE)
-     and we're on a larger screen
      See https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API */
   if ( 'IntersectionObserver' in window ) {
     fig.appRoot.querySelectorAll( '.o-secondary-navigation_list__children' ).forEach( ul => {

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -1,6 +1,28 @@
+import varsBreakpoints from '@cfpb/cfpb-core/src/vars-breakpoints';
+
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import { DESKTOP, viewportIsIn } from '../../../js/modules/util/breakpoint-state.js';
 import * as fig from './fig-sidenav-utils';
+
+/**
+ * The sidenav is nested inside an expandable on smaller screens.
+ * We have to close the expandable before sending the user to the appropriate section.
+ * @param {MouseEvent} event - Event from user clicking/tapping a nav item
+ */
+const handleMobileNav = event => {
+  if ( event.target.matches( '.m-nav-link' ) ) {
+    event.preventDefault();
+    document.querySelector( '.o-fig_sidebar .o-expandable_header' ).click();
+    // Scrolling before the expandable closes causes jitters on some devices
+    setTimeout( () => {
+      fig.scrollIntoViewWithOffset( document.getElementById( event.target.getAttribute( 'href' ).replace( '#', '' ) ), 60 );
+    }, 300 );
+  }
+  if ( event.target.matches( '.o-fig_heading > a' ) ) {
+    event.preventDefault();
+    fig.scrollIntoViewWithOffset( document.getElementById( event.target.getAttribute( 'href' ).replace( '#', '' ) ), 60 );
+  }
+};
 
 /**
  * init - Initialize everything on page load.
@@ -9,7 +31,7 @@ const init = () => {
   /* Only proceed if IntersectionObserver is supported (everything except IE)
      and we're on a larger screen
      See https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API */
-  if ( 'IntersectionObserver' in window && viewportIsIn( DESKTOP ) ) {
+  if ( 'IntersectionObserver' in window ) {
     fig.appRoot.querySelectorAll( '.o-secondary-navigation_list__children' ).forEach( ul => {
       fig.hideElement( ul );
     } );
@@ -32,22 +54,20 @@ const init = () => {
   }
 
   if ( !viewportIsIn( DESKTOP ) ) {
-    fig.appRoot.addEventListener( 'click', event => {
-      if ( event.target.matches( '.m-nav-link' ) ) {
-        event.preventDefault();
-        document.querySelector( '.o-fig_sidebar .o-expandable_header' ).click();
-        // Scrolling before the expandable closes causes jitters on some devices
-        setTimeout( () => {
-          fig.scrollIntoViewWithOffset( document.getElementById( event.target.getAttribute( 'href' ).replace( '#', '' ) ), 60 );
-        }, 300 );
-      }
-      if ( event.target.matches( '.o-fig_heading > a' ) ) {
-        event.preventDefault();
-        fig.scrollIntoViewWithOffset( document.getElementById( event.target.getAttribute( 'href' ).replace( '#', '' ) ), 60 );
-      }
-    } );
+    fig.appRoot.addEventListener( 'click', handleMobileNav );
   }
 };
+
+/* If the browser window is no greater than 900px, enable the mobile nav
+   functionality. Otherwise, disable it. This event is triggered whenever
+   the user resizes the viewport and its width passes the 900px threshold. */
+window.matchMedia( `(max-width: ${ varsBreakpoints.bpSM.max }px)` ).addEventListener( 'change', mediaQuery => {
+  if ( mediaQuery.matches ) {
+    fig.appRoot.addEventListener( 'click', handleMobileNav );
+  } else {
+    fig.appRoot.removeEventListener( 'click', handleMobileNav );
+  }
+} );
 
 Expandable.init();
 

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide-helpers.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide-helpers.cy.js
@@ -1,7 +1,7 @@
 export class FilingInstructionGuide {
 
   url() {
-    return '/compliance/compliance-resources/small-business-lending/1071-filing-instruction-guide/';
+    return Cypress.env( 'FIG_URL' );
   }
 
   open() {

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -1,223 +1,214 @@
 import { FilingInstructionGuide } from './filing-instruction-guide-helpers.cy.js';
-import { skipOn } from '@cypress/skip-test';
+import { onlyOn } from '@cypress/skip-test';
 
 const fig = new FilingInstructionGuide();
 
-/* TODO: Remove the before hook, it( 'skips tests if page does not exist')
-   test, and skipOn once the FIG page has been published */
-before( () => {
-  cy.request( {
-    url: fig.url(),
-    failOnStatusCode: false
-  } ).as( 'figPage' );
-} );
+describe( '1071 Filing Instruction Guide (FIG)', () => {
 
-it( 'skips tests if page does not exist', function() {
+  describe( 'FIG table of contents', () => {
 
-  skipOn( this.figPage.status === 404, () => {
+    /* Our FIG sample page only exists in certain environments so continue
+       this test suite only if the user explicitly provides a URL via
+       CYPRESS_FIG_URL=https://blah.cfpb.gov/xxxxxx/yyyyyy/zzzzzz/.
+       Once the FIG reaches production we can disable this check. */
+    onlyOn( Boolean( fig.url() ), () => {
 
-    describe( '1071 Filing Instruction Guide (FIG)', () => {
+      context( 'Desktop experience', () => {
 
-      describe( 'FIG table of contents', () => {
+        const desktops = [
+          'macbook-13',
+          'macbook-15'
+        ];
 
-        context( 'Desktop experience', () => {
+        desktops.forEach( desktop => {
 
-          const desktops = [
-            'macbook-13',
-            'macbook-15'
-          ];
+          context( desktop, () => {
 
-          desktops.forEach( desktop => {
+            beforeEach( () => {
+              cy.viewport( desktop );
+            } );
 
-            context( desktop, () => {
+            it( 'should be present', () => {
+              fig.open();
+              fig.toc().should( 'be.visible' );
+            } );
 
-              beforeEach( () => {
-                cy.viewport( desktop );
-              } );
+            it( 'should highlight the first section by default', () => {
+              fig.getNavItem( 1 ).should( 'have.class', 'm-nav-link__current' );
+              fig.getNavItem( 2 ).should( 'not.have.class', 'm-nav-link__current' );
+              fig.getNavItem( 3 ).should( 'not.have.class', 'm-nav-link__current' );
+              fig.getNavItem( 4 ).should( 'not.have.class', 'm-nav-link__current' );
+            } );
 
-              it( 'should be present', () => {
-                fig.open();
-                fig.toc().should( 'be.visible' );
-              } );
+            it( 'should be sticky', () => {
+              fig.toc().should( 'be.visible' );
+              cy.scrollTo( 0, 1000 );
+              // Verify it's still in the viewport after scrolling down the page
+              fig.toc().should( 'be.visible' );
+              fig.getNavItem( 1 ).should( 'be.visible' );
+            } );
 
-              it( 'should highlight the first section by default', () => {
-                fig.getNavItem( 1 ).should( 'have.class', 'm-nav-link__current' );
-                fig.getNavItem( 2 ).should( 'not.have.class', 'm-nav-link__current' );
-                fig.getNavItem( 3 ).should( 'not.have.class', 'm-nav-link__current' );
-                fig.getNavItem( 4 ).should( 'not.have.class', 'm-nav-link__current' );
-              } );
+            it( 'should be sticky when scrolled to bottom of page', () => {
+              fig.toc().should( 'be.visible' );
+              fig.scrollToBottom();
+              fig.toc().should( 'be.visible' );
+            } );
 
-              it( 'should be sticky', () => {
-                fig.toc().should( 'be.visible' );
-                cy.scrollTo( 0, 1000 );
-                // Verify it's still in the viewport after scrolling down the page
-                fig.toc().should( 'be.visible' );
-                fig.getNavItem( 1 ).should( 'be.visible' );
-              } );
+            it( 'should highlight the current section', () => {
+              fig.goToSection( 2 );
+              fig.getNavItem( 2 ).should( 'have.class', 'm-nav-link__current' );
+              fig.getNavItem( 1 ).should( 'not.have.class', 'm-nav-link__current' );
+              fig.getNavItem( 3 ).should( 'not.have.class', 'm-nav-link__current' );
+              fig.getNavItem( 4 ).should( 'not.have.class', 'm-nav-link__current' );
+            } );
 
-              it( 'should be sticky when scrolled to bottom of page', () => {
-                fig.toc().should( 'be.visible' );
-                fig.scrollToBottom();
-                fig.toc().should( 'be.visible' );
-              } );
+            it( 'should auto-expand subsections', () => {
+              fig.goToSection( 'uli' );
+              fig.getNavItem( 3 ).should( 'be.visible' );
+              fig.getNavItem( 'uli' ).should( 'be.visible' );
+              fig.getNavItem( 'application-date' ).should( 'be.visible' );
 
-              it( 'should highlight the current section', () => {
-                fig.goToSection( 2 );
-                fig.getNavItem( 2 ).should( 'have.class', 'm-nav-link__current' );
-                fig.getNavItem( 1 ).should( 'not.have.class', 'm-nav-link__current' );
-                fig.getNavItem( 3 ).should( 'not.have.class', 'm-nav-link__current' );
-                fig.getNavItem( 4 ).should( 'not.have.class', 'm-nav-link__current' );
-              } );
+              fig.goToSection( 'application-date' );
+              fig.getNavItem( 3 ).should( 'be.visible' );
+              fig.getNavItem( 'uli' ).should( 'be.visible' );
+              fig.getNavItem( 'application-date' ).should( 'be.visible' );
+            } );
 
-              it( 'should auto-expand subsections', () => {
-                fig.goToSection( 4.1 );
-                fig.getNavItem( 4 ).should( 'be.visible' );
-                fig.getNavItem( 4.1 ).should( 'be.visible' );
-                fig.getNavItem( 4.2 ).should( 'be.visible' );
+            it( 'should auto-close subsections', () => {
+              fig.goToSection( 2 );
+              fig.getNavItem( 3 ).should( 'be.visible' );
+              fig.getNavItem( 'uli' ).should( 'not.be.visible' );
+            } );
 
-                fig.goToSection( 4.2 );
-                fig.getNavItem( 4 ).should( 'be.visible' );
-                fig.getNavItem( 4.1 ).should( 'be.visible' );
-                fig.getNavItem( 4.2 ).should( 'be.visible' );
-              } );
+            it( 'should jump to correct sections', () => {
+              fig.clickNavItem( 4 );
+              fig.getSection( 4 ).should( 'be.inViewport' );
+              fig.getSection( 1 ).should( 'not.be.inViewport' );
+              fig.getSection( 2 ).should( 'not.be.inViewport' );
+              fig.getSection( 3 ).should( 'not.be.inViewport' );
+            } );
 
-              it( 'should auto-close subsections', () => {
-                fig.goToSection( 2 );
-                fig.getNavItem( 4 ).should( 'be.visible' );
-                fig.getNavItem( 4.1 ).should( 'not.be.visible' );
-              } );
+            it( 'should highlight correction section when clicking heading', () => {
+              fig.clickSectionHeading( 1 );
+              fig.getNavItem( 1 ).should( 'have.class', 'm-nav-link__current' );
+              fig.getNavItem( 'uli' ).should( 'not.be.visible' );
 
-              it( 'should jump to correct sections', () => {
-                fig.clickNavItem( 4 );
-                fig.getSection( 4 ).should( 'be.inViewport' );
-                fig.getSection( 1 ).should( 'not.be.inViewport' );
-                fig.getSection( 2 ).should( 'not.be.inViewport' );
-                fig.getSection( 3 ).should( 'not.be.inViewport' );
-              } );
+              fig.clickSectionHeading( 2 );
+              fig.getNavItem( 2 ).should( 'have.class', 'm-nav-link__current' );
+              fig.getNavItem( 'uli' ).should( 'not.be.visible' );
 
-              it( 'should highlight correction section when clicking heading', () => {
-                fig.clickSectionHeading( 1 );
-                fig.getNavItem( 1 ).should( 'have.class', 'm-nav-link__current' );
-                fig.getNavItem( 4.1 ).should( 'not.be.visible' );
-
-                fig.clickSectionHeading( 2 );
-                fig.getNavItem( 2 ).should( 'have.class', 'm-nav-link__current' );
-                fig.getNavItem( 4.1 ).should( 'not.be.visible' );
-
-                fig.clickSectionHeading( 4 );
-                fig.getNavItem( 4 ).should( 'have.class', 'm-nav-link__current' );
-                fig.getNavItem( 4.1 ).should( 'be.visible' );
-              } );
-
+              fig.clickSectionHeading( 3 );
+              fig.getNavItem( 3 ).should( 'have.class', 'm-nav-link__current' );
+              fig.getNavItem( 'uli' ).should( 'be.visible' );
             } );
 
           } );
 
         } );
 
-        context( 'Tablet experience', () => {
+      } );
 
-          const tablets = [
-            'ipad-2',
-            'ipad-mini'
-          ];
+      context( 'Tablet experience', () => {
 
-          tablets.forEach( tablet => {
+        const tablets = [
+          'ipad-2',
+          'ipad-mini'
+        ];
 
-            context( tablet, () => {
+        tablets.forEach( tablet => {
 
-              beforeEach( () => {
-                cy.viewport( tablet );
-              } );
+          context( tablet, () => {
 
-              it( 'should be present', () => {
-                fig.open();
-                fig.toc().should( 'be.visible' );
-              } );
+            beforeEach( () => {
+              cy.viewport( tablet );
+            } );
 
-              it( 'should expand', () => {
-                fig.toggleToc();
-                fig.getNavItem( 1 ).should( 'be.visible' );
-              } );
+            it( 'should be present', () => {
+              fig.open();
+              fig.toc().should( 'be.visible' );
+            } );
 
-              it( 'should collapse', () => {
-                fig.toggleToc();
-                fig.getNavItem( 1 ).should( 'not.be.visible' );
-              } );
+            it( 'should expand', () => {
+              fig.toggleToc();
+              fig.getNavItem( 1 ).should( 'be.visible' );
+            } );
 
-              it( 'should be sticky', () => {
-                fig.toc().should( 'be.visible' );
-                cy.scrollTo( 0, 1000 );
-                fig.toc().should( 'be.visible' );
-              } );
+            it( 'should collapse', () => {
+              fig.toggleToc();
+              fig.getNavItem( 1 ).should( 'not.be.visible' );
+            } );
 
-              it( 'jump to correct sections', () => {
-                fig.toggleToc();
-                fig.clickNavItem( 4 );
-                fig.getSection( 4 ).should( 'be.inViewport' );
-                fig.getSection( 2 ).should( 'not.be.inViewport' );
+            it( 'should be sticky', () => {
+              fig.toc().should( 'be.visible' );
+              cy.scrollTo( 0, 1000 );
+              fig.toc().should( 'be.visible' );
+            } );
 
-                fig.toggleToc();
-                fig.clickNavItem( 1 );
-                fig.getSection( 1 ).should( 'be.inViewport' );
-                fig.getSection( 4 ).should( 'not.be.inViewport' );
-              } );
+            it( 'jump to correct sections', () => {
+              fig.toggleToc();
+              fig.clickNavItem( 4 );
+              fig.getSection( 4 ).should( 'be.inViewport' );
+              fig.getSection( 2 ).should( 'not.be.inViewport' );
 
+              fig.toggleToc();
+              fig.clickNavItem( 1 );
+              fig.getSection( 1 ).should( 'be.inViewport' );
+              fig.getSection( 4 ).should( 'not.be.inViewport' );
             } );
 
           } );
 
         } );
 
-        context( 'Mobile experience', () => {
+      } );
 
-          const mobiles = [
-            'iphone-6',
-            'iphone-xr',
-            'samsung-note9'
-          ];
+      context( 'Mobile experience', () => {
 
-          mobiles.forEach( mobile => {
+        const mobiles = [
+          'iphone-6',
+          'iphone-xr',
+          'samsung-note9'
+        ];
 
-            context( mobile, () => {
+        mobiles.forEach( mobile => {
 
-              beforeEach( () => {
-                cy.viewport( mobile );
-              } );
+          context( mobile, () => {
 
-              it( 'should be present', () => {
-                fig.open();
-                fig.toc().should( 'be.visible' );
-              } );
+            beforeEach( () => {
+              cy.viewport( mobile );
+            } );
 
-              it( 'should expand', () => {
-                fig.toggleToc();
-                fig.getNavItem( 1 ).should( 'be.visible' );
-              } );
+            it( 'should be present', () => {
+              fig.open();
+              fig.toc().should( 'be.visible' );
+            } );
 
-              it( 'should collapse', () => {
-                fig.toggleToc();
-                fig.getNavItem( 1 ).should( 'not.be.visible' );
-              } );
+            it( 'should expand', () => {
+              fig.toggleToc();
+              fig.getNavItem( 1 ).should( 'be.visible' );
+            } );
 
-              it( 'should be sticky', () => {
-                fig.toc().should( 'be.visible' );
-                cy.scrollTo( 0, 1000 );
-                fig.toc().should( 'be.visible' );
-              } );
+            it( 'should collapse', () => {
+              fig.toggleToc();
+              fig.getNavItem( 1 ).should( 'not.be.visible' );
+            } );
 
-              it( 'jump to correct sections', () => {
-                fig.toggleToc();
-                fig.clickNavItem( 4 );
-                fig.getSection( 4 ).should( 'be.inViewport' );
-                fig.getSection( 2 ).should( 'not.be.inViewport' );
+            it( 'should be sticky', () => {
+              fig.toc().should( 'be.visible' );
+              cy.scrollTo( 0, 1000 );
+              fig.toc().should( 'be.visible' );
+            } );
 
-                fig.toggleToc();
-                fig.clickNavItem( 1 );
-                fig.getSection( 1 ).should( 'be.inViewport' );
-                fig.getSection( 4 ).should( 'not.be.inViewport' );
-              } );
+            it( 'jump to correct sections', () => {
+              fig.toggleToc();
+              fig.clickNavItem( 4 );
+              fig.getSection( 4 ).should( 'be.inViewport' );
+              fig.getSection( 2 ).should( 'not.be.inViewport' );
 
+              fig.toggleToc();
+              fig.clickNavItem( 1 );
+              fig.getSection( 1 ).should( 'be.inViewport' );
+              fig.getSection( 4 ).should( 'not.be.inViewport' );
             } );
 
           } );


### PR DESCRIPTION
Currently, the interactive FIG desktop side nav and mobile accordion nav are initialized on page load based on the user's viewport width. They are not re-initialized if the user changes the width of their browser. This PR uses [`matchMedia`](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) to listen for viewport resizing and enable/disable FIG features as needed.

I also instructed the FIG browser tests to not run unless a `CYPRESS_FIG_URL` environment variable is defined because the FIG URL is a moving target until we launch so it probably shouldn't be hardcoded.

## Changes

- Moved the FIG mobile nav logic into its own function so it can be enabled/disabled if/when the user resizes their browser window.
- Simplified the FIG browser test file to skip the FIG tests if the user hasn't defined a `CYPRESS_FIG_URL` environment variable.

## Additions

- `CYPRESS_FIG_URL` environment variable that has to be defined or the FIG tests won't run (which is good because most of us don't have a FIG page on our localhost).

## How to test this PR

1. Units tests should pass: `yarn jest fig-sidenav-utils-spec.js`
1. Functional tests should pass headlessly:
    `yarn cypress run --spec test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js --env FIG_URL=/data-research/small-business-lending/filing-instruction-guide/filing-instructions-guide-test/ --config baseUrl=https://<secret-dev4-subdomain>.cfpb.gov`
1. Functional tests should pass with your local copy of Chrome:
    `yarn cypress open --e2e --browser chrome --env FIG_URL=/data-research/small-business-lending/filing-instruction-guide/filing-instructions-guide-test/ --config baseUrl=https://<secret-dev4-subdomain>.cfpb.gov `


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
