### PR TITLE
FIG data points: Allow html tags in certain fields

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -12,7 +12,7 @@
                 </a>
             </h3>
             <p>Rule section: {{point.rule_section }}</p>
-            <p>{{point.intro_text }}</p>
+            <p>{{point.intro_text | safe }}</p>
 
             {{ data_fields_directory(data_fields) }}
 
@@ -54,7 +54,7 @@
         {{field.info.get('short_name', '')}}
 
         <h5>Instructions</h5>
-        {{field.info.get('instruction_text', '')}}
+        {{field.info.get('instruction_text', '') | safe }}
         <ul>
             <li>Field type: {{field.info.get('type', '')}} </li>
             <li>{{field.info.get('conditionality', '')}} </li>


### PR DESCRIPTION
Some data points want bullet points or multiple paragraphs of explanation. The existing data points template only allows single paragraphs. Update to allow custom html in certain parts of the template that will sometimes have more complex text.

## Changes

- Mark a few fields as `safe` in the jinja template.


## How to test this PR

1. Use a data points JSON file that has HTML styling in a `intro_text` or `instruction_text` field. (There's an example in the `test` branch of our private repo)
2. Import it into your test FIG as usual
3. See that it displays as rendered HTML


## Notes and todos

-  If this is too much of a risk (e.g. for XSS attacks), help me think of a better solution.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance