### PR TITLE
Minor FIG markup improvements

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
@@ -16,6 +16,7 @@
 {% set block_heading_level = block_types[block_type].heading | default('h4') %}
 {% set block_class = block_types[block_type].class | default('o-fig_section') %}
 
+{% set data_attr = '' %}
 {% if block_type in ['Fig_Section', 'Fig_Subsection'] %}
     {% set header = value.section_id + ". " + value.header %}
     {% set data_attr = 'data-scrollspy' %}

--- a/cfgov/jinja2/v1/_includes/organisms/secondary-navigation-fig.html
+++ b/cfgov/jinja2/v1/_includes/organisms/secondary-navigation-fig.html
@@ -46,13 +46,13 @@
         <p class="u-hide-on-desktop">
             Effective {{ effective_start_date }} to {{ effective_end_date }}
         </p>
+        <div id="ctrl-f"></div>
         <ul class="m-list
                  m-list__unstyled
                  o-secondary-navigation_list
                  o-secondary-navigation_list__parents">
             {%- for item in toc_headers %}
             <li class="m-list_item">
-                <div id="ctrl-f"></div>
                 {{ nav_link.render(item.id + ". " + item.header, item.anchor, true) }}
                 {% if item.children %}
                 <ul class="m-list


### PR DESCRIPTION
Move FIG search bar outside loop, set default search data attribute.

The search bar container was inside a loop and being rendered multiple times (this went unnoticed because it's smart enough to only initialize once) and some FIG sections had a raw `{{ data_attr }}` in their markup because no default empty value was specified.

## How to test this PR

1. I deployed this branch to dev4, https://<dev4>.cfpb.gov/data-research/small-business-lending/filing-instruction-guide/202x-filing-instructions-guide/ should look and behave normlly.
