### PR TITLE
Fix retirement linter errors

### DIFF
--- a/cfgov/unprocessed/apps/retirement/js/utils/handle-string-input.js
+++ b/cfgov/unprocessed/apps/retirement/js/utils/handle-string-input.js
@@ -20,7 +20,7 @@ function handleStringInput( numberString ) {
   }
 
   // Strip non-numeric values, maintaining periods
-  numberString = numberString.replace( /[^0-9\.]+/g, '' );
+  numberString = numberString.replace( /[^0-9.]+/g, '' );
 
   /**
    * This helper function places commas in the string. It's set up to

--- a/cfgov/unprocessed/apps/retirement/js/utils/num-to-money.js
+++ b/cfgov/unprocessed/apps/retirement/js/utils/num-to-money.js
@@ -7,7 +7,7 @@ function numToMoney( num ) {
   let money;
   // When num is a string, we should, ironically, strip its numbers first.
   if ( typeof num === 'string' ) {
-    num = Number( num.replace( /[^0-9\.]+/g, '' ) );
+    num = Number( num.replace( /[^0-9.]+/g, '' ) );
   }
   if ( typeof num === 'object' ) {
     num = 0;

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -4,7 +4,7 @@ import isElementInView from '../utils/is-element-in-view';
 import nextStepsView from './next-steps-view';
 import numToMoney from '../utils/num-to-money';
 import questionsView from './questions-view';
-import strToNum from '../utils/handle-string-input';
+import handleStringInput from '../utils/handle-string-input';
 import validDates from '../utils/valid-dates';
 
 // TODO: remove jquery.
@@ -88,6 +88,7 @@ function gettext( msgid ) {
 }
 
 function init() {
+  console.log( 'init graph view' );
   getTranslations();
 
   $( 'input[name="benefits-display"]' ).click( function() {
@@ -129,7 +130,7 @@ function init() {
 
   // reformat salary
   $( '#salary-input' ).blur( function() {
-    const salaryNumber = strToNum( $( '#salary-input' ).val() ),
+    const salaryNumber = handleStringInput( $( '#salary-input' ).val() ),
           salary = numToMoney( salaryNumber );
     $( '#salary-input' ).val( salary );
   } );
@@ -227,7 +228,7 @@ function validateBirthdayFields() {
 function getYourEstimates() {
   const dataLang = document.querySelector( 'html' ).getAttribute( 'lang' );
   const dates = validateBirthdayFields();
-  const salary = strToNum( $( '#salary-input' ).val() );
+  const salary = handleStringInput( $( '#salary-input' ).val() );
   let SSData;
 
   // Hide warnings, show loading indicator

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -88,7 +88,6 @@ function gettext( msgid ) {
 }
 
 function init() {
-  const SSData = getModelValues.benefits();
   getTranslations();
 
   $( 'input[name="benefits-display"]' ).click( function() {
@@ -229,7 +228,6 @@ function getYourEstimates() {
   const dataLang = document.querySelector( 'html' ).getAttribute( 'lang' );
   const dates = validateBirthdayFields();
   const salary = strToNum( $( '#salary-input' ).val() );
-  let lifetimeData;
   let SSData;
 
   // Hide warnings, show loading indicator
@@ -240,7 +238,6 @@ function getYourEstimates() {
   $.when( fetch.apiData( dates.concat, salary, dataLang ) ).done( function( resp ) {
     if ( resp.error === '' ) {
       SSData = getModelValues.benefits();
-      lifetimeData = getModelValues.lifetime();
       $( '.step-two .question' ).css( 'display', 'inline-block' );
       $(
         '.step-one-hidden,' +
@@ -332,8 +329,8 @@ function setTextByAge() {
   const selectedFRA = selectedAge === SSData.fullAge;
   const selectedAboveFRA = selectedAge > SSData.fullAge;
   const selectedCurrent = selectedAge === SSData.currentAge;
-  const isFRA = SSData.currentAge === SSData.fullAge;
-  const isYoungerThanFRA = SSData.currentAge < SSData.fullAge;
+  // const isFRA = SSData.currentAge === SSData.fullAge;
+  // const isYoungerThanFRA = SSData.currentAge < SSData.fullAge;
   const $benefitsMod = $( '.benefit-modification-text' );
   const $selectedAgeText = $( '#selected-retirement-age-value' );
   const $fullAgeBenefits = $( '#full-age-benefits-text' );

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -88,7 +88,6 @@ function gettext( msgid ) {
 }
 
 function init() {
-  console.log( 'init graph view' );
   getTranslations();
 
   $( 'input[name="benefits-display"]' ).click( function() {

--- a/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
@@ -1,8 +1,6 @@
 // TODO: remove jquery.
 import $ from 'jquery';
 
-let currentTooltip;
-
 function init() {
   // Tooltip handler
   const tooltipHandlers = document.querySelectorAll( '[data-tooltip-target]' );
@@ -18,6 +16,8 @@ function init() {
 }
 
 function toolTipper( elem ) {
+  let currentTooltip;
+
   // position tooltip-container based on the element clicked.
   const $elem = $( elem );
   const $ttc = $( '#tooltip-container' );


### PR DESCRIPTION
## Changes

- Remove or comment out unused variables.
- Remove extraneous escaped regex characters.
- Move scope of variable that was out of scope.


## How to test this PR

1. `yarn build` and visit /consumer-tools/retirement/before-you-claim/ and make sure the app still works.