### PR TITLE
FIG: Allow HTML in table cells 

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -62,32 +62,35 @@
 
         {{ list_if_present(field.info.get('examples'), "Examples") }}
 
-        {%- set valid_values = field.info.get('valid_values') -%}
-        {% if valid_values %}
-            {%- set header_row = valid_values[0] -%}
-            {%- set body_rows = valid_values[1:] -%}
-                <table>
-                    <thead>
-                        <tr>
-                           {% for column in header_row %}
-                           <th>{{ column }}</th>
-                           {% endfor %}
-                        </tr>
-                    </thead>
-                    <tbody>
-                    {% for row in body_rows %}
-                        <tr>
-                        {% for cell in row %}
-                            <td> {{cell}}</td>
-                        {% endfor %}
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-        {% endif %}
+        {{ values_table(field.info.get('valid_values')) }}
 
         {{ list_if_present(field.info.get('validations'), 'Validations') }}
     </div>
+{% endmacro %}
+
+{% macro values_table(valid_values) %}
+    {% if valid_values %}
+        {%- set header_row = valid_values[0] -%}
+        {%- set body_rows = valid_values[1:] -%}
+            <table>
+                <thead>
+                    <tr>
+                       {% for column in header_row %}
+                       <th>{{ column }}</th>
+                       {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                {% for row in body_rows %}
+                    <tr>
+                    {% for cell in row %}
+                        <td> {{cell | safe }}</td>
+                    {% endfor %}
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+    {% endif %}
 {% endmacro %}
 
 {% macro list_if_present(items, header) %}

--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -54,7 +54,7 @@
         {{field.info.get('short_name', '')}}
 
         <h5>Instructions</h5>
-        {{field.info.get('instruction_text', '') | safe }}
+        <p>{{field.info.get('instruction_text', '') | safe }}<p>
         <ul>
             <li>Field type: {{field.info.get('type', '')}} </li>
             <li>{{field.info.get('conditionality', '')}} </li>


### PR DESCRIPTION
This is an expansion to #7296. Now we're allowing html formatting within table cells, and improving formatting for instruction text.


## Changes

- Minor spacing improvement with a `<p>` tag
- Use `safe` to allow html in table cells
- Better compartmentalization of code


## How to test this PR

1. Use a data points JSON file that has HTML styling in a valid_values field. (There's an example in the test branch of our private repo)
2. Import it into your test FIG as usual
3. See that it displays as rendered HTML


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance