### PR TITLE
Remove/adjust unused variables

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/form-explainer.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/form-explainer/form-explainer.js
@@ -578,7 +578,7 @@ class FormExplainer {
   /* Initialize the DOM events for the entire explainer UI. */
   initializeEvents() {
     const uiElements = this.elements;
-    const delay = 700;
+    const delay = 600;
 
     this.stickImage();
 
@@ -685,7 +685,7 @@ class FormExplainer {
           );
 
           this.updateAttention( closestFormExplainer, CSS.HAS_ATTENTION );
-          this.updateImagePositionAfterAnimation( 600 );
+          this.updateImagePositionAfterAnimation( delay );
         }
       }
     );

--- a/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
@@ -16,7 +16,6 @@ function init() {
 }
 
 function toolTipper( elem ) {
-  let currentTooltip;
 
   // position tooltip-container based on the element clicked.
   const $elem = $( elem );
@@ -35,7 +34,6 @@ function toolTipper( elem ) {
   $ttc.width( $( '#claiming-social-security' ).width() / 3 );
 
   $ttc.find( '.content' ).html( content );
-  currentTooltip = $elem;
 
   $ttc.show();
   const newTop = $elem.offset().top + $elem.outerHeight() + 10;
@@ -90,7 +88,6 @@ function toolTipper( elem ) {
     };
     $ttc.hide();
     $ttc.find( '.content' ).html( '' );
-    currentTooltip = null;
   } );
 
   window.addEventListener( 'resize', function() {


### PR DESCRIPTION
## Changes

- Uses `delay` variable in form explainer, which had been unused.
- Removes `currentTooltip` variable, which is set, but otherwise unreferenced.


## How to test this PR

1. https://www.consumerfinance.gov/consumer-tools/retirement/before-you-claim/ and http://localhost:8000/owning-a-home/loan-estimate/ should work as before.