### PR TITLE
FIG data points: Add optional field "citation"

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -50,6 +50,11 @@
             </a>
         </h4>
 
+        {%- set citation = field.info.get('citation', '') -%}
+        {% if citation %}
+            <p>Rule section: {{ citation }}</p>
+        {% endif %}
+
         <h5>Short name</h5>
         {{field.info.get('short_name', '')}}
 


### PR DESCRIPTION
Certain data fields want a more specific rule citation than their parent data point. This PR allows them to show on the page, if they're included in the JSON as a `citation` property of a `data_field` object.

## Additions

- "Rule section: {{ citation }}" where present in the JSON


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance