### PR TITLE
Regs3k: Delete nonfunctional test

### DIFF
--- a/test/unit_tests/apps/regulations3k/js/index-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/index-spec.js
@@ -1,7 +1,0 @@
-import app from '../../../../../cfgov/unprocessed/apps/regulations3k/js/index.js';
-
-describe( 'The app', () => {
-  it( 'should not throw any errors on init', () => {
-    expect( () => app ).not.toThrow();
-  } );
-} );


### PR DESCRIPTION
See [GHE]/CFGOV/platform/issues/4483

This test is importing a module that doesn't have an export. 

The value of `app` is an empty object `{}`. Throwing an error in the `init` method of the tested file doesn't make a difference. This PR throws out the test (maybe in the future it could be re-written to be more effective).

## Removals

- Removes nonfunctional regs3k index test.


## How to test this PR

1. PR checks should pass.
