### PR TITLE
Analytics: Use modern query params for logging

### DIFF
--- a/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
+++ b/cfgov/unprocessed/apps/analytics-gtm/js/util/analytics-util.js
@@ -30,7 +30,13 @@ function addEventListenerToElem( elem, event, callback ) {
  * @param {string} msg - Message to load to the console.
  */
 function analyticsLog( ...msg ) {
-  if ( getQueryParameter( 'debug-gtm' ) === true ) {
+
+  // Get query params.
+  const queryParams = new Proxy(new URLSearchParams(window.location.search), {
+    get: (searchParams, prop) => searchParams.get(prop),
+  });
+
+  if ( queryParams['debug-gtm'] === 'true' ) {
     console.log( `ANALYTICS DEBUG MODE: ${ msg }` );
   }
 }
@@ -91,30 +97,11 @@ function hostsAreEqual( host1, host2 ) {
   return createTestHost( host1 ) === createTestHost( host2 );
 }
 
-/**
- * Retrieve a URL query string parameter by parameter name.
- * @param  {string} key - The name of the parameter in the URL.
- * @returns {string|null} The value of the parameter.
- */
-function getQueryParameter( key ) {
-  const url = window.location.href;
-  const param = key.replace( /[\[\]]/g, '\\$&' );
-  const regex = new RegExp( '[?&]' + param + '(=([^&#]*)|&|#|$)' );
-  const results = regex.exec( url );
-  if ( !results ) return null;
-  if ( !results[2] ) return '';
-  const decoded = decodeURIComponent( results[2].replace( /\+/g, ' ' ) );
-  if ( decoded === 'true' ) return true;
-  if ( decoded === 'false' ) return false;
-  return decoded;
-}
-
 module.exports = {
   addEventListenerToSelector,
   addEventListenerToElem,
   analyticsLog,
   Delay,
-  getQueryParameter,
   hostsAreEqual,
   track
 };


### PR DESCRIPTION
The `gtm-debug=true` URL parameter can be added to log out some analytics calls. This uses an antiquated method of retrieving the URL parameters. This PR updates it to use a modern method.

## Changes

- Update URL parameter query retrieval method in analytics-utils.


## How to test this PR

1. `yarn build` and visit http://localhost:8000/?debug-gtm=true and open the dev console and scroll the page. You should see analytics events logged regarding scrolling the page.
