### PR TITLE
FIG: Improve layout of information about data points

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -59,11 +59,11 @@
         {{field.info.get('short_name', '')}}
 
         <h5>Instructions</h5>
-        <p>{{field.info.get('instruction_text', '') | safe }}<p>
         <ul>
             <li>Field type: {{field.info.get('type', '')}} </li>
             <li>{{field.info.get('conditionality', '')}} </li>
         </ul>
+        <p>{{field.info.get('instruction_text', '') | safe }}<p>
 
         {{ list_if_present(field.info.get('examples'), "Examples") }}
 


### PR DESCRIPTION
Field type and Conditionality are now the top bullet points under the "Instructions" header, since they need to be easy to find.


## Changes

- Minor change to the data points template in the FIG page


## Screenshots

[See internal GH ticket 269]


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
