### PR TITLE
Fix a few straggling jsdoc lint warnings

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -27,7 +27,7 @@ const scrollY = () => window.scrollY || window.pageYOffset;
  * getFirstMatch - Get the first match of a REGEX
  *
  * @param {string} haystack - String to search
- * @param {regex} needle - REGEX to search for
+ * @param {string} needle - REGEX to search for
  * @returns {string} Matched string or empty string
  */
 const getFirstMatch = (haystack, needle) => {
@@ -40,8 +40,8 @@ const getFirstMatch = (haystack, needle) => {
 /**
  * getYLocation - Get Y location of provided element on the page.
  *
- * @param {node} el - HTML element.
- * @returns {type} TODO add description.
+ * @param {HTMLElement} el - HTML element.
+ * @returns {number} Pixel value of vertical page location of element.
  */
 const getYLocation = (el) => {
   const elOffset = el.getBoundingClientRect().top;
@@ -52,7 +52,7 @@ const getYLocation = (el) => {
  * getParagraphPositions - Get an array of all paragraphs with their IDs
  * mapped to their Y position (number of pixels from top of page).
  *
- * @param {nodelist} paragraphs - Nodelist of HTML elements with IDs.
+ * @param {NodeList} paragraphs - Nodelist of HTML elements with IDs.
  * @returns {Array} Array of objects w/ paragraph IDs and y positions.
  */
 const getParagraphPositions = (paragraphs) => {
@@ -77,7 +77,7 @@ const getParagraphPositions = (paragraphs) => {
  *
  * @param {number} currentPosition - Current viewport Y coordinate.
  * @param {Array} paragraphs - List of paragraphs on the page.
- * @returns {str} HTML ID of closest paragraph
+ * @returns {string} HTML ID of closest paragraph
  */
 const getCurrentParagraph = (currentPosition, paragraphs) => {
   let currentId = null;
@@ -248,7 +248,7 @@ const updateWayfinder = function (scroll, wayfinder, mainContent) {
 /**
  * updateParagraphPositions - Update the array that tracks paragraph positions.
  *
- * @returns {type} Array of paragraph positions.
+ * @returns {Array} Array of paragraph positions.
  */
 const updateParagraphPositions = () => {
   const paragraphs = document.querySelectorAll('.regdown-block');

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -396,8 +396,9 @@ function generateCSV() {
     ' or underserved?, Date processed\n';
 
   /**
+   * Process each cell in a table row.
    *
-   * @param element
+   * @param {HTMLElement} element - A table data element to process.
    */
   function _loopHandler(element) {
     const isHidden = DT.hasClass(DT.getParentEls('.js-table'), 'u-hidden');

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
@@ -55,9 +55,9 @@ function applyAll(elements, applyFn) {
 
 /**
  *
- * @param elements
- * @param events
- * @param callback
+ * @param {Array} elements - A list of HTML DOM nodes.
+ * @param {Array|string} events - A list or single event type.
+ * @param {Function} callback - A function to call at the end.
  */
 function bindEvents(elements, events, callback) {
   if (Array.isArray(events) === false) {
@@ -72,9 +72,8 @@ function bindEvents(elements, events, callback) {
 }
 
 /**
- *
- * @param parent
- * @param child
+ * @param {HTMLElement|string} parent - An HTML element node or CSS selector.
+ * @param {HTMLElement|string} child - An HTML element node or snippet.
  */
 function addEl(parent, child) {
   return fastDom.mutate(function () {
@@ -114,7 +113,7 @@ function changeElHTML(selector, HTML) {
 /**
  * Code copied from jQuery with minimal modifications.
  *
- * @param {HTMLElement} HTML - An HTML DOM node.
+ * @param {HTMLElement|string} HTML - An HTML DOM node or snippet.
  * @returns {DocumentFragment} The created document fragment node.
  */
 function createEl(HTML) {
@@ -216,7 +215,7 @@ function filter(element, propName, filter) {
 }
 
 /**
- * @param {string} selector - A CSS selector.
+ * @param {HTMLElement|string} selector - An HTML element node or CSS selector.
  * @returns {HTMLElement} An HTML node returned by the passed selector,
  *  or the selector passed into this method.
  */
@@ -228,7 +227,7 @@ function getEl(selector) {
 }
 
 /**
- * @param {string} selector - A CSS selector.
+ * @param {HTMLElement|string} selector - An HTML element node or CSS selector.
  * @returns {NodeList} A list of HTML nodes returned by the passed selector,
  *  or the selector passed into this method.
  */
@@ -278,8 +277,9 @@ function getNextEls(element, filterNode) {
 }
 
 /**
+ * Check whether something is a NodeList, HTML element, or window.
  *
- * @param element
+ * @param {*} element - An object to check for element-ness.
  */
 function isEl(element) {
   return (
@@ -291,8 +291,6 @@ function isEl(element) {
 }
 
 /**
- * Check whether something is a NodeList, HTML element, or window.
- *
  * @param {*} selector - Something, possibly a list, element or window instance.
  */
 function hide(selector) {
@@ -302,8 +300,6 @@ function hide(selector) {
 }
 
 /**
- * Check whether something is a NodeList, HTML element, or window.
- *
  * @param {*} selector - Something, possibly a list, element or window instance.
  */
 function show(selector) {
@@ -315,7 +311,7 @@ function show(selector) {
 /**
  * @param {string} selector - A CSS selector for an element.
  * @param {number} time - When to call the callback.
- * @param {[Function]} callback - Function to call after delay.
+ * @param {Function} [callback] - Function to call after delay.
  */
 function fadeIn(selector, time, callback) {
   const element = getEl(selector);
@@ -336,7 +332,7 @@ function fadeIn(selector, time, callback) {
 /**
  * @param {string} selector - A CSS selector for an element.
  * @param {number} time - When to call the callback.
- * @param {[Function]} callback - Function to call after delay.
+ * @param {Function} [callback] - Function to call after delay.
  */
 function fadeOut(selector, time, callback) {
   const element = getEl(selector);
@@ -361,7 +357,8 @@ function mutate(callback) {
 }
 
 /**
- * @param {Function} callback - Function to pass to the wrapped call to requestAnimationFrame.
+ * @param {Function} callback - Function to pass to the wrapped call
+ *   to requestAnimationFrame.
  */
 function nextFrame(callback) {
   fastDom.raf(callback);

--- a/cfgov/unprocessed/js/modules/youtube-api.js
+++ b/cfgov/unprocessed/js/modules/youtube-api.js
@@ -75,7 +75,7 @@ function fetchImageURL(videoId) {
  * @param {HTMLElement} iframeContainerDom - A reference to <iframe>
  *   to embed the video.
  * @param {string} videoId - A YouTube video ID.
- * @returns {YT.Player} A YouTube Player instance.
+ * @returns {object} A YouTube Player instance (YT.Player).
  * @throws {Error} If the IFrame API has not loaded.
  */
 function instantiatePlayer(iframeContainerDom, videoId) {

--- a/cfgov/unprocessed/js/organisms/EmailPopup.js
+++ b/cfgov/unprocessed/js/organisms/EmailPopup.js
@@ -12,7 +12,7 @@ import FormSubmit from './FormSubmit.js';
  * @class
  * @classdesc Initializes the organism.
  * @param {HTMLElement} element - The HTML DOM element.
- * @returns {EmailSignup} An instance.
+ * @returns {EmailPopup} An instance.
  */
 function EmailPopup(element) {
   const VISIBLE_CLASS = 'o-email-popup__visible';
@@ -69,9 +69,6 @@ function EmailPopup(element) {
 
   /**
    * Callback function invoked after successful email submission.
-   *
-   * @param {Event} event - Click event.
-   * @param {Event} event - Click event.
    */
   function _onEmailSignupSuccess() {
     emailHelpers.recordEmailRegistration(_popupLabel);

--- a/test/unit_tests/js/modules/Analytics-spec.js
+++ b/test/unit_tests/js/modules/Analytics-spec.js
@@ -10,8 +10,10 @@ describe('Analytics', () => {
 
   beforeEach(() => {
     /**
+     * Mock for window.dataLayer.push.
      *
-     * @param object
+     * @param {*} object - What to push onto the window.dataLayer.
+     * @returns {Array} New pushed array items.
      */
     function push(object) {
       if (
@@ -22,6 +24,7 @@ describe('Analytics', () => {
       }
       return [].push.call(this, object);
     }
+
     window.dataLayer = [];
     window.dataLayer.push = push;
     delete window['google_tag_manager'];

--- a/test/unit_tests/js/modules/util/behavior-spec.js
+++ b/test/unit_tests/js/modules/util/behavior-spec.js
@@ -23,10 +23,9 @@ const HTML_SNIPPET = `
 `;
 
 /**
- *
- * @param target
- * @param eventType
- * @param eventOption
+ * @param {HTMLElement} target - The target element of the event.
+ * @param {string} eventType - The event type description.
+ * @param {string} eventOption - A keyCode, if the event is a keyup event.
  */
 function triggerEvent(target, eventType, eventOption) {
   const event = document.createEvent('Event');


### PR DESCRIPTION
Last follow up to https://github.com/cfpb/consumerfinance.gov/pull/7328 to correct warnings.

## Changes

- Set correct param types.
- Fill in TODOs and empty comments.


## How to test this PR

1. PR checks should pass.

## Notes and todos

- I've left much of the TDP and buying a car linting warnings, custom return type warnings, and absent return types (which would require more checks to get right).
