### PR TITLE
Remove unnecessary block class from FIG content

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -3,7 +3,7 @@
     {% for point in page.data_points.order_by('number') %}
         {%- set data_fields = point.data_fields_json.order_by("pk") -%}
 
-        <div class="block o-fig_section__sub" data-search-section>
+        <div class="o-fig_section__sub" data-search-section>
             <h3 class="report-header o-fig_heading">
                 <a id="{{ point.anchor }}"
                    href="#{{ point.anchor }}"
@@ -42,7 +42,7 @@
 {% endmacro %}
 
 {% macro individual_data_field(field) %}
-    <div class="block o-fig_section__sub-sub" data-search-section>
+    <div class="o-fig_section__sub-sub" data-search-section>
         <h4 class="report-header o-fig_heading">
             <a id="{{field.info.get('short_name', '')}}"
                     href="#{{field.info.get('short_name', '')}}">

--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
@@ -24,9 +24,9 @@
     {% set header = value.header %}
 {% endif %}
 
-<div class="block {{ block_class }}" data-search-section>
+<div class="{{ block_class }}" data-search-section>
     <{{ block_heading_level }}
-        class="report-header o-fig_heading">
+        class="o-fig_heading">
         <a id="{{ value.section_id }}"
            href="#{{ value.section_id }}"
            {{ data_attr }}>

--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
@@ -2,7 +2,6 @@
 @import '../node_modules/ctrl-f/dist/css/index.css';
 
 .o-fig {
-
   // Make the side navigation sticky
   .content_sidebar {
     position: sticky;
@@ -16,7 +15,6 @@
       overflow-y: auto;
     }
   } );
-
 }
 
 .o-fig_main {
@@ -27,37 +25,33 @@
 
   h2 {
     .h1();
+    margin-top: 60px;
   }
 
   h3 {
     .h2();
+    margin-top: 45px;
   }
 
-  :not( .m-info-unit_heading-text ) > h4 {
+  :not(.m-info-unit_heading-text) > h4 {
     .h3();
+    margin-top: 30px;
   }
 
   h5 {
     .h4();
-  }
-
-  // Set the gap above all headings to 30px
-  * + h2,
-  * + h3,
-  * + h4,
-  * + h5 {
-    margin-top: unit( 30px / @base-font-size-px, em );
+    margin-top: 30px;
   }
 
   pre {
-    font-family: Menlo, "Andale Mono", "Courier New", monospace;
+    font-family: Menlo, 'Andale Mono', 'Courier New', monospace;
     overflow-x: auto;
-    font-size: unit( 14px / @base-font-size-px, em );
+    font-size: unit(14px / @base-font-size-px, em);
     white-space: pre;
   }
 
   .o-table {
-    margin-top: unit( 30px / @base-font-size-px, em );
+    margin-top: unit(30px / @base-font-size-px, em);
     td {
       vertical-align: top;
       hyphens: auto;
@@ -92,21 +86,21 @@
 }
 
 .o-fig_section__sub-sub {
-  margin-top: unit( 45px / @base-font-size-px, em );
-  margin-bottom: unit( 45px / @base-font-size-px, em );
+  margin-top: unit(45px / @base-font-size-px, em);
+  margin-bottom: unit(45px / @base-font-size-px, em);
 
   // Put a horizontal rule below all sub level 3 headings
   &:after {
     display: inline-block;
-    content: "";
+    content: '';
     border-top: 2px solid @gray-50;
-    width: calc( 100% + 30px );
-    margin: unit( 45px / @base-font-size-px, em ) 0 0 unit( -30px / @base-font-size-px, em );
+    width: calc(100% + 30px);
+    margin: unit(45px / @base-font-size-px, em) 0 0
+      unit(-30px / @base-font-size-px, em);
   }
 }
 
 .o-fig_sidebar {
-
   .o-expandable_label {
     width: 95%;
   }
@@ -120,7 +114,7 @@
       // Add a large buffer underneath to ensure mobile users
       // can use assistive technology like Reachability to access
       // items at the bottom of the list
-      padding-bottom: unit( 420px / @base-font-size-px, em );
+      padding-bottom: unit(420px / @base-font-size-px, em);
     }
   }
 
@@ -131,28 +125,28 @@
   } );
 
   .m-nav-link {
-    padding-left: unit( 40px / @base-font-size-px, em );
-    text-indent: unit( -30px / @base-font-size-px, em );
+    padding-left: unit(40px / @base-font-size-px, em);
+    text-indent: unit(-30px / @base-font-size-px, em);
   }
 
   .o-secondary-navigation_list__parents > li > a {
-    padding-left: unit( 30px / @base-font-size-px, em );
-    text-indent: unit( -18px / @base-font-size-px, em );
+    padding-left: unit(30px / @base-font-size-px, em);
+    text-indent: unit(-18px / @base-font-size-px, em);
   }
 
   h4 {
-    padding-left: unit( 19px / @size-iv, em );
+    padding-left: unit(19px / @size-iv, em);
   }
 
   .o-report-sidenav__appendix > li > a {
-    text-indent: unit( -20px / @base-font-size-px, em );
+    text-indent: unit(-20px / @base-font-size-px, em);
   }
 
   .parent-header {
-    .o-secondary-navigation_list__children  {
+    .o-secondary-navigation_list__children {
       display: block;
       margin-top: 0;
-      margin-bottom:0.5em;
+      margin-bottom: 0.5em;
       .m-nav-link {
         padding-top: 0.5em;
         padding-bottom: 0.5em;
@@ -161,12 +155,12 @@
   }
 }
 
-
 .research-report {
   // 670px, plus a 15px gutter on each side (standard paragrah widths)
-  max-width: unit( (670 + 30) / 16, em );
+  max-width: unit((670 + 30) / 16, em);
 
-  .lead-paragraph, .author-names {
+  .lead-paragraph,
+  .author-names {
     margin: 30px 0 30px 0;
   }
 
@@ -210,5 +204,5 @@
 }
 
 #ctrl-f-modal h3 {
-  font-size: unit( 16px / @base-font-size-px, em );
+  font-size: unit(16px / @base-font-size-px, em);
 }


### PR DESCRIPTION
The spacing on the FIG page is wonky. The main culprit is that we unnecessarily wrap every section in a `block` class. This PR removes that class (and another unnecessary `report-header` class) and fixes the spacing.

I also linted our CSS file to be in line with our new syntax standards which is why that file is showing a lot of changes.

## How to test this PR

1. Pull down this branch.
1. `yarn styles`
1. Nothing should substantially be different on your local FIG page except the spacing will be a little smaller between sections.

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
