### PR TITLE
Configure default Python formatter for VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": false
+  "editor.formatOnPaste": false,
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.python"
+  }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,6 +109,19 @@ Once activated, our Python CI requirements can be installed in the virtualenv:
 pip install -r requirements/ci.txt
 ```
 
+### Configure VSCode formatters (optional)
+
+For developers who use [Visual Studio Code](https://code.visualstudio.com/)
+as their editor of choice, you may wish to install certain
+[extensions](https://marketplace.visualstudio.com/VSCode)
+to support easier code formatting.
+
+This repository includes a `.vscode/settings.json` file that sets the
+[Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+as the default code formatter. It also sets the
+[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+as the formatter for Python files.
+
 ### Install pre-commit
 
 We use `pre-commit` to automatically run our linting tools before a commit


### PR DESCRIPTION
PR #7325 configured the VSCode settings for this repository so that Prettier is the default code formatter. This doesn't work for Python files. This commit changes the VSCode settings to set the Python extension as the default formatter; this lets VSCode users use black to format Python files.

This commit also adds documentation about these VSCode extensions.

## Screenshots

<img width="755" alt="image" src="https://user-images.githubusercontent.com/654645/201958538-1dec02f2-4e7a-4024-835e-518a286aa583.png">