### PR TITLE
FIG: Rename "column name" header

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -55,7 +55,7 @@
             <p>Rule section: {{ citation }}</p>
         {% endif %}
 
-        <h5>Short name</h5>
+        <h5>Column name</h5>
         {{field.info.get('short_name', '')}}
 
         <h5>Instructions</h5>


### PR DESCRIPTION
A usability improvement, driven by user tests. Users did not recognize the "short name" label.


## Screenshots

![Screen Shot 2022-11-15 at 4 37 03 PM](https://user-images.githubusercontent.com/4295388/202030774-6a6e2c54-22b8-4913-88eb-bc2fe9e87037.png)




## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
