### PR TITLE
Improve 1071 FIG TOC scrollspy accuracy

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -3,11 +3,10 @@
     {% for point in page.data_points.order_by('number') %}
         {%- set data_fields = point.data_fields_json.order_by("pk") -%}
 
-        <div class="o-fig_section__sub" data-search-section>
+        <div class="o-fig_section__sub" data-search-section data-scrollspy="{{ point.anchor }}">
             <h3 class="report-header o-fig_heading">
                 <a id="{{ point.anchor }}"
-                   href="#{{ point.anchor }}"
-                   data-scrollspy>
+                   href="#{{ point.anchor }}">
                     {{parent_section_id}}.{{point.number}} {{ point.title }}
                 </a>
             </h3>
@@ -19,7 +18,7 @@
         </div>
 
         {% for field in data_fields %}
-            {{ individual_data_field(field) }}
+            {{ individual_data_field(field, point.anchor) }}
         {% endfor %}
 
     {% endfor %}
@@ -41,8 +40,8 @@
     {% endif %}
 {% endmacro %}
 
-{% macro individual_data_field(field) %}
-    <div class="o-fig_section__sub-sub" data-search-section>
+{% macro individual_data_field(field, nav_section) %}
+    <div class="o-fig_section__sub-sub" data-search-section data-scrollspy="{{ nav_section }}">
         <h4 class="report-header o-fig_heading">
             <a id="{{field.info.get('short_name', '')}}"
                     href="#{{field.info.get('short_name', '')}}">

--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/data_points.html
@@ -76,6 +76,7 @@
     {% if valid_values %}
         {%- set header_row = valid_values[0] -%}
         {%- set body_rows = valid_values[1:] -%}
+        <div class="o-table o-table-wrapper__scrolling">
             <table>
                 <thead>
                     <tr>
@@ -95,6 +96,7 @@
                 {% endfor %}
                 </tbody>
             </table>
+        </div>
     {% endif %}
 {% endmacro %}
 

--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
@@ -16,20 +16,17 @@
 {% set block_heading_level = block_types[block_type].heading | default('h4') %}
 {% set block_class = block_types[block_type].class | default('o-fig_section') %}
 
-{% set data_attr = '' %}
 {% if block_type in ['Fig_Section', 'Fig_Subsection'] %}
     {% set header = value.section_id + ". " + value.header %}
-    {% set data_attr = 'data-scrollspy' %}
 {% else %}
     {% set header = value.header %}
 {% endif %}
 
-<div class="{{ block_class }}" data-search-section>
+<div class="{{ block_class }}" data-search-section data-scrollspy="{{ value.section_id }}">
     <{{ block_heading_level }}
         class="o-fig_heading">
         <a id="{{ value.section_id }}"
-           href="#{{ value.section_id }}"
-           {{ data_attr }}>
+           href="#{{ value.section_id }}">
                 {{ header }}
         </a>
     </{{ block_heading_level }}>

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav-utils.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav-utils.js
@@ -87,7 +87,7 @@ const updateNav = (target) => {
 const handleIntersect = (entries) => {
   entries.forEach((entry) => {
     if (entry.intersectionRatio > 0) {
-      updateNav(entry.target.getAttribute('href'));
+      updateNav('#' + entry.target.getAttribute('data-scrollspy'));
     }
   });
 };

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav-utils.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav-utils.js
@@ -84,6 +84,8 @@ const updateNav = (target) => {
  * @param {IntersectionObserverEntry} entries - array of observer entries
  * See https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry
  */
+/* Cypress tests cover IntersectionObserver behavior */
+/* istanbul ignore next */
 const handleIntersect = (entries) => {
   entries.forEach((entry) => {
     if (entry.intersectionRatio > 0) {

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -58,7 +58,7 @@ const init = () => {
       root: document,
 
       /* Sets an intersection area that spans 5% above the top of the viewport and
-         50% above the bottom of the viewport, resulting in a box that is 30% of
+         5% above the bottom of the viewport, resulting in a box that is 30% of
          the viewport height with 5% hanging over the top. */
       rootMargin: '5% 0px -75% 0px',
     });

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -58,12 +58,12 @@ const init = () => {
       root: document,
 
       /* Sets an intersection area that spans 5% above the top of the viewport and
-         95% above the bottom of the viewport, resulting in a box that is 10% of
+         50% above the bottom of the viewport, resulting in a box that is 30% of
          the viewport height with 5% hanging over the top. */
-      rootMargin: '5% 0px -95% 0px',
+      rootMargin: '5% 0px -75% 0px',
     });
 
-    const sections = fig.appRoot.querySelectorAll('a[data-scrollspy]');
+    const sections = fig.appRoot.querySelectorAll('[data-scrollspy]');
 
     sections.forEach((section) => observer.observe(section));
   }

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -83,12 +83,28 @@ describe('1071 Filing Instruction Guide (FIG)', () => {
               fig.getNavItem(1).should('have.class', 'm-nav-link__current');
               fig.getNavItem('credit-type').should('not.be.visible');
 
-              fig.clickSectionHeading(2);
-              fig.getNavItem(2).should('have.class', 'm-nav-link__current');
+              fig.clickSectionHeading(3);
+              fig.getNavItem(3).should('have.class', 'm-nav-link__current');
+              fig.getNavItem('credit-type').should('be.visible');
+
+              fig.clickSectionHeading('application-method');
+              fig
+                .getNavItem('application-method')
+                .should('have.class', 'm-nav-link__current');
+              fig.getNavItem('credit-type').should('be.visible');
+
+              fig.clickSectionHeading(5);
+              fig.getNavItem(5).should('have.class', 'm-nav-link__current');
               fig.getNavItem('credit-type').should('not.be.visible');
 
               fig.clickSectionHeading(3);
               fig.getNavItem(3).should('have.class', 'm-nav-link__current');
+              fig.getNavItem('credit-type').should('be.visible');
+
+              fig.clickSectionHeading('action-taken');
+              fig
+                .getNavItem('action-taken')
+                .should('have.class', 'm-nav-link__current');
               fig.getNavItem('credit-type').should('be.visible');
             });
 


### PR DESCRIPTION
The table of contents in the sidenav highlights the section that the
user is currently viewing. It was doing so by tracking the position of
each section heading in the main content. Now that some sections are
looooooooong, headings can be few and far between, causing the nav
to not get highlighted until a heading is reached.

The section container divs are now being tracked instead of just the
headings to make the scrollspy more accurate.

Fixes https://github.local/CFPB/1071-data-collection/issues/291

## Changes

- Adds the `data-scrollspy` attribute to FIG section containers instead of their headings.
- Unrelated, it makes the FIG tables responsive (see https://github.local/CFPB/1071-data-collection/issues/317)

## How to test this PR

(This branch has been deployed to dev4.)

1. Pull down this branch.
1. Functional tests should pass:
    `yarn cypress run --spec test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js --env FIG_URL=/data-research/small-business-lending/filing-instructions-guide/filing-instructions-guide-test/ --config baseUrl=https://<secret-dev4-subdomain>.cfpb.gov`
1. Manually click around dev4 and double check it satisfies https://github.local/CFPB/1071-data-collection/issues/291