### PR TITLE
Regs3k/TDP: Remove unused `clearCheckbox` method

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search-utils.js
@@ -76,17 +76,6 @@ function hideLoading(el) {
 }
 
 /**
- * Uncheck checkbox.
- *
- * @param {HTMLElement} el - Input element to uncheck.
- * @returns {HTMLElement} Input element.
- */
-function clearCheckbox(el) {
-  el.checked = false;
-  return el;
-}
-
-/**
  * Update the page's URL via replaceState
  *
  * @param {string} base - URL's base.
@@ -125,12 +114,11 @@ function handleError(code) {
 }
 
 module.exports = {
-  getSearchValues: getSearchValues,
-  serializeFormFields: serializeFormFields,
-  buildSearchResultsURL: buildSearchResultsURL,
-  showLoading: showLoading,
-  hideLoading: hideLoading,
-  clearCheckbox: clearCheckbox,
-  handleError: handleError,
-  updateUrl: updateUrl,
+  getSearchValues,
+  serializeFormFields,
+  buildSearchResultsURL,
+  showLoading,
+  hideLoading,
+  handleError,
+  updateUrl,
 };

--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/search-utils.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/search-utils.js
@@ -73,17 +73,6 @@ function hideLoading(el) {
 }
 
 /**
- * Uncheck checkbox.
- *
- * @param {HTMLElement} el - Input element to uncheck.
- * @returns {HTMLElement} Input element.
- */
-function clearCheckbox(el) {
-  el.checked = false;
-  return el;
-}
-
-/**
  * Update the page's URL via replaceState
  *
  * @param {string} base - URL's base.
@@ -122,12 +111,11 @@ function handleError(code) {
 }
 
 module.exports = {
-  getSearchValues: getSearchValues,
-  serializeFormFields: serializeFormFields,
-  buildSearchResultsURL: buildSearchResultsURL,
-  showLoading: showLoading,
-  hideLoading: hideLoading,
-  clearCheckbox: clearCheckbox,
-  handleError: handleError,
-  updateUrl: updateUrl,
+  getSearchValues,
+  serializeFormFields,
+  buildSearchResultsURL,
+  showLoading,
+  hideLoading,
+  handleError,
+  updateUrl,
 };

--- a/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-utils-spec.js
@@ -49,11 +49,6 @@ describe('The Regs3K search utils', () => {
     expect(el.style.opacity).toEqual(1);
   });
 
-  it('should clear a checkbox', () => {
-    const checkbox = utils.clearCheckbox({ checked: true });
-    expect(checkbox.checked).toBeFalsy();
-  });
-
   it('should handle errors', () => {
     const searchError = utils.handleError('no-results');
     expect(searchError.msg).toEqual('Your query returned zero results.');

--- a/test/unit_tests/apps/teachers-digital-platform/js/search-utils-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/search-utils-spec.js
@@ -42,11 +42,6 @@ describe('The TDP search utils', () => {
     expect(el.style.opacity).toEqual(1);
   });
 
-  it('should clear a checkbox', () => {
-    const checkbox = utils.clearCheckbox({ checked: true });
-    expect(checkbox.checked).toBeFalsy();
-  });
-
   it('should handle errors', () => {
     const searchError = utils.handleError('no-results');
     expect(searchError.msg).toEqual('Your query returned zero results.');


### PR DESCRIPTION
I could only find a reference to `clearCheckbox` in the tests.

## Removals

- Remove unused `clearCheckbox` method

## How to test this PR

1. PR checks should pass.
