### PR TITLE
Fix: Item introduction categories don't link

### DIFF
--- a/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
+++ b/cfgov/jinja2/v1/_includes/organisms/item-introduction.html
@@ -36,7 +36,7 @@
 
 <div class="o-item-introduction">
     {% if filter_page_url and page.categories.count() > 0 and value.show_category %}
-        {{ category_slug.render(category=page.categories.first().name, href=page_url) }}
+        {{ category_slug.render(category=page.categories.first().name, href=filter_page_url) }}
     {% endif %}
     <h1>{{ value.heading | safe }}</h1>
 


### PR DESCRIPTION
Item introduction categories originally linked back to a filtered version of their parent filter, when the item introduction configuration option "Show category" is checked.

This was broken by [this commit](https://github.com/cfpb/consumerfinance.gov/commit/705d8f0f9cad6f4aa807bd2f9147d4649fcc96aa) back in 2018 (by yours truly).

We use "Show category" sparingly on item introductions. An example production page with this option checked is [this one](
https://www.consumerfinance.gov/foia-requests/foia-electronic-reading-room/2017-student-banking-report-correspondence/).

Note that currently the category renders as a plain text "Record" that doesn't link anywhere. With this commit, the category renders as a bold link that links back to the parent filterable list.

|Before|After|
|-|-|
|<img width="766" alt="image" src="https://user-images.githubusercontent.com/654645/203145856-15bfb51a-efff-418d-a220-2b2e3af145c0.png">|<img width="770" alt="image" src="https://user-images.githubusercontent.com/654645/203146312-f03d69b3-edcf-485c-96a4-68c1bfef559d.png">|


## Notes and todos

It doesn't strike me as obvious that users would know they could click on the category, even if this updated version. I note that the CFPB Design System page on [item introductions](https://cfpb.github.io/design-system/patterns/item-introductions) shows that the category should render with some kind of icon:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/654645/203146144-270961c0-ceaf-4001-94e2-f0a5cbc0f96d.png">

I believe the icons come from [this hardcoded list](https://github.com/cfpb/consumerfinance.gov/blob/121e303ea26e49863279d0c4e3c9986155b42b05/cfgov/jinja2/v1/_includes/macros/category-icon.html); in this case the page category of "Record" isn't in the list so no icon appears. Would it make sense to show some kind of fallback icon in that case? Ping @jenn-franklin. The heading with a fallback `information-round` matches what is in the DS, and looks like this:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/654645/203147021-382ed235-83be-4c24-b8e6-92e7c5c1168c.png">


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)