### PR TITLE
Deprecate VSCode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true,
-  "editor.formatOnPaste": false,
-  "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
-  }
-}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -109,19 +109,6 @@ Once activated, our Python CI requirements can be installed in the virtualenv:
 pip install -r requirements/ci.txt
 ```
 
-### Configure VSCode formatters (optional)
-
-For developers who use [Visual Studio Code](https://code.visualstudio.com/)
-as their editor of choice, you may wish to install certain
-[extensions](https://marketplace.visualstudio.com/VSCode)
-to support easier code formatting.
-
-This repository includes a `.vscode/settings.json` file that sets the
-[Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-as the default code formatter. It also sets the
-[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-as the formatter for Python files.
-
 ### Install pre-commit
 
 We use `pre-commit` to automatically run our linting tools before a commit


### PR DESCRIPTION
As written, the current Visual Studio Code configuration file establishes Prettier as the default code formatter, and automatically formats files on save. This causes problems if you edit HTML files in VSCode, because these files get reformatted in undesirable ways.

This config file was just added last month in #7325, and then had to be further customized in #7343 to prevent Prettier from editing Python files. I propose that we remove editor configuration from this repository; we can document standards and enforce them with precommit and/or GitHub Actions.