### PR TITLE
Remove broken TEST.md file and update docs structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This Django project includes the front-end assets and build tools,
 code to configure our CMS, [Wagtail](https://wagtail.io/),
 and several standalone Django apps for specific parts of the site.
 
-## Quickstart
+## Documentation
 
-Full installation and usage instructions are available in
-[our documentation](https://cfpb.github.io/consumerfinance.gov).
+Full documentation for this project is available in the [docs/](docs/) directory
+and [online](https://cfpb.github.io/consumerfinance.gov/).
+
+## Quickstart
 
 This quickstart requires a working Docker Desktop installation and git:
 
@@ -53,22 +55,6 @@ Our documentation will be available at <http://localhost:8888> (docker-compose o
 
 The Wagtail admin area will be available at <http://localhost:8000/admin/>,
 which you can log into with the credentials `admin`/`admin`.
-
-## Documentation
-
-Full documentation for this project is available in the [docs/](docs/) directory
-and [online](https://cfpb.github.io/consumerfinance.gov/).
-
-If you would like to browse the documentation locally, you can do so
-with [`mkdocs`](https://www.mkdocs.org/):
-
-```sh
-pip install -r requirements/docs.txt
-mkdocs serve
-```
-
-Documentation will be available locally at
-[http://localhost:8000/](http://localhost:8000/).
 
 ## Getting the package
 

--- a/TEST.md
+++ b/TEST.md
@@ -1,4 +1,0 @@
-# Testing
-
-Please see [docs/testing.md](docs/testing.md) or our [online
-testing instructions](https://cfpb.github.io/consumerfinance.gov/testing/).

--- a/docs/running-docs.md
+++ b/docs/running-docs.md
@@ -1,0 +1,17 @@
+# Running documentation site locally
+
+If you would like to browse this documentation site locally, you can do so
+with [`mkdocs`](https://www.mkdocs.org/):
+
+```sh
+pip install -r requirements/docs.txt
+mkdocs serve
+```
+
+Documentation will be available locally at
+[http://localhost:8000/](http://localhost:8000/).
+
+!!! note
+If you are currently running the consumerfinance.gov site locally and
+would like to access the docs at a different port, run,
+for example `mkdocs serve -a localhost:8001` to serve the docs at port 8001.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,56 +3,57 @@ site_name: consumerfinance.gov
 repo_url: https://github.com/cfpb/consumerfinance.gov
 
 nav:
-- Introduction: index.md
-- Setup: installation.md
-- Running this Project:
-    - Running in a Virtual Environment: running-virtualenv.md
-    - Running in Docker: running-docker.md
-    - Debugging and Monitoring: debugging-monitoring.md
-    - Artifacts and Deployment: deployment.md
-- Pages and Components:
-    - Atomic Structure and Design: atomic-structure.md
-    - Creating and Editing Components: editing-components.md
-    - Debugging Templates: debugging-templates.md
-    - Django and Wagtail Migrations: migrations.md
-    - Wagtail Pages: wagtail-pages.md
-- Supporting Features:
-    - Caching: caching.md
-    - Feature Flags: feature-flags.md
-    - Filterable Lists: filterable-lists.md
-    - Page Search: page-search.md
-    - Site Search: site-search.md
-    - Translation: translation.md
-- Testing:
-    - JavaScript Unit Testing: javascript-unit-tests.md
-    - Python Unit Testing: python-unit-tests.md
-    - Functional Testing: functional-testing.md
-    - Profiling Django: profiling-django.md
-    - Other Front-end Testing: other-front-end-testing.md
-- Contributing:
-    - Branching and Merging: branching-merging.md
-    - Contributing to the Docs: contributing-docs.md
-    - Related Projects: related-projects.md
-    - Development Tips: development-tips.md
-    - How We Use GitHub Actions: github-actions.md
-- APIs and Data:
-    - Ask CFPB: ask-cfpb.md
-    - Consumer Complaints: consumer-complaint-database.md
-    - Find a Housing Counselor Tool: housing-counselor-tool.md
+  - Introduction: index.md
+  - Setup: installation.md
+  - Running this Project:
+      - Running in a Virtual Environment: running-virtualenv.md
+      - Running in Docker: running-docker.md
+      - Running documentation site locally: running-docs.md
+      - Debugging and Monitoring: debugging-monitoring.md
+      - Artifacts and Deployment: deployment.md
+  - Pages and Components:
+      - Atomic Structure and Design: atomic-structure.md
+      - Creating and Editing Components: editing-components.md
+      - Debugging Templates: debugging-templates.md
+      - Django and Wagtail Migrations: migrations.md
+      - Wagtail Pages: wagtail-pages.md
+  - Supporting Features:
+      - Caching: caching.md
+      - Feature Flags: feature-flags.md
+      - Filterable Lists: filterable-lists.md
+      - Page Search: page-search.md
+      - Site Search: site-search.md
+      - Translation: translation.md
+  - Testing:
+      - JavaScript Unit Testing: javascript-unit-tests.md
+      - Python Unit Testing: python-unit-tests.md
+      - Functional Testing: functional-testing.md
+      - Profiling Django: profiling-django.md
+      - Other Front-end Testing: other-front-end-testing.md
+  - Contributing:
+      - Branching and Merging: branching-merging.md
+      - Contributing to the Docs: contributing-docs.md
+      - Related Projects: related-projects.md
+      - Development Tips: development-tips.md
+      - How We Use GitHub Actions: github-actions.md
+  - APIs and Data:
+      - Ask CFPB: ask-cfpb.md
+      - Consumer Complaints: consumer-complaint-database.md
+      - Find a Housing Counselor Tool: housing-counselor-tool.md
 
 theme:
-    name: readthedocs
-    custom_dir: docs/theme-overrides/ # @TODO: We may be able to remove this custom template when MkDocs 1.1 is released
+  name: readthedocs
+  custom_dir: docs/theme-overrides/ # @TODO: We may be able to remove this custom template when MkDocs 1.1 is released
 extra_css:
-    - css/overrides.css
+  - css/overrides.css
 
 markdown_extensions:
-    - admonition
-    - pymdownx.betterem
-    - pymdownx.highlight
-    - pymdownx.magiclink
-    - pymdownx.superfences
-    - pymdownx.tilde
-    - tables
-    - toc:
-        permalink: "¶"
+  - admonition
+  - pymdownx.betterem
+  - pymdownx.highlight
+  - pymdownx.magiclink
+  - pymdownx.superfences
+  - pymdownx.tilde
+  - tables
+  - toc:
+      permalink: '¶'


### PR DESCRIPTION
We renamed `testing.md` five years ago in https://github.com/cfpb/consumerfinance.gov/pull/3602, so the contents of `TEST.md` have been 404s. This PR removes that markdown file and moves the readme contents regarding running documentation locally to within the documentation site itself.

## Removals

- Remove unused and broken `TEST.md` file.


## Changes

- Moves instructions for running the doc site locally to within the doc site itself.
- Removes redundant reference to docs site in the main readme file.
- Adds note on changing mkdoc port number, if you already have cfgov running at the same time.
- Formatting autofix for the docs TOC that indents markdown bullet lists one level.

## How to test this PR

1. Run `mkdocs serve -a localhost:8001` and visit http://localhost:8001/ and see that there's a new `Running documentation site locally` section.
