### PR TITLE
Set Prettier to ignore HTML

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ cfgov/agreements/static/agreements/js/jquery-3.5.1.min.js
 cfgov/static_built/
 cfgov/legacy/static/nemo/_/js/
 collectstatic/
+
+# Ignore all HTML files:
+*.html


### PR DESCRIPTION
Prettier was messing with our jinja. This sets it to ignore HTML.

## Changes

- Set Prettier to ignore HTML.


## How to test this PR

1. Editing a jinja template should not cause it to be autoformatted on save.