### PR TITLE
Adjust Prettier linting exclusions and lint some things

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,14 @@
 .github/
 .tox/
+helm
 cfgov/agreements/static/agreements/js/chosen.jquery.js
 cfgov/agreements/static/agreements/js/jquery-3.5.1.min.js
+cfgov/alerts/tests/json/
+cfgov/data_research/data/
+cfgov/retirement_api/data/
 cfgov/static_built/
 cfgov/legacy/static/nemo/_/js/
+**/fixtures/
 collectstatic/
 
 # Ignore all HTML files:

--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
@@ -33,7 +33,7 @@
     margin-top: 45px;
   }
 
-  :not(.m-info-unit_heading-text) > h4 {
+  :not( .m-info-unit_heading-text ) > h4 {
     .h3();
     margin-top: 30px;
   }
@@ -46,12 +46,12 @@
   pre {
     font-family: Menlo, 'Andale Mono', 'Courier New', monospace;
     overflow-x: auto;
-    font-size: unit(14px / @base-font-size-px, em);
+    font-size: unit( 14px / @base-font-size-px, em );
     white-space: pre;
   }
 
   .o-table {
-    margin-top: unit(30px / @base-font-size-px, em);
+    margin-top: unit( 30px / @base-font-size-px, em );
     td {
       vertical-align: top;
       hyphens: auto;
@@ -86,17 +86,17 @@
 }
 
 .o-fig_section__sub-sub {
-  margin-top: unit(45px / @base-font-size-px, em);
-  margin-bottom: unit(45px / @base-font-size-px, em);
+  margin-top: unit( 45px / @base-font-size-px, em );
+  margin-bottom: unit( 45px / @base-font-size-px, em );
 
   // Put a horizontal rule below all sub level 3 headings
   &:after {
     display: inline-block;
     content: '';
     border-top: 2px solid @gray-50;
-    width: calc(100% + 30px);
-    margin: unit(45px / @base-font-size-px, em) 0 0
-      unit(-30px / @base-font-size-px, em);
+    width: calc( 100% + 30px );
+    margin: unit( 45px / @base-font-size-px, em ) 0 0
+      unit( -30px / @base-font-size-px, em );
   }
 }
 
@@ -114,7 +114,7 @@
       // Add a large buffer underneath to ensure mobile users
       // can use assistive technology like Reachability to access
       // items at the bottom of the list
-      padding-bottom: unit(420px / @base-font-size-px, em);
+      padding-bottom: unit( 420px / @base-font-size-px, em );
     }
   }
 
@@ -125,21 +125,21 @@
   } );
 
   .m-nav-link {
-    padding-left: unit(40px / @base-font-size-px, em);
-    text-indent: unit(-30px / @base-font-size-px, em);
+    padding-left: unit( 40px / @base-font-size-px, em );
+    text-indent: unit( -30px / @base-font-size-px, em );
   }
 
   .o-secondary-navigation_list__parents > li > a {
-    padding-left: unit(30px / @base-font-size-px, em);
-    text-indent: unit(-18px / @base-font-size-px, em);
+    padding-left: unit( 30px / @base-font-size-px, em );
+    text-indent: unit( -18px / @base-font-size-px, em );
   }
 
   h4 {
-    padding-left: unit(19px / @size-iv, em);
+    padding-left: unit( 19px / @size-iv, em );
   }
 
   .o-report-sidenav__appendix > li > a {
-    text-indent: unit(-20px / @base-font-size-px, em);
+    text-indent: unit( -20px / @base-font-size-px, em );
   }
 
   .parent-header {
@@ -157,7 +157,7 @@
 
 .research-report {
   // 670px, plus a 15px gutter on each side (standard paragrah widths)
-  max-width: unit((670 + 30) / 16, em);
+  max-width: unit( (670 + 30) / 16, em );
 
   .lead-paragraph,
   .author-names {
@@ -204,5 +204,5 @@
 }
 
 #ctrl-f-modal h3 {
-  font-size: unit(16px / @base-font-size-px, em);
+  font-size: unit( 16px / @base-font-size-px, em );
 }

--- a/cfgov/unprocessed/apps/owning-a-home/config.json
+++ b/cfgov/unprocessed/apps/owning-a-home/config.json
@@ -1,4 +1,4 @@
 {
   "rateCheckerAPI": "/oah-api/rates/rate-checker",
-  "countyAPI":      "/oah-api/county/"
+  "countyAPI": "/oah-api/county/"
 }

--- a/cfgov/unprocessed/root/site.webmanifest
+++ b/cfgov/unprocessed/root/site.webmanifest
@@ -1,19 +1,19 @@
 {
-    "name": "Consumer Financial Protection Bureau",
-    "short_name": "CFPB",
-    "icons": [
-        {
-            "src": "/static/android-chrome-192x192.png",
-            "sizes": "192x192",
-            "type": "image/png"
-        },
-        {
-            "src": "/static/android-chrome-512x512.png",
-            "sizes": "512x512",
-            "type": "image/png"
-        }
-    ],
-    "theme_color": "#ffffff",
-    "background_color": "#ffffff",
-    "display": "standalone"
+  "name": "Consumer Financial Protection Bureau",
+  "short_name": "CFPB",
+  "icons": [
+    {
+      "src": "/static/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,13 +1,12 @@
-version: "3.4"
+version: '3.4'
 
 services:
-
-    python:
-        build:
-            target: cfgov-dev
-        ports:
-            - "127.0.0.1:8000:8000" # Django
-        volumes: &python_volumes
-            - ./:/src/consumerfinance.gov/
-            - ./.env:/etc/profile.d/dev-env.sh
-            - ./extend-environment.sh:/etc/profile.d/extend-environment.sh
+  python:
+    build:
+      target: cfgov-dev
+    ports:
+      - '127.0.0.1:8000:8000' # Django
+    volumes: &python_volumes
+      - ./:/src/consumerfinance.gov/
+      - ./.env:/etc/profile.d/dev-env.sh
+      - ./extend-environment.sh:/etc/profile.d/extend-environment.sh

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,31 +1,30 @@
-version: "3.4"
+version: '3.4'
 
 volumes:
-    postgres_data:
+  postgres_data:
 
 services:
+  elasticsearch:
+    environment:
+      ES_JAVA_OPTS: '-Xms1g -Xmx1g'
 
-    elasticsearch:
-        environment:
-            ES_JAVA_OPTS: "-Xms1g -Xmx1g"
-
-    python:
-        image: cfgov_python:prod
-        build:
-            target: cfgov-prod
-        environment:
-            ALLOW_ADMIN_URL: 'True'
-            APACHE_PORT: 8000
-            APACHE_UPLOADS_F_ALIAS: /src/consumerfinance.gov/cfgov/f/
-            DJANGO_ADMIN_USERNAME: admin
-            DJANGO_ADMIN_PASSWORD: admin
-            SECRET_KEY: abcdefghijklmnopqrstuvwxyz
-            MEDIA_ROOT: /src/consumerfinance.gov/cfgov/f/
-            WATCHMAN_TOKENS: "token"
-            APACHE_STATUS_ALLOW_FROM: 127.0.0.1
-        ports:
-            - "8000:8000"
-        volumes:
-            - ./cfgov/apache/conf/:/src/consumerfinance.gov/cfgov/apache/conf/
-            - ./cfgov/apache/conf.d/:/src/consumerfinance.gov/cfgov/apache/conf.d/
-            - ./cfgov/apache/conf.modules.d/:/src/consumerfinance.gov/cfgov/apache/conf.modules.d/
+  python:
+    image: cfgov_python:prod
+    build:
+      target: cfgov-prod
+    environment:
+      ALLOW_ADMIN_URL: 'True'
+      APACHE_PORT: 8000
+      APACHE_UPLOADS_F_ALIAS: /src/consumerfinance.gov/cfgov/f/
+      DJANGO_ADMIN_USERNAME: admin
+      DJANGO_ADMIN_PASSWORD: admin
+      SECRET_KEY: abcdefghijklmnopqrstuvwxyz
+      MEDIA_ROOT: /src/consumerfinance.gov/cfgov/f/
+      WATCHMAN_TOKENS: 'token'
+      APACHE_STATUS_ALLOW_FROM: 127.0.0.1
+    ports:
+      - '8000:8000'
+    volumes:
+      - ./cfgov/apache/conf/:/src/consumerfinance.gov/cfgov/apache/conf/
+      - ./cfgov/apache/conf.d/:/src/consumerfinance.gov/cfgov/apache/conf.d/
+      - ./cfgov/apache/conf.modules.d/:/src/consumerfinance.gov/cfgov/apache/conf.modules.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,70 +1,70 @@
-version: "3.4"
+version: '3.4'
 
 volumes:
-    postgres_data:
+  postgres_data:
 
 services:
-    elasticsearch:
-        build:
-            context: ./
-            dockerfile: ./docker/elasticsearch/Dockerfile
-        ports:
-            - 127.0.0.1:9200:9200
-            - 127.0.0.1:9300:9300
-        environment:
-            discovery.type: single-node
-            ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-    kibana:
-        image: docker.elastic.co/kibana/kibana:7.16.0
-        depends_on:
-            - elasticsearch
-        ports:
-            - 127.0.0.1:5601:5601
-    postgres:
-        image: postgres:13-alpine
-        user: postgres
-        restart: always
-        volumes:
-            - postgres_data:/var/lib/postgresql/data/
-        environment:
-            POSTGRES_USER: cfpb
-            POSTGRES_PASSWORD: cfpb
-            POSTGRES_DB: cfgov
-        ports:
-            - 127.0.0.1:5432:5432
-    python:
-        image: cfgov_python:local
-        build:
-            context: .
-            dockerfile: Dockerfile
-        depends_on:
-            - elasticsearch
-            - postgres
-        stdin_open: true
-        tty: true
-        environment:
-            PGDATABASE: cfgov
-            PGUSER: cfpb
-            PGPASSWORD: cfpb
-            POSTGRES_USER: cfpb
-            PGHOST: postgres
-            PGPORT: 5432
-            ES_HOST: elasticsearch
-            SECRET_KEY: abcdefghijklmnopqrstuvwxyz
-    docs:
-        build:
-            context: ./
-            dockerfile: ./docker/docs/Dockerfile
-        ports:
-            - 127.0.0.1:8888:8888
-        environment:
-            LANG: en_US.utf8
-            LC_ALL: en_US.utf8
-        volumes:
-            - ./:/src/consumerfinance.gov
-        entrypoint:
-            - sh
-            - /src/consumerfinance.gov/docker/docs/entrypoint.sh
-        working_dir: /src/consumerfinance.gov
-        stdin_open: true
-        tty: true
+  elasticsearch:
+    build:
+      context: ./
+      dockerfile: ./docker/elasticsearch/Dockerfile
+    ports:
+      - 127.0.0.1:9200:9200
+      - 127.0.0.1:9300:9300
+    environment:
+      discovery.type: single-node
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.16.0
+    depends_on:
+      - elasticsearch
+    ports:
+      - 127.0.0.1:5601:5601
+  postgres:
+    image: postgres:13-alpine
+    user: postgres
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    environment:
+      POSTGRES_USER: cfpb
+      POSTGRES_PASSWORD: cfpb
+      POSTGRES_DB: cfgov
+    ports:
+      - 127.0.0.1:5432:5432
+  python:
+    image: cfgov_python:local
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - elasticsearch
+      - postgres
+    stdin_open: true
+    tty: true
+    environment:
+      PGDATABASE: cfgov
+      PGUSER: cfpb
+      PGPASSWORD: cfpb
+      POSTGRES_USER: cfpb
+      PGHOST: postgres
+      PGPORT: 5432
+      ES_HOST: elasticsearch
+      SECRET_KEY: abcdefghijklmnopqrstuvwxyz
+  docs:
+    build:
+      context: ./
+      dockerfile: ./docker/docs/Dockerfile
+    ports:
+      - 127.0.0.1:8888:8888
+    environment:
+      LANG: en_US.utf8
+      LC_ALL: en_US.utf8
+    volumes:
+      - ./:/src/consumerfinance.gov
+    entrypoint:
+      - sh
+      - /src/consumerfinance.gov/docker/docs/entrypoint.sh
+    working_dir: /src/consumerfinance.gov
+    stdin_open: true
+    tty: true

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -1,6 +1,6 @@
 # Docker Swarm compatible Compose file.  Intended for use
 # with this repo's Jenkinsfile, not local development.
-version: "3.7"
+version: '3.7'
 
 services:
   elasticsearch:
@@ -58,7 +58,7 @@ services:
   python:
     image: ${CFGOV_PYTHON_IMAGE}
     environment:
-      ALLOW_ADMIN_URL: "True"
+      ALLOW_ADMIN_URL: 'True'
       APACHE_PORT: 8000
       APACHE_UPLOADS_F_ALIAS: /src/consumerfinance.gov/cfgov/f/
       PGDATABASE: cfgov
@@ -105,13 +105,13 @@ services:
         reservations:
           memory: 512M
     command: >
-                bash -c "
+      bash -c "
 
-                ./cfgov/manage.py opensearch index --force rebuild
+      ./cfgov/manage.py opensearch index --force rebuild
 
-                ./cfgov/manage.py opensearch document --force --refresh --parallel index
+      ./cfgov/manage.py opensearch document --force --refresh --parallel index
 
-                httpd -d /src/consumerfinance.gov/cfgov/apache -f /src/consumerfinance.gov/cfgov/apache/conf/httpd.conf -D FOREGROUND"
+      httpd -d /src/consumerfinance.gov/cfgov/apache -f /src/consumerfinance.gov/cfgov/apache/conf/httpd.conf -D FOREGROUND"
 
 networks:
   app:

--- a/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
+++ b/test/unit_tests/js/organisms/MortgagePerformanceTrends/utils-spec.js
@@ -1,4 +1,4 @@
-global.fetch = jest.fn( url =>
+global.fetch = jest.fn((url) =>
   Promise.resolve({
     json: jest.fn(() => Promise.resolve({ mock: url })),
   })
@@ -51,30 +51,30 @@ describe('Mortgage Performance utilities', () => {
 
   it('should get metro data', () => {
     const cb = jest.fn();
-    utils.getMetroData(cb).then(() =>{
+    utils.getMetroData(cb).then(() => {
       expect(cb).toBeCalledWith({ mock: BASE_URL + 'state_msa_meta' });
-    })
+    });
   });
 
   it('should get non-metro data', () => {
     const cb = jest.fn();
-    utils.getNonMetroData(cb).then(() =>{
+    utils.getNonMetroData(cb).then(() => {
       expect(cb).toBeCalledWith({ mock: BASE_URL + 'non_msa_fips' });
-    })
-   });
+    });
+  });
 
   it('should get county data', () => {
     const cb = jest.fn();
-    utils.getCountyData(cb).then(() =>{
+    utils.getCountyData(cb).then(() => {
       expect(cb).toBeCalledWith({ mock: BASE_URL + 'state_county_meta' });
-    })
+    });
   });
 
   it('should get state data', () => {
     const cb = jest.fn();
-    utils.getStateData(cb).then(() =>{
+    utils.getStateData(cb).then(() => {
       expect(cb).toBeCalledWith({ mock: BASE_URL + 'state_meta' });
-    })
+    });
   });
 
   it('should be able to calculate zoom levels', () => {


### PR DESCRIPTION
## Changes

- Exclude fixtures and app data JSON files from Prettier. Also exclude Helm config files. 


## How to test this PR

1. PR checks should pass.
2. Check PR with whitespace changes off.

## Notes and todos

- Do any of the changes to config files that wrong to you? We can exclude them too! Let me know.
- Both `cfgov/unprocessed/root/code.json` and `cfgov/unprocessed/root/data.json` will be hit by the linter, but I did not adjust them here or ignore them. They will be formatted in future runs of the linter. Does that matter?
