### PR TITLE
Regs3k: Use native fetch

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/index.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/index.js
@@ -1,4 +1,4 @@
-import * as utils from './regs3k-utils';
+import { getNewHash, isOldHash } from './regs3k-utils';
 import { handleContentClick, handleNavClick } from './analytics';
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable';
 import { queryOne as find } from '@cfpb/cfpb-atomic-component/src/utilities/dom-traverse.js';
@@ -48,8 +48,8 @@ const init = () => {
     bindSecondaryNav();
     bindAnalytics();
   }
-  if (utils.isOldHash(window.location.hash)) {
-    window.location.hash = utils.getNewHash(window.location.hash);
+  if (isOldHash(window.location.hash)) {
+    window.location.hash = getNewHash(window.location.hash);
   }
 };
 

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -1,4 +1,3 @@
-import { fetch } from './regs3k-utils';
 import { queryOne as find } from '@cfpb/cfpb-atomic-component/src/utilities/dom-traverse.js';
 
 const NOTICES_URL = './recent-notices-json';
@@ -29,17 +28,21 @@ const processNotices = (notices) => {
 };
 
 const init = () => {
+  console.log('init called!!!!!');
   const noticesContainer = find('#regs3k-notices');
-  fetch(NOTICES_URL, (err, notices) => {
-    if (err !== null) {
+  fetch(NOTICES_URL)
+    .then((response) => response.json())
+    .then((notices) => {
+      console.log('notices', notices);
+      notices = notices.results;
+      const html = processNotices(notices);
+      noticesContainer.innerHTML = '';
+      noticesContainer.appendChild(html);
+    })
+    .catch((err) => {
       // No need to handle the error, the default HTML is a graceful fallback.
-      return console.error(err);
-    }
-    notices = JSON.parse(notices).results;
-    const html = processNotices(notices);
-    noticesContainer.innerHTML = '';
-    return noticesContainer.appendChild(html);
-  });
+      console.error(err);
+    });
 };
 
 window.addEventListener('load', init);

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -28,7 +28,6 @@ const processNotices = (notices) => {
 };
 
 const init = () => {
-  console.log('init called!!!!!');
   const noticesContainer = find('#regs3k-notices');
   fetch(NOTICES_URL)
     .then((response) => response.json())

--- a/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/recent-notices.js
@@ -33,7 +33,6 @@ const init = () => {
   fetch(NOTICES_URL)
     .then((response) => response.json())
     .then((notices) => {
-      console.log('notices', notices);
       notices = notices.results;
       const html = processNotices(notices);
       noticesContainer.innerHTML = '';

--- a/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js
@@ -1,18 +1,3 @@
-import { ajaxRequest as xhr } from '../../../js/modules/util/ajax-request';
-
-/**
- * fetch - Wrapper for our ajax request method with callback support.
- *
- * @param {string} url - URL to request.
- * @param {Function} cb - Success/failure callback.
- * @returns {object} XMLHttpRequest object
- */
-const fetch = (url, cb) =>
-  xhr('GET', url, {
-    success: (data) => cb(null, data),
-    fail: (err) => cb(err),
-  });
-
 /**
  * getNewHash - Convert an old eRegs hash into a Regs3K hash.
  *
@@ -37,4 +22,4 @@ const getNewHash = (hash) => {
  */
 const isOldHash = (hash) => /^#?\d\d\d\d/.test(hash);
 
-export { fetch, getNewHash, isOldHash };
+export { getNewHash, isOldHash };

--- a/test/unit_tests/apps/regulations3k/js/recent-notices-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/recent-notices-spec.js
@@ -1,5 +1,11 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
 import { simulateEvent } from '../../../../util/simulate-event.js';
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
+import {
+  processNotice,
+  processNotices,
+} from '../../../../../cfgov/unprocessed/apps/regulations3k/js/recent-notices.js';
+
+enableFetchMocks();
 
 const HTML_SNIPPET = `
   <ul id="regs3k-notices"></ul>
@@ -24,27 +30,18 @@ const TEST_DATA = {
 };
 /* eslint-enable camelcase */
 
-// Back up global xhr
-const xhr = global.XMLHttpRequest;
-
 // Mock console logging
 delete global.console;
 global.console = { error: jest.fn(), log: jest.fn() };
 
-// Reference to the script recent-notices.js
-let app;
-
 describe('The Regs3K search page', () => {
   beforeEach(() => {
-    app = require(`${BASE_JS_PATH}/js/recent-notices.js`);
-
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
   });
 
   afterEach(() => {
-    // Reset global XHR
-    global.XMLHttpRequest = xhr;
+    fetch.resetMocks();
   });
 
   it('should process a notice', () => {
@@ -53,7 +50,7 @@ describe('The Regs3K search page', () => {
       html_url: 'https://federalregister.gov/',
       title: 'Really great notice',
     };
-    const processedNotice = app.processNotice(notice);
+    const processedNotice = processNotice(notice);
     expect(processedNotice.constructor.name).toEqual('HTMLLIElement');
     expect(processedNotice.className).toEqual('m-list_link');
     expect(processedNotice.querySelector('a').href).toEqual(
@@ -74,7 +71,7 @@ describe('The Regs3K search page', () => {
       },
     ];
     /* eslint-enable camelcase */
-    const processedNotices = app.processNotices(notices);
+    const processedNotices = processNotices(notices);
     expect(processedNotices.querySelectorAll('li').length).toEqual(3);
     expect(processedNotices.querySelectorAll('a')[2].textContent).toContain(
       'More'
@@ -82,43 +79,21 @@ describe('The Regs3K search page', () => {
   });
 
   it('should load recent notices', () => {
-    // Mock the browser's XHR
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 200,
-      responseText: JSON.stringify(TEST_DATA),
-    };
-    global.XMLHttpRequest = jest.fn(() => mockXHR);
-
     // Fire `load` event
     simulateEvent('load', window, { currentTarget: window });
 
-    // Complete XHR
-    mockXHR.onreadystatechange();
-
-    const numNotices = document.querySelectorAll('.m-list_link').length;
-    expect(numNotices).toEqual(4);
+    // Wait for window.load to trigger.
+    setTimeout(() => {
+      const numNotices = document.querySelectorAll('.m-list_link').length;
+      expect(numNotices).toEqual(4);
+    }, 1000);
   });
 
   it('should fail to load recent notices', (done) => {
-    // Mock the browser's XHR
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 404,
-      onreadystatechange: jest.fn(),
-      responseText: 'Server error!',
-    };
-    global.XMLHttpRequest = jest.fn(() => mockXHR);
+    fetch.mockReject(new Error('Server error!'));
 
     // Fire `load` event
     simulateEvent('load', window, { currentTarget: window });
-
-    // Complete XHR
-    mockXHR.onreadystatechange();
 
     setTimeout(() => {
       // eslint-disable-next-line no-console

--- a/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/regs3k-utils-spec.js
@@ -1,84 +1,42 @@
-const BASE_JS_PATH = '../../../../../cfgov/unprocessed/apps/regulations3k';
-
-const utils = require(`${BASE_JS_PATH}/js/regs3k-utils.js`);
+import {
+  getNewHash,
+  isOldHash,
+} from '../../../../../cfgov/unprocessed/apps/regulations3k/js/regs3k-utils.js';
 
 describe('The Regs3K search utils', () => {
-  describe('AJAX utils', () => {
-    it('should fetch a resource', (done) => {
-      const mockXHR = {
-        open: jest.fn(),
-        send: jest.fn(),
-        readyState: 4,
-        status: 200,
-        onreadystatechange: jest.fn(),
-        responseText: [
-          { searchResult: 'one' },
-          { anotherSearchResult: 'two' },
-        ],
-      };
-      global.XMLHttpRequest = jest.fn(() => mockXHR);
-      utils.fetch('api/search', (err, data) => {
-        expect(err).toEqual(null);
-        expect(data).toEqual([
-          { searchResult: 'one' },
-          { anotherSearchResult: 'two' },
-        ]);
-        done();
-      });
-      mockXHR.onreadystatechange();
-    });
-
-    it('should fail to fetch a resource', (done) => {
-      const mockXHR = {
-        open: jest.fn(),
-        send: jest.fn(),
-        readyState: 4,
-        status: 404,
-        onreadystatechange: jest.fn(),
-        responseText: 'Server error!',
-      };
-      global.XMLHttpRequest = jest.fn(() => mockXHR);
-      utils.fetch('api/search', (err) => {
-        expect(err).toEqual(404);
-        done();
-      });
-      mockXHR.onreadystatechange();
-    });
-  });
-
   describe('Hash utils', () => {
     it('should convert a hash', () => {
-      expect(utils.getNewHash('1010-Interp-1')).toEqual('Interp-1');
-      expect(utils.getNewHash('#1010-Interp-1')).toEqual('Interp-1');
+      expect(getNewHash('1010-Interp-1')).toEqual('Interp-1');
+      expect(getNewHash('#1010-Interp-1')).toEqual('Interp-1');
 
-      expect(utils.getNewHash('1011-4-a')).toEqual('a');
-      expect(utils.getNewHash('#1011-4-a')).toEqual('a');
+      expect(getNewHash('1011-4-a')).toEqual('a');
+      expect(getNewHash('#1011-4-a')).toEqual('a');
 
-      expect(utils.getNewHash('1003-2-f-Interp-3')).toEqual('2-f-Interp-3');
-      expect(utils.getNewHash('#1003-2-f-Interp-3')).toEqual('2-f-Interp-3');
+      expect(getNewHash('1003-2-f-Interp-3')).toEqual('2-f-Interp-3');
+      expect(getNewHash('#1003-2-f-Interp-3')).toEqual('2-f-Interp-3');
 
-      expect(utils.getNewHash('1003-4-a-9-ii-C')).toEqual('a-9-ii-C');
-      expect(utils.getNewHash('#1003-4-a-9-ii-C')).toEqual('a-9-ii-C');
+      expect(getNewHash('1003-4-a-9-ii-C')).toEqual('a-9-ii-C');
+      expect(getNewHash('#1003-4-a-9-ii-C')).toEqual('a-9-ii-C');
     });
 
     it('should check if a hash needs to be converted', () => {
-      expect(utils.isOldHash('1010-Interp-1')).toBeTrue;
-      expect(utils.isOldHash('#1010-Interp-1')).toBeTrue;
+      expect(isOldHash('1010-Interp-1')).toBeTrue;
+      expect(isOldHash('#1010-Interp-1')).toBeTrue;
 
-      expect(utils.isOldHash('101-Interp-1')).toBeFalse;
-      expect(utils.isOldHash('#101-Interp-1')).toBeFalse;
+      expect(isOldHash('101-Interp-1')).toBeFalse;
+      expect(isOldHash('#101-Interp-1')).toBeFalse;
 
-      expect(utils.isOldHash('1003-2-f-Interp-3')).toBeTrue;
-      expect(utils.isOldHash('#1003-2-f-Interp-3')).toBeTrue;
+      expect(isOldHash('1003-2-f-Interp-3')).toBeTrue;
+      expect(isOldHash('#1003-2-f-Interp-3')).toBeTrue;
 
-      expect(utils.isOldHash('003-2-f-Interp-3')).toBeFalse;
-      expect(utils.isOldHash('#003-2-f-Interp-3')).toBeFalse;
+      expect(isOldHash('003-2-f-Interp-3')).toBeFalse;
+      expect(isOldHash('#003-2-f-Interp-3')).toBeFalse;
 
-      expect(utils.isOldHash('bloop')).toBeFalse;
-      expect(utils.isOldHash('#bloop')).toBeFalse;
+      expect(isOldHash('bloop')).toBeFalse;
+      expect(isOldHash('#bloop')).toBeFalse;
 
-      expect(utils.isOldHash('asdf-2-f-Interp-3')).toBeFalse;
-      expect(utils.isOldHash('#asdf-2-f-Interp-3')).toBeFalse;
+      expect(isOldHash('asdf-2-f-Interp-3')).toBeFalse;
+      expect(isOldHash('#asdf-2-f-Interp-3')).toBeFalse;
     });
   });
 });

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -1,6 +1,9 @@
+import { enableFetchMocks } from 'jest-fetch-mock';
 const simulateEvent = require('../../../../util/simulate-event').simulateEvent;
 
 import('../../../../../cfgov/unprocessed/apps/regulations3k/js/search.js');
+
+enableFetchMocks();
 
 const HTML_SNIPPET = `
   <form action="/search" data-js-hook="behavior_submit-search">
@@ -29,7 +32,6 @@ const HTML_SNIPPET = `
   <div id="regs3k-results"></div>
 `;
 
-const xhr = global.XMLHttpRequest;
 global.console = { error: jest.fn(), log: jest.fn() };
 
 /**
@@ -48,8 +50,7 @@ function mockWindowLocation() {
 
 describe('The Regs3K search page', () => {
   beforeEach(() => {
-    // Reset global XHR
-    global.XMLHttpRequest = xhr;
+    fetch.resetMocks();
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
@@ -70,15 +71,6 @@ describe('The Regs3K search page', () => {
   });
 
   it('should clear a filter when its X icon is clicked', () => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 200,
-      onreadystatechange: jest.fn(),
-      responseText: [],
-    };
-    global.XMLHttpRequest = jest.fn(() => mockXHR);
     const clearIcon = document.querySelector('svg');
 
     let numFilters = document.querySelectorAll('div.a-tag').length;
@@ -87,8 +79,6 @@ describe('The Regs3K search page', () => {
     simulateEvent('click', clearIcon);
     numFilters = document.querySelectorAll('div.a-tag').length;
     expect(numFilters).toEqual(0);
-
-    mockXHR.onreadystatechange();
   });
 
   it('should not clear a filter when its tag is clicked', () => {
@@ -103,15 +93,6 @@ describe('The Regs3K search page', () => {
   });
 
   it('should clear all filters when the `clear all` link is clicked', () => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 200,
-      onreadystatechange: jest.fn(),
-      responseText: [],
-    };
-    global.XMLHttpRequest = jest.fn(() => mockXHR);
     const clearAllLink = document.querySelector('.filters_clear');
 
     let numFilters = document.querySelectorAll('div.a-tag').length;
@@ -120,20 +101,10 @@ describe('The Regs3K search page', () => {
     simulateEvent('click', clearAllLink);
     numFilters = document.querySelectorAll('div.a-tag').length;
     expect(numFilters).toEqual(0);
-
-    mockXHR.onreadystatechange();
   });
 
   it('should handle errors when the server is down', (done) => {
-    const mockXHR = {
-      open: jest.fn(),
-      send: jest.fn(),
-      readyState: 4,
-      status: 404,
-      onreadystatechange: jest.fn(),
-      responseText: 'Server error!',
-    };
-    global.XMLHttpRequest = jest.fn(() => mockXHR);
+    fetch.mockReject(new Error('Server error!'));
     const clearIcon = document.querySelector('svg');
 
     simulateEvent('click', clearIcon);
@@ -142,7 +113,5 @@ describe('The Regs3K search page', () => {
       expect(console.error).toBeCalled();
       done();
     }, 100);
-
-    mockXHR.onreadystatechange();
   });
 });


### PR DESCRIPTION
## Changes

- Regs3k: Use native fetch in place of xhr wrapper.


## How to test this PR

1. `yarn build` and the sidebar on http://localhost:8000/rules-policy/regulations/ should work. 
2. Regs search at http://localhost:8000/rules-policy/regulations/search-regulations/results/ should work.
3. PR checks should pass.
