### PR TITLE
Remove use of safe in homepage template

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -27,7 +27,7 @@
     ],
 } -%}
 
-{%- set answers_heading = "<b>Find answers</b> to your money questions" -%}
+{%- set answers_heading = "Find answers to your money questions" -%}
 
 {%- set topics = {
     "cards": [
@@ -59,26 +59,6 @@
     ],
 } -%}
 
-<!-- NOTE: "body" fields here should have a 100-character limit -->
-{%- set recents = [
-    {
-        "heading": "The CFPB is standing up for you",
-        "body": "<ul><li><strong>3.1 million+</strong> consumer complaints received responses</li><li><strong>$14.9 billion</strong> in financial relief as a result of CFPB actions</li><li><strong>183 million</strong> Americans eligible for financial relief </li></ul>",
-        "link": {
-            "text": "",
-            "url": "",
-        },
-    },
-    {
-        "heading": "Protecting you from the side effects of surprise medical bills",
-        "body": "If you face unexpectedly high medical costs, you now have protections under the No Surprises Act.",
-        "link": {
-            "text": "Read about medical fees",
-            "url": "/about-us/blog/no-surprises-act-how-we-are-protecting-people-from-side-effects-surprise-medical-bills/",
-        },
-    },
-] -%}
-
 <!-- {%- set highlights_heading = "Bureau highlights" -%} -->
 
 {%- set highlights = [
@@ -105,7 +85,7 @@
     },
 ] -%}
 
-{%- set breakout_cards_heading = "<b>Get help planning</b> for future goals" -%}
+{%- set breakout_cards_heading = "Get help planning for future goals" -%}
 
 {%- set breakout_cards = [
     {

--- a/cfgov/v1/jinja2/v1/home_page/home_page.html
+++ b/cfgov/v1/jinja2/v1/home_page/home_page.html
@@ -22,11 +22,9 @@ content_main__flush-inner
 
         <section class="o-well">
             <div class="o-info-unit-group">
-
                 <div class="content-l">
                     {% for highlight in hardcoded.highlights %}
                     <div class="content-l_col content-l_col-1-3">
-
                         <div class="m-info-unit">
                             <div style="padding-bottom:.25em;">
                                 <img style="max-height:2.5em;" src="{{ highlight.img_src }}" alt="">
@@ -57,7 +55,7 @@ content_main__flush-inner
 {% block content_main %}
     {% import "v1/home_page/_hardcoded_" ~ language ~ ".html" as hardcoded with context %}
     <section class="block u-text-centered">
-        <h2 class="h1">{{ hardcoded.answers_heading | safe }}</h2>
+        <h2 class="h1">{{ hardcoded.answers_heading }}</h2>
     </section>
 
     <section class="block">
@@ -87,26 +85,38 @@ content_main__flush-inner
         <section class="block">
             <div class="o-info-unit-group">
                 <div class="content-l">
-                    {% for recent in hardcoded.recents %}
                     <div class="content-l_col content-l_col-1-2">
                         <div class="m-info-unit">
-                            <a class="m-info-unit_heading-link" href="{{ recent.link.url }}">
                                 <div class="m-info-unit_heading-text">
-                                    <h2>{{ recent.heading }}</h2>
+                                    <h2>The CFPB is standing up for you</h2>
+                                </div>
+                            <div class="m-info-unit_content">
+                                <ul>
+                                  <li><strong>3.1 million+</strong> consumer complaints received responses</li>
+                                  <li><strong>$14.9 billion</strong> in financial relief as a result of CFPB actions</li>
+                                  <li><strong>183 million</strong> Americans eligible for financial relief</li>
+                                </ul>
+                           </div>
+                        </div>
+                    </div>
+                    <div class="content-l_col content-l_col-1-2">
+                        <div class="m-info-unit">
+                            <a class="m-info-unit_heading-link" href="/about-us/blog/no-surprises-act-how-we-are-protecting-people-from-side-effects-surprise-medical-bills/">
+                                <div class="m-info-unit_heading-text">
+                                    <h2>Protecting you from the side effects of surprise medical bills</h2>
                                 </div>
                             </a>
                             <div class="m-info-unit_content">
-                                <p>{{ recent.body | safe }}</p>
+                                <p>If you face unexpectedly high medical costs, you now have protections under the No Surprises Act.</p>
                                 <ul class="m-list m-list__links u-mt15">
                                     <li class="m-list_item">
-                                        <a class="m-list_link" href="{{ recent.link.url }}">
-                                            {{- recent.link.text -}}
+                                        <a class="m-list_link" href="/about-us/blog/no-surprises-act-how-we-are-protecting-people-from-side-effects-surprise-medical-bills/">
+                                           Read about medical fees
                                         </a>
                                 </ul>
                             </div>
                         </div>
                     </div>
-                    {% endfor %}
                 </div>
             </div>
 
@@ -116,7 +126,7 @@ content_main__flush-inner
 
         <section class="block block__flush-bottom content_level-2">
             {{ card_group.render( {
-                'heading': hardcoded.breakout_cards_heading | safe,
+                'heading': hardcoded.breakout_cards_heading,
                 'type_group': 'column-3',
                 'type_card': 'breakout',
                 'cards': hardcoded.breakout_cards


### PR DESCRIPTION
Following #7408, this hardcodes the new structure into the homepage and removes a couple unnecessary uses of `| safe`, which we should avoid when possible.
<img width="1333" alt="Screen Shot 2022-12-13 at 2 36 56 PM" src="https://user-images.githubusercontent.com/1558033/207428368-d071eea2-d5da-497b-807a-bb57991dc733.png">
