### PR TITLE
Fix filterable language tests

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
@@ -75,7 +75,7 @@
     {% set date_desc = controls.post_date_description or post_date_description %}
     {% set cat_controls = controls.categories %}
     {% set show_categories = cat_controls.show_preview_categories if cat_controls is defined else true %}
-    <article class="o-post-preview">
+    <article class="o-post-preview" lang="{{ post.language }}">
         <div class="m-meta-header">
             {% if show_categories and post.categories.exists()  %}
             <div class="m-meta-header_left">

--- a/test/cypress/integration/components/filterable-lists/filter-blog-posts.cy.js
+++ b/test/cypress/integration/components/filterable-lists/filter-blog-posts.cy.js
@@ -345,9 +345,14 @@ describe('Filter Blog Posts based on content', () => {
     filter.clickLanguage('es');
     // And I click "Apply filters" button
     blog.applyFilters();
-    // Then I should see only results posted by the selected language
     blog.notification().should('be.visible');
-    blog.resultsContent().should('contain', 'Estafas con beneficios');
+    // Then I should see only results posted by the selected language
+    blog.resultsContent().get('.o-post-preview[lang|="es"]').should(
+      'have.length.greaterThan', 0
+    );
+    blog.resultsContent().get('.o-post-preview[lang]:not(.o-post-preview[lang|="es"])').should(
+      'have.length', 0
+    );
     // And the page url should contain "language=es"
     cy.url().should('include', 'language=es');
     // And the page url should not contain "language=en"
@@ -361,8 +366,9 @@ describe('Filter Blog Posts based on content', () => {
     blog.applyFilters();
     // Then I should see only results posted by at least one of the two selected languages
     blog.notification().should('be.visible');
-    blog.resultsContent().should('contain', 'Estafas con beneficios');
-    blog.resultsContent().should('contain', 'Paano tutulungan');
+    blog.resultsContent().get('.o-post-preview[lang|="es"], .o-post-preview[lang|="tl"]').should(
+      'have.length.greaterThan', 0
+    );
     // And the page url should contain "language=es"
     cy.url().should('include', 'language=es');
     // And the page url should contain "language=ar"
@@ -377,7 +383,12 @@ describe('Filter Blog Posts based on content', () => {
     blog.applyFilters();
     // Then I should see only results posted by the selected language
     blog.notification().should('be.visible');
-    blog.resultsContent().should('contain', 'Estafas con beneficios');
+    blog.resultsContent().get('.o-post-preview[lang|="es"]').should(
+      'have.length.greaterThan', 0
+    );
+    blog.resultsContent().get('.o-post-preview[lang]:not(.o-post-preview[lang|="es"])').should(
+      'have.length', 0
+    );
     // And the page url should contain "language=es"
     cy.url().should('include', 'language=es');
     // And the page url should not contain "language=en"


### PR DESCRIPTION
Our filterable list tests for language selection are currently failing because they're looking for specific text from specific blog posts in Spanish and in Tagalog. The Tagalog post in question has disappeared behind the blog's pagination, and so the test can't find the text it's looking for (there is a second Tagalog post in the combined results, as of this writing). 

This PR makes two changes intended to fix our failing filterable list language selection tests:

1. Adds a `lang` attribute to post previews. 
   
   Because we currently include posts in multiple languages, include a lang attribute with the post-preview to allow us to select based on the language of the post.

2. Changes content-dependent filterable language tests to use that attribute in selection.

   Our language tests now use that `lang` attribute of the post preview in the filter results to check for results that match the selected language(s).

## How to test this PR

1. [Load a database](https://cfpb.github.io/consumerfinance.gov/installation/#load-a-database-dump), either the [test database in this repository](https://github.com/cfpb/consumerfinance.gov/blob/main/test.sql.gz), or the production dump.
2. [Run our functional tests locally](https://cfpb.github.io/consumerfinance.gov/functional-testing/#cypress-app) with `yarn cypress open` and run the `test/cypress/integration/components/filterable-lists/filter-blog-posts.cy.js` spec file.

Repeat against the other database dump.

Observe that these tests:

- "Select a single language"
- "Select multiple languages"
- "Type-ahead languages"

Pass against both databases.

Note: I do see that occasionally category and topic tests in the `filter-blog-posts.cy.js` spec will fail for me locally. This seems to be performance/Elasticsearch related. If I shut down a bunch of other running stuff on my Mac they'll pass consistently. But failures of these due to timeouts is not something to be concerned with in this PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)