### PR TITLE
Bump Jinja2 version from 2.11.3 to 3.0.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,7 +18,7 @@ djangosaml2==1.5.0
 edgegrid-python==1.2.1
 elasticsearch<7.11  # Keep pinned to the deployed ES version
 govdelivery==1.4.0
-Jinja2==2.11.3
+Jinja2==3.0.3
 lxml==4.9.1
 opensearch-dsl==1.0.0
 opensearch-py==1.1.0
@@ -39,6 +39,3 @@ wagtailmedia==0.9.0
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.3/owning_a_home_api-0.17.3-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
-
-# Temporarily pin Jinja 2.11's MarkupSafe dependency.
-MarkupSafe==2.0.1


### PR DESCRIPTION
This commit bumps the version of the Jinja2 templating library from 2.11.3 to 3.0.3. Version 3.1.x of Jinja2 is not supported until Wagtail 3.x (we are still on 2.15.x).

This allows for removal of a pinned MarkupSafe dependency.

See Jinja2 changelog here:
https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-0-3

## Notes

To check whether this version upgrade introduces any template changes, I rendered every Wagtail page using [wagtail-bakery](https://github.com/wagtail/wagtail-bakery) on `main` and then with this change. Diffing the two batches of HTML showed no differences.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)