### PR TITLE
ROUT: Handle jsonp-p commonjs import

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
@@ -1,4 +1,5 @@
-import jsonpP from 'jsonp-p';
+import jsonpPModule from 'jsonp-p';
+const jsonpP = jsonpPModule.default;
 import { addEl, createEl, getEl, removeClass } from './dom-tools.js';
 import { incrementTotal } from './count.js';
 

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-tiger.js
@@ -1,4 +1,6 @@
-import jsonpP from 'jsonp-p';
+import jsonpPModule from 'jsonp-p';
+const jsonpP = jsonpPModule.default;
+
 /**
  * Call the Census geospatial API.
  *


### PR DESCRIPTION
When the scripts are all ESM, we'll need to handle this older dependency import. This gets it ready for an ESM world.

## Changes

- Reference default export in jsonp-p import.


## How to test this PR

1. PR checks should pass.
