### PR TITLE
Deprecate unused Wagtail search fields

### DIFF
--- a/cfgov/ask_cfpb/models/answer_page.py
+++ b/cfgov/ask_cfpb/models/answer_page.py
@@ -12,8 +12,6 @@ from wagtail.admin.edit_handlers import (
     TabbedInterface,
 )
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.core.models import Page
-from wagtail.search import index
 from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -291,11 +289,6 @@ class AnswerPage(CFGOVPage):
 
     sidebar_panels = [
         StreamFieldPanel("sidebar"),
-    ]
-
-    search_fields = Page.search_fields + [
-        index.SearchField("answer_content"),
-        index.SearchField("short_answer"),
     ]
 
     edit_handler = TabbedInterface(

--- a/cfgov/ask_cfpb/models/snippets.py
+++ b/cfgov/ask_cfpb/models/snippets.py
@@ -1,14 +1,13 @@
 from django.db import models
 
 from wagtail.core.fields import RichTextField
-from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 from modelcluster.fields import ParentalKey
 
 
 @register_snippet
-class GlossaryTerm(index.Indexed, models.Model):
+class GlossaryTerm(models.Model):
     name_en = models.CharField(max_length=255, verbose_name="TERM (ENGLISH)")
     definition_en = RichTextField(
         null=True, blank=True, verbose_name="DEFINITION (ENGLISH)"
@@ -50,12 +49,6 @@ class GlossaryTerm(index.Indexed, models.Model):
     portal_topic = ParentalKey(
         "v1.PortalTopic", related_name="glossary_terms", null=True, blank=True
     )
-    search_fields = [
-        index.SearchField("name_en", partial_match=True),
-        index.SearchField("definition_en", partial_match=True),
-        index.SearchField("name_es", partial_match=True),
-        index.SearchField("definition_es", partial_match=True),
-    ]
 
     def name(self, language="en"):
         if language == "es":

--- a/cfgov/form_explainer/models.py
+++ b/cfgov/form_explainer/models.py
@@ -5,7 +5,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from form_explainer.blocks import Explainer
 from v1.atomic_elements import molecules, organisms
@@ -55,5 +54,3 @@ class FormExplainerPage(CFGOVPage):
     )
 
     template = "form-explainer/index.html"
-
-    search_fields = CFGOVPage.search_fields + [index.SearchField("header")]

--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -11,9 +11,8 @@ from wagtail.admin.edit_handlers import (
     TabbedInterface,
 )
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import Orderable, Page
+from wagtail.core.models import Orderable
 from wagtail.documents.edit_handlers import DocumentChooserPanel
-from wagtail.search import index
 
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 
@@ -239,28 +238,6 @@ class ActivityPage(CFGOVPage):
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )
-
-    # admin use only
-    search_fields = Page.search_fields + [
-        index.SearchField("summary"),
-        index.SearchField("big_idea"),
-        index.SearchField("essential_questions"),
-        index.SearchField("objectives"),
-        index.SearchField("what_students_will_do"),
-        index.FilterField("date"),
-        index.FilterField("building_block"),
-        index.FilterField("school_subject"),
-        index.FilterField("topic"),
-        index.FilterField("grade_level"),
-        index.FilterField("age_range"),
-        index.FilterField("student_characteristics"),
-        index.FilterField("activity_type"),
-        index.FilterField("teaching_strategy"),
-        index.FilterField("blooms_taxonomy_level"),
-        index.FilterField("activity_duration"),
-        index.FilterField("jump_start_coalition"),
-        index.FilterField("council_for_economic_education"),
-    ]
 
     def get_subtopic_ids(self):
         """Get a list of this activity's subtopic ids."""

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -20,7 +20,6 @@ from wagtail.admin.edit_handlers import (
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page, Site
 from wagtail.images.edit_handlers import ImageChooserPanel
-from wagtail.search import index
 
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
@@ -131,10 +130,6 @@ class CFGOVPage(Page):
 
     # This is used solely for subclassing pages we want to make at the CFPB.
     is_creatable = False
-
-    search_fields = Page.search_fields + [
-        index.SearchField("sidefoot"),
-    ]
 
     # These fields show up in either the sidebar or the footer of the page
     # depending on the page type.

--- a/cfgov/v1/models/blog_page.py
+++ b/cfgov/v1/models/blog_page.py
@@ -1,7 +1,6 @@
 from wagtail.admin.edit_handlers import StreamFieldPanel
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import organisms, schema
@@ -29,10 +28,6 @@ class BlogPage(AbstractFilterPage):
     )
     template = "v1/blog/blog_page.html"
 
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("content")
-    ]
-
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
 
@@ -57,7 +52,3 @@ class LegacyBlogPage(AbstractFilterPage):
         content_panel=StreamFieldPanel("content")
     )
     template = "v1/blog/blog_page.html"
-
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("content")
-    ]

--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -8,7 +8,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from v1.atomic_elements import molecules, organisms
 from v1.documents import (
@@ -75,11 +74,6 @@ class BrowseFilterablePage(FilterableListMixin, CFGOVPage):
         "Left-hand navigation, no right-hand sidebar. Use if children should "
         "be searchable using standard search filters module."
     )
-
-    search_fields = CFGOVPage.search_fields + [
-        index.SearchField("content"),
-        index.SearchField("header"),
-    ]
 
     @property
     def page_js(self):

--- a/cfgov/v1/models/browse_page.py
+++ b/cfgov/v1/models/browse_page.py
@@ -8,7 +8,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from data_research.blocks import MortgageDataDownloads
 from jobmanager.blocks import JobListingTable
@@ -87,11 +86,6 @@ class BrowsePage(CFGOVPage):
     template = "v1/browse-basic/index.html"
 
     page_description = "Left-hand navigation, no right-hand sidebar."
-
-    search_fields = CFGOVPage.search_fields + [
-        index.SearchField("content"),
-        index.SearchField("header"),
-    ]
 
     @property
     def page_js(self):

--- a/cfgov/v1/models/enforcement_action_page.py
+++ b/cfgov/v1/models/enforcement_action_page.py
@@ -11,7 +11,6 @@ from wagtail.admin.edit_handlers import (
 from wagtail.core.fields import StreamField
 from wagtail.core.models import Page
 from wagtail.images.edit_handlers import ImageChooserPanel
-from wagtail.search import index
 
 from modelcluster.fields import ParentalKey
 
@@ -288,10 +287,6 @@ class EnforcementActionPage(AbstractFilterPage):
     )
 
     template = "v1/enforcement-action/index.html"
-
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("content")
-    ]
 
     @property
     def status_strings(self):

--- a/cfgov/v1/models/landing_page.py
+++ b/cfgov/v1/models/landing_page.py
@@ -4,7 +4,6 @@ from wagtail.admin.edit_handlers import (
     TabbedInterface,
 )
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage
@@ -43,8 +42,3 @@ class LandingPage(CFGOVPage):
     )
 
     template = "v1/landing-page/index.html"
-
-    search_fields = CFGOVPage.search_fields + [
-        index.SearchField("content"),
-        index.SearchField("header"),
-    ]

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -22,7 +22,6 @@ from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Page
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.edit_handlers import ImageChooserPanel
-from wagtail.search import index
 
 from localflavor.us.models import USStateField
 
@@ -100,8 +99,6 @@ class AbstractFilterPage(CFGOVPage):
     # This page class cannot be created.
     is_creatable = False
 
-    search_fields = CFGOVPage.search_fields + [index.SearchField("header")]
-
     @classmethod
     def generate_edit_handler(self, content_panel):
         content_panels = [
@@ -159,10 +156,6 @@ class LearnPage(AbstractFilterPage):
 
     page_description = "Right-hand sidebar, no left-hand sidebar."
 
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("content")
-    ]
-
 
 class DocumentDetailPage(AbstractFilterPage):
     content = StreamField(
@@ -183,10 +176,6 @@ class DocumentDetailPage(AbstractFilterPage):
         content_panel=StreamFieldPanel("content")
     )
     template = "v1/document-detail/index.html"
-
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("content")
-    ]
 
 
 class AgendaItemBlock(blocks.StructBlock):
@@ -343,16 +332,6 @@ class EventPage(AbstractFilterPage):
 
     # Agenda content fields
     agenda_items = StreamField([("item", AgendaItemBlock())], blank=True)
-
-    search_fields = AbstractFilterPage.search_fields + [
-        index.SearchField("body"),
-        index.SearchField("archive_body"),
-        index.SearchField("live_video_id"),
-        index.SearchField("flickr_url"),
-        index.SearchField("archive_video_id"),
-        index.SearchField("future_body"),
-        index.SearchField("agenda_items"),
-    ]
 
     # General content tab
     content_panels = CFGOVPage.content_panels + [

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -6,7 +6,6 @@ from wagtail.admin.edit_handlers import (
     StreamFieldPanel,
 )
 from wagtail.core.fields import RichTextField, StreamField
-from wagtail.search import index
 from wagtail.snippets.models import register_snippet
 
 from v1.atomic_elements import molecules
@@ -19,7 +18,7 @@ from v1.blocks import ReusableTextChooserBlock  # noqa
 
 
 @register_snippet
-class ReusableText(index.Indexed, models.Model):
+class ReusableText(models.Model):
     title = models.CharField(
         verbose_name="Snippet title (internal only)", max_length=255
     )
@@ -32,12 +31,6 @@ class ReusableText(index.Indexed, models.Model):
         "[GHE]/flapjack/Modules-V1/wiki/Atoms#slugs",
     )
     text = RichTextField()
-
-    search_fields = [
-        index.SearchField("title", partial_match=True),
-        index.SearchField("sidefoot_heading", partial_match=True),
-        index.SearchField("text", partial_match=True),
-    ]
 
     def __str__(self):
         return self.title
@@ -78,18 +71,11 @@ class Contact(models.Model):
 
 
 @register_snippet
-class RelatedResource(index.Indexed, models.Model):
+class RelatedResource(models.Model):
     title = models.CharField(max_length=255)
     title_es = models.CharField(max_length=255, blank=True, null=True)
     text = RichTextField(blank=True, null=True)
     text_es = RichTextField(blank=True, null=True)
-
-    search_fields = [
-        index.SearchField("title", partial_match=True),
-        index.SearchField("text", partial_match=True),
-        index.SearchField("title_es", partial_match=True),
-        index.SearchField("text_es", partial_match=True),
-    ]
 
     def trans_title(self, language="en"):
         if language == "es":
@@ -106,7 +92,7 @@ class RelatedResource(index.Indexed, models.Model):
 
 
 @register_snippet
-class EmailSignUp(index.Indexed, models.Model):
+class EmailSignUp(models.Model):
     topic = models.CharField(
         verbose_name="Topic name (internal only)",
         max_length=255,
@@ -164,12 +150,6 @@ class EmailSignUp(index.Indexed, models.Model):
             'Privacy Act Statement".'
         ),
     )
-
-    search_fields = [
-        index.SearchField("topic", partial_match=True),
-        index.SearchField("code", partial_match=True),
-        index.SearchField("url", partial_match=True),
-    ]
 
     panels = [
         FieldPanel("topic"),

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -5,7 +5,6 @@ from wagtail.admin.edit_handlers import (
 )
 from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
-from wagtail.search import index
 
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage
@@ -62,11 +61,6 @@ class SublandingFilterablePage(FilterableListMixin, CFGOVPage):
         "Right-hand sidebar, no left-hand sidebar. Use if children should be "
         "searchable using standard search filters module."
     )
-
-    search_fields = CFGOVPage.search_fields + [
-        index.SearchField("content"),
-        index.SearchField("header"),
-    ]
 
 
 class ResearchHubPage(CategoryFilterableMixin, SublandingFilterablePage):

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -9,7 +9,6 @@ from wagtail.admin.edit_handlers import (
 from wagtail.core import blocks
 from wagtail.core.fields import StreamField
 from wagtail.images.blocks import ImageChooserBlock
-from wagtail.search import index
 
 from jobmanager.blocks import JobListingList
 from v1.atomic_elements import molecules, organisms
@@ -118,11 +117,6 @@ class SublandingPage(CFGOVPage):
     )
 
     template = "v1/sublanding-page/index.html"
-
-    search_fields = CFGOVPage.search_fields + [
-        index.SearchField("content"),
-        index.SearchField("header"),
-    ]
 
     def get_browsefilterable_posts(self, limit):
         filter_pages = [


### PR DESCRIPTION
This commit cleans up some unused Wagtail search configuration that is no longer necessary after 2c793d2305e33230d1af24dab5f3ef33cbb82dba.

Defining `search_fields` on models are only necessary if we want them to be searched using Wagtail search, but we no longer use Wagtail search to search pages.

## How to test this PR

All tests continue to work.

## Notes and todos

I've left behind the one supported place where we actually rely on Wagtail search, which is our [`IndexedPageRevision`](https://github.com/cfpb/consumerfinance.gov/blob/54dddc061b5f843a575a6887bb412a4033de8365/cfgov/v1/models/indexed_page_revision.py#L5) class.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
