### PR TITLE
Youth Financial Education: Remove headless skips on tests

### DIFF
--- a/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
+++ b/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
@@ -14,14 +14,11 @@ describe('Youth Financial Education Survey: Errors', () => {
     survey.clickNext();
   }
 
-  // This tests fails in headless browsers, so skip it there
-  skipOn('headless', () => {
-    it('jumps to errors at top', () => {
-      refreshErrors();
-      cy.wait(1200);
-      cy.window().then((win) => {
-        expect(win.scrollY).lessThan(400);
-      });
+  it('jumps to errors at top', () => {
+    refreshErrors();
+    cy.wait(1200);
+    cy.window().then((win) => {
+      expect(win.scrollY).lessThan(400);
     });
   });
 
@@ -51,15 +48,12 @@ describe('Youth Financial Education Survey: Errors', () => {
     );
   });
 
-  // This tests fails in headless browsers, so skip it there
-  skipOn('headless', () => {
-    it('links jump to questions', () => {
-      refreshErrors();
-      cy.get('form .m-notification__error li:nth-child(2) a').click();
-      cy.wait(1200);
-      cy.window().then((win) => {
-        expect(win.scrollY).greaterThan(1000);
-      });
+  it('links jump to questions', () => {
+    refreshErrors();
+    cy.get('form .m-notification__error li:nth-child(2) a').click();
+    cy.wait(1200);
+    cy.window().then((win) => {
+      expect(win.scrollY).greaterThan(1000);
     });
   });
 

--- a/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
+++ b/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
@@ -1,5 +1,4 @@
 import { TdpSurveyHelpers } from './survey-helpers.cy.js';
-import { skipOn } from '@cypress/skip-test';
 
 const survey = new TdpSurveyHelpers();
 

--- a/test/cypress/integration/consumer-tools/youth-financial-education/survey-progress.cy.js
+++ b/test/cypress/integration/consumer-tools/youth-financial-education/survey-progress.cy.js
@@ -71,32 +71,29 @@ describe('Youth Financial Education Survey: Progress', () => {
     });
   }
 
-  // This tests fails in headless browsers, so skip it there
-  skipOn('headless', () => {
-    it('updates section UI', () => {
-      cy.window().then((win) => win.sessionStorage.clear());
-      survey.open('3-5/p1');
-      verifySectionColors(['blue']);
-      survey.selectAnswers([0, 0, 0, 0, 0, 0]);
-      survey.clickNext();
+  it('updates section UI', () => {
+    cy.window().then((win) => win.sessionStorage.clear());
+    survey.open('3-5/p1');
+    verifySectionColors(['blue']);
+    survey.selectAnswers([0, 0, 0, 0, 0, 0]);
+    survey.clickNext();
 
-      verifySectionColors(['green', 'blue']);
-      survey.selectAnswers([0, 0]);
-      survey.clickNext();
+    verifySectionColors(['green', 'blue']);
+    survey.selectAnswers([0, 0]);
+    survey.clickNext();
 
-      verifySectionColors(['green', 'green', 'blue']);
-      cy.get(
-        '.tdp-survey-section:first-child .tdp-survey-section__edit span'
-      ).click();
+    verifySectionColors(['green', 'green', 'blue']);
+    cy.get(
+      '.tdp-survey-section:first-child .tdp-survey-section__edit span'
+    ).click();
 
-      verifySectionColors(['blue', 'green', 'white']);
-      survey.clickNext();
+    verifySectionColors(['blue', 'green', 'white']);
+    survey.clickNext();
 
-      verifySectionColors(['green', 'blue', 'white']);
-      survey.clickNext();
+    verifySectionColors(['green', 'blue', 'white']);
+    survey.clickNext();
 
-      verifySectionColors(['green', 'green', 'blue']);
-    });
+    verifySectionColors(['green', 'green', 'blue']);
   });
 
   it('stores answers without submit', () => {

--- a/test/cypress/integration/consumer-tools/youth-financial-education/survey-progress.cy.js
+++ b/test/cypress/integration/consumer-tools/youth-financial-education/survey-progress.cy.js
@@ -1,5 +1,4 @@
 import { TdpSurveyHelpers } from './survey-helpers.cy.js';
-import { skipOn } from '@cypress/skip-test';
 
 const survey = new TdpSurveyHelpers();
 


### PR DESCRIPTION
Several Youth Financial Education tests are skipped on headless mode. However, I removed the skips and the tests passed locally. Maybe this has been rectified through updates to Cypress, so this PR removes the gates to see how they perform on GH actions. 

## Removals

- Remove skipOn headless gates from some Youth Financial Education tests.

## How to test this PR

1. PR functional tests for the Youth Financial Education tests should pass.
