### PR TITLE
Fix FIG TOC highlighting with manually created FIG sections

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/section.html
@@ -18,11 +18,15 @@
 
 {% if block_type in ['Fig_Section', 'Fig_Subsection'] %}
     {% set header = value.section_id + ". " + value.header %}
+    {% set block_toc_id = value.section_id %}
 {% else %}
     {% set header = value.header %}
+    {# Level 3 sections are identified by their level 2 parent in the TOC #}
+    {# e.g. A level 3 section with id 4.2.5 should have a toc id of 4.2 #}
+    {% set block_toc_id = value.section_id.split('.') | batch(2) | first | join('.') %}
 {% endif %}
 
-<div class="{{ block_class }}" data-search-section data-scrollspy="{{ value.section_id }}">
+<div class="{{ block_class }}" data-search-section data-scrollspy="{{ block_toc_id }}">
     <{{ block_heading_level }}
         class="o-fig_heading">
         <a id="{{ value.section_id }}"

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide-helpers.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide-helpers.cy.js
@@ -80,7 +80,7 @@ export class FilingInstructionGuide {
   }
 
   scrollToBottom() {
-    return cy.get('footer').scrollIntoView();
+    return cy.get('.o-fig_heading').last().scrollIntoView();
   }
 
   getUnrenderedListTags() {

--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -3,6 +3,11 @@ import { onlyOn } from '@cypress/skip-test';
 
 const fig = new FilingInstructionGuide();
 
+let windowConsoleError;
+Cypress.on('window:before:load', (win) => {
+  windowConsoleError = cy.spy(win.console, 'error');
+});
+
 describe('1071 Filing Instruction Guide (FIG)', () => {
   describe('FIG table of contents', () => {
     /* Our FIG sample page only exists in certain environments so continue
@@ -17,6 +22,10 @@ describe('1071 Filing Instruction Guide (FIG)', () => {
           context(desktop, () => {
             beforeEach(() => {
               cy.viewport(desktop);
+            });
+
+            afterEach(() => {
+              expect(windowConsoleError).to.not.be.called;
             });
 
             it('should be present', () => {
@@ -126,6 +135,10 @@ describe('1071 Filing Instruction Guide (FIG)', () => {
               cy.viewport(tablet);
             });
 
+            afterEach(() => {
+              expect(windowConsoleError).to.not.be.called;
+            });
+
             it('should be present', () => {
               fig.open();
               fig.toc().should('be.visible');
@@ -169,6 +182,10 @@ describe('1071 Filing Instruction Guide (FIG)', () => {
           context(mobile, () => {
             beforeEach(() => {
               cy.viewport(mobile);
+            });
+
+            afterEach(() => {
+              expect(windowConsoleError).to.not.be.called;
             });
 
             it('should be present', () => {


### PR DESCRIPTION
Most of our level 3 FIG sections are auto-generated from the data points JSON. However, when we manually create them, their TOC highlighting is semi-broken because they don't correctly identify their level 2 parent. You can see the issue when you visit the draft FIG on content, open your browser console and scroll to section 4.

This PR fixes that by correctly attributing level 3 sections to their level 2 parent in the TOC.

## Changes

- Fixed a jinja template
- Added a smoke test to confirm there are never console errors
- Improved the reliability of an unrelated test


## How to test this PR

1. Pull down this branch.
1. Import a prod DB dump if you haven't recently to get the FIG draft that's currently staged on content.
1. Publish the FIG page locally with whatever slug you'd like, e.g. `/data-research/small-business-lending-data/filing-instructions-guide/2024-guide/`
1. Tests should pass headlessly with the aforementioned slug:
    `yarn cypress run --spec test/cypress/integration/compliance/small-business-lending/ --env FIG_URL=/data-research/small-business-lending-data/filing-instructions-guide/2024-guide/`
1. Tests should pass with your local copy of Chrome (click on filing-instruction-guide.cy.js):
    `yarn cypress open --e2e --browser chrome --env FIG_URL=/data-research/small-business-lending-data/filing-instructions-guide/2024-guide/`
1. Tests should *fail* when run against content where the current bug exists (change the content URL below):
    `yarn cypress run --spec test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js --env FIG_URL=/data-research/small-business-lending-data/filing-instructions-guide/filing-instructions-guide-for-small-business-lending-rule-data/ --config baseUrl=https://secret-content-url.consumerfinance.gov`

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
