### PR TITLE
Update tdp spy tests for esm

### DIFF
--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
@@ -12,20 +12,20 @@ const HTML_SNIPPET = `
 
 describe('The TDP survey grade-level page', () => {
   let surveys;
-  const remove = jest.fn();
-  const init = jest.fn();
+  const cookieRemove = jest.fn();
+  const modalsInit = jest.fn();
 
   beforeAll(async () => {
     jest.unstable_mockModule('js-cookie', () => ({
       default: {
-        remove,
+        remove: cookieRemove,
       },
     }));
 
     jest.unstable_mockModule(
       '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js',
       () => ({
-        init,
+        init: modalsInit,
         close: jest.fn(),
       })
     );
@@ -44,9 +44,9 @@ describe('The TDP survey grade-level page', () => {
 
     surveys.init();
 
-    expect(remove.mock.calls[0][0]).toEqual(RESULT_COOKIE);
-    expect(remove.mock.calls[1][0]).toEqual(SURVEY_COOKIE);
+    expect(cookieRemove.mock.calls[0][0]).toEqual(RESULT_COOKIE);
+    expect(cookieRemove.mock.calls[1][0]).toEqual(SURVEY_COOKIE);
     expect(sessionStorage.getItem(ANSWERS_SESS_KEY)).toBeNull();
-    expect(init).toHaveBeenCalled();
+    expect(modalsInit).toHaveBeenCalled();
   });
 });

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
@@ -30,9 +30,11 @@ describe('The TDP survey grade-level page', () => {
       })
     );
 
-    surveys = await import(
-      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
-    );
+    surveys = (
+      await import(
+        '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+      )
+    ).default;
 
     document.body.innerHTML = HTML_SNIPPET;
   });
@@ -40,7 +42,7 @@ describe('The TDP survey grade-level page', () => {
   it('should be recognized from HTML', () => {
     sessionStorage.setItem(ANSWERS_SESS_KEY, 'testItem');
 
-    surveys.default.init();
+    surveys.init();
 
     expect(remove.mock.calls[0][0]).toEqual(RESULT_COOKIE);
     expect(remove.mock.calls[1][0]).toEqual(SURVEY_COOKIE);

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-spec.js
@@ -1,36 +1,50 @@
 import { jest } from '@jest/globals';
-import surveys from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js';
-import Cookies from 'js-cookie';
 import {
   ANSWERS_SESS_KEY,
   RESULT_COOKIE,
   SURVEY_COOKIE,
 } from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/config.js';
-import * as modals from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js';
 
 const HTML_SNIPPET = `
 <div data-tdp-page="grade-level">
 </div>
 `;
 
-xdescribe('The TDP survey grade-level page', () => {
-  beforeEach(() => {
+describe('The TDP survey grade-level page', () => {
+  let surveys;
+  const remove = jest.fn();
+  const init = jest.fn();
+
+  beforeAll(async () => {
+    jest.unstable_mockModule('js-cookie', () => ({
+      default: {
+        remove,
+      },
+    }));
+
+    jest.unstable_mockModule(
+      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js',
+      () => ({
+        init,
+        close: jest.fn(),
+      })
+    );
+
+    surveys = await import(
+      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+    );
+
     document.body.innerHTML = HTML_SNIPPET;
   });
 
   it('should be recognized from HTML', () => {
-    const cookieSpy = jest.spyOn(Cookies, 'remove');
-    const modalSpy = jest.spyOn(modals, 'init');
     sessionStorage.setItem(ANSWERS_SESS_KEY, 'testItem');
 
-    surveys.init();
+    surveys.default.init();
 
-    expect(cookieSpy.mock.calls[0][0]).toEqual(RESULT_COOKIE);
-    expect(cookieSpy.mock.calls[1][0]).toEqual(SURVEY_COOKIE);
+    expect(remove.mock.calls[0][0]).toEqual(RESULT_COOKIE);
+    expect(remove.mock.calls[1][0]).toEqual(SURVEY_COOKIE);
     expect(sessionStorage.getItem(ANSWERS_SESS_KEY)).toBeNull();
-    expect(modalSpy).toHaveBeenCalled();
-
-    cookieSpy.mockRestore();
-    modalSpy.mockRestore();
+    expect(init).toHaveBeenCalled();
   });
 });

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-spec.js
@@ -33,9 +33,11 @@ describe('The TDP survey results page', () => {
       })
     );
 
-    surveys = await import(
-      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
-    );
+    surveys = (
+      await import(
+        '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+      )
+    ).default;
 
     resultsPage = (
       await import(
@@ -59,7 +61,7 @@ describe('The TDP survey results page', () => {
   it('should be recognized from HTML', () => {
     sessionStorage.setItem(ANSWERS_SESS_KEY, 'testItem');
 
-    surveys.default.init();
+    surveys.init();
 
     expect(sessionStorage.getItem(ANSWERS_SESS_KEY)).toBeNull();
     expect(remove.mock.calls[0][0]).toEqual(SURVEY_COOKIE);

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-spec.js
@@ -9,27 +9,27 @@ const $ = document.querySelector.bind(document);
 
 describe('The TDP survey results page', () => {
   let initials, surveys, resultsPage, obfuscation;
-  const remove = jest.fn();
-  const init = jest.fn();
-  const close = jest.fn();
-  const copy = jest.fn();
+  const cookieRemove = jest.fn();
+  const modalsInit = jest.fn();
+  const modalsClose = jest.fn();
+  const copyClipboard = jest.fn();
 
   beforeAll(async () => {
     jest.unstable_mockModule('js-cookie', () => ({
       default: {
-        remove,
+        remove: cookieRemove,
       },
     }));
 
     jest.unstable_mockModule('copy-to-clipboard', () => ({
-      default: copy,
+      default: copyClipboard,
     }));
 
     jest.unstable_mockModule(
       '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js',
       () => ({
-        init,
-        close,
+        init: modalsInit,
+        close: modalsClose,
       })
     );
 
@@ -64,8 +64,8 @@ describe('The TDP survey results page', () => {
     surveys.init();
 
     expect(sessionStorage.getItem(ANSWERS_SESS_KEY)).toBeNull();
-    expect(remove.mock.calls[0][0]).toEqual(SURVEY_COOKIE);
-    expect(init).toHaveBeenCalled();
+    expect(cookieRemove.mock.calls[0][0]).toEqual(SURVEY_COOKIE);
+    expect(modalsInit).toHaveBeenCalled();
   });
 
   it('should read initials', () => {
@@ -99,7 +99,7 @@ describe('The TDP survey results page', () => {
 
     $('#modal-reset [data-cancel="1"]').click();
 
-    expect(close).toHaveBeenCalled();
+    expect(modalsClose).toHaveBeenCalled();
 
     $('#modal-reset [data-cancel=""]').click();
 
@@ -134,7 +134,7 @@ describe('The TDP survey results page', () => {
 
     shared.click();
 
-    expect(copy).toHaveBeenCalled();
+    expect(copyClipboard).toHaveBeenCalled();
     expect($('.share-output__copied').hidden).toBeFalsy();
   });
 });

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-spec.js
@@ -10,16 +10,16 @@ import HTML_SNIPPET from '../../html/survey-page.js';
 const $ = document.querySelector.bind(document);
 
 describe('The TDP survey page', () => {
-  const modalInit = jest.fn();
-  const close = jest.fn();
+  const modalsInit = jest.fn();
+  const modalsClose = jest.fn();
   let scrollToEl, surveyPage, surveys;
 
   beforeAll(async () => {
     jest.unstable_mockModule(
       '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js',
       () => ({
-        init: modalInit,
-        close,
+        init: modalsInit,
+        close: modalsClose,
       })
     );
 
@@ -28,9 +28,11 @@ describe('The TDP survey page', () => {
     );
     scrollToEl = surveyExports.scrollToEl;
     surveyPage = surveyExports.surveyPage;
-    surveys = await import(
-      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
-    );
+    surveys = (
+      await import(
+        '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+      )
+    ).default;
   });
 
   beforeEach(() => {
@@ -40,7 +42,7 @@ describe('The TDP survey page', () => {
   it('should be recognized from HTML', () => {
     sessionStorage.clear();
 
-    surveys.default.init();
+    surveys.init();
 
     const answers = JSON.parse(sessionStorage.getItem(ANSWERS_SESS_KEY));
     expect(answers).toEqual({ 'p1-q6': '3' });
@@ -76,7 +78,7 @@ describe('The TDP survey page', () => {
     window.location = {};
     const modal = $('#modal-restart [data-cancel="1"]');
     modal.click();
-    expect(close).toHaveBeenCalled();
+    expect(modalsClose).toHaveBeenCalled();
 
     $('#modal-restart [data-cancel=""]').click();
 

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-spec.js
@@ -1,52 +1,53 @@
 import { jest } from '@jest/globals';
 import Cookies from 'js-cookie';
-import surveys from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js';
-import {
-  ChoiceField,
-  scrollToEl,
-  surveyPage,
-  progressBar,
-} from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/survey-page.js';
 import {
   ANSWERS_SESS_KEY,
   RESULT_COOKIE,
   SCORES_UNSET_KEY,
 } from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/config.js';
-import * as modals from '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js';
 import HTML_SNIPPET from '../../html/survey-page.js';
 
 const $ = document.querySelector.bind(document);
 
-xdescribe('The TDP survey page', () => {
+describe('The TDP survey page', () => {
+  const modalInit = jest.fn();
+  const close = jest.fn();
+  let scrollToEl, surveyPage, surveys;
+
+  beforeAll(async () => {
+    jest.unstable_mockModule(
+      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/modals.js',
+      () => ({
+        init: modalInit,
+        close,
+      })
+    );
+
+    const surveyExports = await import(
+      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/survey-page.js'
+    );
+    scrollToEl = surveyExports.scrollToEl;
+    surveyPage = surveyExports.surveyPage;
+    surveys = await import(
+      '../../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+    );
+  });
+
   beforeEach(() => {
     document.body.innerHTML = HTML_SNIPPET;
   });
 
   it('should be recognized from HTML', () => {
-    const modalSpy = jest.spyOn(modals, 'init');
-    const cf1Spy = jest.spyOn(ChoiceField, 'init');
-    const cf2Spy = jest.spyOn(ChoiceField, 'watchAndStore');
-    const cf3Spy = jest.spyOn(ChoiceField, 'restoreFromSession');
-    ChoiceField.cache = Object.create(null);
     sessionStorage.clear();
-    expect(progressBar).toBeUndefined();
 
-    surveys.init();
+    surveys.default.init();
 
     const answers = JSON.parse(sessionStorage.getItem(ANSWERS_SESS_KEY));
     expect(answers).toEqual({ 'p1-q6': '3' });
-    expect(modalSpy).toHaveBeenCalled();
-    expect(cf1Spy).toHaveBeenCalled();
-    expect(cf2Spy).toHaveBeenCalled();
-    expect(cf3Spy).toHaveBeenCalled();
-    expect(progressBar.totalNum).toEqual(20);
     expect(sessionStorage.getItem(SCORES_UNSET_KEY)).toEqual('1');
-
-    modalSpy.mockRestore();
   });
 
   it('should update progress', () => {
-    ChoiceField.cache = Object.create(null);
     sessionStorage.clear();
     surveyPage();
     const label = $('label[for="id_p1-q1_0"]');
@@ -54,56 +55,9 @@ xdescribe('The TDP survey page', () => {
 
     const answers = JSON.parse(sessionStorage.getItem(ANSWERS_SESS_KEY));
     expect(answers).toEqual({ 'p1-q1': '0', 'p1-q6': '3' });
-    expect(progressBar.numDone).toEqual(2);
-    expect(ChoiceField.get('p1-q1')).toBeInstanceOf(ChoiceField);
-    expect(ChoiceField.get('p1-q1').value).toEqual('0');
-  });
-
-  it('should catch missing answers', () => {
-    const clickNext = () =>
-      $('.tdp-survey-page button[type="submit"]').click();
-
-    ChoiceField.cache = Object.create(null);
-    sessionStorage.clear();
-    surveyPage();
-    clickNext();
-
-    expect($('form > .m-notification__visible')).not.toBeUndefined();
-
-    // Missed first question
-    let legend = $('legend + .a-form-alert').previousElementSibling;
-    expect(legend.textContent).toMatch('1.');
-    const scrollLink = $('.m-notification_explanation a');
-    expect(scrollLink.textContent).toEqual(legend.textContent);
-
-    scrollLink.click();
-
-    $('label[for="id_p1-q1_0"]').click();
-
-    clickNext();
-
-    // Missed second
-    legend = $('legend + .a-form-alert').previousElementSibling;
-    expect(legend.textContent).toMatch('2.');
-
-    [1, 2, 3, 4, 5, 6].forEach((num) => {
-      $(`label[for="id_p1-q${num}_0"]`).click();
-    });
-
-    const form = $('.tdp-survey-page form');
-    let returnValue = false;
-    form.addEventListener('submit', (event) => {
-      returnValue = event.returnValue;
-      event.preventDefault();
-    });
-
-    clickNext();
-
-    expect(returnValue).toBeTruthy();
   });
 
   it('should set buttons from storage', () => {
-    ChoiceField.cache = Object.create(null);
     sessionStorage.clear();
     sessionStorage.setItem(
       ANSWERS_SESS_KEY,
@@ -120,10 +74,9 @@ xdescribe('The TDP survey page', () => {
     const origLocation = location;
     delete window.location;
     window.location = {};
-    const closeSpy = jest.spyOn(modals, 'close');
-    $('#modal-restart [data-cancel="1"]').click();
-
-    expect(closeSpy).toHaveBeenCalled();
+    const modal = $('#modal-restart [data-cancel="1"]');
+    modal.click();
+    expect(close).toHaveBeenCalled();
 
     $('#modal-restart [data-cancel=""]').click();
 

--- a/test/unit_tests/apps/teachers-digital-platform/js/tdp-surveys-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/tdp-surveys-spec.js
@@ -1,47 +1,58 @@
 import { jest } from '@jest/globals';
-import surveys from '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js';
-import * as gradeLevelModule from '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/grade-level-page.js';
-import * as resultsModule from '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/result-page.js';
-import * as surveyModule from '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/survey-page.js';
 
-let glp;
-let rp;
-let sp;
+const gl =
+  '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/grade-level-page.js';
+const res =
+  '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/result-page.js';
+const sur =
+  '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/survey-page.js';
 
-xdescribe('The TDP survey router', () => {
-  beforeEach(() => {
-    glp = jest
-      .spyOn(gradeLevelModule, 'gradeLevelPage')
-      .mockImplementation(() => 1);
-    rp = jest.spyOn(resultsModule, 'resultsPage').mockImplementation(() => 1);
-    sp = jest.spyOn(surveyModule, 'surveyPage').mockImplementation(() => 1);
-  });
+let surveys, g, r, s;
 
-  afterEach(() => {
-    jest.restoreAllMocks();
+describe('The TDP survey router', () => {
+  beforeAll(async () => {
+    jest.unstable_mockModule(gl, () => ({
+      gradeLevelPage: jest.fn(),
+    }));
+
+    jest.unstable_mockModule(res, () => ({
+      resultsPage: jest.fn(),
+    }));
+
+    jest.unstable_mockModule(sur, () => ({
+      surveyPage: jest.fn(),
+    }));
+
+    surveys = await import(
+      '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
+    );
+    surveys = surveys.default;
+    g = await import(gl);
+    r = await import(res);
+    s = await import(sur);
   });
 
   it('recognizes grade level page', () => {
     document.body.innerHTML = '<div data-tdp-page="grade-level"></div>';
     surveys.init();
-    expect(glp).toHaveBeenCalled();
-    expect(sp).not.toHaveBeenCalled();
-    expect(rp).not.toHaveBeenCalled();
+    expect(g.gradeLevelPage).toHaveBeenCalled();
+    expect(r.resultsPage).not.toHaveBeenCalled();
+    expect(s.surveyPage).not.toHaveBeenCalled();
   });
 
   it('recognizes survey page', () => {
     document.body.innerHTML = '<div data-tdp-page="survey"></div>';
     surveys.init();
-    expect(glp).not.toHaveBeenCalled();
-    expect(sp).toHaveBeenCalled();
-    expect(rp).not.toHaveBeenCalled();
+    expect(g.gradeLevelPage.mock.calls.length).toBe(1);
+    expect(s.surveyPage.mock.calls.length).toBe(1);
+    expect(r.resultsPage).not.toHaveBeenCalled();
   });
 
   it('recognizes results page', () => {
     document.body.innerHTML = '<div data-tdp-page="results"></div>';
     surveys.init();
-    expect(glp).not.toHaveBeenCalled();
-    expect(sp).not.toHaveBeenCalled();
-    expect(rp).toHaveBeenCalled();
+    expect(g.gradeLevelPage.mock.calls.length).toBe(1);
+    expect(s.surveyPage.mock.calls.length).toBe(1);
+    expect(r.resultsPage.mock.calls.length).toBe(1);
   });
 });

--- a/test/unit_tests/apps/teachers-digital-platform/js/tdp-surveys-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/tdp-surveys-spec.js
@@ -7,7 +7,7 @@ const res =
 const sur =
   '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/survey/survey-page.js';
 
-let surveys, g, r, s;
+let surveys, gradeLevelPage, resultsPage, surveyPage;
 
 describe('The TDP survey router', () => {
   beforeAll(async () => {
@@ -27,32 +27,32 @@ describe('The TDP survey router', () => {
       '../../../../../cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-surveys.js'
     );
     surveys = surveys.default;
-    g = await import(gl);
-    r = await import(res);
-    s = await import(sur);
+    gradeLevelPage = (await import(gl)).gradeLevelPage;
+    resultsPage = (await import(res)).resultsPage;
+    surveyPage = (await import(sur)).surveyPage;
   });
 
   it('recognizes grade level page', () => {
     document.body.innerHTML = '<div data-tdp-page="grade-level"></div>';
     surveys.init();
-    expect(g.gradeLevelPage).toHaveBeenCalled();
-    expect(r.resultsPage).not.toHaveBeenCalled();
-    expect(s.surveyPage).not.toHaveBeenCalled();
+    expect(gradeLevelPage).toHaveBeenCalled();
+    expect(resultsPage).not.toHaveBeenCalled();
+    expect(surveyPage).not.toHaveBeenCalled();
   });
 
   it('recognizes survey page', () => {
     document.body.innerHTML = '<div data-tdp-page="survey"></div>';
     surveys.init();
-    expect(g.gradeLevelPage.mock.calls.length).toBe(1);
-    expect(s.surveyPage.mock.calls.length).toBe(1);
-    expect(r.resultsPage).not.toHaveBeenCalled();
+    expect(gradeLevelPage.mock.calls.length).toBe(1);
+    expect(surveyPage.mock.calls.length).toBe(1);
+    expect(resultsPage).not.toHaveBeenCalled();
   });
 
   it('recognizes results page', () => {
     document.body.innerHTML = '<div data-tdp-page="results"></div>';
     surveys.init();
-    expect(g.gradeLevelPage.mock.calls.length).toBe(1);
-    expect(s.surveyPage.mock.calls.length).toBe(1);
-    expect(r.resultsPage.mock.calls.length).toBe(1);
+    expect(gradeLevelPage.mock.calls.length).toBe(1);
+    expect(surveyPage.mock.calls.length).toBe(1);
+    expect(resultsPage.mock.calls.length).toBe(1);
   });
 });


### PR DESCRIPTION
Mostly keeps test logic intact while replacing spies