### PR TITLE
Add CSP entries for Google Optimize

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -452,9 +452,11 @@ CSP_SCRIPT_SRC = (
     "'unsafe-inline'",
     "'unsafe-eval'",
     "*.consumerfinance.gov",
+    "*.googleanalytics.com",
     "*.google-analytics.com",
     "*.googletagmanager.com",
     "*.googleoptimize.com",
+    "optimize.google.com",
     "api.mapbox.com",
     "js-agent.newrelic.com",
     "bam.nr-data.net",
@@ -473,6 +475,8 @@ CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",
     "*.consumerfinance.gov",
+    "optimize.google.com",
+    "fonts.googleapis.com",
     "api.mapbox.com",
 )
 
@@ -485,6 +489,7 @@ CSP_IMG_SRC = (
     "img.youtube.com",
     "*.google-analytics.com",
     "*.googletagmanager.com",
+    "optimize.google.com",
     "api.mapbox.com",
     "*.tiles.mapbox.com",
     "blob:",
@@ -502,13 +507,14 @@ CSP_FRAME_SRC = (
     "*.googletagmanager.com",
     "*.google-analytics.com",
     "*.googleoptimize.com",
+    "optimize.google.com",
     "www.youtube.com",
     "*.qualtrics.com",
     "mailto:",
 )
 
 # These specify where we allow fonts to come from
-CSP_FONT_SRC = "'self'"
+CSP_FONT_SRC = ("'self'", "fonts.gstatic.com")
 
 # These specify hosts we can make (potentially) cross-domain AJAX requests to
 CSP_CONNECT_SRC = (


### PR DESCRIPTION
We're ramping up to restart A/B testing on cf.gov using Google Optimize. Optimize and the Optimize Chrome extension require some third-party scripts and styles from domains that weren't included in our CSP. See https://support.google.com/optimize/answer/7388531 for Google's official list of what needs to be included in the CSP and GHE/Design-Development/Design-Thinking-and-User-Research/issues/63 for more details. That internal issue has a screenshot of the error we get right now when trying to run the Optimize Chrome extension.

---

## Additions

- Entries to the CSP to allow Google Optimize and the Optimize Chrome extension to run

## How to test this PR

As far as I can tell, there's no good way to test this until it's deployed and we can see if we can run Optimize A/B tests and the Optimize Chrome extension.

## Notes and todos

- The addition to `font-src` probably isn't strictly necessary; I assume the Chrome extension will just fall back to system fonts if it can't load whatever Google fonts it uses. But I kept it in there anyway to match what Google recommends in their Optimize documentation.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)