### PR TITLE
Update Wagtail-TreeModelAdmin to 1.6.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -33,7 +33,7 @@ wagtail-flags==5.2.0
 wagtail-inventory==1.6
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.7
-wagtail-treemodeladmin==1.5.0
+wagtail-treemodeladmin==1.6.0
 wagtailmedia==0.9.0
 
 # These packages are installed from GitHub.


### PR DESCRIPTION
This small change updates Wagtail-TreeModelAdmin to [1.6.0](https://github.com/cfpb/wagtail-treemodeladmin/releases/tag/1.6.0). This is a small version update that adds support for Wagtail 3.x.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
