### PR TITLE
Workaround for fbjs global undefined issue

### DIFF
--- a/cfgov/unprocessed/apps/admin/js/global.js
+++ b/cfgov/unprocessed/apps/admin/js/global.js
@@ -1,3 +1,7 @@
+// This is a workaround to an issue in fbjs.
+// See https://github.com/facebook/fbjs/issues/290
+global = globalThis;
+
 const env = location.hostname.split('.')[0];
 
 const body = document.querySelector('body');

--- a/cfgov/unprocessed/apps/admin/js/rich-text-table.js
+++ b/cfgov/unprocessed/apps/admin/js/rich-text-table.js
@@ -3,6 +3,7 @@
 import { stateToHTML } from 'draft-js-export-html';
 
 const body = document.querySelector('body');
+
 /**
  * @param {MouseEvent} event - The mouse event from a modal click.
  */


### PR DESCRIPTION
See background in [GHE]/Design-Development/Design-and-Content-Team/issues/129

## Changes

- Set `global` to `globalThis`, which was re-named.


## How to test this PR

1. Check out this branch
2. Install requirements, `pip install -r requirements/local.txt`
3. Run local server, `./runserver.sh`
4. Login to Wagtail admin and create a new BlogPage: http://localhost:8000/admin/pages/add/v1/blogpage/319/
5. Confirm there are no errors in the dev console.
