### PR TITLE
Skip troublesome TDP functional test

### DIFF
--- a/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
+++ b/test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js
@@ -13,7 +13,15 @@ function refreshErrors() {
 }
 
 describe('Youth Financial Education Survey: Errors', () => {
-  it('jumps to errors at top', () => {
+  /**
+   * TODO: This scroll test frequently fails on headless runs in our pipeline.
+   * We'll skip it for now, but we should come back to it in a future version
+   * of Cypress to see if it's working reliably.
+   *
+   * See https://github.com/cfpb/consumerfinance.gov/pull/7450 for a possibly
+   * related issue with smooth scrolling in Cypress tests.
+   */
+  xit('jumps to errors at top', () => {
     refreshErrors();
     cy.get('.m-notification__visible');
     cy.get('main h1').isScrolledTo();


### PR DESCRIPTION
This TDP test is meant to check that the financial education survey tool scrolls to the error message at the top of the page if there's an error on submission. That test has always been flaky, and we've tried various fixes and workarounds (see #7243, #7424, #7447). Despite all of that, the test continues to fail intermittently on headless runs in our CI/CD pipeline, preventing automatic releases and deployments. At this point, we've decided the test is more trouble than it's worth, so we're going to mark it as pending with `xit` so it won't run for the time being.

---

## Changes

- Skip troublesome TDP scroll test (and add a TODO comment noting why)

## How to test this PR

1. Run Cypress tests however you like: `yarn cypress open` to run them in the Cypress UI, `yarn cypress run` to run them all headless, or `yarn cypress run --spec test/cypress/integration/consumer-tools/youth-financial-education/survey-errors.cy.js` to just run the changed test headless
2. Any way you do it, the `jumps to errors at top` test should be skipped and appear as "pending" in the test results as in the screenshot below

## Screenshots

![pending-test](https://user-images.githubusercontent.com/1862695/212391595-e51a9579-1cfd-4e50-a60e-a5503d16a0b2.png)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets