### PR TITLE
Minor improvements to import_translation_links

### DIFF
--- a/cfgov/v1/tests/management/commands/test_import_translation_links.py
+++ b/cfgov/v1/tests/management/commands/test_import_translation_links.py
@@ -56,10 +56,29 @@ class TestImportTranslationLinks(TestCase, WagtailTestUtils):
         self.assertIsNone(self.spanish_live_and_draft_page.english_page)
         self.assertTrue(self.spanish_live_and_draft_page.live)
 
-    def test_invalid_path_fails(self):
+    def test_ignore_missing(self):
         with self.make_tempfile(b"/invalid/,/en/\n") as tf:
             with self.assertRaises(Http404):
                 call_command("import_translation_links", "--dry-run", tf.name)
+
+            call_command(
+                "import_translation_links",
+                "--dry-run",
+                "--ignore-missing",
+                tf.name,
+            )
+
+    def test_skip_header(self):
+        with self.make_tempfile(b"from,to\n/es/,/en/\n") as tf:
+            with self.assertRaises(Http404):
+                call_command("import_translation_links", "--dry-run", tf.name)
+
+            call_command(
+                "import_translation_links",
+                "--dry-run",
+                "--skip-header",
+                tf.name,
+            )
 
     def test_save_requires_username(self):
         with self.make_tempfile(b"/es/,/en/\n/es2/,/en/\n") as tf:


### PR DESCRIPTION
This commit updates the import_translation_links management command:

- Excel-generated CSV files can now be read, by opening the file using Python's `utf-8-sig` encoding.
- New `--ignore-missing` option lets the script ignore any URLs in the input CSV that don't exist (yet).
- New `--skip-header` option lets the script skip the first row of the CSV.

Unit tests have been updated to cover the new behavior.

## How to test this PR

Download the Excel file at internal D&CT/issues/122#issuecomment-329066, then save as CSV, then run:

> cfgov/manage.py import_translation_links --revision-username your.username --republish --skip-header --ignore-missing import-spreadsheet.csv

The script will work properly, skipping the header row, and ignoring the URLs in the CSV that don't exist yet.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)