### PR TITLE
Add translation links to BrowsePage template

### DIFF
--- a/cfgov/v1/jinja2/v1/browse-basic/index.html
+++ b/cfgov/v1/jinja2/v1/browse-basic/index.html
@@ -20,6 +20,8 @@
         {% endif %}
     {%- endfor %}
 
+    {% include "v1/includes/molecules/translation-links.html" %}
+
     {% if page.share_and_print %}
         {% import "v1/includes/molecules/social-media.html" as social_media with context -%}
         <div class="block block__flush-top block__flush-bottom block__padded-bottom">


### PR DESCRIPTION
This commit adds the translation-links module to BrowsePages, placing it between the header section and content sections of the page (also above the "share and print" module, if that is added).

Using a production dump with our internal set of translation links, a good URL to test this with is

http://localhost:8000/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/

Note that the styling, language, and order of the translation links still needs some work; those things are to be addressed in other PRs.

## Screenshots

Auto-generated links are circled in red:

![image](https://user-images.githubusercontent.com/654645/214048419-705817f8-3d50-4767-8354-254c4f5e3c4f.png)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)