### PR TITLE
Fix ordering of translation links

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -226,15 +226,15 @@ DATABASES = {
 LANGUAGE_CODE = "en-us"
 
 LANGUAGES = (
-    ("ar", _("Arabic")),
-    ("zh-Hant", _("Chinese (Traditional)")),
     ("en", _("English")),
-    ("ht", _("Haitian Creole")),
-    ("ko", _("Korean")),
-    ("ru", _("Russian")),
     ("es", _("Spanish")),
-    ("tl", _("Tagalog")),
+    ("zh-Hant", _("Chinese (Traditional)")),
     ("vi", _("Vietnamese")),
+    ("ko", _("Korean")),
+    ("tl", _("Tagalog")),
+    ("ru", _("Russian")),
+    ("ar", _("Arabic")),
+    ("ht", _("Haitian Creole")),
 )
 
 LOCALE_PATHS = (os.path.join(PROJECT_ROOT, "locale"),)

--- a/cfgov/mega_menu/models.py
+++ b/cfgov/mega_menu/models.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 from django.conf import settings
 from django.db import models
 
@@ -10,7 +12,9 @@ from mega_menu.frontend_conversion import FrontendConverter
 
 class Menu(models.Model):
     language = models.CharField(
-        choices=settings.LANGUAGES, max_length=100, primary_key=True
+        choices=sorted(settings.LANGUAGES, key=itemgetter(1)),
+        max_length=100,
+        primary_key=True,
     )
 
     submenus = StreamField(MenuStreamBlock())

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -609,7 +609,7 @@ class TestCFGOVPageTranslations(TestCase):
                 {
                     "href": "/es/",
                     "language": "es",
-                    "text": "Español",
+                    "text": "Spanish",
                 },
             ],
         )
@@ -620,7 +620,7 @@ class TestCFGOVPageTranslations(TestCase):
                 {
                     "href": "/es/",
                     "language": "es",
-                    "text": "Español",
+                    "text": "Spanish",
                 },
             ],
         )

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -559,11 +559,11 @@ class TestCFGOVPageTranslations(TestCase):
 
         self.assertSequenceEqual(
             page_en.get_translations().values_list("language", flat=True),
-            ["en", "es", "ht", "ko"],
+            ["en", "es", "ko", "ht"],
         )
         self.assertSequenceEqual(
             page_es.get_translations().values_list("language", flat=True),
-            ["en", "es", "ht", "ko"],
+            ["en", "es", "ko", "ht"],
         )
 
     def test_page_not_live_excluded(self):
@@ -609,7 +609,7 @@ class TestCFGOVPageTranslations(TestCase):
                 {
                     "href": "/es/",
                     "language": "es",
-                    "text": "Spanish",
+                    "text": "Español",
                 },
             ],
         )
@@ -620,7 +620,7 @@ class TestCFGOVPageTranslations(TestCase):
                 {
                     "href": "/es/",
                     "language": "es",
-                    "text": "Spanish",
+                    "text": "Español",
                 },
             ],
         )

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -1,6 +1,7 @@
 import html
 from datetime import date
 from functools import partial
+from operator import itemgetter
 
 from django.conf import settings
 from django.utils import html as html_util
@@ -374,7 +375,9 @@ class TranslatedPagesReportFilterSet(WagtailFilterSet):
         label="Translation",
         method="filter_language",
         choices=[
-            (code, name) for code, name in settings.LANGUAGES if code != "en"
+            (code, name)
+            for code, name in sorted(settings.LANGUAGES, key=itemgetter(1))
+            if code != "en"
         ],
     )
 


### PR DESCRIPTION
This commit updates the CFGOVPage.get_translations method to adjust the order of returned page translations. Instead of returning translations by the alphabetical order of their language (ar, en, es, ...), they are now returned in a deliberate arbitrary order to be consistent with the website header:

en, es, zh-Hant, vi, ko, tl, ru, ar, ht

~~Similarly, the link text returned by CFGOVPage.get_translation_links is also changed so that instead of returning the English name of the language, as defined in settings (English, Spanish, ...), it returns a deliberate arbitrary set of language name translations:~~

~~English, Español, 繁體中文, Tiếng Việt, 한국어, Tagalog, Pусский, العربية, Kreyòl Ayisyen~~

Technically, this is achieved by annotating the PageQuerySet returned by CFGOVPage.get_translations so that it has ~~two~~ one new field~~s~~:

language_display_order: integer order of the page's language
~~language_display_name: display name of the page's language~~

See internal D&CT#122 for additional background on these changes.

## How to test this PR

First, enable the translation links feature flag at http://localhost:8000/admin/flags/TRANSLATION_LINKS/.

Using a local production dump, a good page for testing is

http://localhost:8000/about-us/blog/know-your-rights-and-protections-when-it-comes-to-medical-bills-and-collections/

Alternatively, you can use the test database (`./refresh-data.sh ./test.sql.gz`) and visit 

http://localhost:8000/about-us/blog/translated-page-english/

## Screenshots

<img width="818" alt="image" src="https://user-images.githubusercontent.com/654645/214126446-f6a58d57-c21f-4002-81ae-7568d2397bd3.png">

## Notes and todos

Note that the names and styling of the translation links still needs some work; this is to be addressed in other PRs.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)