### PR TITLE
Remove unused "is_event" Jinja function

### DIFF
--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -155,7 +155,6 @@ class V1Extension(Extension):
                 "get_unique_id": get_unique_id,
                 "image_alt_value": image_alt_value,
                 "is_blog": ref.is_blog,
-                "is_event": ref.is_event,
                 "is_report": ref.is_report,
                 "is_filter_selected": contextfunction(is_filter_selected),
                 "render_stream_child": contextfunction(render_stream_child),

--- a/cfgov/v1/util/ref.py
+++ b/cfgov/v1/util/ref.py
@@ -294,11 +294,6 @@ def is_blog(page):
         return True
 
 
-def is_event(page):
-    if "Event" in page.specific_class.__name__:
-        return True
-
-
 def is_report(page):
     for category in page.categories.all():
         for choice in choices_for_page_type("research-reports"):


### PR DESCRIPTION
Remove unused `is_event` Jinja function.

## How to test this PR

Grep the codebase, this wasn't used anywhere.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)