### PR TITLE
Render translation links in their own language

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -185,6 +185,7 @@ TEMPLATES = [
                 "jinja2.ext.loopcontrols",
                 "flags.jinja2tags.flags",
                 "core.jinja2tags.filters",
+                "core.jinja2tags.language",
                 "agreements.jinja2tags.agreements",
                 "mega_menu.jinja2tags.MegaMenuExtension",
                 "prepaid_agreements.jinja2tags.prepaid_agreements",

--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -1,5 +1,7 @@
+from django.utils import translation
+
 from jinja2 import contextfilter
-from jinja2.ext import Extension
+from jinja2.ext import Extension, nodes
 
 from core.templatetags.richtext import richtext_isempty
 from core.templatetags.svg_icon import svg_icon
@@ -23,4 +25,42 @@ class CoreExtension(Extension):
         )
 
 
+class LanguageExtension(Extension):
+    """Jinja extension used to translate text into a specific language.
+
+    For example:
+
+    {% language "es" %}{{ _( 'Spanish' ) }}{% endlanguage %}
+
+    This will render "Español".
+
+    Based off of the Django {% language %} tag documented at:
+
+    https://docs.djangoproject.com/en/4.1/topics/i18n/translation/#switching-language-in-templates
+    """
+
+    tags = {"language"}
+
+    def parse(self, parser):
+        # Line number of the {% language %} tag.
+        lineno = next(parser.stream).lineno
+
+        # Parse the language code argument, e.g. "es" from {% language "es" %}.
+        args = [parser.parse_expression()]
+
+        # Parse the content up to and including the {% endlanguage %} tag.
+        body = parser.parse_statements(["name:endlanguage"], drop_needle=True)
+
+        # Return the node that will activate the specified language
+        # before rendering the parsed content.
+        return nodes.CallBlock(
+            self.call_method("activate_language", args), [], [], body
+        ).set_lineno(lineno)
+
+    def activate_language(self, language_code, caller):
+        with translation.override(language_code):
+            return caller()
+
+
 filters = CoreExtension
+language = LanguageExtension

--- a/cfgov/core/tests/test_jinja2tags.py
+++ b/cfgov/core/tests/test_jinja2tags.py
@@ -111,3 +111,27 @@ class SlugifyUniqueTests(SimpleTestCase):
                 self.render(self.template, {"request": HttpRequest()}),
                 "some-text",
             )
+
+
+class LanguageTagTests(SimpleTestCase):
+    def setUp(self):
+        self.engine = engines["wagtail-env"]
+
+    def render(self, template):
+        return self.engine.from_string(template).render()
+
+    def test_english_translation(self):
+        self.assertEqual(
+            self.render(
+                "{% language 'en' %}{{ _( 'English' ) }}{% endlanguage %}"
+            ),
+            "English",
+        )
+
+    def test_spanish_translation(self):
+        self.assertEqual(
+            self.render(
+                "{% language 'es' %}{{ _( 'English' ) }}{% endlanguage %}"
+            ),
+            "Inglés",
+        )

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -42,7 +42,7 @@
     {% if render_link -%}
         <a href="{{ link.href }}" hreflang="{{ link.language }}">
     {%- endif %}
-    {{- link.text -}}
+    {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
     {% if render_link %}</a>{% endif %}
     {% if not loop.last %}|{% endif %}
 {% endfor -%}

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -435,11 +435,13 @@ class CFGOVPage(Page):
         return pages
 
     def get_translation_links(self, request, inclusive=True, live=True):
+        language_names = dict(settings.LANGUAGES)
+
         return [
             {
                 "href": translation.get_url(request=request),
                 "language": translation.language,
-                "text": translation.get_language_display(),
+                "text": language_names[translation.language],
             }
             for translation in self.get_translations(
                 inclusive=inclusive, live=live


### PR DESCRIPTION
This commit introduces a new Jinja {% language %} tag modeled after the Django {% language %} tag, and uses it to ensure that page translation links always get rendered in the destination language (e.g. links to a Spanish translation always say "Español" regardless of the language of the page being viewed).

## How to test this PR

To test using a production dump with translation links imported using the method described in #7461, a good page to test with is http://localhost:8000/es/coronavirus/asistencia-hipotecas-y-viviendas/:

<img width="631" alt="image" src="https://user-images.githubusercontent.com/654645/214330191-7751cab1-49ee-401f-9004-540cefcacf94.png">

The lack of translation for "Chinese (Traditional)" is to be expected; that will come with the new translations added in #7392.

Alternatively, to test with our test database (`./refresh-data.sh ./test.sql.tz`), a good page to test with is http://localhost:8000/about-us/blog/translated-page-english/.

In both cases above you'll need to enable the translation links feature flag at http://localhost:8000/admin/flags/TRANSLATION_LINKS/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)