### PR TITLE
Bump Jinja2 version from 3.0.3 to 3.1.2

### DIFF
--- a/cfgov/core/jinja2tags.py
+++ b/cfgov/core/jinja2tags.py
@@ -1,6 +1,6 @@
 from django.utils import translation
 
-from jinja2 import contextfilter
+from jinja2 import pass_context
 from jinja2.ext import Extension, nodes
 
 from core.templatetags.richtext import richtext_isempty
@@ -20,7 +20,7 @@ class CoreExtension(Extension):
         self.environment.filters.update(
             {
                 "richtext_isempty": richtext_isempty,
-                "slugify_unique": contextfilter(slugify_unique),
+                "slugify_unique": pass_context(slugify_unique),
             }
         )
 

--- a/cfgov/mega_menu/jinja2tags.py
+++ b/cfgov/mega_menu/jinja2tags.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 
-from jinja2 import contextfunction
+from jinja2 import pass_context
 from jinja2.ext import Extension
 
 from mega_menu.models import Menu
@@ -41,8 +41,6 @@ class MegaMenuExtension(Extension):
 
         self.environment.globals.update(
             {
-                "get_mega_menu_content": contextfunction(
-                    get_mega_menu_content
-                ),
+                "get_mega_menu_content": pass_context(get_mega_menu_content),
             }
         )

--- a/cfgov/regulations3k/jinja2tags.py
+++ b/cfgov/regulations3k/jinja2tags.py
@@ -48,7 +48,7 @@ class RegulationsExtension(Extension):
 
         self.environment.globals.update(
             {
-                "routablepageurl": jinja2.contextfunction(routablepageurl),
+                "routablepageurl": jinja2.pass_context(routablepageurl),
                 "ap_date": ap_date,
             }
         )

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -20,7 +20,7 @@ from wagtail.fields import StreamField
 from wagtailsharing.models import ShareableRoutablePageMixin
 
 import requests
-from jinja2 import Markup
+from markupsafe import Markup
 from regdown import regdown
 
 from ask_cfpb.models.pages import SecondaryNavigationJSMixin

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -465,7 +465,7 @@
                     Filters applied
                 </span>
                 <div class="results_filters-tags">
-                    {% for facet_name, facet_items in facets.items() %}
+                    {% for facet_name, facet_items in facets | items %}
                         {% if facet_name == 'topic'%}
                             {{ build_nested_filter_tags(facet_items, facet_name) }}
                         {% else %}

--- a/cfgov/v1/jinja2/v1/template_debug.html
+++ b/cfgov/v1/jinja2/v1/template_debug.html
@@ -41,7 +41,7 @@
         </ul>
         {% endif %}
 
-        {% for name, rendered in debug_test_cases.items() %}
+        {% for name, rendered in debug_test_cases | items %}
         <div class="content_line"></div>
         <div id="{{ name | slugify }}" class="test-case">
             <h2>

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -2,8 +2,9 @@ import html
 
 from django.utils.module_loading import import_string
 
-from jinja2 import Markup, pass_context
+from jinja2 import pass_context
 from jinja2.ext import Extension
+from markupsafe import Markup
 
 from core.feature_flags import environment_is
 from v1.jinja2tags.datetimes import DatetimesExtension

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -2,7 +2,7 @@ import html
 
 from django.utils.module_loading import import_string
 
-from jinja2 import Markup, contextfunction
+from jinja2 import Markup, pass_context
 from jinja2.ext import Extension
 
 from core.feature_flags import environment_is
@@ -156,12 +156,12 @@ class V1Extension(Extension):
                 "image_alt_value": image_alt_value,
                 "is_blog": ref.is_blog,
                 "is_report": ref.is_report,
-                "is_filter_selected": contextfunction(is_filter_selected),
-                "render_stream_child": contextfunction(render_stream_child),
-                "unique_id_in_context": contextfunction(unique_id_in_context),
+                "is_filter_selected": pass_context(is_filter_selected),
+                "render_stream_child": pass_context(render_stream_child),
+                "unique_id_in_context": pass_context(unique_id_in_context),
                 "app_url": app_url,
                 "app_page_url": app_page_url,
-                "search_gov_affiliate": contextfunction(search_gov_affiliate),
+                "search_gov_affiliate": pass_context(search_gov_affiliate),
             }
         )
 

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -626,7 +626,7 @@
                     </span>
                 </dd>
 
-        {% for slug, means in group_means.items() %}
+        {% for slug, means in group_means | items %}
             {% for group_name, group_data in means %}
                 <dt class="comparison_data-point {{ slug }}_group">{{ _(group_name) }}</dt>
                 <dd class="comparison_data-point {{ slug }}_mean">

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,7 +18,7 @@ djangosaml2==1.5.0
 edgegrid-python==1.2.1
 elasticsearch<7.11  # Keep pinned to the deployed ES version
 govdelivery==1.4.0
-Jinja2==3.0.3
+Jinja2==3.1.2
 lxml==4.9.1
 opensearch-dsl==1.0.0
 opensearch-py==1.1.0


### PR DESCRIPTION
(Note: this PR is going to the upgrade/wagtail branch, not main.)

This PR upgrades the version of the [Jinja2](https://pypi.org/project/Jinja2/) Python library from 3.0.3 to 3.1.2. 3.0.3 is the latest version we can be on with Wagtail 2.15.x, so this PR is going into our Wagtail 3.x upgrade branch.

See Jinja2 release notes [here](https://jinja.palletsprojects.com/en/3.1.x/changes/). See specific commits below for details of the changes; there are no user-facing differences.

Addresses internal D&CT#113.

## How to test this PR

The only template change is migrating some use of `dict.items()` to `dict | items`. We had three uses of `.items()`; the proper functionality of these pages can be verified locally at:

- http://localhost:8000/admin/template_debug/v1/featured_content/
- http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/?q=&topic=4&topic=26&topic=2&topic=5
- http://localhost:8000/consumer-tools/financial-well-being/results/#compare

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)