### PR TITLE
Translation links: Add less file and rework markup to be a list

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -81,6 +81,7 @@
 @import (less) 'molecules/global-search.less';
 @import (less) 'molecules/info-unit.less';
 @import (less) 'molecules/inset.less';
+@import (less) 'molecules/translation-links.less';
 @import (less) 'molecules/nav-link.less';
 @import (less) 'molecules/related-metadata.less';
 @import (less) 'molecules/related-posts.less';

--- a/cfgov/unprocessed/css/molecules/translation-links.less
+++ b/cfgov/unprocessed/css/molecules/translation-links.less
@@ -1,0 +1,61 @@
+ul.m-translation-links {
+  padding: 0;
+  list-style: none;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 21px;
+  overflow: hidden;
+
+  & > li {
+    margin-bottom: 0;
+    white-space: nowrap;
+
+    a {
+      border: none;
+    }
+  }
+
+  & > li + li {
+    position: relative;
+
+    // Vertical divider.
+    &::before {
+      position: absolute;
+      left: -11px;
+      top: 2px;
+      content: '';
+      display: block;
+      background: gray;
+      width: 1px;
+      height: 20px;
+    }
+  }
+}
+
+/*
+For right-to-left languages, we need to move the flex items to the end and
+move the divider to the right instead of the left.
+*/
+html[lang='ar'] ul.m-translation-links {
+  justify-content: flex-end;
+
+  & > li + li::before {
+    display: none;
+  }
+
+  & > li {
+    position: relative;
+
+    // Vertical divider
+    &::after {
+      position: absolute;
+      right: -11px;
+      top: 2px;
+      content: '';
+      display: block;
+      background: gray;
+      width: 1px;
+      height: 20px;
+    }
+  }
+}

--- a/cfgov/unprocessed/css/molecules/translation-links.less
+++ b/cfgov/unprocessed/css/molecules/translation-links.less
@@ -1,3 +1,13 @@
+@import (reference) 'cfpb-core.less';
+
+.u-divider {
+  content: '';
+  display: block;
+  background: @gray;
+  width: 1px;
+  height: unit(20px / @base-font-size-px, em);
+}
+
 ul.m-translation-links {
   padding: 0;
   list-style: none;
@@ -23,11 +33,7 @@ ul.m-translation-links {
       position: absolute;
       left: -11px;
       top: 2px;
-      content: '';
-      display: block;
-      background: gray;
-      width: 1px;
-      height: 20px;
+      .u-divider();
     }
   }
 }
@@ -51,11 +57,7 @@ html[lang='ar'] ul.m-translation-links {
       position: absolute;
       right: -11px;
       top: 2px;
-      content: '';
-      display: block;
-      background: gray;
-      width: 1px;
-      height: 20px;
+      .u-divider();
     }
   }
 }

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -49,7 +49,7 @@
         {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
         {% if render_link %}
             </a>
-        {% endif %}
+        {% endif -%}
         </li>
     {% endfor -%}
 </ul>

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -36,17 +36,23 @@
 {% endif -%}
 
 {%- if value.links and value.links|length > 1 %}
-<div class="m-translation-links">
-{%- for link in value.links %}
-    {% set render_link = value.language and link.language != value.language %}
-    {% if render_link -%}
-        <a href="{{ link.href }}" hreflang="{{ link.language }}">
-    {%- endif %}
-    {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
-    {% if render_link %}</a>{% endif %}
-    {% if not loop.last %}|{% endif %}
-{% endfor -%}
-</div>
+<ul dir="ltr" class="m-translation-links">
+    {%- for link in value.links %}
+        {% set render_link = value.language and link.language != value.language %}
+        <li>
+        {% if render_link -%}
+            <a href="{{ link.href }}"
+               lang="{{ link.language }}"
+               hreflang="{{ link.language }}"
+               translate="no">
+        {%- endif %}
+        {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
+        {% if render_link %}
+            </a>
+        {% endif %}
+        </li>
+    {% endfor -%}
+</ul>
 {%- endif %}
 
 {%- endif %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -38,7 +38,7 @@
 {%- if value.links and value.links|length > 1 %}
 <ul dir="ltr" class="m-translation-links">
     {%- for link in value.links %}
-        {% set render_link = value.language and link.language != value.language %}
+        {%- set render_link = value.language and link.language != value.language %}
         <li>
         {%- if render_link %}
             <a href="{{ link.href }}"

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -40,7 +40,7 @@
     {%- for link in value.links %}
         {% set render_link = value.language and link.language != value.language %}
         <li>
-        {% if render_link -%}
+        {%- if render_link %}
             <a href="{{ link.href }}"
                lang="{{ link.language }}"
                hreflang="{{ link.language }}"


### PR DESCRIPTION
## Changes

- Convert `div` enclosed list of translation links into an unordered list.
- Add `dir`, `translate`, and `lang` attributes to markup.
- Add CSS to lay out links in a flexbox and handle rtl layout.


## How to test this PR

1. Pull branch, run `yarn build`.
2. Visit https://[GHE]/Design-Development/Design-and-Content-Team/issues/147#issue-110288 to see places to check the language links. Resize page to see how it wraps.

## Screenshots

<img width="338" alt="Screen Shot 2023-01-26 at 1 04 46 PM" src="https://user-images.githubusercontent.com/704760/214916953-95d9dd50-3128-4690-9e0f-037963f959b1.png">

<img width="340" alt="Screen Shot 2023-01-26 at 1 04 54 PM" src="https://user-images.githubusercontent.com/704760/214916956-9661b1c4-5629-4c01-b2c2-bfdeca5a6811.png">

<img width="340" alt="Screen Shot 2023-01-26 at 1 05 07 PM" src="https://user-images.githubusercontent.com/704760/214916958-5d21654d-5771-418d-a398-9c4950834a03.png">

<img width="732" alt="Screen Shot 2023-01-26 at 1 06 51 PM" src="https://user-images.githubusercontent.com/704760/214916959-9e747c0b-dfd7-4b0e-91f0-f0f903df05cc.png">
