### PR TITLE
Deprecate custom JobCategory admin code

### DIFF
--- a/cfgov/jobmanager/wagtail_hooks.py
+++ b/cfgov/jobmanager/wagtail_hooks.py
@@ -1,11 +1,8 @@
-from django.forms.models import ModelForm
-
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin,
     ModelAdminGroup,
     modeladmin_register,
 )
-from wagtail.contrib.modeladmin.views import CreateView, EditView, InspectView
 
 from jobmanager import template_debug
 from jobmanager.models import (
@@ -33,36 +30,10 @@ class JobGradeModelAdmin(ModelAdmin):
     list_display = ("grade", "salary_min", "salary_max")
 
 
-class JobCategoryForm(ModelForm):
-    class Meta:
-        fields = "__all__"
-        model = JobCategory
-
-
-class JobCategoryModelFormMixin:
-    def get_form_class(self):
-        return JobCategoryForm
-
-
-class JobCategoryCreateView(JobCategoryModelFormMixin, CreateView):
-    pass
-
-
-class JobCategoryEditView(JobCategoryModelFormMixin, EditView):
-    pass
-
-
-class JobCategoryInspectView(JobCategoryModelFormMixin, InspectView):
-    pass
-
-
 class JobCategoryModelAdmin(ModelAdmin):
     model = JobCategory
     menu_label = "Divisions"
     menu_icon = "snippet"
-    create_view_class = JobCategoryCreateView
-    edit_view_class = JobCategoryEditView
-    inspect_view_class = JobCategoryInspectView
 
 
 class JobRegionModelAdmin(ModelAdmin):


### PR DESCRIPTION
This commit deprecates some unnecessary custom admin code related to the jobmanager.JobCategory model. This code was necessary at one point when this model used a custom editor which required its own JavaScript (TinyMCE). That functionality was removed in 1458acdf43fb5a2627f994a109d104ae1f80812d, which migrated the "blurb" field to a standard Wagtail rich text field. This removed the need for any custom ModelAdmin code.

## How to test this PR

To test locally: http://localhost:8000/admin/jobmanager/jobcategory/ and then try to edit a category (Using a production data, one with blurb content is http://localhost:8000/admin/jobmanager/jobcategory/edit/33/).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)