### PR TITLE
Add new publish_pages management command

### DIFF
--- a/cfgov/v1/management/commands/publish_pages.py
+++ b/cfgov/v1/management/commands/publish_pages.py
@@ -1,0 +1,93 @@
+# Publish Wagtail pages given a list of relative URLs in a file.
+#
+# Usage:
+#
+#    manage.py publish_pages
+#       [--dry-run]
+#       [--ignore-missing]
+#       input.txt
+#
+#    --dry-run: Only read file and validate URLs, don't publish anything
+#    --ignore-missing: Ignore any invalid URLs in the input file
+#
+# Expected input file format:
+#
+#    /path/to/page1/
+#    /path/to/page2/
+#    ...
+
+import argparse
+
+from django.core.management import BaseCommand
+from django.http import Http404
+from django.test import RequestFactory
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Site
+
+
+class Command(BaseCommand):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.site = Site.objects.get(is_default_site=True)
+        self.site_root = self.site.root_page
+        self.request_factory = RequestFactory()
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "filename", type=argparse.FileType("r", encoding="utf-8-sig")
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only read file and validate URLs, don't publish anything",
+        )
+        parser.add_argument(
+            "--ignore-missing",
+            action="store_true",
+            help="Ignore any invalid URLs in the input file",
+        )
+
+    def handle(self, *args, **options):
+        for relative_url in options["filename"]:
+            try:
+                page = self.route(relative_url.strip())
+            except Http404:
+                if options["ignore_missing"]:
+                    continue
+                else:
+                    raise
+
+            page = page.get_latest_revision_as_page()
+
+            if not options["dry_run"]:
+                page.save_revision().publish()
+
+    def route(self, relative_url):
+        try:
+            return self._route(relative_url)
+        except Http404:
+            try:
+                redirect = Redirect.get_for_site(self.site).get(
+                    old_path=Redirect.normalise_path(relative_url)
+                )
+            except Redirect.DoesNotExist:
+                pass
+            else:
+                if redirect and redirect.redirect_page:
+                    return redirect.redirect_page.specific
+
+        raise Http404(relative_url)
+
+    def _route(self, relative_url):
+        request = self.request_factory.get(relative_url)
+        path_components = [
+            component for component in relative_url.split("/") if component
+        ]
+
+        page, _, __ = self.site_root.localized.specific.route(
+            request, path_components
+        )
+
+        return page

--- a/cfgov/v1/tests/management/commands/test_publish_pages.py
+++ b/cfgov/v1/tests/management/commands/test_publish_pages.py
@@ -1,0 +1,79 @@
+import tempfile
+from contextlib import contextmanager
+
+from django.core.management import call_command
+from django.http import Http404
+from django.test import TestCase
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Site
+
+from v1.models import BrowsePage
+
+
+class PublishPagesTests(TestCase):
+    def setUp(self):
+        self.site_root = Site.objects.get(is_default_site=True).root_page
+        self.pages = list(
+            map(self.make_page_with_draft_revision, ["a", "b", "c"])
+        )
+
+    def make_page_with_draft_revision(self, slug):
+        page = BrowsePage(title=slug, slug=slug, live=True)
+        self.site_root.add_child(instance=page)
+
+        page.title = f"{slug}-modified"
+        page.live = False
+        page.save_revision()
+
+        return page
+
+    @contextmanager
+    def make_tempfile(self, content):
+        tf = tempfile.NamedTemporaryFile()
+        tf.write(content)
+        tf.seek(0)
+        yield tf
+
+    def test_dry_run(self):
+        with self.make_tempfile(b"/a/\n/b/\n/c/\n") as tf:
+            call_command("publish_pages", "--dry-run", tf.name)
+
+        for page in self.pages:
+            page.refresh_from_db()
+            self.assertEqual(page.revisions.count(), 1)
+            self.assertNotIn("-modified", page.title)
+
+    def test_ignore_missing(self):
+        with self.make_tempfile(b"/a/\n/b/\n/c/\n/invalid/") as tf:
+            with self.assertRaises(Http404):
+                call_command("publish_pages", "--dry-run", tf.name)
+
+            call_command(
+                "publish_pages", "--dry-run", "--ignore-missing", tf.name
+            )
+
+    def test_publish(self):
+        with self.make_tempfile(b"/a/\n/b/\n/c/\n") as tf:
+            call_command("publish_pages", tf.name)
+
+        for page in self.pages:
+            page.refresh_from_db()
+            self.assertEqual(page.revisions.count(), 2)
+            self.assertIn("-modified", page.title)
+
+    def test_handles_redirect(self):
+        redirect_target = self.make_page_with_draft_revision("d")
+
+        Redirect.objects.create(old_path="/e", redirect_page=redirect_target)
+
+        redirect_target.refresh_from_db()
+        self.assertEqual(redirect_target.revisions.count(), 1)
+        self.assertNotIn("-modified", redirect_target.title)
+
+        with self.make_tempfile(b"/e/\n") as tf:
+            call_command("publish_pages", tf.name)
+
+        redirect_target.refresh_from_db()
+        self.assertEqual(redirect_target.revisions.count(), 2)
+        self.assertIn("-modified", redirect_target.title)


### PR DESCRIPTION
This commit adds a new `publish_pages` management command which allows for the bulk publishing of multiple Wagtail pages, given a list of URLs in a text file.

See command file comments and management command help for usage details. Unit tests have been added to cover the command's functionality.

See internal D&CP#122 for additional context.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)