### PR TITLE
Remove definitions of default_app_config

### DIFF
--- a/cfgov/core/__init__.py
+++ b/cfgov/core/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "core.apps.CoreAppConfig"

--- a/cfgov/jobmanager/__init__.py
+++ b/cfgov/jobmanager/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "jobmanager.apps.JobManagerAppConfig"

--- a/cfgov/v1/__init__.py
+++ b/cfgov/v1/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "v1.apps.V1AppConfig"


### PR DESCRIPTION
Django 3.2 removed the need to define a default_app_config in an app's \_\_init__.py file:

https://docs.djangoproject.com/en/4.1/releases/3.2/#automatic-appconfig-discovery

This is deprecated as of 3.2 and defining it triggers warnings like:

> RemovedInDjango41Warning: 'v1' defines default_app_config = 'v1.apps.V1AppConfig'. Django now detects this configuration automatically. You can remove default_app_config.

This commit removes our default_app_config definitions to remove those deprecation warnings.