### PR TITLE
Remove pre-Wagtail 2.11 `FilterableListMixin` render overrides

### DIFF
--- a/cfgov/v1/models/filterable_list_mixins.py
+++ b/cfgov/v1/models/filterable_list_mixins.py
@@ -1,5 +1,4 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.template.response import TemplateResponse
 
 from wagtail.contrib.routable_page.models import route
 from wagtail.core.models import Site
@@ -152,16 +151,9 @@ class FilterableListMixin(ShareableRoutablePageMixin):
                 self.set_do_not_index(field, value)
         return form_data, has_active_filters
 
-    def render(self, request, *args, context_overrides=None, **kwargs):
-        """Render with optional context overrides."""
-        # TODO: the context-overriding and template rendering can be replaced
-        # with super().render() in Wagtail 2.11, where RoutablePageMixin gains
-        # the context_overrides functionality built-in.
-        context = self.get_context(request, *args, **kwargs)
-        context.update(context_overrides or {})
-        response = TemplateResponse(
-            request, self.get_template(request, *args, **kwargs), context
-        )
+    def render(self, request, *args, **kwargs):
+        """Render with optional X-Robots-Tag in response headers"""
+        response = super().render(request, *args, **kwargs)
 
         # Set noindex for crawlers if needed
         if self.do_not_index:

--- a/cfgov/v1/tests/models/test_filterable_list_mixins.py
+++ b/cfgov/v1/tests/models/test_filterable_list_mixins.py
@@ -118,6 +118,15 @@ class FilterableRoutesTestCase(ElasticsearchTestsMixin, TestCase):
             response.get("Edge-Cache-Tag"), self.filterable_page.slug
         )
 
+    def test_x_robots_tag(self):
+        response = self.client.get(
+            self.filterable_page.url, {"topics": "test1"}
+        )
+        self.assertIsNone(response.get("X-Robots-Tag"))
+
+        response = self.client.get(self.filterable_page.url, {"title": "test"})
+        self.assertEqual(response.get("X-Robots-Tag"), "noindex")
+
 
 class MockSearch:
     def __init__(self, search_root, children_only):


### PR DESCRIPTION
This removes a set of overrides in `FilterableListMixin`’s `render` method. Prior to [Wagtail 2.11](https://docs.wagtail.org/en/stable/releases/2.11.html#other-features), `RoutablePageMixin`, which `FilterableListMixin` inherits from, did not make use of the `context_overrides` keyword argument, so we overrode template rendering.

That’s no longer the case, so this override code can be removed.

The `render` method is preserved for use of our `X-Robots-Tag` setting only.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
