### PR TITLE
Set `min_num` and `max_num` on banner `content` field

### DIFF
--- a/cfgov/v1/models/banners.py
+++ b/cfgov/v1/models/banners.py
@@ -3,19 +3,9 @@ from django.db import models
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.edit_handlers import FieldPanel, StreamFieldPanel
-from wagtail.core.blocks import StreamBlock
 from wagtail.core.fields import StreamField
 
 from v1.atomic_elements.molecules import Notification
-
-
-class BannerContent(StreamBlock):
-    content = Notification()
-
-    class Meta:
-        block_counts = {
-            "content": {"min_num": 1, "max_num": 1},
-        }
 
 
 class Banner(models.Model):
@@ -33,10 +23,7 @@ class Banner(models.Model):
         ),
         validators=[RegexValidator(regex=r"[A-Za-z0-9\-_.:/?&|\^$]")],
     )
-    # TODO: Add `min_num` and `max_num` arguments of 1 to the StreamField
-    # and eliminate the BannerContent StreamBlock
-    # if https://github.com/wagtail/wagtail/pull/5185 ever gets merged.
-    content = StreamField(BannerContent)
+    content = StreamField([("content", Notification())], min_num=1, max_num=1)
 
     enabled = models.BooleanField()
 


### PR DESCRIPTION
This change removes our `BannerContent` steam block model, which existed to enforce a `min_num` and `max_num` count on the notification content of a `Banner`. Since [Wagtail 2.13](https://docs.wagtail.org/en/stable/releases/2.13.html#other-features), Wagtail has supported passing those values from the `StreamField` itself.

Perhaps unintuitively, this change does not require a migration, because the overall structure of the `StreamField` in the database is unchanged.

There is one subtle difference between the way the content block behaved prior to this change and after it:

Before this change, you could click the "+" above and below an existing `content` block, and the option to add a new content block would be greyed-out:

![The edit page of a banner after the "+" has been clicked to add a block showing that the option to add another "content" block is greyed-out](https://user-images.githubusercontent.com/10562538/215554592-52f7cb83-d8bd-4075-813b-9f4d7e59da3c.png)

After this change, the ability to click the "+" above and below an existing `content` block is greyed-out and cannot be clicked. This seems a very, very slight improvement to me, but perhaps it's worth noting.

![The edit page of a banner before the "+" has been clicked to add a block showing that the "+" itself is greyed-out](https://user-images.githubusercontent.com/10562538/215554905-e57b7f56-732d-4292-bf5a-249338d757fe.png)

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)