### PR TITLE
Report full link text w/ FIG analytics

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-search.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-search.js
@@ -79,10 +79,9 @@ const getSearchData = (sections) => {
  * @param {object} event - Search result follow event
  */
 const onFollow = (event) => {
-  const target = event.target
-    .closest('a')
-    .getAttribute('href')
-    .replace('#', '');
+  const target = event.target.closest('a');
+  const figLinkID = target.getAttribute('href').replace('#', '');
+  const figHeadingLabel = target.querySelector('h4').innerText;
 
   // Only proceed if the browser window is no greater than 900px
   if (window.matchMedia(`(max-width: ${varsBreakpoints.bpSM.max}px)`).matches) {
@@ -90,12 +89,16 @@ const onFollow = (event) => {
     document.querySelector('.o-fig_sidebar button.o-expandable_header').click();
     // Scrolling before the expandable closes causes jitters on some devices
     setTimeout(() => {
-      scrollIntoViewWithOffset(document.getElementById(target), 60);
+      scrollIntoViewWithOffset(document.getElementById(figLinkID), 60);
     }, 300);
   }
 
   // Track clicks on individual search results
-  track('Small Business Lending FIG event', 'searchresults:click', target);
+  track(
+    'Small Business Lending FIG event',
+    'searchresults:click',
+    figHeadingLabel
+  );
 };
 
 /**

--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -5,6 +5,10 @@ import varsBreakpoints from '@cfpb/cfpb-core/src/vars-breakpoints.js';
 
 import Expandable from '@cfpb/cfpb-expandables/src/Expandable.js';
 import {
+  addEventListenerToSelector,
+  track,
+} from '../../../apps/analytics-gtm/js/util/analytics-util';
+import {
   DESKTOP,
   viewportIsIn,
 } from '../../../js/modules/util/breakpoint-state.js';
@@ -94,6 +98,15 @@ const init = () => {
   if (!viewportIsIn(DESKTOP)) {
     appRoot.addEventListener('click', handleMobileNav);
   }
+
+  // Track clicks on the FIG sidebar nav links
+  addEventListenerToSelector('.o-fig_sidebar .m-nav-link', 'click', (event) => {
+    track(
+      'Small Business Lending FIG event',
+      'toc:click',
+      event.target?.innerText
+    );
+  });
 };
 
 export { init };


### PR DESCRIPTION
Instead of just reporting the HTML ID of the element selected by the user, report the full innerText. Also, track table of contents clicks.

## How to test this PR

1. Pull down this branch.
1. Import a prod DB dump if you haven't recently to get the FIG draft that's currently staged on content.
1. Publish the FIG draft locally so that it’s viewable and no longer a draft.
1. Tests should pass headlessly:
    `yarn cypress run --spec test/cypress/integration/compliance/small-business-lending/ --env FIG_URL=/data-research/small-business-lending-data/filing-instructions-guide/2024-guide/`
1. Tests should pass with your local copy of Chrome (click on filing-instruction-guide.cy.js):
    `yarn cypress open --e2e --browser chrome --env FIG_URL=/data-research/small-business-lending-data/filing-instructions-guide/2024-guide/`

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
