### PR TITLE
Bump version of ccdb5-api from 1.6.6. to 1.7.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -38,4 +38,4 @@ wagtailmedia==0.9.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.17.3/owning_a_home_api-0.17.3-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.6.6/ccdb5_api-1.6.6-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.7.0/ccdb5_api-1.7.0-py3-none-any.whl


### PR DESCRIPTION
No functional changes; only addresses a deprecation warning.

See ccdb5-api v1.7.0 release notes:

https://github.com/cfpb/ccdb5-api/releases/tag/1.7.0

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)