### PR TITLE
Python formatting fixes for black 23.1.0

### DIFF
--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -5,7 +5,6 @@ import requests
 
 
 class NewRelicAlertViolations:
-
     newrelic_url = "https://api.newrelic.com/v2/"
 
     def __init__(

--- a/cfgov/ask_cfpb/documents.py
+++ b/cfgov/ask_cfpb/documents.py
@@ -11,7 +11,6 @@ from search.elasticsearch_helpers import (
 
 @registry.register_document
 class AnswerPageDocument(Document):
-
     autocomplete = fields.TextField(analyzer=ngram_tokenizer)
     portal_topics = fields.KeywordField()
     portal_categories = fields.TextField()

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -74,7 +74,6 @@ class AnswerStringTest(TestCase):
 
 
 class ArticlePageTest(TestCase):
-
     fixtures = ["ask_tests"]
 
     def setUp(self):
@@ -122,7 +121,6 @@ class ArticlePageTest(TestCase):
 
 
 class PortalSearchPageTest(TestCase):
-
     fixtures = [
         "ask_tests",
         "portal_topics",
@@ -558,7 +556,6 @@ class PortalSearchPageTest(TestCase):
 
 
 class AnswerPageTest(TestCase):
-
     fixtures = ["ask_tests", "portal_topics"]
 
     def create_answer_page(self, **kwargs):

--- a/cfgov/ask_cfpb/tests/test_search.py
+++ b/cfgov/ask_cfpb/tests/test_search.py
@@ -129,7 +129,6 @@ class TestAnswerPageSearch(ElasticsearchTestsMixin, TestCase):
 
     @mock.patch("ask_cfpb.forms.AutocompleteForm")
     def test_ask_search_autocomplete_honors_max_chars(self, mock_query):
-
         valid_term_1 = "Here is an ask_cfpb query that is exactly,"
         valid_term_2 = " like 100 percent, 75 characters."
         overage = " This is overage text that should not appear in the query"

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -31,7 +31,6 @@ class GeoValidationTests(django.test.TestCase):
     fixtures = ["mortgage_metadata.json", "mortgage_constants.json"]
 
     def setUp(self):
-
         baker.make(
             State,
             fips="12",
@@ -287,7 +286,6 @@ class MortgageBaseCountiesTest(unittest.TestCase):
 
 
 class MortgagePerformancePageTests(django.test.TestCase):
-
     fixtures = ["mortgage_metadata.json"]
 
     def setUp(self):
@@ -329,7 +327,6 @@ class MortgagePerformancePageTests(django.test.TestCase):
 
 
 class ModelStringTest(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def test_county_string_max_length(self):
@@ -353,11 +350,9 @@ class ModelStringTest(django.test.TestCase):
 
 
 class MortgageModelTests(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         self.base_data = baker.make(
             CountyMortgageData,
             fips="12081",

--- a/cfgov/data_research/tests/test_mortgage_utilities.py
+++ b/cfgov/data_research/tests/test_mortgage_utilities.py
@@ -7,7 +7,6 @@ from data_research.mortgage_utilities.fips_meta import load_constants
 
 
 class LoadConstantsTest(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     @mock.patch("data_research.mortgage_utilities.fips_meta.FIPS")

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -66,7 +66,6 @@ THROUGH_DATE = datetime.date(2016, 12, 1)
 
 
 class SourceToTableTest(django.test.TestCase):
-
     fixtures = [
         "mortgage_states.json",
         "mortgage_counties.json",
@@ -214,11 +213,9 @@ class SourceToTableTest(django.test.TestCase):
 
 
 class DataLoadIntegrityTest(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         FL = baker.make(
             State,
             fips="12",
@@ -301,11 +298,9 @@ class DataLoadIntegrityTest(django.test.TestCase):
 
 
 class MergeTheDadesTest(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         self.old_dade_fips = "12025"
         self.new_dade_fips = "12086"
 
@@ -362,7 +357,6 @@ class DataExportTest(django.test.TestCase):
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         baker.make(
             State,
             fips="12",
@@ -541,7 +535,6 @@ class DataLoadTest(django.test.TestCase):
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         FL = baker.make(
             State,
             fips="12",
@@ -707,11 +700,9 @@ class DataLoadTest(django.test.TestCase):
 
 
 class UpdateSamplingDatesTest(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):
-
         baker.make(
             CountyMortgageData,
             current=1250,
@@ -802,7 +793,6 @@ class SaveMetadataTests(django.test.TestCase):
 
 
 class BuildStateMsaDropdownTests(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json"]
 
     def setUp(self):
@@ -882,7 +872,6 @@ class BuildStateMsaDropdownTests(django.test.TestCase):
 
 
 class UpdateStateMsaDropdownTests(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     @mock.patch(

--- a/cfgov/data_research/tests/test_views.py
+++ b/cfgov/data_research/tests/test_views.py
@@ -50,7 +50,6 @@ class YearMonthValidatorTests(unittest.TestCase):
 
 
 class TimeseriesViewTests(django.test.TestCase):
-
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     def setUp(self):

--- a/cfgov/diversity_inclusion/forms.py
+++ b/cfgov/diversity_inclusion/forms.py
@@ -71,7 +71,7 @@ class VoluntaryAssessmentForm(forms.Form):
         from_email = settings.DEFAULT_FROM_EMAIL
         recipient_list = ["OMWI_diversityassessments@cfpb.gov"]
 
-        for (name, field) in self.fields.items():
+        for name, field in self.fields.items():
             message += field.label + ": " + self.cleaned_data[name] + "\n"
 
         try:

--- a/cfgov/filing_instruction_guide/models.py
+++ b/cfgov/filing_instruction_guide/models.py
@@ -63,7 +63,6 @@ class FIGPageForm(WagtailAdminPageForm):
 
 
 class FIGContentPage(CFGOVPage, ClusterableModel):
-
     # FIG Header Section Fields
     eyebrow = models.CharField(max_length=100, blank=True)
     page_header = models.CharField(max_length=200, blank=True)

--- a/cfgov/housing_counselor/results_archiver.py
+++ b/cfgov/housing_counselor/results_archiver.py
@@ -9,6 +9,7 @@ json_file_name = "HUD_approved_housing_counselors.json"
 # list of the full results we receive from the HUD API, in case of
 # future enforcement actions.
 
+
 # As an MVP, we're saving the complete JSON response, zipped. As a
 # future enhancement, we could consider improving the format of the
 # data, e.g. as CSV.

--- a/cfgov/login/tests/test_login_views.py
+++ b/cfgov/login/tests/test_login_views.py
@@ -95,7 +95,6 @@ class LoginViewsTestCase(TestCase):
 
 
 class PasswordResetViewTestCase(TestCase, WagtailTestUtils):
-
     # The setup methods come from Wagtail's TestPasswordReset test case.
     # They handle user and password-reset token creation.
     def setUp(self):
@@ -105,7 +104,6 @@ class PasswordResetViewTestCase(TestCase, WagtailTestUtils):
         )
 
     def setup_password_reset_confirm_tests(self):
-
         # Get user
         self.user = get_user_model().objects.get(email="test@email.com")
 

--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -45,14 +45,12 @@ OUT_FILE = "paying_for_college/fixtures/bls_data.json"
 
 
 def load_bls_data(csvfile):
-
     with open(csvfile, "rU") as f:
         reader = cdr(f)
         return [row for row in reader]
 
 
 def add_bls_dict_with_region(base_bls_dict, region, csvfile):
-
     CATEGORIES_KEY_MAP = {
         "Food": "Food",
         "Housing": "Housing",
@@ -109,7 +107,6 @@ def add_bls_dict_with_region(base_bls_dict, region, csvfile):
 
 
 def bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile):
-
     bls_dict = {
         "Food": {"note": "Dining out and in; all food costs"},
         "Housing": {"note": "Mortgage, rent, utilities, insurance"},
@@ -143,7 +140,6 @@ def create_bls_json_file(
     mw_csvfile=MW_CSVFILE,
     so_csvfile=SO_CSVFILE,
 ):
-
     with open(OUT_FILE, "w") as outfile:
         bls_dict = bls_as_dict(we_csvfile, ne_csvfile, mw_csvfile, so_csvfile)
         json.dump(bls_dict, outfile)

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -27,7 +27,6 @@ To run the script, use this manage.py command:
 
 
 class ProgramSerializer(serializers.Serializer):
-
     # required fields
     ipeds_unit_id = serializers.CharField(max_length=6)  # '210960'
     program_code = serializers.CharField(max_length=255)
@@ -142,7 +141,6 @@ def strip_control_chars(ustring):
 
 
 def clean(data):
-
     number_fields = (
         "program_level",
         "program_length",
@@ -262,7 +260,6 @@ def load(source, s3=False):
 
         else:  # There is error
             for key, error_list in dict.items(serializer.errors):
-
                 fail_msg = "ERROR on row {}: {}: ".format(
                     raw_data.index(row) + 1, key
                 )

--- a/cfgov/paying_for_college/documents.py
+++ b/cfgov/paying_for_college/documents.py
@@ -12,7 +12,6 @@ from search.elasticsearch_helpers import (
 
 @registry.register_document
 class SchoolDocument(Document):
-
     autocomplete = fields.TextField(analyzer=ngram_tokenizer)
     text = fields.TextField(attr="primary_alias", boost=10)
     url = fields.TextField()

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -150,7 +150,6 @@ class TaggingTests(django.test.TestCase):
 
 
 class PurgeTests(django.test.TestCase):
-
     fixtures = ["test_fixture.json", "test_program.json"]
 
     def test_purges(self):
@@ -169,7 +168,6 @@ class PurgeTests(django.test.TestCase):
 
 
 class TestScripts(django.test.TestCase):
-
     fixtures = ["test_fixture.json", "test_contacts.json"]
     api_fixture = "{}/fixtures/sample_4yr_api_result.json".format(COLLEGE_ROOT)
 

--- a/cfgov/paying_for_college/tests/test_search.py
+++ b/cfgov/paying_for_college/tests/test_search.py
@@ -12,7 +12,6 @@ from paying_for_college.views import school_autocomplete
 
 # paying-for-college2/understanding-your-financial-aid-offer/api/search-schools.json?q=Kansas
 class SchoolSearchTest(TestCase):
-
     fixtures = ["test_fixture.json", "test_school.json"]
 
     @mock.patch.object(SchoolDocument, "search")

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -84,7 +84,6 @@ class TestViews(django.test.TestCase):
 
 
 class SchoolProgramTest(django.test.TestCase):
-
     fixtures = ["test_fixture.json", "test_program.json"]
 
     def test_get_school(self):
@@ -142,7 +141,6 @@ class ConstantsTest(django.test.TestCase):
 
 
 class OfferTest(django.test.TestCase):
-
     fixtures = ["test_fixture.json", "test_program.json"]
 
     # /paying-for-college2/understanding-your-financial-aid-offer/offer/?[QUERYSTRING]
@@ -213,7 +211,6 @@ class OfferTest(django.test.TestCase):
 
 
 class APITests(django.test.TestCase):
-
     fixtures = [
         "test_fixture.json",
         "test_constants.json",
@@ -310,7 +307,6 @@ class APITests(django.test.TestCase):
 
 
 class VerifyViewTest(django.test.TestCase):
-
     fixtures = ["test_fixture.json"]
     post_data = {
         "oid": "f38283b5b7c939a058889f997949efa566c616c5",

--- a/cfgov/permissions_viewer/wagtail_hooks.py
+++ b/cfgov/permissions_viewer/wagtail_hooks.py
@@ -14,7 +14,6 @@ except ImportError:
 
 @hooks.register("register_admin_urls")
 def register_admin_urls():
-
     urls = [
         re_path(
             r"^permissions/",

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -92,7 +92,7 @@ class PrivacyActForm(forms.Form):
     # Form validations
     def escaped_fields(self):
         data = {}
-        for (key, value) in self.cleaned_data.items():
+        for key, value in self.cleaned_data.items():
             data.update({key: escape(value)})
         return data
 

--- a/cfgov/regulations3k/documents.py
+++ b/cfgov/regulations3k/documents.py
@@ -7,7 +7,6 @@ from search.elasticsearch_helpers import environment_specific_index
 
 @registry.register_document
 class SectionParagraphDocument(Document):
-
     text = fields.TextField(attr="paragraph", boost=10)
     title = fields.TextField()
     part = fields.KeywordField()

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -487,7 +487,6 @@ class ParagraphParsingTestCase(unittest.TestCase):
         )
 
     def test_divine_interp_tag(self):
-
         # HD1 elements
         HD = bS("<HD1>Introduction\n</HD1>", "lxml-xml").find("HD1")
         self.assertEqual(divine_interp_tag_use(HD, "1002"), "intro")
@@ -516,7 +515,6 @@ class ParagraphParsingTestCase(unittest.TestCase):
 
 
 class ParserIdTestCase(unittest.TestCase):
-
     LEVEL_STATE = IdLevelState()
 
     def test_current_token(self):
@@ -654,7 +652,6 @@ class ParserIdTestCase(unittest.TestCase):
 
 
 class PatternsTestCase(unittest.TestCase):
-
     levelstate = IdLevelState()
 
     def test_appendix_level_1_initial(self):

--- a/cfgov/regulations3k/tests/test_scripts.py
+++ b/cfgov/regulations3k/tests/test_scripts.py
@@ -15,7 +15,6 @@ from regulations3k.scripts.insert_section_links import (
 
 
 class LinkScriptTestCase(TestCase):
-
     fixtures = ["tree_limb"]
 
     def test_bad_part_number_is_skipped(self):

--- a/cfgov/regulations3k/tests/test_search_indexes.py
+++ b/cfgov/regulations3k/tests/test_search_indexes.py
@@ -8,7 +8,6 @@ from regulations3k.models import Section, SectionParagraph
 
 
 class RegulationIndexTestCase(TestCase):
-
     # a single reg branch: Part > EffectiveDate > Subpart > Section
     fixtures = ["tree_limb.json"]
 

--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -77,7 +77,6 @@ class ActivityIndexPageTests(WagtailPageTests):
 
 
 class ActivitySetUpTests(TestCase):
-
     from teachers_digital_platform.documents import ActivityPageDocument
 
     fixtures = ["tdp_initial_data"]

--- a/cfgov/teachers_digital_platform/tests/test_documents.py
+++ b/cfgov/teachers_digital_platform/tests/test_documents.py
@@ -14,7 +14,6 @@ from teachers_digital_platform.models import (
 
 
 class TeachersDigitalPlatformDocumentTest(TestCase):
-
     fixtures = ["tdp_initial_data"]
 
     def setUp(self):

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -22,7 +22,6 @@ from v1.models.newsroom_page import LegacyNewsroomPage, NewsroomPage
 
 @registry.register_document
 class FilterablePagesDocument(Document):
-
     tags = fields.ObjectField(
         properties={"slug": fields.KeywordField(), "name": fields.TextField()}
     )
@@ -184,7 +183,6 @@ class FilterablePagesDocumentSearch:
         to_date=None,
         from_date=None,
     ):
-
         if topics is None:
             topics = []
         if categories is None:

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -342,7 +342,6 @@ class FilterableListForm(forms.Form):
 
 
 class EnforcementActionsFilterForm(FilterableListForm):
-
     statuses = forms.MultipleChoiceField(
         required=False,
         choices=enforcement_action_page.enforcement_statuses,

--- a/cfgov/v1/models/indexed_page_revision.py
+++ b/cfgov/v1/models/indexed_page_revision.py
@@ -3,7 +3,6 @@ from wagtail.search import index
 
 
 class IndexedPageRevision(index.Indexed, PageRevision):
-
     search_fields = [
         index.SearchField("content_json"),
         index.FilterField("created_at"),

--- a/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_related_posts.py
@@ -17,7 +17,6 @@ from v1.tests.wagtail_pages import helpers
 
 class RelatedPostsTestCase(TestCase):
     def setUp(self):
-
         # add some authors to a CFGOV page and give it some tags
 
         self.author1 = "Some Author"

--- a/cfgov/v1/tests/models/test_portal_topics.py
+++ b/cfgov/v1/tests/models/test_portal_topics.py
@@ -4,7 +4,6 @@ from v1.models.portal_topics import PortalCategory, PortalTopic
 
 
 class TestPortalTagObjects(TestCase):
-
     fixtures = [
         "portal_categories.json",
         "portal_topics.json",

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -22,7 +22,6 @@ class TestUnicodeCompatibility(TestCase):
 
 class TestTranslations(TestCase):
     def test_related_resource_translations(self):
-
         test_resource = RelatedResource(
             title="English title",
             title_es="Spanish title",

--- a/cfgov/v1/tests/test_signals.py
+++ b/cfgov/v1/tests/test_signals.py
@@ -149,7 +149,6 @@ class FilterableListInvalidationTestCase(TestCase):
 
 
 class RefreshActivitiesTestCase(DjangoTestCase):
-
     fixtures = ["tdp_minimal_data"]
 
     def setUp(self):

--- a/cfgov/v1/util/util.py
+++ b/cfgov/v1/util/util.py
@@ -117,7 +117,6 @@ def get_secondary_nav_items(request, current_page):
 
 
 def valid_destination_for_request(request, url):
-
     view, args, kwargs = resolve(url)
     kwargs["request"] = request
     try:


### PR DESCRIPTION
Black version 23.1.0 was released last night:

https://github.com/psf/black/blob/main/CHANGES.md#2310

This makes some minor changes to required code style, requiring these changes.

## How to test this PR

 To test:

```
tox -r -e lint
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)