### PR TITLE
Fix couple FIG mobile bugs

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
@@ -88,6 +88,7 @@
 .o-fig_heading {
   a {
     color: @black;
+    word-break: break-word;
   }
 }
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/secondary-navigation-fig.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/secondary-navigation-fig.html
@@ -43,9 +43,11 @@
     {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
     {% call() expandable(sec_nav_settings) %}
         {% import 'v1/includes/molecules/nav-link.html' as nav_link %}
-        <p class="u-hide-on-desktop">
-            Effective {{ effective_start_date }} to {{ effective_end_date }}
-        </p>
+        {% if version_status %}
+            <p class="u-hide-on-desktop">
+                Effective {{ effective_start_date }} to {{ effective_end_date }}
+            </p>
+        {% endif %}
         <div id="ctrl-f"></div>
         <ul class="m-list
                  m-list__unstyled


### PR DESCRIPTION
The effective date was being shown on mobile even if a status wasn't set. Also, really long validation IDs like `amount_applied_for_flag.invalid_enum_value` were forcing a horizontal scrollbar so now they break to the next line on smaller screens.

## How to test this PR

1. PR checks should pass.
1. Pull down this branch.
1. If a FIG's version status is `Current` there should be no `Effective...` sentence at the top of the table of contents. If it's not `Current`, the sentence should exist.

## Screenshots

| before | after |
|--------|-------|
| <img width="472" alt="Screen Shot 2023-02-02 at 12 57 40 PM" src="https://user-images.githubusercontent.com/1060248/216407669-1273283b-35bb-48f5-ab8c-275ebdc38726.png"> | <img width="472" alt="Screen Shot 2023-02-02 at 12 58 03 PM" src="https://user-images.githubusercontent.com/1060248/216407649-fb40a042-ca8e-44fe-bbd4-efc34d14bf13.png"> |

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
