### PR TITLE
Re-hide "Delete" link on page actions dropdown

### DIFF
--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -6,9 +6,8 @@
     </a>
     <div class="t-dark">
         <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
-        Delete' as delete_label
         {% for button in buttons %}
-            {% if button.label != delete_label %}
+            {% if button.label != "Delete" %}
             <li class="c-dropdown__item ">
                 <a href="{{ button.url }}" title="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
                     {{ button.label }}


### PR DESCRIPTION
Commit cd92d27c71c5d8ef23aa788a734867dd09b22984 accidentally exposed a weird "Delete' as delete_label" string that was appearing in the Wagtail admin. This commit fixes that.

Fixes internal D&CT#156.

## How to test this PR

Browse the page tree, for example: http://localhost:8000/admin/pages/319/

## Screenshots

|Before|After|
|-|-|
|<img width="581" alt="image" src="https://user-images.githubusercontent.com/654645/216418696-a9cd8b4d-7bc9-40b6-97b8-842cfcd7afdc.png">|<img width="583" alt="image" src="https://user-images.githubusercontent.com/654645/216418621-23195c4f-1428-4f27-8ed0-8f6526c3f067.png">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
