### PR TITLE
Remove WATCHMAN_TOKENS environment variable

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -135,12 +135,6 @@ export HUD_API_ENDPOINT=http://localhost:8000/hud-api-replace/
 
 # export MAPBOX_ACCESS_TOKEN=<access_token>
 
-#########################################################
-# Django-Watchman, our global status monitoring endpoint.
-#########################################################
-
-export WATCHMAN_TOKENS=''
-
 #######################################################
 # USAJOBS (optional) - for checking job posting status.
 #######################################################

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,6 @@ services:
       DJANGO_ADMIN_PASSWORD: admin
       SECRET_KEY: abcdefghijklmnopqrstuvwxyz
       MEDIA_ROOT: /src/consumerfinance.gov/cfgov/f/
-      WATCHMAN_TOKENS: 'token'
       APACHE_STATUS_ALLOW_FROM: 127.0.0.1
     ports:
       - '8000:8000'

--- a/helm/overrides/dev-vars.yaml
+++ b/helm/overrides/dev-vars.yaml
@@ -13,8 +13,6 @@ extraEnvs:
     value: "abcdefghijklmnopqrstuvwxyz"
   - name: MEDIA_ROOT
     value: "/src/consumerfinance.gov/cfgov/f/"
-  - name: WATCHMAN_TOKENS
-    value: "token"
   - name: APACHE_STATUS_ALLOW_FROM
     value: "127.0.0.1"
   - name: AWS_CONFIG_FILE


### PR DESCRIPTION
This commit removes the definition of an unused WATCHMAN_TOKENS environment variable. This was needed when this project used the django-watchman package, but support for that was removed in April 2022:

https://github.com/cfpb/consumerfinance.gov/commit/b7676c26ffa611ce616a6fe426cc9a8b5d0c4d87

This commit removes a few references that were left behind.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)