### PR TITLE
Jinja markup: fix redundant block classes and extraneous spacing

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/templates/render_block.html
+++ b/cfgov/v1/jinja2/v1/includes/templates/render_block.html
@@ -1,17 +1,25 @@
 {% macro render(block, index) %}
-    {%- import 'v1/includes/macros/accessible-languages.html' as accessible_languages with context -%}
-    <div class="block
-                {{ 'block__flush-top' if index == 1
-                   and not (block.value.has_top_border or block.value.has_top_rule_line) else '' }}
+   {%- import 'v1/includes/macros/accessible-languages.html' as accessible_languages with context -%}
+   {% set block_classes = ['block'] %}
 
-                {{ 'block__padded-top block__border-top'
-                   if block.value.has_top_border or block.value.has_top_rule_line else '' }}
+   {% if index == 1 and not (block.value.has_top_border or block.value.has_top_rule_line) %}
+      {{ block_classes.append('block__flush-top') }}
+   {% endif %}
 
-                {{ 'block__padded-bottom block__border-bottom'
-                   if block.value.has_rule or block.value.has_bottom_border else '' }}
+   {% if block.value.has_top_border or block.value.has_top_rule_line %}
+      {{ block_classes.append('block__padded-top block__border-top') }}
+   {% endif %}
 
-                {{ block.block.meta.classname if block.block.meta.classname else '' -}}"
-        {{ accessible_languages.render() }}>
-        {{ render_stream_child(block) | safe }}
-    </div>
+   {% if block.value.has_rule or block.value.has_bottom_border %}
+      {{ block_classes.append('block__padded-bottom block__border-bottom') }}
+   {% endif %}
+
+   {% if block.block.meta.classname %}
+      {{ block_classes.append(block.block.meta.classname) }}
+   {% endif %}
+
+   <div class="{{ block_classes | unique | join(' ') }}"
+      {{- accessible_languages.render() -}}>
+      {{ render_stream_child(block) | safe }}
+   </div>
 {% endmacro %}


### PR DESCRIPTION
We were delivering redundant classes and large amounts of extraneous space in block classes within the jinja templates. This PR moves the classes into an array and introduces them onto the element as a unique space-joined list.

## Changes

- Jinja markup: fix redundant block classes and extraneous spacing


## How to test this PR

1. Visit https://www.consumerfinance.gov/language/ar/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/extend-forbearance/ and inspect the page and note the large spaces within the block classes and the sometimes redundant `block__flush-top` class.
2. Pull this branch and run locally and visit http://localhost:8000/language/ar/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/extend-forbearance/ and see that the spaces and redundancies are gone.

## Screenshots

Before:
<img width="296" alt="Screen Shot 2023-02-08 at 8 25 22 AM" src="https://user-images.githubusercontent.com/704760/217555251-f6948d75-b168-4bcb-9131-609a24481ded.png">

<img width="371" alt="Screen Shot 2023-02-08 at 9 13 15 AM" src="https://user-images.githubusercontent.com/704760/217555119-2a9245ad-c20f-40aa-9f4c-8ef2f512829c.png">

After:
<img width="359" alt="Screen Shot 2023-02-08 at 9 12 56 AM" src="https://user-images.githubusercontent.com/704760/217555151-5850b023-be0c-4555-9574-bba31a0d0d5d.png">




## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
