### PR TITLE
Change the CCDB API link to a more secure rendering

### DIFF
--- a/docs/consumer-complaint-database.md
+++ b/docs/consumer-complaint-database.md
@@ -6,7 +6,7 @@ Each week the CFPB sends thousands of consumers’ complaints about financial pr
 
 The API allows automation of the same filtering and searching functions offered to website visitors.
 
-Detailed documentation for the search API can be found [here](https://cfpb.github.io/ccdb5-api/documentation/index.html).
+Detailed documentation for the search API can be found [here](https://cfpb.github.io/api/ccdb/api/index.html).
 
 #### Notes
 


### PR DESCRIPTION
The original docs link provided a way to specify a config file for the documentation, which opens the docs to mischief.

The new link removes the config selection box.

You can preview the safer API link via my fork of cfgov, where I've published the new link to gh-pages.

https://higs4281.github.io/consumerfinance.gov/consumer-complaint-database/

