### PR TITLE
Define WAGTAILADMIN_BASE_URL setting

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -736,3 +736,9 @@ except (TypeError, ValueError):
 # A list of domain names that are allowed to be linked to without adding the
 # interstitial page.
 ALLOWED_LINKS_WITHOUT_INTERSTITIAL = ("public.govdelivery.com",)
+
+# Base URL to use when referring to full URLs within the Wagtail admin backend -
+# e.g. in notification emails. Don't include '/admin' or a trailing slash
+WAGTAILADMIN_BASE_URL = os.getenv(
+    "WAGTAILADMIN_BASE_URL", "http://localhost:8000"
+)

--- a/cfgov/login/email.py
+++ b/cfgov/login/email.py
@@ -1,43 +1,16 @@
-from django.contrib.auth.models import User
-from django.core.handlers.wsgi import WSGIRequest
-
 from wagtail.admin.forms.auth import PasswordResetForm
-from wagtail.models import Site
 
 
-def create_request_for_email(method="GET"):
-    """
-    Create an HttpRequest object suitable for use in Django email
-    forms with appropriate hostname and ports. Requires a configured
-    default Wagtail Site object.
-    """
-    try:
-        site = Site.objects.get(is_default_site=True)
-    except Site.DoesNotExist:
-        raise RuntimeError("no default wagtail site configured")
-
-    return WSGIRequest(
-        {
-            "REQUEST_METHOD": method,
-            "SERVER_NAME": site.hostname,
-            "SERVER_PORT": site.port,
-            "wsgi.input": "",
-            "wsgi.url_scheme": "https" if 443 == site.port else "http",
-        }
-    )
-
-
-def send_password_reset_email(email, request=None):
+def send_password_reset_email(email):
     form = PasswordResetForm({"email": email})
-    if not form.is_valid():
-        raise User.DoesNotExist(email)
 
-    request = request or create_request_for_email()
+    if not form.is_valid():
+        raise ValueError(email)
 
     template_base = "wagtailadmin/account/password_reset/"
+
     form.save(
-        request=request,
-        subject_template_name=template_base + "email_subject.txt",
-        email_template_name=template_base + "email.txt",
-        use_https=request.is_secure(),
+        domain_override=True,
+        subject_template_name=f"{template_base}/email_subject.txt",
+        email_template_name=f"{template_base}/email.txt",
     )

--- a/cfgov/login/tests/test_email.py
+++ b/cfgov/login/tests/test_email.py
@@ -1,62 +1,20 @@
-from unittest.mock import patch
-
-from django.contrib.auth.models import User
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core import mail
-from django.http import HttpRequest
 from django.test import TestCase, override_settings
 
-from wagtail.models import Site
-
-from login.email import create_request_for_email, send_password_reset_email
-from model_bakery import baker
-
-
-class CreateEmailRequestTestCase(TestCase):
-    def test_no_sites_raises_exception(self):
-        with patch(
-            "login.email.Site.objects.get", side_effect=Site.DoesNotExist
-        ):
-            self.assertRaises(RuntimeError, create_request_for_email)
-
-    def assertRequestMatches(self, request, hostname, port, is_secure):
-        self.assertEqual(
-            (hostname, port, is_secure),
-            (
-                request.META["SERVER_NAME"],
-                request.META["SERVER_PORT"],
-                request.is_secure(),
-            ),
-        )
-
-    def test_http_site(self):
-        site = baker.prepare(Site, is_default_site=True, port=80)
-        with patch("login.email.Site.objects.get", return_value=site):
-            request = create_request_for_email()
-        self.assertRequestMatches(request, site.hostname, site.port, False)
-
-    def test_https_site(self):
-        site = baker.prepare(Site, is_default_site=True, port=443)
-        with patch("login.email.Site.objects.get", return_value=site):
-            request = create_request_for_email()
-        self.assertRequestMatches(request, site.hostname, site.port, True)
+from login.email import send_password_reset_email
 
 
 class SendEmailTestCase(TestCase):
     def setUp(self):
         self.email = "user@example.com"
-        self.user = User.objects.create(email=self.email)
+        self.user = get_user_model().objects.create(email=self.email)
         self.user.set_password("password")
         self.user.save()
 
-        self.request = HttpRequest()
-        self.request.META["SERVER_NAME"] = "testhost"
-        self.request.META["SERVER_PORT"] = 1234
-
-    def tearDown(self):
-        self.user.delete()
-
     def test_send_password_reset_email(self):
-        send_password_reset_email(self.email, request=self.request)
+        send_password_reset_email(self.email)
         self.assertEqual(len(mail.outbox), 1)
 
         message = mail.outbox[0]
@@ -64,27 +22,17 @@ class SendEmailTestCase(TestCase):
         self.assertEqual(message.from_email, "webmaster@localhost")
         self.assertEqual(message.subject, "Password reset")
         self.assertIn(
-            "http://{SERVER_NAME}:{SERVER_PORT}".format(**self.request.META),
-            message.message().as_string(),
+            settings.WAGTAILADMIN_BASE_URL, message.message().as_string()
         )
 
     @override_settings(DEFAULT_FROM_EMAIL="from@email.com")
     def test_send_password_reset_from_email(self):
-        send_password_reset_email(self.email, request=self.request)
+        send_password_reset_email(self.email)
         self.assertEqual(len(mail.outbox), 1)
 
         message = mail.outbox[0]
         self.assertEqual(message.from_email, "from@email.com")
 
-    def test_send_password_reset_email_no_user(self):
-        self.assertRaises(
-            User.DoesNotExist,
-            send_password_reset_email,
-            "user.example.com",
-            request=self.request,
-        )
-
-    def test_send_with_no_request(self):
-        with patch("login.email.create_request_for_email") as p:
-            send_password_reset_email(self.email)
-            p.assert_called_once_with()
+    def test_send_password_reset_invalid_email(self):
+        with self.assertRaises(ValueError):
+            send_password_reset_email("this is an invalid email")


### PR DESCRIPTION
(This PR is against the upgrade/wagtail branch, not the main branch.)

As of Wagtail 3.0, we need to define a Django setting named [`WAGTAILADMIN_BASE_URL`](https://docs.wagtail.org/en/stable/reference/settings.html#wagtailadmin-base-url) to tell Wagtail the base URL of the running website (example: https://www.consumerfinance.gov).

Without defining this, Django reports this warning when it runs:

> ?: (wagtailadmin.W003) The WAGTAILADMIN_BASE_URL setting is not defined HINT: This should be the base URL used to access the Wagtail admin site. Without this, URLs in notification emails will not display correctly.

This commit sets a default of "http://localhost:8000" for this value, or uses the environment variable `WAGTAILADMIN_BASE_URL` if it is defined.

Ideally we would be able to put "http://localhost:8000" in our settings.local and rely on 
`os.environ["WAGTAILADMIN_BASE_URL"]` in our settings.production. Due to uncertainty around use of cf.gov production settings in Docker-based environments, though, we can't guarantee that environment variable will be set.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)