### PR TITLE
Translation links style iteration

### DIFF
--- a/cfgov/unprocessed/css/molecules/translation-links.less
+++ b/cfgov/unprocessed/css/molecules/translation-links.less
@@ -15,14 +15,11 @@ ul.m-translation-links {
   flex-wrap: wrap;
   gap: 21px;
   overflow: hidden;
+  font-weight: 500;
 
   & > li {
     margin-bottom: 0;
     white-space: nowrap;
-
-    a {
-      border: none;
-    }
   }
 
   & > li + li {

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -34,21 +34,23 @@
 {% endif -%}
 
 {%- if value.links and value.links|length > 1 %}
-<ul dir="ltr" class="m-translation-links">
-    {%- for link in value.links %}
-        {%- set render_link = value.language and link.language != value.language %}
-        <li>
-        {%- if render_link %}
-            <a href="{{ link.href }}"
-               lang="{{ link.language }}"
-               hreflang="{{ link.language }}"
-               translate="no">
-        {%- endif %}
-        {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
-        {% if render_link %}
-            </a>
-        {% endif -%}
-        </li>
-    {% endfor -%}
-</ul>
+<div class="block block__sub">
+    <ul dir="ltr" class="m-translation-links">
+        {%- for link in value.links %}
+            {%- set render_link = value.language and link.language != value.language %}
+            <li>
+            {%- if render_link %}
+                <a href="{{ link.href }}"
+                lang="{{ link.language }}"
+                hreflang="{{ link.language }}"
+                translate="no">
+            {%- endif %}
+            {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
+            {% if render_link %}
+                </a>
+            {% endif -%}
+            </li>
+        {% endfor -%}
+    </ul>
+</div>
 {%- endif %}


### PR DESCRIPTION
This commit makes three minor style changes to how we render Wagtail page translation links:

1. Font weight is set to 500.
2. Links get underlines.
3. The links `<ul>` is wrapped in a `<div class="block block__sub">` to ensure 30px of collapsible margin above and below.

These changes come from @jenn-franklin's guidance on internal D&CP#122#issuecomment-328946.

## How to test this PR

To test locally, `yarn run build` then visit:

- template debug view: http://localhost:8000/admin/template_debug/v1/translation_links/
- BlogPage: http://localhost:8000/about-us/blog/know-your-rights-and-protections-when-it-comes-to-medical-bills-and-collections/
- BrowsePage: http://localhost:8000/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/
- LearnPage: http://localhost:8000/admin/pages/15468/view_draft/
- NewsroomPage: http://localhost:8000/about-us/newsroom/cfpb-and-ny-attorney-general-sue-repeat-offender-moneygram-for-leaving-families-high-and-dry/
- SublandingPage: http://localhost:8000/coronavirus/mortgage-and-housing-assistance/

## Screenshots

|Before|After|
|-|-|
|<img width="646" alt="image" src="https://user-images.githubusercontent.com/654645/218779837-6aaf7e65-4a30-4a18-92a2-de04db26b346.png">|<img width="579" alt="image" src="https://user-images.githubusercontent.com/654645/218780268-445b7c07-d1ce-442a-93f0-17cf4a8a5277.png">|

## Notes and todos

Note that this change does not address the placement of the links on the page; that is to come in a subsequent PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets