### PR TITLE
Move translation links below `<h1>` tags

### DIFF
--- a/cfgov/v1/jinja2/v1/browse-basic/index.html
+++ b/cfgov/v1/jinja2/v1/browse-basic/index.html
@@ -20,8 +20,6 @@
         {% endif %}
     {%- endfor %}
 
-    {% include "v1/includes/molecules/translation-links.html" %}
-
     {% if page.share_and_print %}
         {% import "v1/includes/molecules/social-media.html" as social_media with context -%}
         <div class="block block__flush-top block__flush-bottom block__padded-bottom">

--- a/cfgov/v1/jinja2/v1/includes/article.html
+++ b/cfgov/v1/jinja2/v1/includes/article.html
@@ -55,8 +55,6 @@
         {{ item_introduction.render(data) }}
     </header>
 
-    {% include "v1/includes/molecules/translation-links.html" %}
-
     <div>
         {% for block in page.content %}
             {% if block.block_type == 'full_width_text' %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
@@ -36,9 +36,12 @@
 {% if value.eyebrow %}
     <div class="eyebrow">{{ value.eyebrow }}</div>
 {% endif %}
-{% if value.heading %}
+
+{% if value.heading -%}
     <h1>{{ value.heading }}</h1>
-{% endif %}
+
+    {% include "v1/includes/molecules/translation-links.html" %}
+{%- endif %}
 
 {% if value.intro.source %}
     <div class="lead-paragraph">

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -26,7 +26,7 @@
 
     ======================================================================== #}
 
-{%- if page and not value %}
+{%- if page %}
     {% set value = {
         "language": language | default( "en" ),
         "links": page.get_translation_links( request ),

--- a/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
@@ -38,7 +38,12 @@
     {% if filter_page_url and page.categories.count() > 0 and value.show_category %}
         {{ category_slug.render(category=page.categories.first().name, href=filter_page_url) }}
     {% endif %}
-    <h1>{{ value.heading | safe }}</h1>
+
+    {% if value.heading -%}
+        <h1>{{ value.heading | safe }}</h1>
+
+        {% include "v1/includes/molecules/translation-links.html" %}
+    {%- endif %}
 
     {% if value.paragraph %}
         <div class="lead-paragraph">{{ value.paragraph | safe }}</div>

--- a/cfgov/v1/jinja2/v1/learn-page/index.html
+++ b/cfgov/v1/jinja2/v1/learn-page/index.html
@@ -17,8 +17,6 @@
         {% endif %}
     {%- endfor %}
 
-    {% include "v1/includes/molecules/translation-links.html" %}
-
     {% for block in page.content -%}
         {% if block.block_type == 'contact_expandable_group' %}
             <div class="block">

--- a/cfgov/v1/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/v1/jinja2/v1/sublanding-page/index.html
@@ -19,7 +19,9 @@
 {% endblock %}
 
 {% block content_main %}
-    {% include "v1/includes/molecules/translation-links.html" %}
+    {% if page.has_hero -%}
+        {% include "v1/includes/molecules/translation-links.html" %}
+    {%- endif %}
 
     {% for block in page.content -%}
         {% if block.block_type == 'notification' %}

--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -136,3 +136,14 @@ class SublandingPage(CFGOVPage):
         return sorted(
             posts_list, key=lambda p: p.date_published, reverse=True
         )[:limit]
+
+    @property
+    def has_hero(self):
+        """Returns boolean indicating whether the page includes a hero module.
+
+        TODO: On Wagtail 4.0, this functionality can be removed in favor of
+        using the built-in page.header.first_block_by_name("hero"):
+
+        https://docs.wagtail.org/en/stable/topics/streamfield.html#streamfield-retrieving-blocks-by-name
+        """
+        return bool(len(self.header))

--- a/cfgov/v1/tests/models/test_sublanding_page.py
+++ b/cfgov/v1/tests/models/test_sublanding_page.py
@@ -2,7 +2,7 @@ import datetime as dt
 import json
 from io import StringIO
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from scripts import _atomic_helpers as atomic
 from search.elasticsearch_helpers import ElasticsearchTestsMixin
@@ -95,3 +95,17 @@ class SublandingPageTestCase(ElasticsearchTestsMixin, TestCase):
         posts = self.sublanding_page.get_browsefilterable_posts(self.limit)
         self.assertEqual(len(posts), 1)
         self.assertEqual(self.child1_of_post2, posts[0])
+
+
+class TestSublandingPageHasHero(SimpleTestCase):
+    def test_no_hero(self):
+        self.assertFalse(SublandingPage().has_hero)
+
+    def test_has_hero(self):
+        self.assertTrue(
+            SublandingPage(
+                header=json.dumps(
+                    [{"type": "hero", "value": {"heading": "Heading"}}]
+                )
+            ).has_hero
+        )


### PR DESCRIPTION
This commit moves Wagtail page translation links so that they sit below the `<h1>` tag on all page types. It does this by moving the inclusion of the translation-links.html template out of some of our page templates and into the ItemIntroduction and TextIntroduction modules, which render the `<h1>`.

With this change, the links get rendered:

- In an ItemIntroduction or TextIntroduction, if the heading is defined.
- Or, on SublandingPages, if a hero has been added. On some SLPs we use a TextIntroduction instead of a hero, but we should never use both.
Note that this PR doesn't include changes to the link margin; that is implemented in #7516.

## How to test this PR

To test this, run a local server with a production dump. Here are some example pages to visit to verify functionality is working properly:

- BlogPage: http://localhost:8000/about-us/blog/know-your-rights-and-protections-when-it-comes-to-medical-bills-and-collections/
- BrowsePage: http://localhost:8000/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/
- NewsroomPage: http://localhost:8000/about-us/newsroom/cfpb-and-ny-attorney-general-sue-repeat-offender-moneygram-for-leaving-families-high-and-dry/
- SublandingPage with hero: http://localhost:8000/coronavirus/mortgage-and-housing-assistance/
- SublandingPage without hero: Go to http://localhost:8000/admin/pages/13988/edit/, delete the Hero module, add a TextIntroduction, set a heading, and preview.

## Screenshots

<img width="815" alt="image" src="https://user-images.githubusercontent.com/654645/218872892-bf78a069-5a0a-4112-803e-3c6b11c6a209.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development