### PR TITLE
Use page language for translation links

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -28,7 +28,7 @@
 
 {%- if page %}
     {% set value = {
-        "language": language | default( "en" ),
+        "language": ( language or page.language )| default( "en" ),
         "links": page.get_translation_links( request ),
     } %}
 {% endif -%}


### PR DESCRIPTION
0ee2655b8e4145c2a9e8ca6eeea82c68427befca inadvertently broke how the current page language gets rendered in our translation links, [for example](https://www.consumerfinance.gov/language/vi/mortgages-key-terms/) here the Vietnamese page should not be a link because we are currently viewing it.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/654645/219098712-ee345d84-d645-44ea-bd92-6cb74e949b64.png">

This PR fixes that; if the `language` variable isn't defined when rendering the translation links template, try to grab it off of the page object by using `page.language`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)