### PR TITLE
Tagline: Add missing `is_large` argument code comment

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
@@ -9,6 +9,8 @@
 
    Render HTML for the United States government site tagline.
 
+   is_large: Whether to use a larger font-size for the tagline text.
+
    ========================================================================== #}
 
 {% macro render( is_large ) %}


### PR DESCRIPTION
Just noticed this code comment was missing.

## Additions

- Add missing tagline argument code comment

## How to test this PR

1. PR checks should pass.
