### PR TITLE
Add an active users report

### DIFF
--- a/cfgov/v1/templates/v1/active_users_report.html
+++ b/cfgov/v1/templates/v1/active_users_report.html
@@ -9,6 +9,7 @@
                     <th>Last name</th>
                     <th>Username</th>
                     <th>Email</th>
+                    <th>Last login</th>
                 </tr>
             </thead>
             <tbody>
@@ -18,6 +19,7 @@
                         <td>{{ user.last_name }}</td>
                         <td>{{ user.username }}</td>
                         <td>{{ user.email }}</td>
+                        <td>{{ user.last_login|date }} {{ user.last_login|time }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/cfgov/v1/templates/v1/active_users_report.html
+++ b/cfgov/v1/templates/v1/active_users_report.html
@@ -1,0 +1,28 @@
+{% extends 'wagtailadmin/reports/base_report.html' %}
+
+{% block results %}
+    {% if object_list %}
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th>First name</th>
+                    <th>Last name</th>
+                    <th>Username</th>
+                    <th>Email</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user in object_list %}
+                    <tr>
+                        <td>{{ user.first_name }}</td>
+                        <td>{{ user.last_name }}</td>
+                        <td>{{ user.username }}</td>
+                        <td>{{ user.email }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>No users are active.</p>
+    {% endif %}
+{% endblock %}

--- a/cfgov/v1/tests/views/test_reports_view.py
+++ b/cfgov/v1/tests/views/test_reports_view.py
@@ -2,6 +2,7 @@ import json
 from datetime import date
 from operator import itemgetter
 
+from django.contrib.auth import get_user_model
 from django.test import SimpleTestCase, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -26,6 +27,7 @@ from v1.models.snippets import RelatedResource
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.ref import categories
 from v1.views.reports import (
+    ActiveUsersReportView,
     AskReportView,
     CategoryIconReportView,
     DocumentsReportView,
@@ -288,3 +290,16 @@ class TestTranslatedPagesReport(TestCase, WagtailTestUtils):
         response = self.client.get(self.url + "?language=ht")
         self.assertContains(response, "Translated Pages")
         self.assertContains(response, "No pages found.")
+
+
+class TestActiveUsersReport(TestCase):
+    def test_get_queryset(self):
+        User = get_user_model()
+        test_user = User(
+            username="test", email="test@example.com", is_active=False
+        )
+        test_user.save()
+
+        report_users = ActiveUsersReportView().get_queryset()
+        self.assertGreater(len(User.objects.all()), len(report_users))
+        self.assertNotIn(test_user, report_users)

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -417,6 +417,7 @@ class ActiveUsersReportView(ReportView):
         "last_name",
         "username",
         "email",
+        "last_login",
     ]
 
     def get_queryset(self):

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -4,6 +4,7 @@ from functools import partial
 from operator import itemgetter
 
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.utils import html as html_util
 
 from wagtail.admin.filters import WagtailFilterSet
@@ -403,3 +404,20 @@ class TranslatedPagesReportView(PageReportView):
         context = super().get_context_data(*args, **kwargs)
         context["languages"] = settings.LANGUAGES
         return context
+
+
+class ActiveUsersReportView(ReportView):
+    title = "Active Users"
+    header_icon = "user"
+    template_name = "v1/active_users_report.html"
+    paginate_by = 0
+
+    list_export = [
+        "first_name",
+        "last_name",
+        "username",
+        "email",
+    ]
+
+    def get_queryset(self):
+        return get_user_model().objects.filter(is_active=True)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -39,6 +39,7 @@ from v1.template_debug import (
     video_player_test_cases,
 )
 from v1.views.reports import (
+    ActiveUsersReportView,
     AskReportView,
     CategoryIconReportView,
     DocumentsReportView,
@@ -324,6 +325,26 @@ def register_translated_pages_report_url():
             r"^reports/translated-pages/$",
             TranslatedPagesReportView.as_view(),
             name="translated_pages_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_active_users_report_menu_item():
+    return MenuItem(
+        "Active Users",
+        reverse("active_users_report"),
+        classnames="icon icon-" + ActiveUsersReportView.header_icon,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_active_users_report_url():
+    return [
+        re_path(
+            r"^reports/active-users/$",
+            ActiveUsersReportView.as_view(),
+            name="active_users_report",
         ),
     ]
 


### PR DESCRIPTION
As a way to understand who we need to inform about upgrades (as well as maybe helping when we want to explore more about our users), I’ve added a new Wagtail report that just lists the username, first, last, and email of each active user (has logged in within the last 90 days).

This puts in the Wagtail admin the information we’d usually go to the Django admin for, but Excel-exportable. This should let us compare multiple environments more directly with spreadsheets.

![image](https://user-images.githubusercontent.com/10562538/220454711-f5aac512-eb92-40ba-ad31-d954377728da.png)
## How to test this PR


1. Pull this PR
2. Visit http://localhost:8000/admin/reports/active-users/ to view the report

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)