### PR TITLE
Add missing secondary navigation JS to Spanish pages

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -186,14 +186,11 @@ class AnswerLandingPage(LandingPage):
 
 
 class SecondaryNavigationJSMixin:
-    """A page mixin that adds navigation JS for English pages."""
+    """A page mixin that adds navigation JS."""
 
     @property
     def page_js(self):
-        js = super().page_js
-        if self.language == "en":
-            js += ["secondary-navigation.js"]
-        return js
+        return super().page_js + ["secondary-navigation.js"]
 
 
 class PortalSearchPage(


### PR DESCRIPTION
Currently any pages that inherit from SecondaryNavigationJSMixin only include the secondary navigation JS on English language pages. But the secondary navigation is also used for the "In this section" expandable component rendered on BrowsePages on mobile.

So, on these Spanish pages the JS is currently missing, causing the expandable to render as open (and be un-closeable). For example, visit this page at a mobile width and notice the fixed "En esta sección" component:

https://www.consumerfinance.gov/es/herramientas-del-consumidor/prestamos-del-dia-de-pago/respuestas/

Compare to a comparable English page:

https://www.consumerfinance.gov/consumer-tools/reverse-mortgages/answers/

## Screenshots

|Before|After|
|-|-|
|<img width="884" alt="image" src="https://user-images.githubusercontent.com/654645/221084825-c7aa87a9-2b12-42a6-a7a4-690f1fe8c78f.png">|<img width="884" alt="image" src="https://user-images.githubusercontent.com/654645/221084761-b9979375-564a-4e1a-afdb-0ebe87eec03d.png">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)