### PR TITLE
Bugfix: Add initial class to FormSubmit AlphaTransition

### DIFF
--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -153,7 +153,9 @@ function FormSubmit(element, baseClass, opts) {
    *  Replaces form with notification on success.
    */
   function _replaceFormWithNotification(message) {
-    const transition = new AlphaTransition(_baseElement).init();
+    const transition = new AlphaTransition(_baseElement).init(
+      AlphaTransition.CLASSES.ALPHA_100
+    );
     scrollIntoView(_formElement, { offset: 100, callback: fadeOutForm });
 
     /**


### PR DESCRIPTION
Follow up to https://github.com/cfpb/consumerfinance.gov/pull/7462 that adds the missing initial class to the AlphaTransition.

## Changes

- Adds (now required) missing initial class to the AlphaTransition in the FormSubmit module.


## How to test this PR

1. The codepath for this code is unused, but it would be if `replaceForm` is passed as an option into `new FormSubmit(…)`. You can manually do this by replacing:

```
  const formSubmit = new FormSubmit(emailSignup, BASE_CLASS, {
    validator: (fields) =>
      validators.email(fields.email, '', { language: language }).msg,
    language: language,
  });
``` 

with 

```
  const formSubmit = new FormSubmit(emailSignup, BASE_CLASS, {
    validator: (fields) =>
      validators.email(fields.email, '', { language: language }).msg,
    language: language,
    replaceForm: true,
  });
```

In https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/apps/owning-a-home/js/common.js, building the JS, and visiting http://localhost:8000/owning-a-home/explore-rates/ and using the email signup at the bottom.