### PR TITLE
Remove unnecessary no-js check before using jsl

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
@@ -37,14 +37,6 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function(){
-          {# Include site-wide JavaScript. #}
-          var s = [
-            '{{ static('apps/filing-instruction-guide/js/fig-init.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+        jsl(['{{ static("apps/filing-instruction-guide/js/fig-init.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -362,13 +362,6 @@
     </script>
 
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/find-a-housing-counselor/js/common.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl(['{{ static("apps/find-a-housing-counselor/js/common.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/jinja2/ccdb-complaint/ccdb-search.html
+++ b/cfgov/jinja2/ccdb-complaint/ccdb-search.html
@@ -35,14 +35,9 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            'https://files.consumerfinance.gov/ccdb/metadata.js',
-            '{{ static('apps/ccdb-search/js/main.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl([
+        'https://files.consumerfinance.gov/ccdb/metadata.js',
+        '{{ static("apps/ccdb-search/js/main.js") }}'
+      ]);
     </script>
 {% endblock javascript %}

--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -627,14 +627,9 @@ home price, down payment, and more can affect mortgage interest rates.
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/owning-a-home/js/common.js') }}',
-            '{{ static('apps/owning-a-home/js/explore-rates/index.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl([
+        '{{ static("apps/owning-a-home/js/common.js") }}',
+        '{{ static("apps/owning-a-home/js/explore-rates/index.js") }}'
+      ]);
     </script>
 {% endblock javascript %}

--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -22,15 +22,8 @@ home price, down payment, and more can affect mortgage interest rates.
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        window.cfpbMapboxAccessToken = '{{ mapbox_access_token }}'
-        !function() {
-          var s = [
-            '{{ static('apps/rural-or-underserved-tool/js/common.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      window.cfpbMapboxAccessToken = '{{ mapbox_access_token }}';
+      jsl(['{{ static("apps/rural-or-underserved-tool/js/common.js") }}']);
     </script>
 {% endblock javascript %}
 

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
@@ -71,13 +71,6 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/paying-for-college/js/college-costs.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl(['{{ static("apps/paying-for-college/js/college-costs.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3318,13 +3318,6 @@
 {% block javascript scoped %}
 {{ super() }}
 <script>
-  if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function() {
-      var s = [
-        "{{ static('apps/paying-for-college/js/disclosures/index.js') }}"
-      ];
-      jsl(s);
-    }()
-  }
+  jsl(['{{ static("apps/paying-for-college/js/disclosures/index.js") }}']);
 </script>
 {% endblock javascript %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -153,13 +153,6 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('js/routes/data-research/prepaid-accounts/search-agreements/index.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl(['{{ static("js/routes/data-research/prepaid-accounts/search-agreements/index.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
+++ b/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
@@ -304,13 +304,6 @@
 {% block javascript %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static("js/routes/on-demand/privacy-forms.js") }}'
-          ];
-          jsl(s);
-        }();
-      }
+      jsl(['{{ static("js/routes/on-demand/privacy-forms.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/privacy/jinja2/privacy/records-access-form.html
+++ b/cfgov/privacy/jinja2/privacy/records-access-form.html
@@ -277,13 +277,6 @@
 {% block javascript %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static("js/routes/on-demand/privacy-forms.js") }}'
-          ];
-          jsl(s);
-        }();
-      }
+      jsl(['{{ static("js/routes/on-demand/privacy-forms.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -313,14 +313,9 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/regulations3k/js/index.js') }}',
-            '{{ static('apps/regulations3k/js/permalinks.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl([
+        '{{ static("apps/regulations3k/js/index.js") }}',
+        '{{ static("apps/regulations3k/js/permalinks.js") }}'
+      ]);
     </script>
 {% endblock javascript %}

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -48,14 +48,9 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/regulations3k/js/index.js') }}',
-            '{{ static('apps/regulations3k/js/recent-notices.js') }}'
-          ];
-          jsl(s);
-        }()
-      }
+      jsl([
+        '{{ static("apps/regulations3k/js/index.js") }}',
+        '{{ static("apps/regulations3k/js/recent-notices.js") }}'
+      ]);
     </script>
 {% endblock javascript %}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -212,16 +212,12 @@
 {% block javascript scoped %}
     {{ super() }}
     <script>
-      if ( document.body.parentElement.className.indexOf( 'no-js' ) === -1 ) {
-        !function() {
-          var s = [
-            '{{ static('apps/regulations3k/js/index.js') }}'
-            {% if page.results.search_query %}
-            ,'{{ static('apps/regulations3k/js/search.js') }}'
-            {% endif %}
-          ];
-          jsl(s);
-        }()
-      }
+      jsl([
+        '{{ static("apps/regulations3k/js/index.js") }}'
+        {%- if page.results.search_query -%}
+        ,
+        '{{ static("apps/regulations3k/js/search.js") }}'
+        {%- endif %}
+      ]);
     </script>
 {% endblock javascript %}

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -966,13 +966,6 @@
 {% block javascript scoped %}
 {{ super() }}
 <script>
-  if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function() {
-      var s = [
-        '{{ static('apps/retirement/js/index.js') }}'
-      ];
-      jsl(s);
-    }()
-  }
+  jsl(['{{ static("apps/retirement/js/index.js") }}']);
 </script>
 {% endblock javascript %}

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -1049,13 +1049,6 @@
 {% block javascript scoped %}
 {{ super() }}
 <script>
-  if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function() {
-      var s = [
-        '{{ static('apps/financial-well-being/js/home.js') }}'
-      ];
-      jsl(s);
-    }()
-  }
+  jsl(['{{ static("apps/financial-well-being/js/home.js") }}']);
 </script>
 {% endblock %}

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -724,13 +724,6 @@
 {% block javascript scoped %}
 {{ super() }}
 <script>
-  if (document.body.parentElement.className.indexOf('no-js') === -1) {
-    !function() {
-      var s = [
-        '{{ static('apps/financial-well-being/js/results.js') }}'
-      ];
-      jsl(s);
-    }()
-  }
+  jsl(['{{ static("apps/financial-well-being/js/results.js") }}']);
 </script>
 {% endblock %}


### PR DESCRIPTION
We have a common pattern in our templates where we load individual scripts via our JavaScript loader function, jsl: first, we check to make sure that the page isn't being rendered in no-js mode. The idea behind this check is that we might have no-js even if JavaScript is enabled, in cases where the browser doesn't support fetch.

Here's where we set no-js if the browser doesn't support fetch:

https://github.com/cfpb/consumerfinance.gov/blob/c19933a38d413a313ba39edc53a4f94c7cc819d5/cfgov/v1/jinja2/v1/layouts/base.html#L210-L212

But our jsl function already checks for window.fetch support:

https://github.com/cfpb/consumerfinance.gov/blob/c19933a38d413a313ba39edc53a4f94c7cc819d5/cfgov/v1/jinja2/v1/layouts/base.html#L201-L204

So current logic:

1. Browser doesn't support fetch, we set no-js on the page.
2. If no-js is set on the page, we skip calls to jsl().
3. In jsl(), if the browser supports fetch, we try loading scripts.

The check to no-js is unnecessary since we check against fetch directly.

## Notes and todos

This change was suggested by @anselmbradford at https://github.com/cfpb/consumerfinance.gov/pull/7529#discussion_r1117226566.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)