### PR TITLE
Eyebrow: Tie tagline logic to layout

### DIFF
--- a/cfgov/mega_menu/jinja2/mega_menu/mega-menu.html
+++ b/cfgov/mega_menu/jinja2/mega_menu/mega-menu.html
@@ -220,7 +220,7 @@
 
     {% if nav_depth == 1 %}
     {% import 'v1/includes/molecules/global-eyebrow.html' as global_eyebrow with context %}
-    {{ global_eyebrow.render( language=language, has_tagline=false ) }}
+    {{ global_eyebrow.render( language=language ) }}
     {% endif %}
 </div>
 {% endmacro %}

--- a/cfgov/unprocessed/css/molecules/global-eyebrow.less
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.less
@@ -11,6 +11,9 @@
               <ul class="m-global-eyebrow_languages">
                 <li><a href="/es/" hreflang="es" lang="es">Español</a></li>
               </ul>
+              <span class="m-global-eyebrow_phone">
+                <a href="tel:+1-855-411-2372">(855) 411-2372</a>
+              </span>
             </div>
         </div>
       codenotes:
@@ -23,15 +26,18 @@
               ul.m-global-eyebrow_languages
                 li
                   a
+              span.m-global-eyebrow_phone
     - name: List item example
       markup: |
         <div class="m-global-eyebrow
                     m-global-eyebrow__list">
             <div class="wrapper">
-              <div class="m-global-eyebrow_tagline"></div>
               <ul class="m-global-eyebrow_languages">
                 <li><a href="/es/" hreflang="es" lang="es">Español</a></li>
               </ul>
+              <span class="m-global-eyebrow_phone">
+                <a href="tel:+1-855-411-2372">(855) 411-2372</a>
+              </span>
             </div>
         </div>
       codenotes:
@@ -40,10 +46,10 @@
           -----------------------
           .m-global-eyebrow.m-global-eyebrow__list
             .wrapper
-              .a-tagline
               ul.m-global-eyebrow_languages
                 li
                   a
+              span.m-global-eyebrow_phone
   tags:
     - cfgov-molecules
 */
@@ -110,11 +116,6 @@
     padding-left: unit(@grid_gutter-width / @base-font-size-px, rem);
     padding-right: unit(@grid_gutter-width / 2 / @base-font-size-px, rem);
     padding-bottom: unit(@grid_gutter-width / @base-font-size-px, rem);
-
-    // Only applied if the tagline was included in the global eyebrow template.
-    .a-tagline {
-      display: none;
-    }
 
     .m-global-eyebrow_actions {
       padding: 0;

--- a/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
@@ -9,25 +9,21 @@
    Creates markup for Global Eyebrow molecule.
 
    is_horizontal: Whether the molecule appears horizontally or vertically.
+                  Note: The tagline only renders if the eyebrow is horizontal.
                   defaults to false.
 
    language:      The page's language value (used to display different
                   information on Spanish pages). Defaults to English.
 
-   has_tagline:   Whether this eyebrow should include the tagline or not.
-
    ========================================================================== #}
-{% macro render(
-    is_horizontal=false,
-    language='en',
-    has_tagline=true ) %}
+{% macro render( is_horizontal=false, language='en') %}
 {% import 'v1/includes/atoms/tagline.html' as tagline with context %}
     <div class="m-global-eyebrow
                 m-global-eyebrow__{{ 'horizontal' if is_horizontal
                                       else 'list' }}">
         <div class="wrapper
                     {{ 'wrapper__match-content' if is_horizontal else '' }}">
-            {% if has_tagline -%}
+            {% if is_horizontal -%}
                 {{ tagline.render() }}
             {%- endif %}
             <div class="m-global-eyebrow_actions">

--- a/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
@@ -16,7 +16,7 @@
                   information on Spanish pages). Defaults to English.
 
    ========================================================================== #}
-{% macro render( is_horizontal=false, language='en') %}
+{% macro render( is_horizontal=false, language='en' ) %}
 {% import 'v1/includes/atoms/tagline.html' as tagline with context %}
     <div class="m-global-eyebrow
                 m-global-eyebrow__{{ 'horizontal' if is_horizontal

--- a/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/global-eyebrow.html
@@ -10,7 +10,7 @@
 
    is_horizontal: Whether the molecule appears horizontally or vertically.
                   Note: The tagline only renders if the eyebrow is horizontal.
-                  defaults to false.
+                  Defaults to false.
 
    language:      The page's language value (used to display different
                   information on Spanish pages). Defaults to English.


### PR DESCRIPTION
Follow up to https://github.com/cfpb/consumerfinance.gov/pull/7522

I realized we could tie the tagline inclusion logic to the layout, for which we already had the `is_horizontal` argument. This means that it wouldn't be possible to have a list (vertical) layout AND have a tagline, meaning we can remove its styling as well. Much better!

## Changes

- Tie presence of the tagline in the global eyebrow to the layout format of the eyebrow.
- Add some missing documentation in the code.


## How to test this PR

1. Pull branch and see that there are only two a-taglines in the markup (header and footer).
