### PR TITLE
Prevent some uses of unsafe HTML in tables

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_table.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_table.html
@@ -58,7 +58,8 @@
     'has_data': not not rows,
     'empty_table_msg': 'There are no current openings at this time.',
     'first_row_is_table_header': true,
-    'is_stacked': true
+    'is_stacked': true,
+    'allow_unsafe': false
 } %}
     {% include 'v1/includes/organisms/table.html' %}
 {% endwith %}

--- a/cfgov/jobmanager/tests/test_blocks.py
+++ b/cfgov/jobmanager/tests/test_blocks.py
@@ -135,3 +135,9 @@ class JobListingTableTestCase(JobListingBlockTestUtils, TestCase):
         # https://github.com/wagtail/django-modelcluster/issues/101
         with self.assertNumQueries(13):
             self.render_block()
+
+    def test_disallows_unsafe_content(self):
+        self.make_job("<script>alert('hacked')</script>")
+        html = self.render_block()
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)

--- a/cfgov/v1/jinja2/v1/includes/organisms/contact-us-table.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/contact-us-table.html
@@ -10,7 +10,8 @@
     'has_data': true,
     'first_col_is_header': true,
     'fixed_col_widths': true,
-    'column_widths': ['u-w25pct', 'u-w75pct']
+    'column_widths': ['u-w25pct', 'u-w75pct'],
+    'allow_unsafe': false
 } %}
     {% include 'v1/includes/organisms/table.html' %}
 {% endwith %}

--- a/cfgov/v1/jinja2/v1/includes/organisms/table.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/table.html
@@ -40,14 +40,26 @@
    value.column_widths:   A list of column width (classes) to be applied in
                           order to the table columns.
 
+   value.allow_unsafe:    Boolean indicating whether to pass table data
+                          through the |safe filter, allowing unsafe characters.
+                          Defaults to true.
 
    ========================================================================== #}
 
 
 {% if value.has_data is not defined or value.has_data %}
-{% macro _render_cell(cell) %}
-    {{ (cell or '&nbsp;') | richtext | linebreaksbr | trim | safe }}
-{% endmacro %}
+
+{%- macro _render_cell( cell, allow_unsafe=true ) %}
+    {% set cell_str = (cell or '&nbsp;') | richtext | linebreaksbr | trim %}
+    {% if allow_unsafe %}
+        {% set cell_str = cell_str | safe %}
+    {% endif %}
+
+    {{- cell_str -}}
+{% endmacro -%}
+
+{% set allow_unsafe = value.allow_unsafe | default(true) %}
+
 {% if value.heading_text %}
     <{{ value.heading_level -}}>
         {%- if value.heading_icon %}
@@ -74,7 +86,7 @@
                     {% set width_class = ' class="' + value.column_widths[loop.index0] + '"' %}
                 {% endif %}
             <th scope="col"{{ width_class | default }}>
-                {{ _render_cell(cell) }}
+                {{ _render_cell(cell, allow_unsafe) }}
             </th>
             {% endfor %}
         </tr>
@@ -108,7 +120,7 @@
                     {% set attributes = attributes + ' data-label="' + first_row[loop.index0]|striptags|trim + '"' %}
                 {% endif %}
                 <{{ tag | safe }}{{ attributes | safe }}>
-                    {{ _render_cell(cell) }}
+                    {{ _render_cell(cell, allow_unsafe) }}
                 </{{ tag | safe }}>
             {% endfor %}
         </tr>


### PR DESCRIPTION
Currently we allow unsafe HTML to be entered into any uses of our underlying table template (table.html), whether it is being rendered by our Wagtail AtomicTableBlock or manually rendered via some other template.

I recently added a custom ContactUsTable in #7533, but I realized that because it uses the underlying table template, it also supports unsafe HTML -- but there's no reason to allow it to do so.

Hopefully someday we can eliminate all uses of unsafe HTML, but in the meantime maybe we can prevent some specific uses.

In this PR I've added the ability to prevent unsafe HTML when rendering using table.html, and blocked unsafe HTML in two use cases: the new Contact Us Table and the existing job listings table. All other uses of table.html, including our AtomicTableBlock, still allow unsafe HTML.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)