### PR TITLE
Re-run updatemodulepaths for Wagtail 3 upgrade

### DIFF
--- a/cfgov/ask_cfpb/migrations/0045_set_max_num_on_notifications.py
+++ b/cfgov/ask_cfpb/migrations/0045_set_max_num_on_notifications.py
@@ -2,20 +2,84 @@
 
 from django.db import migrations
 
-import wagtail.core.blocks
-import wagtail.core.fields
+import wagtail.blocks
+import wagtail.fields
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ('ask_cfpb', '0044_update_how_to_schema'),
+        ("ask_cfpb", "0044_update_how_to_schema"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='answerpage',
-            name='notification',
-            field=wagtail.core.fields.StreamField([('notification', wagtail.core.blocks.StructBlock([('type', wagtail.core.blocks.ChoiceBlock(choices=[('information', 'Information'), ('warning', 'Warning')])), ('message', wagtail.core.blocks.CharBlock(help_text='The main notification message to display.', required=True)), ('explanation', wagtail.core.blocks.TextBlock(help_text='Explanation text appears below the message in smaller type.', required=False)), ('links', wagtail.core.blocks.ListBlock(wagtail.core.blocks.StructBlock([('text', wagtail.core.blocks.CharBlock(required=False)), ('aria_label', wagtail.core.blocks.CharBlock(help_text='Add an ARIA label if the link text does not describe the destination of the link (e.g. has ambiguous text like "Learn more" that is not descriptive on its own).', required=False)), ('url', wagtail.core.blocks.CharBlock(default='/', required=False))]), help_text='Links appear on their own lines below the explanation.', required=False))]))], blank=True),
+            model_name="answerpage",
+            name="notification",
+            field=wagtail.fields.StreamField(
+                [
+                    (
+                        "notification",
+                        wagtail.blocks.StructBlock(
+                            [
+                                (
+                                    "type",
+                                    wagtail.blocks.ChoiceBlock(
+                                        choices=[
+                                            ("information", "Information"),
+                                            ("warning", "Warning"),
+                                        ]
+                                    ),
+                                ),
+                                (
+                                    "message",
+                                    wagtail.blocks.CharBlock(
+                                        help_text="The main notification message to display.",
+                                        required=True,
+                                    ),
+                                ),
+                                (
+                                    "explanation",
+                                    wagtail.blocks.TextBlock(
+                                        help_text="Explanation text appears below the message in smaller type.",
+                                        required=False,
+                                    ),
+                                ),
+                                (
+                                    "links",
+                                    wagtail.blocks.ListBlock(
+                                        wagtail.blocks.StructBlock(
+                                            [
+                                                (
+                                                    "text",
+                                                    wagtail.blocks.CharBlock(
+                                                        required=False
+                                                    ),
+                                                ),
+                                                (
+                                                    "aria_label",
+                                                    wagtail.blocks.CharBlock(
+                                                        help_text='Add an ARIA label if the link text does not describe the destination of the link (e.g. has ambiguous text like "Learn more" that is not descriptive on its own).',
+                                                        required=False,
+                                                    ),
+                                                ),
+                                                (
+                                                    "url",
+                                                    wagtail.blocks.CharBlock(
+                                                        default="/",
+                                                        required=False,
+                                                    ),
+                                                ),
+                                            ]
+                                        ),
+                                        help_text="Links appear on their own lines below the explanation.",
+                                        required=False,
+                                    ),
+                                ),
+                            ]
+                        ),
+                    )
+                ],
+                blank=True,
+            ),
         ),
     ]

--- a/cfgov/v1/management/commands/publish_pages.py
+++ b/cfgov/v1/management/commands/publish_pages.py
@@ -23,7 +23,7 @@ from django.http import Http404
 from django.test import RequestFactory
 
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 
 class Command(BaseCommand):

--- a/cfgov/v1/tests/management/commands/test_publish_pages.py
+++ b/cfgov/v1/tests/management/commands/test_publish_pages.py
@@ -6,7 +6,7 @@ from django.http import Http404
 from django.test import TestCase
 
 from wagtail.contrib.redirects.models import Redirect
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from v1.models import BrowsePage
 

--- a/cfgov/v1/tests/views/test_reports_view.py
+++ b/cfgov/v1/tests/views/test_reports_view.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from wagtail.documents.models import Document
 from wagtail.models import Site
-from wagtail.tests.utils import WagtailTestUtils
+from wagtail.test.utils import WagtailTestUtils
 
 from model_bakery import baker
 from taggit.models import Tag


### PR DESCRIPTION
(This PR is to upgrade/wagtail, not to main.)

Re-run `wagtail updatemodulepaths` per the Wagtail 3 upgrade notes:

https://docs.wagtail.org/en/latest/releases/3.0.html#changes-to-module-paths

This reflects changes to the Wagtail module import paths.

We ran this previously in bf2dbcd70e3ec972233440b72ad3fc7b5a187e69 a few weeks back, but since then more code has been merged into cf.gov main.