### PR TITLE
Remove o-expandable_header-left reference

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
@@ -26,7 +26,6 @@
   .block {
     margin: 2rem 0;
   }
-  .o-expandable_header-left,
   .numbered-header {
     align-items: center;
     display: flex;

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -42,12 +42,10 @@
           -----------------------
           .o-expandable.o-secondary-navigation
             .o-expandable_header.o-expandable_target
-                .o-expandable_header-left
-                .o-expandable_header-right
-                  .o-expandable_cue-open
-                    .cf-icon-svg
-                  .o-expandable_cue-close
-                    .cf-icon-svg
+              .o-expandable_cue-open
+                .cf-icon-svg
+              .o-expandable_cue-close
+                .cf-icon-svg
             .o-expandable_content
               .o-secondary-navigation_list.o-secondary-navigation_list__parents
                 li


### PR DESCRIPTION
This class does not exist in the expandable CSS https://github.com/cfpb/design-system/blob/main/packages/cfpb-expandables/src/cfpb-expandables.less

I can't find any markup for the TDP reference, even in the crawler, so it appears it can be removed from the TDP CSS.

## Removals

- Remove `o-expandable_header-left` references.

## How to test this PR

1. PR checks should pass.
