### PR TITLE
Restore ability to use usafe HTML in job listings table

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_table.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_table.html
@@ -58,8 +58,7 @@
     'has_data': not not rows,
     'empty_table_msg': 'There are no current openings at this time.',
     'first_row_is_table_header': true,
-    'is_stacked': true,
-    'allow_unsafe': false
+    'is_stacked': true
 } %}
     {% include 'v1/includes/organisms/table.html' %}
 {% endwith %}

--- a/cfgov/jobmanager/tests/test_blocks.py
+++ b/cfgov/jobmanager/tests/test_blocks.py
@@ -135,9 +135,3 @@ class JobListingTableTestCase(JobListingBlockTestUtils, TestCase):
         # https://github.com/wagtail/django-modelcluster/issues/101
         with self.assertNumQueries(13):
             self.render_block()
-
-    def test_disallows_unsafe_content(self):
-        self.make_job("<script>alert('hacked')</script>")
-        html = self.render_block()
-        self.assertNotIn("<script>", html)
-        self.assertIn("&lt;script&gt;", html)


### PR DESCRIPTION
Reverts change in #7541.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)