### PR TITLE
Add more ask-cfpb cypress tests

### DIFF
--- a/test/cypress/integration/components/header/header.cy.js
+++ b/test/cypress/integration/components/header/header.cy.js
@@ -54,6 +54,7 @@ describe('Header', () => {
       menuDesktop.firstTab().click();
       menuDesktop.firstPanel().should('not.have.class', 'u-is-animating');
       // Then the global search content should not be visible.
+      globalSearch.content().should('not.have.class', 'u-is-animating');
       globalSearch.content().should('not.be.visible');
     });
   });
@@ -102,7 +103,9 @@ describe('Header', () => {
       globalSearch.content().should('be.visible');
       // When I click on the first mega-menu trigger
       menuMobile.rootTrigger().click();
+      menuMobile.firstPanel().should('not.have.class', 'u-is-animating');
       // Then the global search content should not be visible.
+      globalSearch.content().should('not.have.class', 'u-is-animating');
       globalSearch.content().should('not.be.visible');
     });
     it('clicking the overlay to close the mega-menu and global search', () => {

--- a/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
@@ -3,6 +3,14 @@ export class AskCfpbAnswerPage {
     cy.visit('/ask-cfpb/').get('.ask-categories article li a').first().click();
   }
 
+  getSummaryContentLink() {
+    return cy.get('a').contains('how to keep your credit score(s) up');
+  }
+
+  getSummaryBtn() {
+    return cy.get('.o-summary_btn');
+  }
+
   clickSummary() {
     cy.get('.o-summary_btn').click();
   }

--- a/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
@@ -3,15 +3,11 @@ export class AskCfpbAnswerPage {
     cy.visit('/ask-cfpb/').get('.ask-categories article li a').first().click();
   }
 
-  getSummaryContentLink() {
+  getFirstLinkInSummary() {
     return cy.get('.o-summary_content a').first();
   }
 
   getSummaryBtn() {
     return cy.get('.o-summary_btn');
-  }
-
-  clickSummary() {
-    cy.get('.o-summary_btn').click();
   }
 }

--- a/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/ask-cfpb/answer-helpers.cy.js
@@ -4,7 +4,7 @@ export class AskCfpbAnswerPage {
   }
 
   getSummaryContentLink() {
-    return cy.get('a').contains('how to keep your credit score(s) up');
+    return cy.get('.o-summary_content a').first();
   }
 
   getSummaryBtn() {

--- a/test/cypress/integration/consumer-tools/ask-cfpb/ask-cfpb.cy.js
+++ b/test/cypress/integration/consumer-tools/ask-cfpb/ask-cfpb.cy.js
@@ -44,30 +44,54 @@ describe('Ask CFPB', () => {
   });
 
   describe('Answer Page', () => {
-    beforeEach(() => {
-      answerPage.open();
+    describe('on desktop', () => {
+      beforeEach(() => {
+        cy.viewport(1200, 800);
+        answerPage.open();
+      });
+
+      it('should not hide content on desktop', () => {
+        answerPage.getSummaryContentLink().should('be.visible');
+        answerPage.getSummaryContentLink().focus();
+        answerPage.getSummaryContentLink().should('be.visible');
+        answerPage.getSummaryBtn().should('not.be.visible');
+      });
     });
 
-    it('should hide content on mobile', () => {
-      cy.viewport(600, 1000);
-      cy.get('.o-summary_content').should(
-        'have.class',
-        'u-max-height-transition'
-      );
-      cy.get('.o-summary_content').should('have.class', 'u-max-height-summary');
-      cy.get('.o-summary_content').invoke('outerHeight').should('be.lte', 92);
-      answerPage.clickSummary();
-      cy.get('.o-summary_content').should(
-        'have.class',
-        'u-max-height-transition'
-      );
-      cy.get('.o-summary_content').should('not.have.class', 'u-no-animation');
-      cy.get('.o-summary_content').should(
-        'not.have.class',
-        'u-max-height-summary'
-      );
-      cy.get('.o-summary_content').should('have.class', 'u-max-height-default');
-      cy.get('.o-summary_content').invoke('outerHeight').should('be.gt', 92);
+    describe('on mobile', () => {
+      beforeEach(() => {
+        answerPage.open();
+        cy.viewport(480, 800);
+      });
+
+      it('should hide content on mobile', () => {
+        cy.get('.o-summary_content').should(
+          'have.class',
+          'u-max-height-transition'
+        );
+        cy.get('.o-summary_content').should(
+          'have.class',
+          'u-max-height-summary'
+        );
+        cy.get('.o-summary_content').invoke('outerHeight').should('be.lte', 92);
+        answerPage.getSummaryContentLink().should('not.be.visible');
+        answerPage.getSummaryBtn().click();
+        answerPage.getSummaryContentLink().should('be.visible');
+        cy.get('.o-summary_content').should(
+          'have.class',
+          'u-max-height-transition'
+        );
+        cy.get('.o-summary_content').should('not.have.class', 'u-no-animation');
+        cy.get('.o-summary_content').should(
+          'not.have.class',
+          'u-max-height-summary'
+        );
+        cy.get('.o-summary_content').should(
+          'have.class',
+          'u-max-height-default'
+        );
+        cy.get('.o-summary_content').invoke('outerHeight').should('be.gt', 92);
+      });
     });
   });
 });

--- a/test/cypress/integration/consumer-tools/ask-cfpb/ask-cfpb.cy.js
+++ b/test/cypress/integration/consumer-tools/ask-cfpb/ask-cfpb.cy.js
@@ -51,9 +51,9 @@ describe('Ask CFPB', () => {
       });
 
       it('should not hide content on desktop', () => {
-        answerPage.getSummaryContentLink().should('be.visible');
-        answerPage.getSummaryContentLink().focus();
-        answerPage.getSummaryContentLink().should('be.visible');
+        answerPage.getFirstLinkInSummary().should('be.visible');
+        answerPage.getFirstLinkInSummary().focus();
+        answerPage.getFirstLinkInSummary().should('be.visible');
         answerPage.getSummaryBtn().should('not.be.visible');
       });
     });
@@ -74,9 +74,9 @@ describe('Ask CFPB', () => {
           'u-max-height-summary'
         );
         cy.get('.o-summary_content').invoke('outerHeight').should('be.lte', 92);
-        answerPage.getSummaryContentLink().should('not.be.visible');
+        answerPage.getFirstLinkInSummary().should('not.be.visible');
         answerPage.getSummaryBtn().click();
-        answerPage.getSummaryContentLink().should('be.visible');
+        answerPage.getFirstLinkInSummary().should('be.visible');
         cy.get('.o-summary_content').should(
           'have.class',
           'u-max-height-transition'


### PR DESCRIPTION
Follow up to https://github.com/cfpb/consumerfinance.gov/pull/7550 to check that the content is not hidden on clicks of links inside the summary component on desktop when it is suspended.

## Changes

- Break ask-cfpb tests into desktop and mobile and perform additional tests to catch focusin issues.


## How to test this PR

1. PR checks should pass.