### PR TITLE
Attempt to fix flaky header test

### DIFF
--- a/test/cypress/integration/components/header/header.cy.js
+++ b/test/cypress/integration/components/header/header.cy.js
@@ -54,6 +54,7 @@ describe('Header', () => {
       menuDesktop.firstTab().click();
       menuDesktop.firstPanel().should('not.have.class', 'u-is-animating');
       // Then the global search content should not be visible.
+      globalSearch.content().should('not.have.class', 'u-is-animating');
       globalSearch.content().should('not.be.visible');
     });
   });
@@ -102,7 +103,9 @@ describe('Header', () => {
       globalSearch.content().should('be.visible');
       // When I click on the first mega-menu trigger
       menuMobile.rootTrigger().click();
+      menuMobile.firstPanel().should('not.have.class', 'u-is-animating');
       // Then the global search content should not be visible.
+      globalSearch.content().should('not.have.class', 'u-is-animating');
       globalSearch.content().should('not.be.visible');
     });
     it('clicking the overlay to close the mega-menu and global search', () => {


### PR DESCRIPTION
Header tests check visibility of mega menu and global search when clicking between them, but we need to check that they have stopped animating. Hopefully this takes care of the flaky header test.

## Changes

- Add checks for the completion of animation of the global search and mega menu in the header tests.


## How to test this PR

1. PR checks should pass.