### PR TITLE
Fix fragile table functional test

### DIFF
--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -285,7 +285,7 @@ export class AdminPage {
     cy.get('#id_q').type('{enter}');
     cy.wait(1000);
     cy.get('.document-choice').should('contain', text);
-    cy.get('#search-results').should('contain', 'There is 1 match');
+    cy.get('#search-results').should('contain', 'match');
     cy.get('#search-results', { timeout: 10000 }).contains(text).click();
     cy.wait(1000);
   }

--- a/test/cypress/integration/admin/admin.cy.js
+++ b/test/cypress/integration/admin/admin.cy.js
@@ -153,9 +153,8 @@ describe('Admin', () => {
     it('should be able to use link buttons', () => {
       admin.selectTableEditorButton('LINK');
       admin.selectInternalLink('CFGov');
-      const documentName = 'cfpb_interested-vendor-instructions_fy2020.pdf';
       admin.selectTableEditorButton('DOCUMENT');
-      admin.selectDocumentLink(documentName);
+      admin.selectDocumentLink('cfpb');
       admin.closeTableEditor();
     });
 


### PR DESCRIPTION
One of the table functional tests relies on the existence of a hardcoded document in the Wagtail database named
"cfpb_interested-vendor-instructions_fy2020.pdf". If this document does not exist, the test will fail.

This document doesn't exist in our production database, and so this test current fails when run against production or production-like systems.

This commit changes the test to be more flexible and test the functionality of document selection within a table as opposed to the existence of a specific document.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)