### PR TITLE
Restore Wagtail fallback database search

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -301,6 +301,16 @@ WAGTAIL_USER_EDIT_FORM = "login.forms.UserEditForm"
 
 WAGTAILDOCS_SERVE_METHOD = "direct"
 
+# This is needed to maintain autocomplete search behavior in the Wagtail admin.
+# See https://github.com/wagtail/wagtail/issues/7720.
+# TODO: Remove once we're on Wagtail 4.2, where this should be fixed in
+# https://github.com/wagtail/wagtail/pull/9900.
+WAGTAILSEARCH_BACKENDS = {
+    "default": {
+        "BACKEND": "wagtail.search.backends.database.fallback",
+    }
+}
+
 # LEGACY APPS
 MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
 

--- a/test/cypress/integration/admin/admin.cy.js
+++ b/test/cypress/integration/admin/admin.cy.js
@@ -153,7 +153,7 @@ describe('Admin', () => {
     it('should be able to use link buttons', () => {
       admin.selectTableEditorButton('LINK');
       admin.selectInternalLink('CFGov');
-      const documentName = 'cfpb_interested-vendor-instructions_fy2020.pdf';
+      const documentName = 'cfpb_interested-vendor-instructions_';
       admin.selectTableEditorButton('DOCUMENT');
       admin.selectDocumentLink(documentName);
       admin.closeTableEditor();


### PR DESCRIPTION
With the upgrade to Wagtail 3.0 we noticed that search in the Wagtail admin is no longer working as expected; specifically, autocomplete and substring searches don't seem to work the way they used to.

This is because in 3.0, behavior changed such that if you don't define `WAGTAILSEARCH_BACKENDS`, a different search backend is used (https://github.com/wagtail/wagtail/commit/00582ba35a2368890586c167636c9c2aad21cab3#diff-b3aaeb336b53eef65cb0d229f42fcc97756ab3d233fa9d3128c5ab34cdb942c5).

This is also related to https://github.com/wagtail/wagtail/issues/7720, fixed by https://github.com/wagtail/wagtail/pull/9900 in version 4.2, at least for the PostgreSQL database backend.

As a workaround for now, we can use the Wagtail "fallback" database search which uses a simpler substring-based search. If we ever want to use Wagtail search for anything besides the Wagtail admin, we will have to revisit this change.

## How to test this PR

Run Wagtail and search for documents containing "highlights": http://localhost:8000/admin/documents/?q=highlights. Note the number of results you get versus the number without the changes to this PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets