### PR TITLE
Temporarily skip Bandit test for `requests.get()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,8 @@ exclude_dirs = [
 skips = [
     "B308",
     "B703",
+
+    # Calls to requests.get() that don't include a timeout.
+    # TODO: We need to address those with relevant error handling of a timeout.
+    "B113",
 ]


### PR DESCRIPTION
Bandit [1.7.5 adds a test for calls to `requests.get()` that do not include a `timeout` parameter](https://bandit.readthedocs.io/en/1.7.5/plugins/b113_request_without_timeout.html). This PR adds that test to our skipped tests.

We have several of these, and we need to address them, but that can happen without our linting being blocked for all PRs at the moment.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)