### PR TITLE
Replace old Django i18n tags with `translate`/`blocktranslate`

### DIFF
--- a/cfgov/ask_cfpb/templates/admin/export.html
+++ b/cfgov/ask_cfpb/templates/admin/export.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% trans "Export Ask data" %}{% endblock %}
+{% block titletag %}{% translate "Export Ask data" %}{% endblock %}
 
 {% block content %}
 

--- a/cfgov/v1/management/commands/makemessages.py
+++ b/cfgov/v1/management/commands/makemessages.py
@@ -10,7 +10,7 @@
 import re
 
 from django.core.management.commands import makemessages
-from django.utils.translation import template as trans_real
+from django.utils.translation import template as translate_tag
 
 
 class Command(makemessages.Command):
@@ -19,22 +19,22 @@ class Command(makemessages.Command):
         jinja_block_re = re.compile(r"^\s*trans(?:\s+|$)")
         jinja_endblock_re = re.compile(r"^\s*endtrans$")
 
-        # Django uses {% blocktrans %}…{% endblocktrans %}
-        django_block_re = trans_real.block_re
-        django_endblock_re = trans_real.endblock_re
+        # Django uses {% blocktranslate %}…{% endblocktranslate %}
+        django_block_re = translate_tag.block_re
+        django_endblock_re = translate_tag.endblock_re
 
-        # This monkey-patches support for Jinja2's {% trans %}{% endtrans %}
+        # This monkey-patches support for Jinja2's {% translate %}{% endtrans %}
         # blocks into trans_real's block/endblock-matching regular expressions.
-        # These differ from Django's {% blocktrans %}{% endblocktrans %}
+        # These differ from Django's {% blocktranslate %}{% endblocktranslate %}
         # blocks.
         #
         # trans_real's other regular expressions, context_re, inline_re,
         # plural_re, constant_re, and one_percent_re should match both Jinja2
         # and Django conventions.
-        trans_real.block_re = re.compile(
+        translate_tag.block_re = re.compile(
             django_block_re.pattern + "|" + jinja_block_re.pattern
         )
-        trans_real.endblock_re = re.compile(
+        translate_tag.endblock_re = re.compile(
             django_endblock_re.pattern + "|" + jinja_endblock_re.pattern
         )
 
@@ -44,5 +44,5 @@ class Command(makemessages.Command):
         super().handle(*args, **options)
 
         # Restore just the Django-matching regular expressions
-        trans_real.endblock_re = django_endblock_re
-        trans_real.block_re = django_block_re
+        translate_tag.endblock_re = django_endblock_re
+        translate_tag.block_re = django_block_re

--- a/cfgov/v1/templates/cdnadmin/disabled.html
+++ b/cfgov/v1/templates/cdnadmin/disabled.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% trans "CDN Manager" %}{% endblock %}
+{% block titletag %}{% translate "CDN Manager" %}{% endblock %}
 
 {% block content %}
 

--- a/cfgov/v1/templates/cdnadmin/index.html
+++ b/cfgov/v1/templates/cdnadmin/index.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load humanize %}
 
-{% block titletag %}{% trans "CDN Manager" %}{% endblock %}
+{% block titletag %}{% translate "CDN Manager" %}{% endblock %}
 
 {% block content %}
 

--- a/cfgov/v1/templates/v1/_list_translated_page.html
+++ b/cfgov/v1/templates/v1/_list_translated_page.html
@@ -14,7 +14,7 @@
                 <div>
                     <span>{{ translation.language }}:</span>
                     {% if page_perms.can_edit %}
-                        <a href="{% url 'wagtailadmin_pages:edit' translation.id %}" title="{% trans 'Edit this page' %}">{{ translation.get_admin_display_title }}</a>
+                        <a href="{% url 'wagtailadmin_pages:edit' translation.id %}" title="{% translate 'Edit this page' %}">{{ translation.get_admin_display_title }}</a>
                     {% else %}
                         {{ translation.get_admin_display_title }}
                     {% endif %}

--- a/cfgov/v1/templates/v1/export_feedback.html
+++ b/cfgov/v1/templates/v1/export_feedback.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% trans "Export feedback" %}{% endblock %}
+{% block titletag %}{% translate "Export feedback" %}{% endblock %}
 
 {% block extra_css %}
 <style>

--- a/cfgov/v1/templates/v1/page_metadata_report.html
+++ b/cfgov/v1/templates/v1/page_metadata_report.html
@@ -4,7 +4,7 @@
 {% block actions %}
     {% if view.list_export %}
         <div class="actionbutton">
-            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% translate 'Download CSV' %}</a>
         </div>
     {% endif %}
 {% endblock %}

--- a/cfgov/v1/templates/v1/report_no-xlsx_base.html
+++ b/cfgov/v1/templates/v1/report_no-xlsx_base.html
@@ -4,7 +4,7 @@
 {% block actions %}
     {% if view.list_export %}
         <div class="actionbutton">
-            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a>
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% translate 'Download CSV' %}</a>
         </div>
     {% endif %}
 {% endblock %}

--- a/cfgov/v1/templates/v1/translated_pages_report.html
+++ b/cfgov/v1/templates/v1/translated_pages_report.html
@@ -6,5 +6,5 @@
 {% endblock %}
 
 {% block no_results %}
-    <p>{% trans "No pages found." %}</p>
+    <p>{% translate "No pages found." %}</p>
 {% endblock %}

--- a/cfgov/v1/tests/management/commands/test_makemessages_data/templates/test.html
+++ b/cfgov/v1/tests/management/commands/test_makemessages_data/templates/test.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% trans "Test string from Django template." %}
+{% translate "Test string from Django template." %}

--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/login.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/login.html
@@ -60,14 +60,6 @@
                 {% endfor %}
                 {% endblock extra_fields %}
 
-                {% comment %}
-                    Removed until functionality exists
-                    <li class="checkbox">
-                        <div class="field">
-                            <label><input type="checkbox" />{% trans "Remember me" %}</label>
-                        </div>
-                    </li>
-                {% endcomment %}
                 {% endblock %}
                 <li class="submit">
                     {% block submit_buttons %}

--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/shared/page_status_tag.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/shared/page_status_tag.html
@@ -2,18 +2,18 @@
 {% if page.live %}
     {% with page_url=page.full_url %}
         {% if page_url is not None %}
-            <a href="{{ page_url }}" target="_blank" rel="noreferrer" class="status-tag primary" title="{% trans 'Visit the live page' %}">
-                <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+            <a href="{{ page_url }}" target="_blank" rel="noreferrer" class="status-tag primary" title="{% translate 'Visit the live page' %}">
+                <span class="visuallyhidden">{% translate "Current page status:" %}</span> {{ page.status_string }}
             </a>
         {% else %}
             <span class="status-tag primary">
-                <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+                <span class="visuallyhidden">{% translate "Current page status:" %}</span> {{ page.status_string }}
             </span>
         {% endif %}
     {% endwith %}
 {% else %}
     <span class="status-tag">
-        <span class="visuallyhidden">{% trans "Current page status:" %}</span> {{ page.status_string }}
+        <span class="visuallyhidden">{% translate "Current page status:" %}</span> {{ page.status_string }}
     </span>
 {% endif %}
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -41,7 +41,7 @@ In Django templates:
 ```django
 {% load i18n %}
 
-{% trans "Hello World!" %}
+{% translate "Hello World!" %}
 ```
 
 In Python code:


### PR DESCRIPTION
Django replaced these in Django 3.1.

I've left in-place some translation tags that... I'm not sure we need, mostly to keep this scoped to just template changes, rather than regenerating our message files and recompiling them.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)