### PR TITLE
Tiny bit of template cleanup

### DIFF
--- a/cfgov/agreements/jinja2/agreements/search.html
+++ b/cfgov/agreements/jinja2/agreements/search.html
@@ -145,6 +145,3 @@
     <!-- /.content_wrapper -->
 </main>
 {% endblock %}
-
-{% block page_js %}
-{% endblock %}

--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -7,8 +7,6 @@
 
 {% import "v1/includes/molecules/social-media.html" as social_media with context %}
 {% set page={"search_description":"Use this tool throughout your homebuying process to see how your credit score, home price, down payment, and more can affect mortgage interest rates."} %}
-{% set active_page = "explore-rates" %}
-{% set page_js = "explore-rates" %}
 
 {% block title -%}
     Explore interest rates | Consumer Financial Protection Bureau

--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -1,8 +1,6 @@
 {% extends "v1/layouts/base.html" %}
 {% import "_templates/expandable.html" as expandable %}
 {% set page={"search_description":"Use this tool throughout your homebuying process to see how your credit score, home price, down payment, and more can affect mortgage interest rates."} %}
-{% set active_page = "explore-rates" %}
-{% set page_js = "explore-rates" %}
 
 {% block title -%}
     Rural and underserved areas tool | Consumer Financial Protection Bureau


### PR DESCRIPTION
Remove unused and unnecessary definitions of `page_js` and `active_page` in a few templates.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)