### PR TITLE
Identify mixins in equal height columns layout and in owning-a-home

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -210,7 +210,7 @@
     }
 
     figure {
-      .u-reset;
+      .u-reset();
     }
   }
 
@@ -393,7 +393,7 @@
   }
 
   .next-steps-list {
-    .u-reset;
+    .u-reset();
 
     position: relative;
     padding-left: 30px; // match the negative outdent of the numbering

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -83,7 +83,7 @@
   border-bottom: 1px solid @gray-10;
 
   p:last-child {
-    .u-reset;
+    .u-reset();
   }
 
   h4:first-child,

--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -153,19 +153,19 @@
 .content-l {
   .respond-to-min( @bp-sm-min, {
     &__equal-height {
-      .equal-height_container;
+      .equal-height_container();
     }
 
     &_col__equal-height {
-      .equal-height_col;
+      .equal-height_col();
     }
 
     &_body__equal-height {
-      .equal-height_body;
+      .equal-height_body();
     }
 
     &_footer__equal-height {
-      .equal-height_footer;
+      .equal-height_footer();
     }
   } );
 }


### PR DESCRIPTION
Minor adjustment to add `()` to mixins in equal height columns, as we do in other locations.

## Changes

- Add `()` to mixins in equal height columns.
- Add `()` to reset mixin in owning-a-home styles.

## How to test this PR

1. PR checks should pass.

## TODO
This is only used on https://www.consumerfinance.gov/your-story/, so depending on how https://github.com/cfpb/consumerfinance.gov/pull/7409 is threshed out, these layout classes could be removed entirely.
