### PR TITLE
Bump wagtail-sharing version from 2.7 to 2.8

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -32,7 +32,7 @@ wagtail-autocomplete==0.9.0
 wagtail-flags==5.2.0
 wagtail-inventory==1.6
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.7
+wagtail-sharing==2.8
 wagtail-treemodeladmin==1.6.0
 wagtailmedia==0.9.0
 


### PR DESCRIPTION
The [new 2.8 release of wagtail-sharing](https://github.com/cfpb/wagtail-sharing/releases/tag/2.8) adds support for Wagtail 4.x. This doesn't affect anything with how cf.gov runs today, but we want to be able to upgrade to Wagtail 4, so we should bump this version.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)