### PR TITLE
Update wagtail-inventory to 2.0.0

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -61,6 +61,8 @@ INSTALLED_APPS = (
     "localflavor",
     "modelcluster",
     "taggit",
+    "dal",
+    "dal_select2",
     "wagtailinventory",
     "wagtailsharing",
     "flags",

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -2,6 +2,7 @@
 base36==0.1.1
 beautifulsoup4==4.8.2
 boto3==1.22.7
+django-autocomplete-light==3.9.4
 django-cors-headers==3.11.0
 django-csp==3.7
 django-opensearch-dsl==0.4.1
@@ -30,7 +31,7 @@ requests-aws4auth==1.1.2
 s3transfer==0.5.2
 wagtail-autocomplete==0.9.0
 wagtail-flags==5.2.0
-wagtail-inventory==1.6
+wagtail-inventory==2.0.0
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.8
 wagtail-treemodeladmin==1.6.0

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -184,14 +184,26 @@ export class AdminPage {
   }
 
   openBlockInventory() {
-    this.openNavigationTab('Settings');
+    this.openNavigationTab('Reports');
     this.selectSubMenu('Block Inventory');
   }
 
   searchBlocks() {
-    cy.get('#id_form-0-block').select('ask_cfpb.models.blocks.Tip');
-    // This form doesn't follow the standard Wagtail Format
-    cy.get('form[action="/admin/inventory/"]').submit();
+    // Use the Select2 widgets per https://www.cypress.io/blog/2020/03/20/working-with-select-elements-and-select2-widgets-in-cypress/
+    cy.get('.select2-container').first().click()
+    cy.get('input.select2-search__field').first().type(
+        'ask_cfpb.models.blocks.Tip{enter}'
+      )
+    cy.get('#id_include_page_blocks').invoke('val').should('deep.equal', ['ask_cfpb.models.blocks.Tip', ])
+
+    // confirm Select2 widget renders the state name
+    cy.get('.select2-selection__choice').first().should(
+      (list) => {
+        expect(list[0].title).to.equal('ask_cfpb.models.blocks.Tip')
+      }
+    )
+
+    cy.get('.report__filters form').submit();
   }
 
   searchResults() {


### PR DESCRIPTION
This updates wagtail-inventory to the recently released version 2.0.0. This converts the block inventory into a Wagtail report, reviewable in the "Reports" menu.

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
