### PR TITLE
TDP: Remove `results-road` CSS classes

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/survey-results.less
@@ -1,9 +1,9 @@
 .initials-display {
   /**
-     * Hidden to avoid a situation where a student shares online a URL that
-     * displays a naughty word as initials. At least this requires the end-user
-     * to open print preview.
-     */
+   * Hidden to avoid a situation where a student shares online a URL that
+   * displays a naughty word as initials. At least this requires the end-user
+   * to open print preview.
+   */
   display: none;
 
   @media print {
@@ -78,69 +78,6 @@
     }
     path {
       fill: #20aa3f;
-    }
-  }
-}
-
-.results-road {
-  display: flex;
-  margin: 2em 0;
-}
-
-.results-road__starting-out {
-  width: 25%;
-}
-
-.results-road__box {
-  padding: 2.5rem;
-  position: relative;
-  &:before {
-    background-image: linear-gradient(
-      90deg,
-      #000,
-      #000 75%,
-      transparent 75%,
-      transparent 100%
-    );
-    background-size: 14px 1px;
-    content: '';
-    left: 0;
-    height: 1px;
-    position: absolute;
-    width: 100%;
-  }
-}
-
-.results-road--overall {
-  .results-road__box {
-    background-color: #e2efd8;
-    border: 1px solid #1e9642;
-  }
-  .results-road__on-the-road {
-    .results-road__box {
-      background-color: #c7e5b3;
-    }
-  }
-  .results-road__well-on-your-way {
-    .results-road__box {
-      background-color: #addc91;
-    }
-  }
-}
-
-.results-road--planning {
-  .results-road__box {
-    background-color: #daf1f0;
-    border: 1px solid #3b8a86;
-  }
-  .results-road__on-the-road {
-    .results-road__box {
-      background-color: #b3d8d6;
-    }
-  }
-  .results-road__well-on-your-way {
-    .results-road__box {
-      background-color: #93c1bf;
     }
   }
 }


### PR DESCRIPTION
I can't find any references to these `results-road` classes in the crawler or template files.

## Removals

- TDP: Remove `results-road` CSS classes

## How to test this PR

1. PR checks should pass.
