### PR TITLE
Paying for College disclosures: Remove unused template blocks

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -4,34 +4,11 @@
     Understanding your financial aid offer | Consumer Financial Protection Bureau
 {% endblock %}
 
-{% block page_meta %}
-<meta charset="UTF-8" />
-<meta property="og:title" content="{{ page.title }} &gt; Consumer Financial Protection Bureau"/>
-<meta property="og:url" content="{{ URL }}"/>
-{% endblock %}
-
-{% block open_graph_image %}
-<meta property="og:image"
-    content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-student-loans.original.png">
-<meta property="twitter:image"
-    content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-student-loans.original.png">
-{% endblock %}
-
-{% block page_viewport %}
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-{% endblock %}
-
 {% block css %}
 {{ super() }}
 <link rel="stylesheet" href="{{ static('apps/paying-for-college/css/main.css') }}">
 {% endblock %}
 
-{% block responsive_nav %}
-<div class="hidden" id="test-store"></div>
-<a class="toggle-menu" href="#" aria-label="Menu">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 784.5 1200" class="cf-icon-svg"><path d="M65 370.5h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65H65c-35.9 0-65 29.1-65 65s29.1 65 65 65zM719.5 515H65c-35.9 0-65 29.1-65 65s29.1 65 65 65h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65zM719.5 789.4H65c-35.9 0-65 29.1-65 65s29.1 65 65 65h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65z"></path></svg>
-</a>
-{% endblock %}
 {% block content %}
 <main id="main" data-context="{{url_root}}">
     <div id="financial-offer" class="understanding-financial-aid-offer">

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure_technote.html
@@ -4,36 +4,6 @@
     Understanding your financial aid offer | Consumer Financial Protection Bureau
 {% endblock %}
 
-{% block page_meta %}
-<meta charset="UTF-8" />
-<meta property="og:title" content="{{ page.title }} &gt; Consumer Financial Protection Bureau"/>
-<meta property="og:url" content="{{ URL }}"/>
-{% endblock %}
-
-{% block open_graph_image %}
-<meta property="og:image"
-    content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-student-loans.original.png">
-<meta property="twitter:image"
-    content="https://s3.amazonaws.com/files.consumerfinance.gov/f/images/ask-cfpb-social-student-loans.original.png">
-{% endblock %}
-
-{% block page_viewport %}
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
-{% endblock %}
-
-{% block app_css %}
-<!--[if gt IE 8]><!-->
-    <link rel="stylesheet" href="{{ static('apps/paying-for-college/css/main.css') }}">
-<!--<![endif]-->
-
-
-{% endblock %}
-{% block responsive_nav %}
-<a class="toggle-menu" href="#" aria-label="Menu">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 784.5 1200" class="cf-icon-svg"><path d="M65 370.5h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65H65c-35.9 0-65 29.1-65 65s29.1 65 65 65zM719.5 515H65c-35.9 0-65 29.1-65 65s29.1 65 65 65h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65zM719.5 789.4H65c-35.9 0-65 29.1-65 65s29.1 65 65 65h654.5c35.9 0 65-29.1 65-65s-29.1-65-65-65z"></path></svg>
-</a>
-{% endblock %}
-
 {% block content %}
 <main class="understanding-financial-aid-offer" data-context="{{url_root}}">
     <div class="content content__2-1 content__bleedbar">
@@ -1066,9 +1036,4 @@
         </div>
     </div>
 </main>
-
 {% endblock %}
-
-{% block javascript scoped %}
-{{ super() }}
-{% endblock javascript %}


### PR DESCRIPTION
If these blocks don't exist in the extended template, it doesn't look like they get rendered.

## Removals

- Paying for College disclosures: Remove unused template blocks.

## How to test this PR

1. Visit the [disclosures tool](https://[www.consumerfinance.gov](localhost:8000)/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=154022&pid=BAHCA&totl=70950&tuit=14160&hous=7109&book=1150&tran=500&othr=4743&pelg=0&schg=&stag=&othg=&mta=&gib=&wkst=0&ppl=&parl=&perl=&subl=3500&unsl=6000&gpl=&prvl=&prvi=&prvf=&insl=&insi=&inst=&oid=4D0B9265B45716DF4B81EEB4BE117E1DF69871AF) 
2. It should render as normal with no errors. 
3. Click "Yes, this is correct"
4. Click "[Get details about how this tool works](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/about-this-tool/)" and it should render as normal with no errors.
