### PR TITLE
Paying for College disclosures: Replace hardcoded icons with standard icon loader

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -2098,7 +2098,7 @@
                                         <p class="cf-notification_text
                                         metric_notification_text__worse">
                                             <span class="cf-notification_icon
-                                            cf-notification_icon__error">
+                                                         cf-notification_icon__error">
                                                 {{ svg_icon('error-round') }}
                                             </span>
                                             Lower graduation rate than national
@@ -2228,7 +2228,7 @@
                                         <p class="cf-notification_text
                                         metric_notification_text__worse">
                                             <span class="cf-notification_icon
-                                            cf-notification_icon__error">
+                                                         cf-notification_icon__error">
                                                 {{ svg_icon('error-round') }}
                                             </span>
                                             Projected first-year salary is

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -460,11 +460,11 @@
                                             data-financial="pell"
                                             autocorrect="off" value="0">
                                             <div class="aid-form_calc-error" data-calc-error="pell">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 The maximum that can be awarded per year is <span data-cap="pell">$0</span>
                                             </div>
                                             <div class="aid-form_calc-error" data-calc-error="overBorrowing">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 The total of your federal aid can't be more than the total cost of attendance
                                             </div>
                                         </div>
@@ -553,7 +553,7 @@
                                             autocorrect="off" value="0">
                                             <div class="aid-form_calc-error"
                                             data-calc-error="militaryTuitionAssistance">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 The maximum that can be awarded per
                                                 year is <span
                                                 data-cap="militaryTuitionAssistance">$0</span>
@@ -958,7 +958,7 @@
                                             data-financial="perkins"
                                             autocorrect="off" value="0">
                                             <div class="aid-form_calc-error" data-calc-error="perkins">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 The maximum that can be borrowed per year is
                                                 <span data-cap="perkins">$0</span>
                                             </div>
@@ -999,7 +999,7 @@
                                             data-financial="directSubsidized"
                                             autocorrect="off" value="0">
                                             <div class="aid-form_calc-error" data-calc-error="directSubsidized">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 The maximum that can be borrowed per year is
                                                 <span data-cap="directSubsidized">$0</span>
                                             </div>
@@ -1052,7 +1052,7 @@
                                             data-financial="directUnsubsidized"
                                             autocorrect="off" value="0">
                                             <div class="aid-form_calc-error" data-calc-error="directUnsubsidized">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                                 <span data-calc-error_content="directUnsubsidized">The maximum subsidized and unsubsidized loans that can be borrowed per year is</span>
                                                 <span data-cap="directUnsubsidized">$0</span>
                                             </div>
@@ -1176,7 +1176,7 @@
                                                 type="button"
                                                 title="Remove this private loan">
                                                     Remove
-                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                    {{ svg_icon('error-round') }}
                                                 </span>
                                                 </button>
                                             </div>
@@ -1288,7 +1288,7 @@
                                                 type="button"
                                                 title="Remove this private loan">
                                                     Remove
-                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                    {{ svg_icon('error-round') }}
                                                 </span>
                                                 </button>
                                             </div>
@@ -1396,7 +1396,7 @@
                                                 type="button"
                                                 title="Remove this private loan">
                                                     Remove
-                                                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                    {{ svg_icon('error-round') }}
                                                 </span>
                                                 </button>
                                             </div>
@@ -1497,7 +1497,7 @@
                                         private-loans_add-btn" type="button"
                                         title="Add another private loan"
                                         data-add-loan-button="true">
-                                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
+                                            {{ svg_icon('plus-round') }}
                                             Add another private loan
                                         </button>
                                     </div>
@@ -2099,7 +2099,7 @@
                                         metric_notification_text__worse">
                                             <span class="cf-notification_icon
                                             cf-notification_icon__error">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                             </span>
                                             Lower graduation rate than national
                                             average
@@ -2229,7 +2229,7 @@
                                         metric_notification_text__worse">
                                             <span class="cf-notification_icon
                                             cf-notification_icon__error">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                             </span>
                                             Projected first-year salary is
                                             lower than total student debt
@@ -2508,7 +2508,7 @@
                                           metric_notification_text__worse">
                                             <span class="cf-notification_icon
                                                          cf-notification_icon__error">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                             </span>
                                               Loan payment is higher than
                                               recommended 8% of salary
@@ -2919,7 +2919,7 @@
                                         metric_notification_text__worse">
                                             <span class="cf-notification_icon
                                                          cf-notification_icon__error">
-                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm261.8 692.2c19.4 19.6 19.3 51.3-.3 70.7-19.5 19.3-50.9 19.3-70.4 0L499.6 676.6 308 868.1c-19.6 19.4-51.3 19.3-70.7-.3-19.3-19.5-19.3-50.9 0-70.4l191.6-191.5-191.6-191.6c-19.3-19.8-18.9-51.4.9-70.7 19.4-18.9 50.4-18.9 69.8 0l191.6 191.5 191.5-191.5c19.6-19.4 51.3-19.3 70.7.3 19.3 19.5 19.3 50.9 0 70.4L570.3 605.9l191.5 191.5z"></path></svg>
+                                                {{ svg_icon('error-round') }}
                                             </span>
                                             Higher default rate than national
                                             average
@@ -3281,7 +3281,7 @@
                                 type="button"
                                 data-gtm_ignore="true">
                                     <span class="a-btn_icon__on-left">
-                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 761.9 1200" class="cf-icon-svg"><path d="M203.7 889.9h355v50h-355zM203.7 788.4h355v50h-355z"></path><path d="M670.9 368.4L477.3 174.8H122.1c-16.5 0-30 13.5-30 30V500H70c-38.5 0-70 31.5-70 70v305.5c0 38.5 31.5 70 70 70h22.1v60.5c0 16.5 13.5 30 30 30h518.8c16.5 0 30-13.5 30-30v-60.5h21c38.5 0 70-31.5 70-70V569.9c0-38.5-31.5-70-70-70h-21V368.4zm-60 607.6H152.1V742.7h458.8V976zM425 234.8v146.4c0 21.1 17.3 38.4 38.4 38.4h147.5V500H152.1V234.8H425zm237.9 403.9c-16.6 0-30-13.4-30-30s13.4-30 30-30 30 13.4 30 30-13.4 30-30 30z"></path></svg>
+                                        {{ svg_icon('print') }}
                                     </span>
                                     Print
                                 </button>


### PR DESCRIPTION
## Changes

- Paying for College disclosures: Replace hardcoded icons with standard icon loader


## How to test this PR

1. Visit the [disclosures tool](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=154022&pid=BAHCA&totl=70950&tuit=14160&hous=7109&book=1150&tran=500&othr=4743&pelg=0&schg=&stag=&othg=&mta=&gib=&wkst=0&ppl=&parl=&perl=&subl=3500&unsl=6000&gpl=&prvl=&prvi=&prvf=&insl=&insi=&inst=&oid=4D0B9265B45716DF4B81EEB4BE117E1DF69871AF) 
1. start the tool and enter a huge number for the pell grant field to get an error message with a red error icon.
2. Scroll down to see "Add another private loan" and icon.
3. click through to the end of the tool to see print button and icon.


## Screenshots

<img width="145" alt="Screen Shot 2023-03-17 at 4 37 09 PM" src="https://user-images.githubusercontent.com/704760/226035898-86e6ad0e-7bae-4647-8f01-6d8d95581a8e.png">

<img width="564" alt="Screen Shot 2023-03-17 at 4 36 36 PM" src="https://user-images.githubusercontent.com/704760/226035890-8c344c9b-a615-4a6e-b626-007d8a3d8c8c.png">

<img width="294" alt="Screen Shot 2023-03-17 at 4 36 45 PM" src="https://user-images.githubusercontent.com/704760/226035895-4426daa8-744d-4f9d-862e-5d4ffc2111e0.png">
