### PR TITLE
TDP: update icon loader

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/bb-tool.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/bb-tool.html
@@ -19,7 +19,7 @@
         <div class="o-tour_screen o-tour_screen__intro">
             <div class="content_wrapper">
                 <nav class="breadcrumbs" aria-label="Breadcrumbs">
-                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 559.6 1200" class="cf-icon-svg"><path d="M494.5 1090.7c-17.3 0-33.8-6.8-46-19L19 642.1c-25.4-25.4-25.4-66.5 0-91.9l429.5-429.5c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L156.9 596.2l383.6 383.6c25.4 25.4 25.4 66.5.1 91.9-12.3 12.2-28.8 19-46.1 19z"></path></svg>
+                    {{ svg_icon('left') }}
                     <a class="breadcrumbs_link" href="/consumer-tools/educator-tools/youth-financial-education/">
                         Youth financial education
                     </a>
@@ -82,7 +82,9 @@
                             </p>
                             <a class="a-link a-link__icon" href="#youth-financial-capability" data-scroll>
                                 <span class="a-link_text">Next stop: Nuturing youth financial capability</span>
-                                <span class="a-icon">{{ svg_icon('arrow-down-round') }}</span>
+                                <span class="a-icon">
+                                    {{ svg_icon('arrow-down-round') }}
+                                </span>
                             </a>
                         </div>
                     </div>
@@ -114,7 +116,9 @@
                             </p>
                             <a class="a-link a-link__icon" href="#building-blocks" data-scroll>
                                 <span class="a-link_text">Next stop: The building blocks of financial capability</span>
-                                <span class="a-icon">{{ svg_icon('arrow-down-round') }}</span>
+                                <span class="a-icon">
+                                    {{ svg_icon('arrow-down-round') }}
+                                </span>
                             </a>
                         </div>
                     </div>
@@ -161,19 +165,25 @@
                                     <ul class="o-tour_building-blocks-menu">
                                         <li>
                                             <a class="a-link a-link__icon" href="#executive-function" data-scroll>
-                                                <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><circle cx="14" cy="14" r="14" fill="#b4d2d1"/><path d="M22.85,13.15v1.7a.67.67,0,0,1-.55.65l-1.39.25h-.13a7,7,0,0,1-.75,1.8l.09.1.81,1.16a.68.68,0,0,1-.07.85l-1.2,1.2a.68.68,0,0,1-.85.07l-1.16-.81-.1-.09a7.12,7.12,0,0,1-1.82.75.74.74,0,0,1,0,.21l-.21,1.24a.79.79,0,0,1-.75.62H13.23a.79.79,0,0,1-.75-.62L12.27,21a.74.74,0,0,1,0-.21A7.12,7.12,0,0,1,10.45,20l-.1.09-1.16.81a.68.68,0,0,1-.85-.07l-1.2-1.2a.68.68,0,0,1-.07-.85l.81-1.16.09-.1a6.63,6.63,0,0,1-.74-1.8H7.09L5.7,15.5a.67.67,0,0,1-.55-.65v-1.7a.67.67,0,0,1,.55-.65l1.39-.25h.14A6.63,6.63,0,0,1,8,10.45l-.09-.1L7.07,9.19a.68.68,0,0,1,.07-.85l1.2-1.2a.68.68,0,0,1,.85-.07l1.16.81.1.09a7,7,0,0,1,1.8-.75.62.62,0,0,1,0-.13L12.5,5.7a.67.67,0,0,1,.65-.55h1.7a.67.67,0,0,1,.65.55l.25,1.39a.56.56,0,0,1,0,.13,7,7,0,0,1,1.8.75l.1-.09,1.16-.81a.68.68,0,0,1,.85.07l1.2,1.2a.68.68,0,0,1,.07.85l-.81,1.16-.09.1a7,7,0,0,1,.75,1.8h.13l1.39.25A.67.67,0,0,1,22.85,13.15ZM17,14a3,3,0,1,0-3,3A3,3,0,0,0,17,14Z" fill="#257675"/></svg></span>
+                                                <span class="a-icon">
+                                                    {# This is a custom version of the cf-icon-svg__settings icon. #}
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><circle cx="14" cy="14" r="14" fill="#b4d2d1"/><path d="M22.85,13.15v1.7a.67.67,0,0,1-.55.65l-1.39.25h-.13a7,7,0,0,1-.75,1.8l.09.1.81,1.16a.68.68,0,0,1-.07.85l-1.2,1.2a.68.68,0,0,1-.85.07l-1.16-.81-.1-.09a7.12,7.12,0,0,1-1.82.75.74.74,0,0,1,0,.21l-.21,1.24a.79.79,0,0,1-.75.62H13.23a.79.79,0,0,1-.75-.62L12.27,21a.74.74,0,0,1,0-.21A7.12,7.12,0,0,1,10.45,20l-.1.09-1.16.81a.68.68,0,0,1-.85-.07l-1.2-1.2a.68.68,0,0,1-.07-.85l.81-1.16.09-.1a6.63,6.63,0,0,1-.74-1.8H7.09L5.7,15.5a.67.67,0,0,1-.55-.65v-1.7a.67.67,0,0,1,.55-.65l1.39-.25h.14A6.63,6.63,0,0,1,8,10.45l-.09-.1L7.07,9.19a.68.68,0,0,1,.07-.85l1.2-1.2a.68.68,0,0,1,.85-.07l1.16.81.1.09a7,7,0,0,1,1.8-.75.62.62,0,0,1,0-.13L12.5,5.7a.67.67,0,0,1,.65-.55h1.7a.67.67,0,0,1,.65.55l.25,1.39a.56.56,0,0,1,0,.13,7,7,0,0,1,1.8.75l.1-.09,1.16-.81a.68.68,0,0,1,.85.07l1.2,1.2a.68.68,0,0,1,.07.85l-.81,1.16-.09.1a7,7,0,0,1,.75,1.8h.13l1.39.25A.67.67,0,0,1,22.85,13.15ZM17,14a3,3,0,1,0-3,3A3,3,0,0,0,17,14Z" fill="#257675"/></svg></span>
                                                 <span class="a-link_text">Executive function</span>
                                             </a>
                                         </li>
                                         <li>
                                             <a class="a-link a-link__icon" href="#financial-habits" data-scroll>
-                                                <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><path d="M28,14A14,14,0,1,1,14,0,14,14,0,0,1,28,14" fill="#afd2f2"/><path d="M16.89,13.25l-3.13,5.42a.86.86,0,0,1-.66.42H13a.85.85,0,0,1-.65-.3l-1.75-2.1a.88.88,0,0,1-.19-.62.85.85,0,0,1,.3-.57.81.81,0,0,1,.62-.19.83.83,0,0,1,.57.3l1,1.17,2.53-4.37a.82.82,0,0,1,.51-.4.8.8,0,0,1,.64.09.85.85,0,0,1,.31,1.15M11.84,8.7h3.75a.68.68,0,0,1,.68.68.67.67,0,0,1-.68.67H11.84a.67.67,0,0,1-.67-.67.68.68,0,0,1,.67-.68m10.77,3.15h-.7a7.12,7.12,0,0,0-1.64-2.74,6.59,6.59,0,0,1,.18-2.45A6.89,6.89,0,0,1,21,5.26.34.34,0,0,0,21,5.12a.39.39,0,0,0-.34-.43.42.42,0,0,0-.25,0L16.51,7a7,7,0,0,0-1.45-.15H12A7.22,7.22,0,0,0,5,12.69a1.4,1.4,0,0,0,0,2.8,7.18,7.18,0,0,0,2,3.69c.12.13.24.24.37.36V22.6a.71.71,0,0,0,.72.71h2.29A.71.71,0,0,0,11,22.6V21.23a8.24,8.24,0,0,0,1,.07h3a8.24,8.24,0,0,0,1-.07V22.6a.71.71,0,0,0,.72.71h2.29a.72.72,0,0,0,.72-.71V19.54c.13-.12.25-.23.37-.36a7.15,7.15,0,0,0,1.76-2.86h.7a1.79,1.79,0,0,0,1.79-1.79v-.89a1.8,1.8,0,0,0-1.79-1.79" fill="#0072ce"/></svg></span>
+                                                <span class="a-icon">
+                                                    {# This is a custom version of the cf-icon-svg__piggy-bank-check icon. #}
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><path d="M28,14A14,14,0,1,1,14,0,14,14,0,0,1,28,14" fill="#afd2f2"/><path d="M16.89,13.25l-3.13,5.42a.86.86,0,0,1-.66.42H13a.85.85,0,0,1-.65-.3l-1.75-2.1a.88.88,0,0,1-.19-.62.85.85,0,0,1,.3-.57.81.81,0,0,1,.62-.19.83.83,0,0,1,.57.3l1,1.17,2.53-4.37a.82.82,0,0,1,.51-.4.8.8,0,0,1,.64.09.85.85,0,0,1,.31,1.15M11.84,8.7h3.75a.68.68,0,0,1,.68.68.67.67,0,0,1-.68.67H11.84a.67.67,0,0,1-.67-.67.68.68,0,0,1,.67-.68m10.77,3.15h-.7a7.12,7.12,0,0,0-1.64-2.74,6.59,6.59,0,0,1,.18-2.45A6.89,6.89,0,0,1,21,5.26.34.34,0,0,0,21,5.12a.39.39,0,0,0-.34-.43.42.42,0,0,0-.25,0L16.51,7a7,7,0,0,0-1.45-.15H12A7.22,7.22,0,0,0,5,12.69a1.4,1.4,0,0,0,0,2.8,7.18,7.18,0,0,0,2,3.69c.12.13.24.24.37.36V22.6a.71.71,0,0,0,.72.71h2.29A.71.71,0,0,0,11,22.6V21.23a8.24,8.24,0,0,0,1,.07h3a8.24,8.24,0,0,0,1-.07V22.6a.71.71,0,0,0,.72.71h2.29a.72.72,0,0,0,.72-.71V19.54c.13-.12.25-.23.37-.36a7.15,7.15,0,0,0,1.76-2.86h.7a1.79,1.79,0,0,0,1.79-1.79v-.89a1.8,1.8,0,0,0-1.79-1.79" fill="#0072ce"/></svg></span>
                                                 <span class="a-link_text">Financial habits and norms</span>
                                             </a>
                                         </li>
                                         <li>
                                             <a class="a-link a-link__icon" href="#financial-knowledge" data-scroll>
-                                                <span class="a-icon"><svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><circle cx="14" cy="14" r="14" fill="#ffe1b9"/><path d="M21.3,6.47l-5.46.69a.56.56,0,0,0-.41.67.55.55,0,0,0,.17.28l1.47,1.47-3,3h-.13l-3-3,1.47-1.45a.54.54,0,0,0,0-.78.43.43,0,0,0-.23-.14L6.69,6.47a.54.54,0,0,0-.67.4.42.42,0,0,0,0,.27l.7,5.46a.55.55,0,0,0,.67.39.58.58,0,0,0,.25-.15l1.48-1.47,3.46,3.46.15.12v6.89a1.28,1.28,0,1,0,2.55,0V14.92l.15-.12,3.46-3.46,1.47,1.47a.56.56,0,0,0,.79,0,.48.48,0,0,0,.14-.25L22,7.1a.54.54,0,0,0-.44-.64A.43.43,0,0,0,21.3,6.47Z" fill="#ed881b"/></svg></span>
+                                                <span class="a-icon">
+                                                    {# This is a custom version of the cf-icon-svg__split icon. #}
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28"><circle cx="14" cy="14" r="14" fill="#ffe1b9"/><path d="M21.3,6.47l-5.46.69a.56.56,0,0,0-.41.67.55.55,0,0,0,.17.28l1.47,1.47-3,3h-.13l-3-3,1.47-1.45a.54.54,0,0,0,0-.78.43.43,0,0,0-.23-.14L6.69,6.47a.54.54,0,0,0-.67.4.42.42,0,0,0,0,.27l.7,5.46a.55.55,0,0,0,.67.39.58.58,0,0,0,.25-.15l1.48-1.47,3.46,3.46.15.12v6.89a1.28,1.28,0,1,0,2.55,0V14.92l.15-.12,3.46-3.46,1.47,1.47a.56.56,0,0,0,.79,0,.48.48,0,0,0,.14-.25L22,7.1a.54.54,0,0,0-.44-.64A.43.43,0,0,0,21.3,6.47Z" fill="#ed881b"/></svg></span>
                                                 <span class="a-link_text">Financial knowledge and decision-making skills</span>
                                             </a>
                                         </li>
@@ -209,7 +219,9 @@
                                         </p>
                                         <a class="a-link a-link__icon" href="#financial-habits" data-scroll>
                                             <span class="a-link_text">Next: Financial habits and norms</span>
-                                            <span class="a-icon">{{ svg_icon('arrow-down-round') }}</span>
+                                            <span class="a-icon">
+                                                {{ svg_icon('arrow-down-round') }}
+                                            </span>
                                         </a>
                                     </div>
                                 </div>
@@ -241,7 +253,9 @@
                                         </p>
                                         <a class="a-link a-link__icon" href="#financial-knowledge" data-scroll>
                                             <span class="a-link_text">Next: Financial knowledge and decision-making skills</span>
-                                            <span class="a-icon">{{ svg_icon('arrow-down-round') }}</span>
+                                            <span class="a-icon">
+                                                {{ svg_icon('arrow-down-round') }}
+                                            </span>
                                         </a>
                                     </div>
                                 </div>
@@ -273,7 +287,9 @@
                                         </p>
                                         <a class="a-link a-link__icon" href="#integrating-the-building-blocks" data-scroll>
                                             <span class="a-link_text">Next stop: Integrating the building blocks</span>
-                                            <span class="a-icon">{{ svg_icon('arrow-down-round') }}</span>
+                                            <span class="a-icon">
+                                                {{ svg_icon('arrow-down-round') }}
+                                            </span>
                                         </a>
                                     </div>
                                 </div>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
@@ -34,16 +34,20 @@
 
                 <div class="m-notification
                             m-notification__error">
-                    {% include 'icons/error-round.svg' %}
+                    {{ svg_icon('error-round') }}
                     <div class="m-notification_content">
-                        <div class="h4 m-notification_message">You've missed a question. Click the
-                            link(s) to jump to them.</div>
+                        <div class="h4 m-notification_message">
+                            You've missed a question.
+                            Click the link(s) to jump to them.
+                        </div>
                     </div>
                     <ul class="m-notification_explanation"></ul>
                 </div>
                 <div hidden class="a-form-alert a-form-alert__error tdp-survey-alert--clone" role="alert">
-                    {% include 'icons/error-round.svg' %}
-                    <span class="a-form-alert_text">You forgot to answer this question.</span>
+                    {{ svg_icon('error-round') }}
+                    <span class="a-form-alert_text">
+                        You forgot to answer this question.
+                    </span>
                 </div>
 
                 {# E.g. "./6-8/before-page-2.html" #}
@@ -68,19 +72,25 @@
                     <div class="m-btn-group">
                     {% if wizard.steps.prev %}
                         <a class="a-btn" href="../{{ wizard.steps.prev }}/">
-                            <span class="a-btn_icon a-btn_icon__on-left">{% include 'icons/left.svg' %}</span>
+                            <span class="a-btn_icon a-btn_icon__on-left">
+                                {{ svg_icon('left') }}
+                            </span>
                             <span class="a-btn_text">Back</span>
                         </a>
                     {% endif %}
                     {% if wizard.steps.next %}
                         <button class="a-btn" type="submit">
                             <span class="a-btn_text">Next</span>
-                            <span class="a-btn_icon a-btn_icon__on-right">{% include 'icons/right.svg' %}</span>
+                            <span class="a-btn_icon a-btn_icon__on-right">
+                                {{ svg_icon('right') }}
+                            </span>
                         </button>
                     {% else %}
                         <button class="a-btn" type="submit">
                             <span class="a-btn_text">Get my results</span>
-                            <span class="a-btn_icon a-btn_icon__on-right">{% include 'icons/right.svg' %}</span>
+                            <span class="a-btn_icon a-btn_icon__on-right">
+                                {{ svg_icon('right') }}
+                            </span>
                         </button>
                     {% endif %}
                     </div>
@@ -158,7 +168,7 @@
                             </div>
                             <div class="tdp-survey-section__edit"><span>edit</span></div>
                             <div class="tdp-survey-section__icon">
-                                {% include 'icons/approved-round.svg' %}
+                                {{ svg_icon('approved-round') }}
                             </div>
                         </a>
                     {% endfor %}

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/print.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/print.html
@@ -12,14 +12,19 @@
     <div class="o-modal_content">
       <div class="o-modal_body">
         <button class="o-modal_close a-btn a-btn__link" type="button">
-          Close<span class="a-icon a-icon__large a-icon__space-before">{% include 'icons/close-round.svg' %}</span>
+          Close
+          <span class="a-icon a-icon__large a-icon__space-before">
+            {{ svg_icon('error-round') }}
+          </span>
         </button>
         <h2 id="{{ id }}_title" class="h3">Print</h2>
         <div id="{{ id }}_desc">
           <div class="m-notification m-notification__error tdp-survey__initials-error">
-            {% include 'icons/error-round.svg' %}
+            {{ svg_icon('error-round') }}
             <div class="m-notification_content">
-              <div class="h4 m-notification_message">You forgot to enter your initials.</div>
+              <div class="h4 m-notification_message">
+                You forgot to enter your initials.
+              </div>
             </div>
           </div>
 

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/privacy.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/privacy.html
@@ -11,7 +11,10 @@
     <div class="o-modal_content">
       <div class="o-modal_body">
         <button class="o-modal_close a-btn a-btn__link" type="button">
-          Close<span class="a-icon a-icon__large a-icon__space-before">{% include 'icons/close-round.svg' %}</span>
+          Close
+          <span class="a-icon a-icon__large a-icon__space-before">
+            {{ svg_icon('error-round') }}
+          </span>
         </button>
         <h2 id="{{ id }}_title" class="h3">Privacy Notice</h2>
         <div id="{{ id }}_desc">

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/reset.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/reset.html
@@ -11,7 +11,10 @@
     <div class="o-modal_content">
       <div class="o-modal_body">
         <button class="o-modal_close a-btn a-btn__link" type="button">
-          Close<span class="a-icon a-icon__large a-icon__space-before">{% include 'icons/close-round.svg' %}</span>
+          Close
+          <span class="a-icon a-icon__large a-icon__space-before">
+            {{ svg_icon('error-round') }}
+          </span>
         </button>
         <h2 id="{{ id }}_title" class="h3">Reset survey and start over</h2>
         <div id="{{ id }}_desc">

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/restart.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/restart.html
@@ -11,7 +11,10 @@
     <div class="o-modal_content">
       <div class="o-modal_body">
         <button class="o-modal_close a-btn a-btn__link" type="button">
-          Close<span class="a-icon a-icon__large a-icon__space-before">{% include 'icons/close-round.svg' %}</span>
+          Close
+          <span class="a-icon a-icon__large a-icon__space-before">
+            {{ svg_icon('error-round') }}
+          </span>
         </button>
         <h2 id="{{ id }}_title" class="h3">Starting over</h2>
         <div id="{{ id }}_desc">

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/share-url.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/modals/share-url.html
@@ -12,12 +12,15 @@
     <div class="o-modal_content">
       <div class="o-modal_body">
         <button class="o-modal_close a-btn a-btn__link" type="button">
-          Close<span class="a-icon a-icon__large a-icon__space-before">{% include 'icons/close-round.svg' %}</span>
+          Close
+          <span class="a-icon a-icon__large a-icon__space-before">
+            {{ svg_icon('error-round') }}
+          </span>
         </button>
         <h2 id="{{ id }}_title" class="h3">Share</h2>
         <div id="{{ id }}_desc">
           <div class="m-notification m-notification__error tdp-survey__initials-error">
-            {% include 'icons/error-round.svg' %}
+            {{ svg_icon('error-round') }}
             <div class="m-notification_content">
               <div class="h4 m-notification_message">You forgot to enter your initials.</div>
             </div>
@@ -43,7 +46,7 @@
             <div>
               <button class="a-btn">Copy link</button>
               <div class="share-output__copied" hidden>
-                {% include 'icons/approved-round.svg' %}
+                {{ svg_icon('approved-round') }}
                 <div>Link copied to clipboard</div>
               </div>
             </div>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
@@ -79,11 +79,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -118,11 +118,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -157,11 +157,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
@@ -74,11 +74,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -131,11 +131,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -189,11 +189,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
@@ -74,11 +74,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -131,11 +131,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>
@@ -189,11 +189,11 @@
                     <span class="o-expandable_link">
                 <span class="o-expandable_cue o-expandable_cue-open">
                     <span class="u-visually-hidden-on-mobile">Show</span>
-                    {% include 'icons/plus-round.svg' %}
+                    {{ svg_icon('plus-round') }}
                 </span>
                 <span class="o-expandable_cue o-expandable_cue-close">
                     <span class="u-visually-hidden-on-mobile">Hide</span>
-                    {% include 'icons/minus-round.svg' %}
+                    {{ svg_icon('minus-round') }}
                 </span>
             </span>
                 </button>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-save.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-save.html
@@ -6,19 +6,21 @@
   <div class="m-btn-group">
     {% if is_student %}
     <button type="button" class="a-btn" data-open-modal="modal-print">
-      Print results {% include 'icons/print.svg' %}
+      Print results {{ svg_icon('print') }}
     </button>
-    <a href="/consumer-tools/save-as-pdf-instructions/" class="a-btn" target="_blank" rel="noopener noreferrer">How to save results
-      as a PDF {% include 'icons/external-link.svg' %}</a>
+    <a href="/consumer-tools/save-as-pdf-instructions/" class="a-btn" target="_blank" rel="noopener noreferrer">
+      How to save results as a PDF {{ svg_icon('external-link') }}
+    </a>
     <button type="button" class="a-btn" data-open-modal="modal-share-url">
-      Share results {% include 'icons/share.svg' %}
+      Share results {{ svg_icon('share') }}
     </button>
     {% else %}
     <button type="button" class="a-btn" onclick="window.print()">
-      Print results {% include 'icons/print.svg' %}
+      Print results {{ svg_icon('print') }}
     </button>
-    <a href="/consumer-tools/save-as-pdf-instructions/" class="a-btn" target="_blank" rel="noopener noreferrer">How to save results
-      as a PDF {% include 'icons/external-link.svg' %}</a>
+    <a href="/consumer-tools/save-as-pdf-instructions/" class="a-btn" target="_blank" rel="noopener noreferrer">
+      How to save results as a PDF {{ svg_icon('external-link') }}
+    </a>
     {% endif %}
   </div>
 </div>


### PR DESCRIPTION
## Changes

- Change SVG icon `include` syntax to use standard icon `svg_icon(…)` loader.
- Add code comments for custom forks of CFPB icons.
- Minor code formatting.


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/journey and see breadcrumb arrow is correct.
2. Visit http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/assess/survey/ and click through the tool to see that icons still show up.


## Screenshots

<img width="582" alt="Screen Shot 2023-03-21 at 6 44 23 AM" src="https://user-images.githubusercontent.com/704760/226583559-0f92a60f-d5b3-4012-98c2-021d8faa3daf.png">

<img width="500" alt="Screen Shot 2023-03-21 at 6 46 36 AM" src="https://user-images.githubusercontent.com/704760/226584082-2e23e45f-645f-433b-91b3-b4d2c8803a5f.png">

<img width="617" alt="Screen Shot 2023-03-21 at 6 41 29 AM" src="https://user-images.githubusercontent.com/704760/226583284-9f2f43ae-f313-4b96-8c62-0f348aa67f16.png">

<img width="380" alt="Screen Shot 2023-03-21 at 6 41 35 AM" src="https://user-images.githubusercontent.com/704760/226583287-88b6ea60-d029-4b16-8d0a-943abbd2fa22.png">
