### PR TITLE
Adjust where actions run

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   merge_group:
   schedule:
     - cron: '0 7 * * *'

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,6 +1,7 @@
 name: functional
 
 on:
+  pull_request:
   merge_group:
 
 jobs:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,7 +1,6 @@
 name: functional
 
 on:
-  pull_request:
   merge_group:
 
 jobs:
@@ -60,6 +59,9 @@ jobs:
 
     - name: Run Cypress
       uses: cypress-io/github-action@v5
+      with:
+          # Cancel the run after 2 failed tests
+          auto-cancel-after-failures: 2
       env:
           MAPBOX_ACCESS_TOKEN:  ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           CYPRESS_ENVIRONMENT: github

--- a/.github/workflows/helm_lint.yml
+++ b/.github/workflows/helm_lint.yml
@@ -1,6 +1,6 @@
 name: helmlint
 
-on: merge_group
+on: pull_request
 
 jobs:
   lint-test:

--- a/.github/workflows/publish_cfgov.yml
+++ b/.github/workflows/publish_cfgov.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-  merge_group:
+  pull_request:
 
   release:
 


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/7607 adjusted where the GH actions run with a merge queue. This PR makes some tweaks to that config.

## Changes

- Run helm_lint and publish_cfgov on the pull request instead of in the queue.
- Fast fail the functional tests if there are more than two failures.
