### PR TITLE
Remove `show_coverage.sh` script

### DIFF
--- a/show_coverage.sh
+++ b/show_coverage.sh
@@ -1,2 +1,0 @@
-cd cfgov
-coverage report -m


### PR DESCRIPTION
This was added in https://github.com/cfpb/consumerfinance.gov/pull/2468, but our instructions have since been updated to show coverage with `tox -e lint -e unittest -e coverage` or to directly call the `coverage` command https://github.com/cfpb/consumerfinance.gov/blob/main/docs/python-unit-tests.md#coverage

## Removals

- Remove `show_coverage.sh` script.

## How to test this PR

1. PR checks should pass.
