### PR TITLE
Event archive: Cleanup and simplify event links

### DIFF
--- a/cfgov/v1/jinja2/v1/events/_macros.html
+++ b/cfgov/v1/jinja2/v1/events/_macros.html
@@ -276,7 +276,7 @@
                     a-link__jump
                     a-link__external-link"
             href="{{ event.flickr_url }}">
-            See the album for the Event
+            See the album for the event
         </a>
     </p>
     {% endif %}

--- a/cfgov/v1/jinja2/v1/events/_macros.html
+++ b/cfgov/v1/jinja2/v1/events/_macros.html
@@ -268,54 +268,38 @@
 %}
 
 {% if event.speech_transcript or event.video_transcript or event.flickr_url %}
-<div class="block block__border-top">
-    <div class="event-archive_media-container
-                content-l
-                content-l__large-gutters">
-        {% if event.flickr_url %}
-        <section class="{{ col_classes }} block__padded-bottom">
-            <h4>Photography</h4>
-            <p class="u-flexible-container">
-                <img class="u-flexible-container_inner"
-                     src='{{ event.flickr_url }}' >
-            </p>
-            <p class="speech_link-container">
-                <a class="a-link
-                          a-link__jump
-                          a-link__external-link"
-                    href="{{ event.flickr_url }}">
-                    See the album for the Event
-                </a>
-            </p>
-        </section>
-        {% endif %}
-        <div class="{{ col_classes }}">
-            {% if event.speech_transcript %}
-            <section class="block block__flush-top">
-                <h4>Speech text</h4>
-                <p>
-                    <a href="{{ event.speech_transcript.url }}"
-                       class="a-link
-                              a-link__jump">
-                       Download speech
-                    </a>
-                </p>
-            </section>
-            {% endif %}
-            {% if event.video_transcript %}
-            <section class="block block__flush-bottom">
-                <h4>Video transcript</h4>
-                <p>
-                    <a href="{{ event.video_transcript.url }}"
-                       class="a-link
-                              a-link__jump">
-                       Download transcript
-                    </a>
-                </p>
-            </section>
-            {% endif %}
-        </div>
-    </div>
+<div class="block block__border-top block__padded-top">
+    {% if event.flickr_url %}
+    <p>
+        <h4>Photography</h4>
+        <a class="a-link
+                    a-link__jump
+                    a-link__external-link"
+            href="{{ event.flickr_url }}">
+            See the album for the Event
+        </a>
+    </p>
+    {% endif %}
+    {% if event.speech_transcript %}
+    <p>
+        <h4>Speech text</h4>
+        <a href="{{ event.speech_transcript.url }}"
+            class="a-link
+                    a-link__jump">
+            Download speech
+        </a>
+    </p>
+    {% endif %}
+    {% if event.video_transcript %}
+    <p>
+        <h4>Video transcript</h4>
+        <a href="{{ event.video_transcript.url }}"
+            class="a-link
+                    a-link__jump">
+            Download transcript
+        </a>
+    </p>
+    {% endif %}
 </div>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
Event archives can have a link to a flickr album, a video transcript, and a speech transcript. 
These three event archive pages have one of these:

https://www.consumerfinance.gov/about-us/events/archive-past-events/cfpb-rental-assistance-finder-tool-webinar/
https://www.consumerfinance.gov/about-us/events/archive-past-events/field-hearing-arbitration-albuquerque-nm/
https://www.consumerfinance.gov/about-us/events/archive-past-events/june-2016-consumer-advisory-board-meeting/

The flickr option creates an image that links to the flickr album URL, which isn't a valid image URL, so it shows as a broken image. 

## Changes

- Remove extraneous layout nesting.
- Remove unused `event-archive_media-container` and `speech_link-container` classes.
- Remove `content-l__large-gutters` class.
- Place each option block into a paragraph with a heading.


## How to test this PR

1. Visit localhost:8000/about-us/events/archive-past-events/june-2016-consumer-advisory-board-meeting/
and edit the page and add a speech and video transcript and preview the page.


## Screenshots

<img width="696" alt="Screen Shot 2023-03-22 at 2 59 24 PM" src="https://user-images.githubusercontent.com/704760/227010955-2c578fa2-cfd5-487c-8f17-ab355cad7767.png">