### PR TITLE
eregs: convert hardcoded icons to use standard loader

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -28,7 +28,7 @@
     </button>
 
     <div class="o-expandable_content">
-        {{ contents }}
+        {{ contents | safe }}
 
         <p><a href="{{ url }}">See interpretation of {% if section_title %}{{ section_title }}{% else %}this section{% endif %} in {{ interp_location }}</a></p>
     </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -16,13 +16,13 @@
                 <span class="u-visually-hidden-on-mobile">
                     Show
                 </span>
-                <svg viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"/></svg>
+                {{ svg_icon('plus-round') }}
             </span>
             <span class="o-expandable_cue o-expandable_cue-close">
                 <span class="u-visually-hidden-on-mobile">
                     Hide
                 </span>
-                <svg viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"/></svg>
+                {{ svg_icon('minus-round') }}
             </span>
         </span>
     </button>

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -25,7 +25,7 @@ opensearch-dsl==1.0.0
 opensearch-py==1.1.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.2
-regdown==1.0.5
+regdown==1.0.6
 requests==2.27.1
 requests-aws4auth==1.1.2
 s3transfer==0.5.2


### PR DESCRIPTION
## Changes

- eregs: convert hardcoded icons to use standard loader


## How to test this PR

1. Visit http://localhost:8000/rules-policy/regulations/1002/10/ and see that the expandable in the content has a show/hide icon.
 

## Screenshots

<img width="698" alt="Screen Shot 2023-03-22 at 3 14 57 PM" src="https://user-images.githubusercontent.com/704760/227012671-c147576b-bbdd-497d-b672-d3599b94e49c.png">
