### PR TITLE
Add `u-grid_column__top-divider` to info-unit-groups

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
@@ -176,12 +176,6 @@
 // .content_line
 @content_line: @gray-40;
 
-// .grid_column__top-divider
-@grid_column__top-divider: @gray-40;
-
-// .grid_column__top-divider
-@grid_column__left-divider: @gray-40;
-
 /* cf-pagination
    ========================================================================== */
 

--- a/cfgov/unprocessed/css/organisms/info-unit-group.less
+++ b/cfgov/unprocessed/css/organisms/info-unit-group.less
@@ -43,6 +43,23 @@
   tags:
     - cfgov-organisms
 */
+
+.u-grid_column__top-divider {
+  margin-top: unit(((@grid_gutter-width * 2) / @base-font-size-px), em);
+  border-left-width: @grid_gutter-width / 2;
+
+  &::before {
+    display: block;
+    height: 1px;
+    width: 100%;
+    margin-bottom: unit((@grid_gutter-width / @base-font-size-px), em);
+    margin-left: auto !important;
+    position: static;
+    background-color: @gray-40;
+    content: '';
+  }
+}
+
 .o-info-unit-group {
   .content-l {
     margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
@@ -60,13 +77,13 @@
   .content-l__top-divider {
     .content-l_col-1 + .content-l_col-1 {
       // Adds top divider between single-column info units
-      .grid_column__top-divider;
+      .u-grid_column__top-divider();
     }
   }
 
   .content-l__top-divider + .content-l__top-divider {
     // Adds top divider between multi-column info unit rows
-    .grid_column__top-divider;
+    .u-grid_column__top-divider();
     margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
   }
 
@@ -74,7 +91,7 @@
     // Adds top divider between info unit cols on small screens
     .content-l__top-divider {
       .content-l_col + .content-l_col {
-        .grid_column__top-divider;
+        .u-grid_column__top-divider();
         margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
       }
     }
@@ -84,7 +101,7 @@
     .content-l__top-divider + .content-l__top-divider {
       // Matches top divider width to cols on larger screens
       &:before {
-        // Overrides .grid_column__top-divider margin-left !important rule
+        // Overrides .u-grid_column__top-divider margin-left !important rule
         margin-left: 15px !important;
         margin-right: 15px;
         width: auto;


### PR DESCRIPTION
Companion to https://github.com/cfpb/design-system/pull/1613. We only use the `grid_column__top-divider` in info-unit-groups, so this moves this CSS from the design-system to accompany the info unit groups. This is only needed because the existing content layouts use borders for spacing. In the future, using a more modern approach such as CSS grid or flexbox in the info-unit-group layouts would allow this utility to be removed and a straight border style to be used instead.

## Additions

- `.u-grid_column__top-divider` mixin for info-unit-groups.

## How to test this PR

1. Visit a page like https://www.consumerfinance.gov/about-us/the-bureau/ and compare to localhost and the info-unit-group horizontal lines should still be present. If searching in the crawler, search for `content-l__top-divider`
