### PR TITLE
Fix typo | Add parentheses to mixins

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
@@ -179,7 +179,7 @@
 // .grid_column__top-divider
 @grid_column__top-divider: @gray-40;
 
-// .grid_column__top-divider
+// .grid_column__left-divider
 @grid_column__left-divider: @gray-40;
 
 /* cf-pagination

--- a/cfgov/unprocessed/css/organisms/info-unit-group.less
+++ b/cfgov/unprocessed/css/organisms/info-unit-group.less
@@ -60,13 +60,13 @@
   .content-l__top-divider {
     .content-l_col-1 + .content-l_col-1 {
       // Adds top divider between single-column info units
-      .grid_column__top-divider;
+      .grid_column__top-divider();
     }
   }
 
   .content-l__top-divider + .content-l__top-divider {
     // Adds top divider between multi-column info unit rows
-    .grid_column__top-divider;
+    .grid_column__top-divider();
     margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
   }
 
@@ -74,7 +74,7 @@
     // Adds top divider between info unit cols on small screens
     .content-l__top-divider {
       .content-l_col + .content-l_col {
-        .grid_column__top-divider;
+        .grid_column__top-divider();
         margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
       }
     }
@@ -84,7 +84,7 @@
     .content-l__top-divider + .content-l__top-divider {
       // Matches top divider width to cols on larger screens
       &:before {
-        // Overrides .grid_column__top-divider margin-left !important rule
+        // Overrides .grid_column__top-divider() margin-left !important rule
         margin-left: 15px !important;
         margin-right: 15px;
         width: auto;


### PR DESCRIPTION


## Changes

- Fix typo for `.grid_column__left-divider` comment.
- Add parentheses to `.grid_column__top-divider` mixins.


## How to test this PR

1. `yarn build` and visit a page like localhost:8000/about-us/the-bureau/ and the "empower", "enforce" info-unit-group should still have horizontal dividing lines.
