### PR TITLE
Bump regdown to 1.0.7

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -25,7 +25,7 @@ opensearch-dsl==1.0.0
 opensearch-py==1.1.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.2
-regdown==1.0.6
+regdown==1.0.7
 requests==2.27.1
 requests-aws4auth==1.1.2
 s3transfer==0.5.2


### PR DESCRIPTION
This brings Regdown to 1.0.7, fixing an issue that results from our previous attempt to address SVG rendering in #7614. 

Regdown 1.0.6 fixed the SVG rendering, but introduced a placement bug for rendered block references. Regdown 1.0.7 fixes that.

Before:

![image](https://user-images.githubusercontent.com/10562538/227255963-6a065ca8-2d75-49d6-81f9-c9ac6f118dbe.png)

After:

![image](https://user-images.githubusercontent.com/10562538/227255825-46880773-1f01-431f-a2e2-294068b03481.png)


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
