### PR TITLE
OAH: Remove extraneous CSS

### DIFF
--- a/cfgov/jinja2/owning-a-home/_templates/brand-header.html
+++ b/cfgov/jinja2/owning-a-home/_templates/brand-header.html
@@ -1,4 +1,4 @@
-<header aria-label="Buying a House header" class="brand-header content-banner">
+<header aria-label="Buying a House header" class="brand-header">
   <div class="content_wrapper">
     <div class="brand-header__1-2-container brand-header__1-2-container-with-icon">
       <div class="brand-header__headline">

--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -242,7 +242,7 @@ home price, down payment, and more can affect mortgage interest rates.
                             <span class="a-form-alert_text"></span>
                         </div>
                     </section>
-                    <section class="calc-loan-details wrapper">
+                    <section class="calc-loan-details">
                         <div class="upper rate-structure half-width-gt-1230">
                             <label for="rate-structure">Rate type</label>
                             <div class="select-content a-select">
@@ -390,7 +390,7 @@ home price, down payment, and more can affect mortgage interest rates.
                         </div>
                     </section>
                     <p id="timestamp-p" class="data-enabled timestamp-message clear">These rates are current as of <strong id="timestamp">…</strong>.</p>
-                    <section class="compare wrapper data-enabled loading">
+                    <section class="compare data-enabled loading">
                         <h3>
                         Explore what a lower interest rate means for your wallet</h2>
                         <div id="rate-selects">
@@ -425,18 +425,15 @@ home price, down payment, and more can affect mortgage interest rates.
                         <div class="rc-comparison-section rc-comparison-short">
                             <h4 class="rc-comparison-subhead">Interest costs over the first <span class="loan-years">5</span> years</h4>
                             <div class="rc-comparison-subsection">
-                                <div class="wrapper">
-                                    <div class="interest-cost interest-cost-primary rc-comp-3">
-                                        <span class="new-cost">$150,000</span>
-                                    </div>
-                                    <div class="interest-cost interest-cost-secondary rc-comp-3-push">
-                                        <span class="new-cost">$150,000</span>
-                                    </div>
-                                    <div class="interest-summary rc-comp-5" id="rc-comparison-summary-short">
-                                        <p>Over the first <span class="comparison-term">5</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
-                                    </div>
+                                <div class="interest-cost interest-cost-primary rc-comp-3">
+                                    <span class="new-cost">$150,000</span>
                                 </div>
-                                <!-- /.wrapper -->
+                                <div class="interest-cost interest-cost-secondary rc-comp-3-push">
+                                    <span class="new-cost">$150,000</span>
+                                </div>
+                                <div class="interest-summary rc-comp-5" id="rc-comparison-summary-short">
+                                    <p>Over the first <span class="comparison-term">5</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
+                                </div>
                             </div>
                             <!-- /.rc-comparison-subsection -->
                         </div>
@@ -445,24 +442,21 @@ home price, down payment, and more can affect mortgage interest rates.
                             <h4 class="rc-comparison-subhead">
                             Interest costs over <span class="loan-years">30</span> years</h5>
                             <div class="rc-comparison-subsection">
-                                <div class="wrapper">
-                                    <div class="interest-cost interest-cost-primary rc-comp-3">
-                                        <span class="new-cost no-arm">$150,000</span>
-                                        <span class="arm-info u-hidden">Can change</span>
-                                    </div>
-                                    <div class="interest-cost interest-cost-secondary rc-comp-3-push">
-                                        <span class="new-cost no-arm">$150,000</span>
-                                        <span class="arm-info u-hidden">Can change</span>
-                                    </div>
-                                    <div class="interest-summary rc-comp-5" id="rc-comparison-summary-long">
-                                        <p class="no-arm">Over <span class="comparison-term">30</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
-                                        <p class="arm-info u-hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
-                                    </div>
+                                <div class="interest-cost interest-cost-primary rc-comp-3">
+                                    <span class="new-cost no-arm">$150,000</span>
+                                    <span class="arm-info u-hidden">Can change</span>
                                 </div>
-                                <!-- /.wrapper -->
+                                <div class="interest-cost interest-cost-secondary rc-comp-3-push">
+                                    <span class="new-cost no-arm">$150,000</span>
+                                    <span class="arm-info u-hidden">Can change</span>
+                                </div>
+                                <div class="interest-summary rc-comp-5" id="rc-comparison-summary-long">
+                                    <p class="no-arm">Over <span class="comparison-term">30</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
+                                    <p class="arm-info u-hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
+                                </div>
                             </div>
                             <!-- /.rc-comparison-subsection -->
-                            <p class="mobi-yes l-bump">Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
+                            <p class="mobi-yes u-mt30">Interest is only one of many costs associated with getting a mortgage. <a href="/askcfpb/153/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan.html" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
                         </div>
                         <!-- /.rc-comparison-section -->
                     </section>
@@ -471,9 +465,9 @@ home price, down payment, and more can affect mortgage interest rates.
                 <section class="next-steps tabs-layout">
                     <h2><strong>Next steps:</strong> How to get the best interest rate on your mortgage</h2>
                     <!-- put into a container to prevent long line length -->
-                    <div class="wrapper">
-                        <p class="sans">When you’re ready to get serious about buying, the best thing you can do to get a better interest rate on your mortgage is <strong>shop around</strong>. But if you don’t plan to buy for a few months, there are more things you can do to ensure you get a great rate on your mortgage.</p>
-                    </div>
+                    <p class="sans">
+                        When you’re ready to get serious about buying, the best thing you can do to get a better interest rate on your mortgage is <strong>shop around</strong>. But if you don’t plan to buy for a few months, there are more things you can do to ensure you get a great rate on your mortgage.
+                    </p>
                     <ul class="tabs">
                         <li class="tab-list active-tab">
                             <a id="plan-to-buy-tab"
@@ -583,17 +577,13 @@ home price, down payment, and more can affect mortgage interest rates.
                         </div>
                     </div>
                 </div>
-                <section id="about" class="about wrapper">
-                    <div class="content-l">
-                        <div class="content-l_col content-l_col-1">
-                            <h3 class="subhead">About our data source for this tool</h3>
-                            <p>The lenders in our data include a mix of large banks, regional banks, and credit unions. The data is updated semiweekly every Wednesday and Friday at 7 a.m. In the event of a holiday, data will be refreshed on the next available business day.</p>
-                            <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="https://www.informars.com" target="_blank" rel="noopener noreferrer">www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
-                        </div>
+                <section id="about" class="content-l">
+                    <div class="content-l_col content-l_col-1">
+                        <h3 class="subhead">About our data source for this tool</h3>
+                        <p>The lenders in our data include a mix of large banks, regional banks, and credit unions. The data is updated semiweekly every Wednesday and Friday at 7 a.m. In the event of a holiday, data will be refreshed on the next available business day.</p>
+                        <p>The data is provided by Informa Research Services, Inc., Calabasas, CA. <a id="informars" href="https://www.informars.com" target="_blank" rel="noopener noreferrer">www.informars.com</a>. Informa collects the data directly from lenders and every effort is made to collect the most accurate data possible, but they cannot guarantee the data’s accuracy.</p>
                     </div>
-                    <!-- /.wrapper -->
                 </section>
-                <!-- /.about -->
             </div>
             <!-- END .rate-checker -->
         </div>

--- a/cfgov/unprocessed/apps/owning-a-home/css/brand-header.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/brand-header.less
@@ -1,5 +1,4 @@
 // TODO: Remove this code when owning-a-home is migrated Wagtail.
-
 .brand-header {
   background-color: @gray-5;
   padding-top: 15px;

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -5,6 +5,12 @@
 .rate-checker {
   position: relative;
 
+  /* lead paragraphs are typically the first paragraph in a content area */
+  .lead {
+    margin-bottom: unit(30px / @base-font-size-px, em);
+    font-size: 1.125em;
+  }
+
   .page-intro {
     border-bottom: 1px solid @gray-10;
   }
@@ -32,15 +38,11 @@
   .state-col,
   .form-intro {
     .grid_column( 3, 3 );
-
-    .wrapper {
-      padding: 0;
-    }
   }
 
   /*
         Sidebar with all the user input
-        --------------------------- */
+       --------------------------- */
   .calculator {
     .grid_column( 4 );
     .grid_push( 8 );
@@ -381,10 +383,6 @@
       box-sizing: border-box;
       margin-top: 2em;
     }
-
-    > p {
-      margin-bottom: 55px;
-    }
   }
 
   .next-steps-heading {
@@ -492,10 +490,6 @@
 
   .credit-alert {
     margin-top: 2em;
-  }
-
-  .about-data {
-    border-left-width: 0;
   }
 
   .related-links {

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -2,35 +2,9 @@
    Helper Classes & Styles
    ========================================================================== */
 
-.alert-positive {
-  color: @green;
-}
-
-.alert-warning {
-  color: @red;
-}
-
-.alert-neutral {
-  color: @gray-40;
-}
-
 .a-form-alert {
   color: @gray-dark;
   font-size: 0.75em;
-}
-
-// alert containers have a background color but no border
-.alert-container {
-  padding: unit(20px / @base-font-size-px, em);
-  background: @gray-5;
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.block__bg {
-  background-color: @block__bg;
 }
 
 .clear {
@@ -42,17 +16,6 @@
 .highlight-dropdown {
   border-color: @gold;
   border-width: 2px;
-}
-
-/* add a margin above an element */
-.l-bump {
-  margin-top: 2em;
-}
-
-/* lead paragraphs are typically the first paragraph in a content area */
-.lead {
-  margin-bottom: unit(30px / @base-font-size-px, em);
-  font-size: 1.125em;
 }
 
 @keyframes fadein {
@@ -74,24 +37,6 @@
   opacity: 0.3;
 }
 
-/* notes are subtle call out boxes with top and bottom borders */
-.note {
-  color: @black;
-  padding: 20px 10px;
-  margin: 1em 0;
-  border-top: 1px solid @gray-10;
-  border-bottom: 1px solid @gray-10;
-
-  p:last-child {
-    .u-reset();
-  }
-
-  h4:first-child,
-  h5:first-child {
-    margin-top: 0;
-  }
-}
-
 .placeholder {
   min-height: 200px;
   background: @gray-10;
@@ -104,14 +49,6 @@
   strong {
     font-weight: 600;
   }
-}
-
-.u-hidden {
-  display: none !important;
-}
-
-.u-no-bg {
-  background-color: transparent;
 }
 
 .u-pb0 {
@@ -127,12 +64,6 @@
 .u-link-underline {
   border-bottom: 1px dotted;
 }
-
-.respond-to-min( 620p, {
-  .note {
-    padding: unit( 20px / @base-font-size-px, em ) 12%;
-  }
-} );
 
 .respond-to-max( 800px, {
   .mobi-no {


### PR DESCRIPTION
While looking into page layout tweaks, I noticed we sprinkle `wrapper` around many places. This class is almost identical to `content_wrapper`. I'm trying to untangle them a bit to help simplify layout tasks. OAH's rate checker tool uses `wrapper` a lot, which shouldn't be necessary. This PR removes those uses and several other pieces of unused CSS.

## Removals

- Remove unused `content-banner` CSS class.
- Remove `wrapper` CSS class from rate checker tool, as well as sole extraneous wrapper divs.
- Remove unused `about` CSS class.
- Remove unused `about-data` CSS class. (Markup removed in https://github.com/cfpb/consumerfinance.gov/pull/7046)
- Remove unused `alert-positive`, `alert-warning`, `alert-neutral` CSS classes.
- Remove unused `alert-container` CSS class.
- Remove duplicate `block__bg` and `u-hidden` classes, which are provided site-wide by the design system CSS.
- Remove unused `note` CSS class.
- Remove unused `u-no-bg` CSS class.

## Changes

- Use `u-mt30` in place of the custom `l-bump` class.
- Move `lead` class that is only used on rate explorer to its style sheet.


## How to test this PR

1. Compare http://localhost:8000/owning-a-home/explore-rates/ to https://www.consumerfinance.gov/owning-a-home/explore-rates/

The visual changes should be the paragraph under "next steps" is no longer indented (checked with @jenn-franklin on this).
And the about our data source is also no longer indented.


## Screenshots

<table>
  <tr>
    <td>old (current) appearance</td>
    <td>new appearance</td>
  </tr>
  <tr>
    <td>
<img src="https://user-images.githubusercontent.com/704760/227607699-ca331ffb-143b-4e0e-a3a2-52322d6077fb.png">
</td>
    <td><img src="https://user-images.githubusercontent.com/704760/227607735-4b61c176-0731-46e3-9b0c-785433e6ffb5.png">
</td>
  </tr>
<tr>
    <td>
<img src="https://user-images.githubusercontent.com/704760/227607823-8765d65c-05b7-46cf-a943-9890a6f9a1d2.png">
</td>
    <td>
<img src="https://user-images.githubusercontent.com/704760/227607858-51790daa-dfb5-4121-a1f0-c007723747cc.png">
</td>
  </tr>
</table>


## Notes and todos

-  `u-mt30` is 30px, while `l-bump` is 32px, so there's a very slight difference, but not enough to warrant a custom class.