### PR TITLE
Refactor o-sidebar-breakout to incorporate u-centered-on-mobile

### DIFF
--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -80,35 +80,6 @@
 }
 
 /* topdoc
-  name: Centered on mobile utility
-  family: cfgov-cf-enhancements
-  patterns:
-    - name: .u-centered-on-mobile
-      markup: |
-        <div>
-            <div class="u-centered-on-mobile" style="width:100px;height:100px;background-color:green;">
-                Block centered on mobile
-            </div>
-            <p class="u-centered-on-mobile">Paragraph centered on mobile</p>
-        </div>
-      notes:
-        - "Sometimes content (parts/all of a media block, for example)
-           should be centered on mobile, but not on larger screen sizes."
-        - "This implementation conflates inline & block element centering,
-           though they could be made into separate classes."
-  tags:
-    - cfgov-cf-enhancements
-*/
-
-.respond-to-max(@bp-xs-max, {
-  .u-centered-on-mobile {
-    margin-left: auto;
-    margin-right: auto;
-    text-align: center;
-  }
-});
-
-/* topdoc
   name: Reset all
   family: cf-core
   patterns:

--- a/cfgov/unprocessed/css/organisms/sidebar-breakout.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-breakout.less
@@ -69,26 +69,6 @@
 @o-sidebar-breakout_img-height: 170px;
 
 .o-sidebar-breakout {
-  .respond-to-max(@bp-xs-max, {
-    margin-bottom: @margin__em;
-  });
-
-  &_col {
-    .respond-to-max(@bp-sm-max, {
-      width: 100%;
-      &:last-child {
-        padding-top: @margin__em;
-        border-top: 1px solid @gray-40;
-      }
-    });
-
-    .respond-to-min(@bp-med-min, {
-      &:last-child {
-        padding-left: @margin__em;
-      }
-    });
-  }
-
   &_heading {
     margin-bottom: @margin__em;
   }
@@ -104,12 +84,6 @@
   &_img-container {
     max-width: @o-sidebar-breakout_img-width;
     max-height: @o-sidebar-breakout_img-height;
-
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-      float: left;
-      width: @o-sidebar-breakout_img-width / @bp-sm-max * 100%;
-      margin-right: @margin__em;
-    });
   }
 
   &_img-container__round {
@@ -122,12 +96,6 @@
     }
   }
 
-  &_text-container {
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-      overflow: auto;
-    });
-  }
-
   &_text-body {
     margin-bottom: @margin__em;
   }
@@ -135,19 +103,58 @@
   &_text-heading {
     margin-top: @margin__em;
     margin-bottom: @margin__em / 2;
-
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-      margin-top: 0;
-    });
-  }
-
-  .m-related-posts_list .m-list_item {
-    .respond-to-range(@bp-sm-min, @bp-sm-max, {
-      border: 0;
-      width: 100%
-    });
   }
 }
+
+.respond-to-max(@bp-xs-max, {
+  .o-sidebar-breakout {
+
+    margin-bottom: @margin__em;
+
+    &_col {
+      width: 100%;
+      &:last-child {
+        padding-top: @margin__em;
+        border-top: 1px solid @gray-40;
+      }
+    }
+
+    &_img-container {
+      margin-left: auto;
+      margin-right: auto;
+      text-align: center;
+    }
+  }
+});
+
+.respond-to-min(@bp-med-min, {
+  .o-sidebar-breakout_col:last-child {
+    padding-left: @margin__em;
+  }
+});
+
+.respond-to-range(@bp-sm-min, @bp-sm-max, {
+  .o-sidebar-breakout {
+    &_img-container {
+      float: left;
+      width: @o-sidebar-breakout_img-width / @bp-sm-max * 100%;
+      margin-right: @margin__em;
+    }
+
+    &_text-container {
+      overflow: auto;
+    }
+
+    &_text-heading {
+      margin-top: 0;
+    }
+
+    .m-related-posts_list .m-list_item {
+      border: 0;
+      width: 100%
+    }
+  }
+});
 
 /* topdoc
     name: EOF

--- a/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
@@ -64,10 +64,8 @@
                             {% set photo = image(blocks.image.value, 'original') %}
                             <div class="o-sidebar-breakout_img-container
                                         {{ 'o-sidebar-breakout_img-container__round'
-                                           if blocks.is_round | string == 'True' else '' }}
-                                        u-centered-on-mobile">
-                              <div class="o-sidebar-breakout_img
-                                          u-centered-on-mobile"
+                                           if blocks.is_round | string == 'True' else '' }}">
+                              <div class="o-sidebar-breakout_img"
                                    style="background-image:url( {{ photo.url }} )">
                               </div>
                             </div>


### PR DESCRIPTION
Refactor o-sidebar-breakout to incorporate u-centered-on-mobile

## Changes

- Aggregate `o-sidebar-breakout` media queries and move them to the bottom of the Less file.
- Incorporate `u-centered-on-mobile` into `o-sidebar-breakout_img-container`.


## How to test this PR

1. The following pages should be unchanged when resizing to mobile:
 - http://localhost:8000/about-us/careers/
 - http://localhost:8000/find-a-housing-counselor/
 - http://localhost:8000/rules-policy/

## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
