### PR TITLE
Housing counselor: remove extraneous `block__flush-top`

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -46,7 +46,6 @@
 
                     <div class="block
                                 block__flush-top
-                                block__flush-top
                                 u-screen-only
                                 o-sidebar-breakout">
                         <div class="content-l">


### PR DESCRIPTION
There were two of these classes mistakenly applied.

## Removals

- Housing counselor: remove extraneous `block__flush-top`
