### PR TITLE
Adjust mega menu attributes to fix open bug

### DIFF
--- a/cfgov/mega_menu/jinja2/mega_menu/mega-menu.html
+++ b/cfgov/mega_menu/jinja2/mega_menu/mega-menu.html
@@ -125,7 +125,6 @@
 
 {% macro _nav_level( nav_depth, nav_item, overview_link=none, language='en' ) %}
 <div class="{{- _content_classes( nav_depth ) -}}"
-     aria-expanded="false"
      role="navigation"
      data-js-hook="behavior_flyout-menu_content">
 

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -848,7 +848,7 @@ body {
         }
 
         // A main nav label has been selected and the menu is expanded.
-        &[data-open="true"],
+        &[aria-expanded="true"],
         &:active {
           position: relative;
           top: 1px;
@@ -860,7 +860,7 @@ body {
         }
 
         // Do not show hover when menu is expanded.
-        &[data-open="true"]:hover,
+        &[aria-expanded="true"]:hover,
         &:active:hover {
           border-bottom: none;
           padding-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
@@ -870,15 +870,15 @@ body {
           outline-offset: 2px;
         }
 
-        &[data-open="true"]:focus {
+        &[aria-expanded="true"]:focus {
           outline: none;
           box-shadow: 0 -4px 5px 0 @pacific-40,
           -5px -2px 5px 0 @pacific-40,
           5px -2px 5px 0 @pacific-40;
         }
 
-        &[data-open="true"]:hover,
-        &[data-open="true"]:focus {
+        &[aria-expanded="true"]:hover,
+        &[aria-expanded="true"]:focus {
           &:after {
             position: absolute;
             bottom: -5px;
@@ -904,11 +904,11 @@ body {
           display: inline-block;
         }
 
-        &[data-open="true"] &-icon-open .cf-icon-svg {
+        &[aria-expanded="true"] &-icon-open .cf-icon-svg {
           display: inline-block;
         }
 
-        &[data-open="true"] &-icon-closed .cf-icon-svg {
+        &[aria-expanded="true"] &-icon-closed .cf-icon-svg {
           display: none;
         }
 
@@ -925,7 +925,7 @@ body {
           }
         }
 
-        &__current[data-open="true"]:after,
+        &__current[aria-expanded="true"]:after,
         &__current:active:after {
           background-color: transparent;
         }

--- a/test/cypress/integration/components/header/mega-menu-helpers.cy.js
+++ b/test/cypress/integration/components/header/mega-menu-helpers.cy.js
@@ -9,6 +9,18 @@ export class MegaMenuDesktop {
     return this.tabs().first();
   }
 
+  firstTabOpenIcon() {
+    return this.firstTab().find(
+      `${BASE_CLASS}_content-link-icon-open .cf-icon-svg`
+    );
+  }
+
+  firstTabCloseIcon() {
+    return this.firstTab().find(
+      `${BASE_CLASS}_content-link-icon-closed .cf-icon-svg`
+    );
+  }
+
   secondTab() {
     return this.tabs().eq(1);
   }

--- a/test/cypress/integration/components/header/mega-menu.cy.js
+++ b/test/cypress/integration/components/header/mega-menu.cy.js
@@ -24,10 +24,23 @@ describe('Mega-Menu organism for site navigation', () => {
       menuDesktop.secondPanel().should('not.be.visible');
     });
     it('on clicking a tab', () => {
+      menuDesktop
+        .firstTab()
+        .should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+      menuDesktop.firstTab().should('have.css', 'outline-offset', '0px');
+      menuDesktop.firstTabOpenIcon().should('not.be.visible');
+      menuDesktop.firstTabCloseIcon().should('be.visible');
       // When the first tab is clicked to open.
       menuDesktop.firstTab().click();
       // Then the mega-menu organism should have expanded attributes.
+      menuDesktop.firstTab().should('have.css', 'outline-offset', '2px');
+      menuDesktop
+        .firstTab()
+        .should('have.css', 'background-color', 'rgb(247, 248, 249)');
       menuDesktop.firstTab().should('have.attr', 'aria-expanded', 'true');
+      // Then the first tab icons should flip.
+      menuDesktop.firstTabOpenIcon().should('be.visible');
+      menuDesktop.firstTabCloseIcon().should('not.be.visible');
       // Then the mega-menu organism should have correct CSS classes.
       menuDesktop.firstPanel().should('have.class', 'u-move-transition');
       menuDesktop.firstPanel().should('have.class', 'u-move-to-origin');


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/7534 was a little too zealous in converting `aria-expanded` to `data-open`. We did need to remove some of them (https://github.com/cfpb/design-system/pull/1595), but the ones on the links remain and control highlighting the tab when it is open. 

## Changes

- Revert back to targeting aria-expanded on menu links, from data-open.
- Add some Cypress testing for the styles to catch this kind of bug.


## How to test this PR

1. PR checks should pass.
2. Pull branch 'n' build, and visit any page and see that the tab in the desktop menu is highlighted when it is clicked.


## Screenshots

before:
<img width="424" alt="Screen Shot 2023-03-24 at 7 45 45 PM" src="https://user-images.githubusercontent.com/704760/227663106-f787a51c-87ae-4735-816a-ea85e855c2af.png">

after:
<img width="396" alt="Screen Shot 2023-03-24 at 7 45 52 PM" src="https://user-images.githubusercontent.com/704760/227663116-f327cee2-8515-4b02-a231-0c0e740d0219.png">
