### PR TITLE
Delete template/activities-feed.html

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/templates/activities-feed.html
+++ b/cfgov/v1/jinja2/v1/includes/templates/activities-feed.html
@@ -1,6 +1,0 @@
-<header class="m-slug-header">
-    <h2 class="a-heading">
-        Latest Activities
-    </h2>
-</header>
-{{ activities_feed }}


### PR DESCRIPTION
This file was created 8 years ago in https://github.com/cfpb/consumerfinance.gov/commit/97777a78a524b98394259305292fa51b22a9e3f6 and references to it were removed at some point after then.

## Removals

- Unreferenced `templates/activities-feed.html`


## How to test this PR

1. PR checks should pass.
