### PR TITLE
Wagtail: Explicitly reference templates

### DIFF
--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -215,6 +215,8 @@ class JobListingPage(CFGOVPage):
 
     objects = JobListingPageManager()
 
+    template = "jobmanager/job_listing_page.html"
+
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)
 

--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -238,6 +238,8 @@ class ActivityPage(CFGOVPage):
         ]
     )
 
+    template = "teachers_digital_platform/activity_page.html"
+
     def get_subtopic_ids(self):
         """Get a list of this activity's subtopic ids."""
         topic_ids = [topic.id for topic in self.topic.all()]

--- a/cfgov/v1/models/campaign_page.py
+++ b/cfgov/v1/models/campaign_page.py
@@ -52,5 +52,7 @@ class CampaignPage(CFGOVPage):
         ]
     )
 
+    template = "v1/campaign_page.html"
+
     # Sets page to only be createable as the child of the homepage
     parent_page_types = ["v1.HomePage"]

--- a/cfgov/v1/models/story_page.py
+++ b/cfgov/v1/models/story_page.py
@@ -44,4 +44,6 @@ class StoryPage(CFGOVPage):
         ]
     )
 
+    template = "v1/story_page.html"
+
     page_description = "For single-column, image- and narrative-focused pages."


### PR DESCRIPTION
Wagtail page model will automatically search for a template name based on the class name. Very cool! However, we explicitly set a template name in each model except the story page and campaign page, which means if you search the codebase for those templates, their usage location is not found. Since we set the templates for the majority of things, let's set them for these two also. 


## Additions

- Add template references for story and campaign page types.


## How to test this PR

1. You should be able to log into wagtail and create a story and campaign page without error.
