### PR TITLE
Add rate-explorer tests for some dynamic content

### DIFF
--- a/test/cypress/integration/consumer-tools/owning-a-home/explore-rates-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/owning-a-home/explore-rates-helpers.cy.js
@@ -1,13 +1,59 @@
 export class ExploreRates {
-  open() {
-    cy.visit('/owning-a-home/explore-rates/');
-  }
-
   selectState(state) {
     cy.get('#location').select(state);
   }
 
-  graph() {
+  selectRateType(val) {
+    this.getRateTypeSelector().select(val);
+  }
+
+  selectLoanType(val) {
+    this.getLoanTypeSelector().select(val);
+  }
+
+  selectCounty(val) {
+    this.getCountySelector().select(val);
+  }
+
+  getHousePriceInput() {
+    return cy.get('#house-price');
+  }
+
+  getCountySelector() {
+    return cy.get('#county');
+  }
+
+  getCountyAlert() {
+    return cy.get('#county-warning');
+  }
+
+  getHighBalanceAlert() {
+    return cy.get('#hb-warning');
+  }
+
+  // Loan type and term drop-down menus.
+  getRateTypeSelector() {
+    return cy.get('#rate-structure');
+  }
+
+  getLoanTermSelector() {
+    return cy.get('#loan-term');
+  }
+
+  getLoanTypeSelector() {
+    return cy.get('#loan-type');
+  }
+
+  getArmTypeSelector() {
+    return cy.get('#arm-type');
+  }
+
+  // Main graph area.
+  getGraph() {
     return cy.get('#chart-section').within(() => cy.get('figure:first'));
+  }
+
+  getChartResultAlert() {
+    return cy.get('#chart-result-alert');
   }
 }

--- a/test/cypress/integration/consumer-tools/owning-a-home/owning-a-home.cy.js
+++ b/test/cypress/integration/consumer-tools/owning-a-home/owning-a-home.cy.js
@@ -4,10 +4,114 @@ const exploreRates = new ExploreRates();
 
 describe('Owning a Home', () => {
   describe('Explore Rates', () => {
+    beforeEach(() => {
+      cy.visit('/owning-a-home/explore-rates/');
+    });
     it('Should load the interest rates graph when a state has changed', () => {
-      exploreRates.open();
       exploreRates.selectState('Virginia');
-      exploreRates.graph().should('exist');
+      exploreRates.getGraph().should('exist');
+    });
+
+    it('Should display high balance FHA loan when house price is high', () => {
+      exploreRates.getHousePriceInput().type('400000');
+      exploreRates.getCountySelector().should('not.be.visible');
+      exploreRates.getCountyAlert().should('not.be.visible');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="fha-hb"]')
+        .should('not.exist');
+      exploreRates.getHighBalanceAlert().should('not.be.visible');
+
+      exploreRates.selectLoanType('fha');
+      exploreRates.getCountySelector().should('be.visible');
+      exploreRates.getCountyAlert().should('be.visible');
+      exploreRates.selectCounty('Baldwin');
+      exploreRates.getLoanTypeSelector().get('[value="conf"]').should('exist');
+      exploreRates.getLoanTypeSelector().get('[value="fha"]').should('exist');
+      exploreRates.getLoanTypeSelector().get('[value="va"]').should('exist');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="fha-hb"]')
+        .should('exist');
+      exploreRates.getHighBalanceAlert().should('be.visible');
+    });
+
+    it('Should display high balance VA loan when house price is high', () => {
+      exploreRates.getHousePriceInput().type('600000');
+      exploreRates.getCountySelector().should('be.visible');
+      exploreRates.getCountyAlert().should('be.visible');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="va-hb"]')
+        .should('not.exist');
+      exploreRates.getHighBalanceAlert().should('not.be.visible');
+
+      exploreRates.selectLoanType('va');
+      exploreRates.selectCounty('Baldwin');
+      exploreRates.getLoanTypeSelector().get('[value="conf"]').should('exist');
+      exploreRates.getLoanTypeSelector().get('[value="fha"]').should('exist');
+      exploreRates.getLoanTypeSelector().get('[value="va"]').should('exist');
+      exploreRates.getLoanTypeSelector().get('[value="va-hb"]').should('exist');
+      exploreRates.getHighBalanceAlert().should('be.visible');
+    });
+
+    it('Should display conforming jumbo loan type when house price is very high', () => {
+      exploreRates.getHousePriceInput().type('700000');
+      exploreRates.getCountySelector().should('be.visible');
+      exploreRates.getCountyAlert().should('be.visible');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="agency"]')
+        .should('not.exist');
+      exploreRates.getHighBalanceAlert().should('not.be.visible');
+      exploreRates.selectCounty('Baldwin');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="agency"]')
+        .should('exist');
+      exploreRates.getHighBalanceAlert().should('be.visible');
+    });
+
+    it('Should display non-conforming jumbo loan type when house price is very very high', () => {
+      exploreRates.getHousePriceInput().type('1000000');
+      exploreRates.getCountySelector().should('be.visible');
+      exploreRates.getCountyAlert().should('be.visible');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="jumbo"]')
+        .should('not.exist');
+      exploreRates.getHighBalanceAlert().should('not.be.visible');
+      exploreRates.selectCounty('Baldwin');
+      exploreRates.getLoanTypeSelector().get('[value="jumbo"]').should('exist');
+      exploreRates.getHighBalanceAlert().should('be.visible');
+    });
+
+    it('Should display ARM type selector when rate type is adjustable', () => {
+      exploreRates.getChartResultAlert().should('not.be.visible');
+      exploreRates.getArmTypeSelector().should('not.be.visible');
+      exploreRates.selectRateType('Adjustable');
+      exploreRates.getChartResultAlert().should('be.visible');
+      exploreRates.getArmTypeSelector().should('be.visible');
+      exploreRates
+        .getLoanTermSelector()
+        .get('[value="30"]')
+        .should('not.be.disabled');
+      exploreRates
+        .getLoanTermSelector()
+        .get('[value="15"]')
+        .should('be.disabled');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="conf"]')
+        .should('not.be.disabled');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="fha"]')
+        .should('be.disabled');
+      exploreRates
+        .getLoanTypeSelector()
+        .get('[value="va"]')
+        .should('be.disabled');
     });
   });
 });


### PR DESCRIPTION
Touching rate-explorer scares me, lets have some tests for the dynamically displayed drop-downs and alerts.


## Additions

- Add a few more rate-explorer tests to test the different loan types dynamic drop-downs and alerts.

## How to test this PR

1. `yarn cypress open` to test manually.
2. PR checks should pass.
