### PR TITLE
Add `preview_title` to filterable search indexing

### DIFF
--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -38,6 +38,7 @@ class FilterablePagesDocument(Document):
     initial_filing_date = fields.DateField()
     model_class = fields.KeywordField()
     content = fields.TextField()
+    preview_title = fields.TextField()
     preview_description = fields.TextField()
     path = fields.KeywordField()
     depth = fields.IntegerField()
@@ -85,6 +86,10 @@ class FilterablePagesDocument(Document):
             return None
         except IndexError:
             return None
+
+    def prepare_preview_title(self, instance):
+        print("Preview Title", getattr(instance, "preview_title", None))
+        return getattr(instance, "preview_title", None)
 
     def prepare_preview_description(self, instance):
         return unescape(strip_tags(instance.preview_description))
@@ -164,6 +169,7 @@ class FilterablePagesDocumentSearch:
                     "title^10",
                     "tags.name^10",
                     "content",
+                    "preview_title",
                     "preview_description",
                 ],
                 type="phrase_prefix",

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -61,6 +61,7 @@ class FilterablePagesDocumentTest(TestCase):
                 "initial_filing_date",
                 "model_class",
                 "content",
+                "preview_title",
                 "preview_description",
                 "path",
                 "depth",
@@ -95,6 +96,7 @@ class FilterablePagesDocumentTest(TestCase):
     def test_prepare_content_exists(self):
         blog = BlogPage(
             title="Test Blog",
+            preview_title="Blog for Testing",
             content=json.dumps(
                 [
                     {
@@ -112,6 +114,7 @@ class FilterablePagesDocumentTest(TestCase):
         doc = FilterablePagesDocument()
         prepared_data = doc.prepare(blog)
         self.assertEqual(prepared_data["content"], "Blog Text")
+        print(prepared_data)
 
     def test_prepare_content_empty(self):
         blog = BlogPage(title="Test Blog", content=json.dumps([]))
@@ -153,7 +156,7 @@ class FilterableSearchTests(ElasticsearchWagtailPageTreeTestCase):
                 SublandingFilterablePage(title="search1"),
                 [
                     DocumentDetailPage(title="child1"),
-                    DocumentDetailPage(title="child2"),
+                    DocumentDetailPage(title="child2", preview_title="2child"),
                     (
                         SublandingFilterablePage(title="search2"),
                         [
@@ -192,6 +195,15 @@ class FilterableSearchTests(ElasticsearchWagtailPageTreeTestCase):
         self.assertEqual(search.search(title="child").count(), 4)
         self.assertEqual(search.search(title="child1").count(), 2)
         self.assertEqual(search.search(title="child3").count(), 0)
+
+    def test_search_by_preview_title(self):
+        search = FilterablePagesDocumentSearch(
+            self.page_tree[0], children_only=False
+        )
+        results_title = search.search(title="child2")
+        results_preview_title = search.search(title="2child")
+        self.assertEqual(results_title.count(), 2)
+        self.assertEqual(results_preview_title.count(), 1)
 
     def test_get_raw_results(self):
         search = FilterablePagesDocumentSearch(self.page_tree[0])


### PR DESCRIPTION
Add `preview_title` to our filterable search indexing so that if a page has a different `preview_title` from its `title`, the title search will still return a page that matches what the user sees in the filterable search results.

This will also fix functional test failures that happen because the preview title on the filterable list page doesn’t match any search results.

Note: this will require a re-index in our deployed environments.

## Checklist


- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
