### PR TITLE
Change WagtailPageTests to WagtailPageTestCase

### DIFF
--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory, TestCase
 from wagtail.blocks import StreamValue
 from wagtail.documents.models import Document
 from wagtail.models import Site
-from wagtail.test.utils import WagtailPageTests
+from wagtail.test.utils import WagtailPageTestCase
 
 from model_bakery import baker
 
@@ -38,10 +38,13 @@ from teachers_digital_platform.models.activity_index_page import (
 from v1.models import HomePage
 
 
-class ActivityIndexPageTests(WagtailPageTests):
+class ActivityIndexPageTests(WagtailPageTestCase):
     @classmethod
     def setUpClass(self):
         super().setUpClass()
+
+    def setUp(self):
+        self.login()
 
     def test_can_create_an_activity_page_under_activity_index_page(self):
         self.assertCanCreateAt(ActivityIndexPage, ActivityPage)


### PR DESCRIPTION
Per the Wagtail 4.1 release notes, the WagtailPageTests test case class has been renamed to WagtailPageTestCase:

https://docs.wagtail.org/en/stable/releases/4.1.html#recommend-wagtailpagetestcase-in-place-of-wagtailpagetests

We only use this in one place. This commit updates that usage.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)