### PR TITLE
Support django-taggit 3.x

### DIFF
--- a/cfgov/v1/migrations/0199_2022_squash.py
+++ b/cfgov/v1/migrations/0199_2022_squash.py
@@ -14,6 +14,7 @@ import wagtail.snippets.blocks
 import modelcluster.contrib.taggit
 import modelcluster.fields
 import wagtailmedia.blocks
+from taggit import VERSION as TAGGIT_VERSION
 
 import jobmanager.blocks
 import v1.atomic_elements.molecules
@@ -971,7 +972,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('name', models.CharField(max_length=100, unique=True, verbose_name='name')),
-                ('slug', models.SlugField(max_length=100, unique=True, verbose_name='slug')),
+                ('slug', models.SlugField(max_length=100, unique=True, verbose_name='slug', allow_unicode=(TAGGIT_VERSION >= (3, 0, 0)))),
             ],
             options={
                 'verbose_name': 'Content Owner',


### PR DESCRIPTION
Wagtail 4 supports django-taggit>=2.0,<4.0. But django-taggit 3.x changes slugs to allow for unicode storage, which alters how the model is defined in Django and can potentially require migration changes.

This caused the failure here: https://github.com/cfpb/consumerfinance.gov/actions/runs/4598094330/jobs/8121660413?pr=7638

See this Wagtail commit where they ran into the same issue:

https://github.com/wagtail/wagtail/commit/5b4242df3ca5636206d89e134f85725b41fe89cc

## How to test this PR

If you try this command `cfgov/manage.py makemigrations --check --dry-run`, it'll show no changes both on django-taggit 2.x and 3.x.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)