### PR TITLE
Add button-secondary to View Permissions button

### DIFF
--- a/cfgov/permissions_viewer/wagtail_hooks.py
+++ b/cfgov/permissions_viewer/wagtail_hooks.py
@@ -40,6 +40,7 @@ def user_listing_buttons(context, user):
     yield UserListingButton(
         "View Permissions",
         reverse("permissions:user", args=[user.pk]),
+        classes={"button-secondary"},
         attrs={"title": "View permissions for this user"},
         priority=15,
     )


### PR DESCRIPTION
Wagtail 4 [removes `.button-secondary` from `UserListingButton` by default](https://docs.wagtail.org/en/stable/releases/4.1.html#button-styling-class-changes). This change restores that.

User listing buttons in Wagtail 4 before this change:

<img width="262" alt="before" src="https://user-images.githubusercontent.com/10562538/229885034-e576434f-7ddc-40af-b7ac-5603f58735db.png">

And after:

<img width="257" alt="image" src="https://user-images.githubusercontent.com/10562538/229885209-22135d16-bc19-4340-9ea4-abb88854c9a2.png">

Wagtail 3 appearance for reference:

<img width="265" alt="image" src="https://user-images.githubusercontent.com/10562538/229885371-c7b5a346-7cc3-4601-8153-08c9e5c3c577.png">


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
