### PR TITLE
Fix page previews on Wagtail 4

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -53,35 +53,41 @@ def parse_links(html, request_path=None, encoding=None):
 
 
 class ParseLinksMiddleware:
+    response_flag = "links_parsed"
+
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-        if self.should_parse_links(
-            request.path, response.get("Content-Type", "")
-        ):
+
+        if self.should_parse_links(request, response):
             response.content = parse_links(
                 response.content, request.path, encoding=response.charset
             )
+            setattr(response, self.response_flag, True)
         return response
 
     @classmethod
-    def should_parse_links(cls, request_path, response_content_type):
+    def should_parse_links(cls, request, response):
         """Determine if links should be parsed for a given request/response.
 
         Returns True if
 
-        1. The response has the settings.DEFAULT_CONTENT_TYPE (HTML) AND
-        2. The request path does not match settings.PARSE_LINKS_EXCLUSION_LIST
+        1. The response hasn't had this middleware applied before AND
+        2. The response has the settings.DEFAULT_CONTENT_TYPE (HTML) AND
+        3. The request path does not match settings.PARSE_LINKS_EXCLUSION_LIST
 
         Otherwise returns False.
         """
-        if "html" not in response_content_type:
+        if hasattr(response, cls.response_flag):
+            return False
+
+        if "html" not in response.get("Content-Type", ""):
             return False
 
         return not any(
-            re.search(regex, request_path)
+            re.search(regex, request.path)
             for regex in settings.PARSE_LINKS_EXCLUSION_LIST
         )
 


### PR DESCRIPTION
Page previews are currently broken on Wagtail 4. This fixes them.

Previews are currently broken because the preview sidebar loads the preview content in an iframe, and listens for the load event before showing the preview content to the user.

But the load event never fires for preview requests, which you can test directly in the browser by visiting a URL like:

http://localhost:8000/admin/pages/12893/edit/preview/?mode=&in_preview_panel=true

Why doesn't the load event fire? Because the length of the HTTP response doesn't match what gets sent in the Content-Length HTTP header. The header is slightly longer than the actual content. So the browser is waiting for more content which never comes, which keeps the page loading, which prevents the preview content from appearing.

So why is the Content-Length HTTP header wrong? The response content gets modified (shortened) after the header is set.

Where does that happen? By our ParseLinksMiddleware, which processes the HTML response content and adds link icons and such.

But wait, I hear you say. How can the content get shortened by this middleware? If anything, it should get longer.

It turns out that middlewares are actually run twice for Wagtail preview views, once as part of the regular Django request-response cycle and once when the preview response is rendered:

https://github.com/wagtail/wagtail/blob/b3b53c8b708aed6af26e28b21272a0509c152b9e/wagtail/models/__init__.py#L645

And the second time it runs is actually after Django's CommonMiddleware is run, which is the thing that sets the Content-Length header.

So: normally first our ParseLinksMiddleware runs, and alters the content length. Then the CommonMiddleware runs which sets the proper Content-Length header.

But in the preview views, ParseLinksMiddleware runs AGAIN, and RE-parses the HTML, which, somehow, shrinks the content slightly. But we don't re-set the Content-Length header, which gets us into the situation described above.

To fix this: I've modified the ParseLinksMiddleware so that it will never run more than once on the same HTTP response. One amount of link parsing should be enough for anyone.

## How to test this PR

To test that this fixes Wagtail 4 page previews, edit a page in Wagtail 4 (note: one you've never edited before in Wagtail 4! because editing a page resets the preview content which fixes previews on a page-by-page basis sometimes) and note that the sidebar preview will populate shortly after you open it.

On a Wagtail 4 branch without this fix, the sidebar preview will never be populated.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)