### PR TITLE
Always open preview panel links in a new tab

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -97,6 +97,11 @@
 
     {# End of Open Graph properties #}
 
+    {# Always open preview panel links in a new tab. #}
+    {% if request.in_preview_panel %}
+    <base target="_blank">
+    {% endif %}
+
     <link rel="icon" href="{{ static('favicon.ico') }}" sizes="any">
     <link rel="icon" href="{{ static('icon.svg') }}" type="image/svg+xml">
     <link rel="apple-touch-icon" href="{{ static('apple-touch-icon.png') }}">


### PR DESCRIPTION
In the sidebar live preview panel in Wagtail 4.0+, links clicked in the preview panel should open in a new tab, per the release notes:

https://docs.wagtail.org/en/stable/releases/4.0.html#opening-links-within-the-live-preview-panel

Note: this change requires the fix in #7643 to properly test the live preview panel!

## How to test this PR

Edit a page, and click a link the sidebar preview panel. It should open in a new tab. Click on a link on a live page. It should open in the same tab.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)