### PR TITLE
Fix language activation in Wagtail 4 page previews

### DIFF
--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -350,11 +350,17 @@ class CFGOVPage(Page):
         context["is_faq_page"] = self.is_faq_page()
         return context
 
-    def serve(self, request, *args, **kwargs):
-        # Force the page's language on the request
+    def _activate_translation(self, request):
         translation.activate(self.language)
         request.LANGUAGE_CODE = translation.get_language()
+
+    def serve(self, request, *args, **kwargs):
+        self._activate_translation(request)
         return super().serve(request, *args, **kwargs)
+
+    def serve_preview(self, request, *args, **kwargs):
+        self._activate_translation(request)
+        return super().serve_preview(request, *args, **kwargs)
 
     def streamfield_media(self, media_type):
         media = []

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -313,6 +313,30 @@ class TestCFGOVPageContext(TestCase):
         self.assertEqual(True, result)
 
 
+class TestCFGOVPageTranslationActivation(TestCase):
+    def test_english_page_serves_in_english(self):
+        page = LandingPage(title="test", language="en")
+        request = RequestFactory().get("/")
+        response = page.serve(request)
+        self.assertContains(response, "Search")
+
+    def test_spanish_page_serves_in_spanish(self):
+        page = LandingPage(title="test", language="es")
+        request = RequestFactory().get("/")
+        response = page.serve(request)
+        self.assertContains(response, "Buscar")
+
+    def test_english_page_serves_preview_in_english(self):
+        page = LandingPage(title="test", language="en")
+        response = page.make_preview_request()
+        self.assertContains(response, "Search")
+
+    def test_spanish_page_serves_preview_in_spanish(self):
+        page = LandingPage(title="test", language="es")
+        response = page.make_preview_request()
+        self.assertContains(response, "Buscar")
+
+
 class TestCFGOVPageQuerySet(TestCase):
     def setUp(self):
         default_site = Site.objects.get(is_default_site=True)


### PR DESCRIPTION
Wagtail 4.0 decoupled the Page.serve and Page.serve_preview methods, which means that serve() code that would previously run at preview time no longer does:

https://docs.wagtail.org/en/stable/releases/4.0.html#changes-to-page-serve-and-page-serve-preview-methods

Practically, we override Page.serve in order to activate translations for the page language. In Wagtail 4.0, we need to make sure that this same code runs in Page.serve_preview. This commit does so.

To observe how this is broken on the current Wagtail 4 branch, edit a non-English page (for example, on a production dump, http://localhost:8000/admin/pages/17009/edit/) and look at the sidebar preview. If you click in the site search in the header, you'll see the blue search button says "Search" in English, which is wrong -- it should be translated in the page's language.

With this commit, that "Search" term will be properly translated.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)