### PR TITLE
Really fix page previews in Wagtail 4

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -709,7 +709,7 @@ CSRF_REQUIRED_PATHS = (
 # exempt beta from CSRF settings until it's converted to https
 SECURE_REFERRER_POLICY = "same-origin"  # 1
 SESSION_COOKIE_SAMESITE = "Strict"  # 3
-X_FRAME_OPTIONS = "DENY"  # 14
+X_FRAME_OPTIONS = "SAMEORIGIN"  # 13
 
 if DEPLOY_ENVIRONMENT and DEPLOY_ENVIRONMENT != "beta":
     SESSION_COOKIE_SECURE = True

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -55,6 +55,12 @@
                 {{- meta_description if page else '' -}}
             {%- endblock -%}
           ">
+
+    {# Always open preview panel links in a new tab. #}
+    {% if request.in_preview_panel %}
+    <base target="_blank">
+    {% endif %}
+
     <link rel="canonical" href="{{ request.build_absolute_uri() | lower }}">
 
     {# Open Graph properties #}
@@ -164,6 +170,9 @@
   If you come across a script that makes a convincing case to be included in
   the head, then file an issue or PR to discuss including it.
 #}
+    {# Don't load certain scripts in the Wagtail preview panel. -#}
+    {% if not request.in_preview_panel %}
+
     {% if flag_enabled('AB_TESTING') %}
     {# Begin Google Optimize #}
     {# Optimize anti-flicker snippet. #}
@@ -193,6 +202,9 @@
     f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KMMLRS');</script>
     {# End Google Tag Manager #}
+
+    {# End: Don't load certain scripts in the Wagtail preview panel. #}
+    {% endif -%}
 
     {# Schema data in JSON-LD format #}
     {% if schema_json %}
@@ -229,10 +241,16 @@
 
     {% block analytics %}
 
+    {# Don't load certain scripts in the Wagtail preview panel. -#}
+    {% if not request.in_preview_panel %}
+
     {# Google Tag Manager (noscript) #}
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KMMLRS"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     {# End Google Tag Manager (noscript) #}
+
+    {# End: Don't load certain scripts in the Wagtail preview panel. #}
+    {% endif -%}
 
     {% endblock analytics %}
 


### PR DESCRIPTION
This is a followup to #7643 that tries to actually fix sidebar page previews in Wagtail 4; the previous PR was insufficient. (This is also a redo of #7647 which I accidentally force-pushed over as part of trying to rebase upgrade/wagtail4 against main.)

There are two independent commits here that combine to fix sidebar page previews.

First, this PR changes the Django setting for X-Frame-Options from DENY to SAMEORIGIN. Having it set to DENY prevents any cf.gov page from being loaded in an iframe; setting it to SAMEORIGIN instead lets that work as long as the parent page is on the same origin. Changing to SAMEORIGIN complies with our Django baseline.

Second, this PR disables the loading of Google JS (GA and GTM) when the page is viewed in the sidebar preview panel. We don't want to load those scripts when previewing pages in Wagtail, and they interfere with the use of `<base target="_blank">` which is needed to ensure that preview page links open in a new tab, as recommended [in the Wagtail release notes](https://docs.wagtail.org/en/stable/releases/4.0.html#opening-links-within-the-live-preview-panel).

## How to test this PR

Run this PR branch (making sure to upgrade requirements to Wagtail 4), and edit a page ([for example](http://localhost:8000/admin/pages/319/edit/)). Open the live preview panel on the right, and try clicking a link. It should open in a new tab.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)