### PR TITLE
Create new report for draft pages

### DIFF
--- a/cfgov/v1/templates/v1/_list_page_drafts.html
+++ b/cfgov/v1/templates/v1/_list_page_drafts.html
@@ -1,0 +1,32 @@
+{% extends 'wagtailadmin/reports/listing/_list_page_report.html' %}
+
+ 
+{% block extra_columns %}
+    <th>URL</th>
+    <th>Language</th>
+    <th>Tags</th>
+    <th>Categories</th>
+    <th>Content Owner(s)</th>
+{% endblock %}
+
+{% block extra_page_data %}
+    <td valign="top">
+        {{ page.url }}
+    </td>
+    <td valign="top">
+        {{ page.language }}
+    </td>
+    <td valign="top">
+        {{ page.tags.names|join:", " }}
+    </td>
+    <td valign="top">
+        {% for cat in page.categories.all %}
+        {% if cat.get_name_display and not forloop.last %}
+        {{ cat.get_name_display }}, {% else %}{{ cat.get_name_display }}
+        {% endif %}{% endfor %}
+    </td>
+    <td>
+        {{ page.content_owners.names|join:", " }}
+    </td>
+{% endblock %}
+

--- a/cfgov/v1/templates/v1/page_draft_report.html
+++ b/cfgov/v1/templates/v1/page_draft_report.html
@@ -1,0 +1,18 @@
+{% extends 'wagtailadmin/reports/base_page_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block actions %}
+    {% if view.list_export %}
+        <div class="actionbutton">
+            <a href="{{ view.csv_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% translate 'Download CSV' %}</a>
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% block listing %}
+    {% include 'v1/_list_page_drafts.html' %}
+{% endblock %}
+
+{% block no_results %}
+    <p>No unpublished drafts.</p>
+{% endblock %}

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -157,7 +157,8 @@ class DraftReportView(PageReportView):
         return generate_filename("pages")
 
     def get_queryset(self):
-        return CFGOVPage.objects.filter(live=False).prefetch_related(
+        default_site = Site.objects.get(is_default_site=True)
+        return CFGOVPage.objects.in_site(default_site).not_live().prefetch_related(
             "tags", "categories"
         )
 

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -157,9 +157,11 @@ class DraftReportView(PageReportView):
         return generate_filename("pages")
 
     def get_queryset(self):
-        default_site = Site.objects.get(is_default_site=True)
-        return CFGOVPage.objects.in_site(default_site).not_live().prefetch_related(
-            "tags", "categories"
+        default_site = CFGOVPage.objects.get(is_default_site=True)
+        return (
+            CFGOVPage.objects.in_site(default_site)
+            .not_live()
+            .prefetch_related("tags", "categories")
         )
 
 

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -122,6 +122,46 @@ class PageMetadataReportView(PageReportView):
         )
 
 
+class DraftReportView(PageReportView):
+    header_icon = "doc-empty"
+    title = "Draft Pages"
+
+    list_export = PageReportView.list_export + [
+        "url",
+        "language",
+        "tags.names",
+        "categories.all",
+        "content_owners.names",
+    ]
+    export_headings = dict(
+        [
+            ("url", "URL"),
+            ("language", "Language"),
+            ("tags.names", "Tags"),
+            ("categories.all", "Categories"),
+            ("content_owners.names", "Content Owner(s)"),
+        ],
+        **PageReportView.export_headings,
+    )
+
+    custom_field_preprocess = {
+        "categories.all": {
+            "csv": process_categories,
+            "xlsx": process_categories,
+        }
+    }
+
+    template_name = "v1/page_draft_report.html"
+
+    def get_filename(self):
+        return generate_filename("pages")
+
+    def get_queryset(self):
+        return CFGOVPage.objects.filter(live=False).prefetch_related(
+            "tags", "categories"
+        )
+
+
 class DocumentsReportView(ReportView):
     header_icon = "doc-full"
     title = "Documents"

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -43,6 +43,7 @@ from v1.views.reports import (
     AskReportView,
     CategoryIconReportView,
     DocumentsReportView,
+    DraftReportView,
     EnforcementActionsReportView,
     ImagesReportView,
     PageMetadataReportView,
@@ -205,6 +206,26 @@ def register_page_metadata_report_url():
             r"^reports/page-metadata/$",
             PageMetadataReportView.as_view(),
             name="page_metadata_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_page_drafts_report_menu_item():
+    return MenuItem(
+        "Draft Pages",
+        reverse("page_drafts_report"),
+        classnames="icon icon-" + DraftReportView.header_icon,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_page_drafts_report_url():
+    return [
+        re_path(
+            r"^reports/page-drafts/$",
+            DraftReportView.as_view(),
+            name="page_drafts_report",
         ),
     ]
 


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->

This PR creates a new report in the Wagtail administrator panel for un-published pages. This allows content managers to assess and clean up unused sandbox or test pages and improve page database health.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- "Draft Pages" report


## How to test this PR

1. localhost
2. Check under the Reports sidebar item for "Draft Pages"


## Screenshots
![Screen Shot 2023-04-11 at 9 58 34 AM](https://user-images.githubusercontent.com/29648039/231186737-5035bf95-35ce-4b61-a7d2-803e5f283cd7.png)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
