### PR TITLE
Update test_auth_forms.py example email address

### DIFF
--- a/cfgov/login/tests/test_auth_forms.py
+++ b/cfgov/login/tests/test_auth_forms.py
@@ -51,7 +51,7 @@ class UserEditFormTestCase(TestCase):
     def setUp(self):
         self.userdata = {
             "username": "george",
-            "email": "george@washington.com",
+            "email": "george@example.com",
             "first_name": "george",
             "last_name": "washington",
         }


### PR DESCRIPTION
Luv the demo email, but it's possibly a malicious site, so we should likely always use `example.com` for example domains, lest it seem like we're promoting shady domains.

## Changes

- Change test example email address. 


## How to test this PR

1. PR checks should pass.
