### PR TITLE
Remove duplicate `<base>` tag in base template

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -103,11 +103,6 @@
 
     {# End of Open Graph properties #}
 
-    {# Always open preview panel links in a new tab. #}
-    {% if request.in_preview_panel %}
-    <base target="_blank">
-    {% endif %}
-
     <link rel="icon" href="{{ static('favicon.ico') }}" sizes="any">
     <link rel="icon" href="{{ static('icon.svg') }}" type="image/svg+xml">
     <link rel="apple-touch-icon" href="{{ static('apple-touch-icon.png') }}">


### PR DESCRIPTION
(This PR is to the upgrade/wagtail4 branch.)

The base template includes duplicate code about the preview panel:

https://github.com/cfpb/consumerfinance.gov/blob/4f927a4abce7eef3bb4418d6b3a59613468024c5/cfgov/v1/jinja2/v1/layouts/base.html#L59-L62

and

https://github.com/cfpb/consumerfinance.gov/blob/4f927a4abce7eef3bb4418d6b3a59613468024c5/cfgov/v1/jinja2/v1/layouts/base.html#L106-L109

We only need one of these.

To test, preview a page in the Wagtail 4 sidebar and verify that links still open in a new tab.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)