### PR TITLE
Hide Django admin link from non-staff users

### DIFF
--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -218,7 +218,7 @@ class TestDjangoAdminLink(TestCase, WagtailTestUtils):
         user.save()
 
         self.login(**credentials)
-        return self.client.get(reverse(f"wagtailadmin_home"))
+        return self.client.get(reverse("wagtailadmin_home"))
 
     def test_staff_sees_django_admin_link(self):
         response = self.get_admin_response_for_user(is_staff=True)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -138,25 +138,14 @@ def global_admin_css():
     return css_includes
 
 
-class PermissionCheckingMenuItem(MenuItem):
-    """
-    MenuItem that only displays if the user has a certain permission.
-
-    This subclassing approach is recommended by the Wagtail documentation:
-    https://docs.wagtail.io/en/stable/reference/hooks.html#register-admin-menu-item
-    """
-
-    def __init__(self, *args, **kwargs):
-        self.permission = kwargs.pop("permission")
-        super().__init__(*args, **kwargs)
-
+class StaffOnlyMenuItem(MenuItem):
     def is_shown(self, request):
-        return request.user.has_perm(self.permission)
+        return request.user.is_staff
 
 
 @hooks.register("register_admin_menu_item")
 def register_django_admin_menu_item():
-    return MenuItem(
+    return StaffOnlyMenuItem(
         "Django Admin",
         reverse("admin:index"),
         classnames="icon icon-redirect",


### PR DESCRIPTION
Currently users who don't have permission to access the Django admin (i.e. non-staff users) still see a "Django Admin" link in the Wagtail sidebar, which points to /django-admin/.

If those users click on that link, they get stuck in an infinite redirect loop: /django-admin/ bumps them to the Wagtail login with a ?next parameter, Wagtail sees that they're already logged in, and sends them back the Django admin, etc.

It doesn't seem easy/possible to avoid that infinite loop unfortunately. The best we can do is hide the Django admin link for those users, which is what this PR does.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)