### PR TITLE
Move prepaid agreement `filter-section`s into expandable group

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -33,7 +33,7 @@
             </select>
         </div>
 
-        <div class="filter-section">
+        <div class="o-expandable-group">
             {% set selections = filters['prepaid_type'] %}
             {% set expandable_settings = {
                 'label': 'Prepaid product type',
@@ -63,9 +63,7 @@
                 </fieldset>
             </div>
             {% endcall %}
-        </div>
 
-        <div class="filter-section">
             {% set selections = filters['status'] %}
             {% set expandable_settings = {
                 'label': 'Current status',

--- a/cfgov/unprocessed/css/search.less
+++ b/cfgov/unprocessed/css/search.less
@@ -24,28 +24,29 @@
     border: 1px solid @gray-40;
     background-color: #f7f8f9;
 
-    .o-expandable_content,
-    .o-expandable_target {
-      border: 0;
-      padding: 0;
-      &:before,
-      &:after {
-        border: 0;
-        padding: 0;
+    .o-expandable-group {
+      margin-bottom: 15px;
+
+      // TODO: The below customizations should be usurped by an expandable facet.
+      // See https://github.com/cfpb/design-system/pull/1628
+
+      // Override for top border in expandable group.
+      .o-expandable__padded:first-child {
+        border-top: 0;
+      }
+
+      // Override for left/right padding on the label and content.
+      .o-expandable_content,
+      .o-expandable_target {
+        padding-left: 0;
+        padding-right: 0;
       }
     }
+
     .num-results {
       float: right;
     }
-    .o-expandable {
-      padding-bottom: 15px;
-      border-bottom: 1px solid @gray-40;
-      margin-bottom: 15px;
-      &_label {
-        .h4;
-        margin-bottom: 0;
-      }
-    }
+
     .o-form_group {
       margin-bottom: 0;
     }


### PR DESCRIPTION
Prepaid agreements uses a customized expandable for its filter sections. It should be refactored in the future to use an dedicated expandable facet pattern (see https://github.com/cfpb/design-system/pull/1628)

## Changes

- Move prepaid agreement `filter-section`s into expandable group


## How to test this PR

1. Visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and compare to https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/ 
There will be some minor spacing differences, especially noticeable with the focus rectangle. Also, the existing filters have a bug where the checkboxes briefly touch the label when closing. That should be fixed.


## Screenshots

Before:

<img width="382" alt="Screen Shot 2023-04-19 at 9 33 21 AM" src="https://user-images.githubusercontent.com/704760/233091480-93c52947-bccb-46b6-8d1b-a8b95dfd319b.png">

After:

<img width="379" alt="Screen Shot 2023-04-19 at 9 33 51 AM" src="https://user-images.githubusercontent.com/704760/233091525-c0bf6e05-5ed5-4391-b958-9ceae745dfe9.png">
