### PR TITLE
Remove inclusion of deprecated login.css

### DIFF
--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/account/password_reset/confirm.html
@@ -9,13 +9,6 @@
 {% endblock %}
 {% block bodyclass %}login{% endblock %}
 
-
-{% block extra_css %}
-    {{ block.super }}
-
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
-{% endblock %}
-
 {% block furniture %}
     <main class="content-wrapper" id="main">
         {% if validlink %}


### PR DESCRIPTION
Our custom password reset template pulls in a login.css file that is deprecated as of Wagtail 4. This change removes it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)