### PR TITLE
Remove deprecated X-XSS header

### DIFF
--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -6,7 +6,6 @@ KeepAlive On
 MaxKeepAliveRequests 500
 
 Header always set X-Frame-Options SAMEORIGIN
-Header always set X-XSS-Protection: "1; mode=block"
 Header always set X-Content-Type-Options: nosniff
 
 # In prod, LIMIT_REQUEST_BODY is set to 100KB. In all other envs,


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/web/http/headers/x-xss-protection and https://owasp.org/www-project-secure-headers/#x-xss-protection