### PR TITLE
Update `get_latest_revision_as_page` calls

### DIFF
--- a/cfgov/v1/management/commands/publish_pages.py
+++ b/cfgov/v1/management/commands/publish_pages.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
                 else:
                     raise
 
-            page = page.get_latest_revision_as_page()
+            page = page.get_latest_revision_as_object()
 
             if not options["dry_run"]:
                 page.save_revision().publish()

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -178,7 +178,7 @@ def register_cdn_url():
 @hooks.register("before_serve_page")
 def serve_latest_draft_page(page, request, args, kwargs):
     if page.pk in settings.SERVE_LATEST_DRAFT_PAGES:
-        latest_draft = page.get_latest_revision_as_page()
+        latest_draft = page.get_latest_revision_as_object()
         response = latest_draft.serve(request, *args, **kwargs)
         response["Serving-Wagtail-Draft"] = "1"
         return response


### PR DESCRIPTION
Wagtail 4.0 renamed the `get_latest_revision_as_page` method to `get_latest_revision_as_object`; the old name still exists for backwards compatibility, but will be removed in Wagtail 5:

https://docs.wagtail.org/en/stable/releases/4.0.html#page-get-latest-revision-as-page-renamed-to-page-get-latest-revision-as-object

We have a couple of references to the old name, which generate a warning when running tests. This commit renames them.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)