### PR TITLE
Updating No FEAR Act footer link and label

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/footer.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/footer.html
@@ -163,8 +163,8 @@
                         </a>
                     </li>
                     <li class="m-list_item">
-                        <a class="m-list_link" href="/office-civil-rights/no-fear-act/">
-                            No FEAR Act Data
+                        <a class="m-list_link" href="/office-civil-rights/no-fear-act-cummings-act/">
+                            No FEAR Act &amp; Cummings Act
                         </a>
                     </li>
                     {% if language != 'es'%}


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
The page "No FEAR Act" has been updated and renamed [No FEAR Act & Cummings Act](https://www.consumerfinance.gov/office-civil-rights/no-fear-act-cummings-act/). This PR modifies the footer link to reflect that change.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Changes

- Footer link updated


## How to test this PR

1. localhost
2. View footer on any page

