### PR TITLE
Fix our env label with Wagtail's new sidebar

### DIFF
--- a/cfgov/wagtailadmin_overrides/static/css/global.css
+++ b/cfgov/wagtailadmin_overrides/static/css/global.css
@@ -1,7 +1,8 @@
 body:before {
   content: attr(data-env);
   display: block;
-  padding: 0.25em;
+  padding: 1.25em;
+  height: 50px;
   background-color: #bb5b03; /* Dark Orange */
   color: #fff;
   font-weight: bold;
@@ -14,12 +15,27 @@ body:before {
 @media screen and (min-width: 800px) {
   body:before {
     box-sizing: border-box;
-    width: 200px;
-    padding: 0.5em;
     position: fixed;
+    overflow: hidden;
+    z-index: 1000;
     top: 0;
     left: 0;
-    z-index: 100;
+    width: 150px;
+    height: 35px;
+    margin-top: 0.5em;
+    padding: 0.5em;
+    line-height: 1.5;
+    transition-duration: 0.15s;
+    transition-property: inset-inline-start,padding-inline-start,width,transform,margin-top,min-height;
+    transition-timing-function: cubic-bezier(.4,0,.2,1);
+  }
+  button.sidebar__collapse-toggle {
+    z-index: 1010;
+  }
+  body:has(div.sidebar--slim):before {
+    width: 60px;
+    width: 0px;
+    content: "";
   }
 }
 


### PR DESCRIPTION
This change updates our env label for Wagtail’s new sidebar. Instead of sitting on top of the sidebar, it now sits beside the collapse button, and will move with the sidebar to collapse.

It still appears across the top on mobile, but now it appears dimensionally the same as the sidebar button.

Much of this is based on the Wagtail admin's CSS and conforming to that.

On desktop expanded:
<img width="200" alt="image" src="https://user-images.githubusercontent.com/10562538/233998867-178bdc34-6552-4171-af07-2f41cd19706c.png">

On desktop collapsed:
<img width="260" alt="image" src="https://user-images.githubusercontent.com/10562538/233999106-463fce95-c26d-432e-933b-9eab0d70d85e.png">

On mobile:
<img width="357" alt="image" src="https://user-images.githubusercontent.com/10562538/233998462-ce3c267f-4443-44e7-bea5-8acff0fbf7e8.png">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
