### PR TITLE
Modify user viewability of CDN Tools

### DIFF
--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -155,7 +155,11 @@ def register_django_admin_menu_item():
 
 class IfCDNEnabledMenuItem(MenuItem):
     def is_shown(self, request):
-        return cdn_is_configured()
+        return (
+            cdn_is_configured()
+            and request.user
+            and request.user.has_perm("v1.add_cdnhistory")
+        )
 
 
 @hooks.register("register_admin_menu_item")


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR modifies the conditions for the "CDN Tools" sidebar option so that it is only visible for users with the `v1.add_cdnhistory` permission.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->



## Changes

- Changing return conditions for `IfCDNEnabledMenuItem` to check user permissions


## How to test this PR

Because `cdn_is_configured()` will always fail on local, you can test that the rest of the conditional is working properly by removing that section of `wagtail_hooks.py` and then testing by logging in as a user who has the permission (e.g. admin) and a new or existing user who does not (e.g. any user within the Edit-only group).