### PR TITLE
Minor fix to base template spacing

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -341,7 +341,7 @@
           {% if page and page.media_js %}
             {% for js in page.media_js %}
                 {% if 'https://' in js %}
-                  s.push('{{ js}}');
+                  s.push('{{ js }}');
                 {% else %}
                   s.push( '{{ static('js/routes/on-demand/' + js) }}' );
                 {% endif %}


### PR DESCRIPTION
Missing space in `{{ js}}` variable reference, introduced in 3cbc597440e5fdf3c8ac8aa1e8ba7f61212ce183.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)