### PR TITLE
Paying for College - Move expandable code to flyout code

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/09-make-a-plan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/09-make-a-plan.html
@@ -34,8 +34,8 @@
 
         <p>From cheapest to most expensive, here are your options for closing that gap:</p>
 
-        <div class="o-expandable-group">
-            {% set expandable_settings = {
+        <div class="financial-item-group">
+            {% set flyout_settings = {
                 'label': 'Costs',
                 'value': '$0',
                 'is_editable': 'True',
@@ -43,7 +43,7 @@
                 'data_attribute': 'data-financial-item="total_costs"',
                 'note': '<strong>Minimize indirect costs:</strong> Can you reduce your indirect costs by living at home or buying a refurbished laptop?' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 {{
                     input.render({
                         'label': 'Tuition and fees',
@@ -102,14 +102,14 @@
                 }}
             {% endcall %}
 
-            {% set expandable_settings = {
+            {% set flyout_settings = {
                 'label': 'Grants & scholarships',
                 'value': '$99,999',
                 'is_editable': 'True',
                 'data_attribute': 'data-financial-item="total_grantsScholarships"',
                 'note': '<strong>Apply for additional grants and scholarships:</strong> Ask the financial aid office and your school counselor (if you’re currently in high school) for help. <a href="https://studentaid.gov/understand-aid/types/scholarships" target="_blank" class="external-link" rel="noreferrer noopener">The Department of Education has more ideas here.</a>' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 <div class="undergrad-content">
                     {{
                         input.render({
@@ -219,14 +219,14 @@
                     })
                 }}
             {% endcall %}
-            {% set expandable_settings = {
+            {% set flyout_settings = {
                 'label': 'Work-study<span class="graduate-content">, fellowships, and assistantships</span>' | safe,
                 'value': '$99,999',
                 'is_editable': 'True',
                 'data_attribute': 'data-financial-item="total_workStudyFellowAssist"',
                 'note': '<strong>Pursue a work-study position:</strong> Working can reduce borrowing and provide other benefits, as long as it doesn’t interfere with academic progress.' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 {{
                     input.render({
                         'label': 'Work-study',
@@ -255,14 +255,14 @@
                 </div>
             {% endcall %}
 
-            {% set expandable_settings = {
+            {% set flyout_settings = {
                 'label': 'Other sources',
                 'value': '$99,999',
                 'is_editable': 'True',
                 'data_attribute': 'data-financial-item="total_otherResources"',
                 'note': '<span><strong>Find more cash:</strong> Can you contribute more from savings or work? Can anyone in your family help you?</span><span><strong>Ask about tuition payment plans:</strong> If the school offers a no-cost or low-cost installment plan, you and your family may be able to budget for paying your tuition gradually over time. Ask the financial aid office. </span>' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 {{
                     input.render({
                         'label': 'Personal funds',
@@ -321,14 +321,14 @@
                 }}
             {% endcall %}
 
-            {% set expandable_settings = {
+            {% set flyout_settings = {
                 'label': 'Federal loans (minus loan fees)',
                 'value': '$99,999',
                 'is_editable': 'True',
                 'data_attribute': 'data-financial-item="total_fedLoans"',
                 'note': '<strong>Take out more federal loans:</strong> Generally, your financial aid offer includes the maximum amount of Direct Loans available to you. Contact the financial aid office to find out more.' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 <div class="block block__mid block__flush-top financial-item-group undergrad-content">
                     {{
                         input.render({
@@ -384,14 +384,14 @@
                     }}
                 </div>
             {% endcall %}
-            {% set expandable_settings = {
+            {% set flyout_settings = {
                 'label': 'Other loans (minus loan fees)' | safe,
                 'value': '$99,999',
                 'is_editable': 'True',
                 'data_attribute': 'data-financial-item="total_publicLoans"',
                 'note': '<strong>Borrow more from the school:</strong> Contact the financial aid office to find out more. Remember, these loans may not offer the same protections as federal student loans.' | safe
             } %}
-            {% call() expandable(expandable_settings) %}
+            {% call() flyout(flyout_settings) %}
                 <div class="block block__mid block__flush-top financial-item-group">
                     {{
                         input.render({
@@ -510,14 +510,14 @@
                     </ul>' | safe
                 ) }}
 
-                <div class="plus-loan-expandable graduate-content">
-                    {% set expandable_settings = {
+                <div class="plus-loan-flyout graduate-content">
+                    {% set flyout_settings = {
                         'label': 'Direct PLUS (Grad PLUS) loan' | safe,
                         'value': '$0',
                         'is_editable': 'True',
                         'data_attribute': 'data-financial-item="total_plusLoans"'
                     } %}
-                    {% call() expandable(expandable_settings) %}
+                    {% call() flyout(flyout_settings) %}
                         <div class="plus-loan-form" >
                             {{
                                 input.render({
@@ -552,14 +552,14 @@
                         ) }}
                     {% endcall %}
                 </div>
-                <div class="plus-loan-expandable dependent-content">
-                    {% set expandable_settings = {
+                <div class="plus-loan-flyout dependent-content">
+                    {% set flyout_settings = {
                         'label': 'Parent PLUS loan' | safe,
                         'value': '$0',
                         'is_editable': 'True',
                         'data_attribute': 'data-financial-item="total_plusLoans"'
                     } %}
-                    {% call() expandable(expandable_settings) %}
+                    {% call() flyout(flyout_settings) %}
                          <div class="plus-loan-form">
                             {{
                                 input.render({
@@ -603,15 +603,15 @@
                         ) }}
                     {% endcall %}
                 </div>
-                 <div class="private-loan-expandable">
-                    {% set expandable_settings = {
+                 <div class="private-loan-flyout">
+                    {% set flyout_settings = {
                         'label': 'Private loans',
                         'value': '$0',
                         'is_editable': 'True',
                         'data_attribute': 'data-financial-item="total_privateLoans"',
                         'note': 'If you need a private loan, you\'ll have to apply directly to lenders. Shop around for the lowest interest rates and loan fees. Private lenders typically require a cosigner for these loans.'
                     } %}
-                    {% call() expandable(expandable_settings) %}
+                    {% call() flyout(flyout_settings) %}
                         <div class="private-loan-form">
                             <h4>Private Loan</h4>
                             {{

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
@@ -157,13 +157,13 @@
 
         <p>Check out the average expenses reported by people living in this <span data-state-based-visibility="no-program-selected">school</span><span data-state-based-visibility="program-is-selected">program</span>'s region and salary. Enter your actual expenses if you know them, or research reasonable figures for the lifestyle you plan to have.</p>
 
-        {% set expandable_settings = {
+        {% set flyout_settings = {
             'label': 'Average monthly expenses',
             'value': '$0',
             'is_editable': 'True',
             'data_attribute': 'data-expenses-item="total_expenses"'
         } %}
-        {% call() expandable(expandable_settings) %}
+        {% call() flyout(flyout_settings) %}
         {{
             input.render({
                 'label': 'Housing',

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
@@ -27,12 +27,12 @@
    ========================================================================== #}
 
 {% macro flyout(value) %}
-<div class="o-costs-group" data-js-hook="behavior_flyout-menu">
+<div class="o-costs-group">
     <button class="o-costs-group_header
                    o-costs-group_header__collapsed
                    financial-item
                    financial-item__flyout
-                   {{ ('financial-item__' + value.status | safe ) if value.status else ''}}" data-js-hook="behavior_flyout-menu_trigger"
+                   {{ ('financial-item__' + value.status | safe ) if value.status else ''}}" 
             type="button">
       <span class="flex-container">
         <span class="h4 o-costs-group_label">
@@ -56,7 +56,7 @@
             </span>
         {% endif %}
     </button>
-    <div class="o-costs-group_content" data-js-hook="behavior_flyout-menu_content">
+    <div class="o-costs-group_content">
         {% if caller is defined %}
             {{ caller() }}
         {% endif %}

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
@@ -29,8 +29,7 @@
 {% macro flyout(value) %}
 <div class="o-costs-group" data-js-hook="behavior_flyout-menu">
     <button class="o-costs-group_header
-                   o-costs-group_target
-                   o-costs-group_target__collapsed
+                   o-costs-group_header__collapsed
                    financial-item
                    financial-item__flyout
                    {{ ('financial-item__' + value.status | safe ) if value.status else ''}}" data-js-hook="behavior_flyout-menu_trigger"
@@ -43,10 +42,10 @@
             <span class="financial-item_value" {{ value.data_attribute | safe if value.data_attribute else '' }} >
                {{ value.value }}
             </span>
-            <span class="o-expandable_cue-open" role="img" aria-label="{{ 'Edit' if value.is_editable else 'Show' }}">
+            <span class="o-costs-group_cue-open" role="img" aria-label="{{ 'Edit' if value.is_editable else 'Show' }}">
                 {{ svg_icon('edit') if value.is_editable else svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" role="img" aria-label="{{ 'Save' if value.is_editable else 'Hide' }}">
+            <span class="o-costs-group_cue-close" role="img" aria-label="{{ 'Save' if value.is_editable else 'Hide' }}">
                 {{ svg_icon('approved-round') if value.is_editable else svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-flyout.html
@@ -1,23 +1,23 @@
 {# ==========================================================================
 
-   Expandable
+   Costs Group (organism using flyout code)
 
    ==========================================================================
 
    Description:
 
-   Create a financial item expandable when given:
+   Create a financial item costs group flyout when given:
 
    value:                   Object with following properties:
 
-   value.label:             Label for expandable header.
+   value.label:             Label for costs group header.
 
-   value.value:             Value for expandable header.
+   value.value:             Value for costs group header.
 
-   value.is_editable:       Whether expandable contains form elements.
+   value.is_editable:       Whether costs group contains form elements.
                             Determines the open/close cues.
 
-   value.note:              Additional text for expandable header.
+   value.note:              Additional text for costs group header.
 
    value.data_attribute:    Data attribute for value element.
 
@@ -26,19 +26,20 @@
 
    ========================================================================== #}
 
-{% macro expandable(value) %}
-<div class="o-expandable
-            o-expandable__padded">
-    <button class="o-expandable_header
+{% macro flyout(value) %}
+<div class="o-costs-group" data-js-hook="behavior_flyout-menu">
+    <button class="o-costs-group_header
+                   o-costs-group_target
+                   o-costs-group_target__collapsed
                    financial-item
-                   financial-item__expandable
-                   {{ ('financial-item__' + value.status | safe ) if value.status else ''}}"
+                   financial-item__flyout
+                   {{ ('financial-item__' + value.status | safe ) if value.status else ''}}" data-js-hook="behavior_flyout-menu_trigger"
             type="button">
       <span class="flex-container">
-        <span class="h4 o-expandable_label">
+        <span class="h4 o-costs-group_label">
             {{ value.label }}
         </span>
-        <span class="o-expandable_link">
+        <span class="o-costs-group_link">
             <span class="financial-item_value" {{ value.data_attribute | safe if value.data_attribute else '' }} >
                {{ value.value }}
             </span>
@@ -56,7 +57,7 @@
             </span>
         {% endif %}
     </button>
-    <div class="o-expandable_content">
+    <div class="o-costs-group_content" data-js-hook="behavior_flyout-menu_content">
         {% if caller is defined %}
             {{ caller() }}
         {% endif %}
@@ -65,5 +66,5 @@
 {% endmacro %}
 
 {% if value %}
-    {{ expandable(value) }}
+    {{ flyout(value) }}
 {% endif %}

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
@@ -3,7 +3,7 @@
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 {% import 'v1/includes/atoms/radio-button.html' as radio %}
 {% import 'v1/includes/molecules/notification.html' as notification with context %}
-{% from 'college-cost-blocks/macros/financial-item-expandable.html' import expandable with context %}
+{% from 'college-cost-blocks/macros/financial-item-flyout.html' import flyout with context %}
 {% import 'college-cost-blocks/macros/financial-item-input.html' as input with context %}
 {% import 'college-cost-blocks/macros/financial-item-text.html' as text_item with context %}
 {% import 'college-cost-blocks/macros/number-callout.html' as number_callout with context %}

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/college-costs.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/college-costs.less
@@ -79,7 +79,7 @@
       box-sizing: border-box;
     }
 
-    .o-expandable {
+    .o-costs-group {
       &_header,
       &_content {
         padding-left: 0;
@@ -131,7 +131,7 @@
         margin-top: unit(30px / @base-font-size-px, em);
       }
 
-      .o-expandable_header {
+      .o-costs-group_header {
         border-top: 1px solid @black;
         border-bottom: 1px solid @black;
       }

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
@@ -1,7 +1,7 @@
 .financial-item {
   margin-top: unit(30px / @base-font-size-px, em);
 
-  &:not(&__expandable) {
+  &:not(&__flyout) {
     .financial-item_label,
     .financial-item_value {
       display: inline-block;
@@ -45,18 +45,25 @@
     }
   }
 
-  &__expandable {
+  &__flyout {
+    padding: 0.625em 0.9375em;
     margin-top: 0;
+    background-color: #FFF;
 
     .h4 {
       margin-bottom: 0;
     }
 
-    .o-expandable_label {
+    .o-costs-group_label {
       width: auto;
     }
 
     .financial-item_note {
+      text-align: left;
+      margin-top: unit(15px / @base-font-size-px, em);
+    }
+
+    .financial-item_note span {
       margin-top: unit(15px / @base-font-size-px, em);
     }
 
@@ -65,22 +72,25 @@
     }
   }
 
-  &.o-expandable_header {
-    &[aria-expanded='false'] {
-      .o-expandable_cue-close {
+  &.o-costs-group_target {
+    border: none;
+    margin-bottom: unit(15px / @base-font-size-px, em);
+
+    &__collapsed {
+      .o-costs-group_cue-close {
         display: none;
       }
-      .o-expandable_cue-open {
+      .o-costs-group_cue-open {
         display: inline;
         margin-left: unit(5px / @base-font-size-px, em);
       }
     }
 
-    &[aria-expanded='true'] {
-      .o-expandable_cue-open {
+    &__expanded {
+      .o-costs-group_cue-open {
         display: none;
       }
-      .o-expandable_cue-close {
+      .o-costs-group_cue-close {
         display: inline;
         margin-left: unit(5px / @base-font-size-px, em);
       }
@@ -89,9 +99,18 @@
     .flex-container {
       display: flex;
 
-      .o-expandable_label {
+      .o-costs-group_label {
         flex: 1;
+        text-align: left;
+        flex-grow: 1;
       }
+    }
+
+    .o-costs-group_link .o-costs-group_cue {
+      text-align: right;
+      color: #0072ce;
+      font-size: 1em;
+      line-height: 1.375;
     }
   }
 
@@ -112,11 +131,38 @@
       margin-top: unit(5px / @base-font-size-px, em);
     }
   }
+
+  .o-costs-group_content {
+    .u-clearfix();
+
+    &__transition {
+      transition: max-height @flyout__transition-speed ease-in-out;
+    }
+
+    &.u-is-animating {
+      overflow: hidden;
+    }
+  }
+
+  .financial-item_label p {
+    font-size: unit(5px / @base-font-size-px, em);
+  }
 }
 
 .financial-item-group {
-  .financial-item {
-    margin-top: unit(15px / @base-font-size-px, em);
+  .flyout {
+      border-bottom: 1px solid @flyout__border;
+      &:first-child {
+        border-top: 1px solid @flyout__border;
+    }
+  }
+
+  .o-costs-group-content {
+    .financial-item {
+      margin-top: unit(15px / @base-font-size-px, em);
+    }
+
+    margin-bottom: unit(15px / @base-font-size-px, em);
   }
 }
 

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
@@ -46,7 +46,7 @@
   }
 
   &__flyout {
-    padding: 0.625em 0.9375em;
+    padding: 0.625em;
     margin-top: 0;
     background-color: #FFF;
 
@@ -72,9 +72,10 @@
     }
   }
 
-  &.o-costs-group_target {
+  &.o-costs-group_header {
     border: none;
     margin-bottom: unit(15px / @base-font-size-px, em);
+    text-align: left;
 
     &__collapsed {
       .o-costs-group_cue-close {
@@ -101,14 +102,13 @@
 
       .o-costs-group_label {
         flex: 1;
-        text-align: left;
         flex-grow: 1;
       }
     }
 
-    .o-costs-group_link .o-costs-group_cue {
-      text-align: right;
-      color: #0072ce;
+    .o-costs-group_link .o-costs-group_cue-close,
+    .o-costs-group_link .o-costs-group_cue-open {
+      color: @pacific;
       font-size: 1em;
       line-height: 1.375;
     }
@@ -132,32 +132,20 @@
     }
   }
 
-  .o-costs-group_content {
-    .u-clearfix();
-
-    &__transition {
-      transition: max-height @flyout__transition-speed ease-in-out;
-    }
-
-    &.u-is-animating {
-      overflow: hidden;
-    }
-  }
-
   .financial-item_label p {
     font-size: unit(5px / @base-font-size-px, em);
   }
 }
 
 .financial-item-group {
-  .flyout {
+  .o-costs-group {
       border-bottom: 1px solid @flyout__border;
       &:first-child {
         border-top: 1px solid @flyout__border;
     }
   }
 
-  .o-costs-group-content {
+  .o-costs-group_content {
     .financial-item {
       margin-top: unit(15px / @base-font-size-px, em);
     }

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/vars.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/vars.less
@@ -1,3 +1,5 @@
 @college-costs-chart-min: #d14124;
 @college-costs-chart-median: #ff9e1b;
 @college-costs-chart-max: #257675;
+@flyout__transition-speed: 0.25s;
+@flyout__border: @gray-40;

--- a/cfgov/unprocessed/apps/paying-for-college/js/college-costs/CostsGroup.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/college-costs/CostsGroup.js
@@ -22,7 +22,7 @@ const BASE_CLASS = 'o-costs-group';
 function CostsGroup(element) {
   const _dom = checkDom(element, BASE_CLASS);
   const _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
-  const _targetDom = _dom.querySelector(`.${BASE_CLASS}_target`);
+  const _targetDom = _dom.querySelector(`.${BASE_CLASS}_header`);
   let _transition;
   let _flyout;
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/college-costs/CostsGroup.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/college-costs/CostsGroup.js
@@ -1,0 +1,78 @@
+import {
+  add as addDataHook,
+  checkDom,
+  instantiateAll,
+  setInitFlag,
+  FlyoutMenu,
+  MaxHeightTransition,
+  EventObserver,
+} from '@cfpb/cfpb-atomic-component';
+
+const BASE_CLASS = 'o-costs-group';
+
+/**
+ * CostsGroup
+ *
+ * @class
+ * @classdesc Initializes a new CostsGroup organism.
+ * @param {HTMLElement} element - The DOM element within which to search
+ *   for the organism.
+ * @returns {CostsGroup} An instance.
+ */
+function CostsGroup(element) {
+  const _dom = checkDom(element, BASE_CLASS);
+  const _contentDom = _dom.querySelector(`.${BASE_CLASS}_content`);
+  const _targetDom = _dom.querySelector(`.${BASE_CLASS}_target`);
+  let _transition;
+  let _flyout;
+
+  /**
+   * @returns {CostsGroup} An instance.
+   */
+  function init() {
+    if (!setInitFlag(_dom)) {
+      return this;
+    }
+
+    // Add FlyoutMenu behavior data-js-hooks.
+    addDataHook(_dom, 'behavior_flyout-menu');
+    addDataHook(_contentDom, 'behavior_flyout-menu_content');
+    addDataHook(_targetDom, 'behavior_flyout-menu_trigger');
+
+    _configFlyout();
+
+    return this;
+  }
+
+  /**
+   * Configure the flyout.
+   */
+  function _configFlyout() {
+    _flyout = new FlyoutMenu(_dom);
+    _transition = new MaxHeightTransition(_contentDom);
+    _transition.init(MaxHeightTransition.CLASSES. MH_ZERO);
+    _flyout.setTransition(
+      _transition,
+      _transition.maxHeightZero,
+      _transition.maxHeightDefault
+    );
+    _flyout.init();
+  }
+
+  // Attach public events.
+  const eventObserver = new EventObserver();
+  this.addEventListener = eventObserver.addEventListener;
+  this.removeEventListener = eventObserver.removeEventListener;
+  this.dispatchEvent = eventObserver.dispatchEvent;
+
+  this.init = init;
+
+  return this;
+}
+
+CostsGroup.BASE_CLASS = BASE_CLASS;
+CostsGroup.init = (scope) => {
+  instantiateAll(`.${BASE_CLASS}`, CostsGroup, scope);
+}
+
+export { CostsGroup };

--- a/cfgov/unprocessed/apps/paying-for-college/js/college-costs/views/app-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/college-costs/views/app-view.js
@@ -7,6 +7,7 @@ import { sendAnalyticsEvent } from '../util/analytics.js';
 import { updateFinancialViewAndFinancialCharts } from '../dispatchers/update-view.js';
 import { updateState } from '../dispatchers/update-state.js';
 import { getStateValue } from '../dispatchers/get-model-values.js';
+import { CostsGroup } from '../CostsGroup.js';
 
 const HIDDEN_CLASS = 'u-hidden';
 const appView = {
@@ -123,7 +124,7 @@ const appView = {
     appView._includeParentPlusBtn = document.querySelector(
       '#plan__parentPlusFeeRepay'
     );
-
+    
     _addButtonListeners();
   },
 };
@@ -178,5 +179,13 @@ function _handleActionPlanClick(event) {
   const target = event.target;
   updateState.byProperty('actionPlan', target.value);
 }
+
+/**
+ * Initialize Costs Groups organism
+ */
+const collegeCosts = document.querySelector( '.college-costs' );
+CostsGroup.init( collegeCosts );
+
+
 
 export { appView };


### PR DESCRIPTION
A change in `cf-expandables` broke customization in the Financial Path tool, and @anselmbradford generously gave us guidance on how to fix this so that we weren't dependent on the `cf-expandables` pattern (which should not be customized). 

## Changes
- remove references to `cf-expandables`
- Change class names
- Update JS, including adding 


## How to test this PR
1. Generally, the "expandables" in the Covering Your Costs > Make a Plan section of the app should look better!
2. All features of the application should function as before.


## Screenshots


## Notes and todos

-


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
