### PR TITLE
Remove unused related_links_2

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/related-links.html
+++ b/cfgov/v1/jinja2/v1/includes/related-links.html
@@ -14,43 +14,15 @@
                     Example link: ['/', 'Home']
                     Example related_links: [['/', 'Home'],['/login', 'Login']]
 
-   related_links_2: You can optionally pass in another array which will
-                    activate a two column layout where each array renders in
-                    its own column.
-
    ========================================================================== #}
 
-{%- macro render(related_links, related_links_2) -%}
+{%- macro render(related_links) -%}
 <div class="related-links">
     <header class="m-slug-header">
         <h2 class="a-heading">
             Related links
         </h2>
     </header>
-{%- if related_links_2 %}
-    <div class="content-l
-                content-l__main
-                content-l__large-gutters">
-        <div class="content-l_col content-l_col-1-2">
-            <ul class="m-list m-list__links">
-            {%- for link in related_links %}
-                <li class="m-list_item">
-                    {{- link_template(link) -}}
-                </li>
-            {%- endfor %}
-            </ul>
-        </div>
-        <div class="content-l_col content-l_col-1-2">
-            <ul class="m-list m-list__links">
-            {%- for link in related_links_2 %}
-                <li class="m-list_item">
-                    {{- link_template(link) -}}
-                </li>
-            {%- endfor %}
-            </ul>
-        </div>
-    </div><!-- END .content-l -->
-{%- else %}
     <ul class="m-list m-list__links">
     {%- for link in related_links %}
         <li class="m-list_item">
@@ -58,7 +30,6 @@
         </li>
     {%- endfor %}
     </ul>
-{%- endif %}
 </div>
 {% endmacro -%}
 


### PR DESCRIPTION
This was added 9 years ago in https://github.com/cfpb/consumerfinance.gov/commit/1218b7b7b68499dd456997be3b25b741195d8a72, and does not appear to be used.

This macro is used on events/event.html and newsroom/index.html

## Removals

- Remove unused related_links_2 from related-links macro.

## How to test this PR

1. Check related links on http://localhost:8000/about-us/newsroom/ and (e.g.) http://localhost:8000/about-us/events/archive-past-events/enforcers-training-how-to-build-a-technologist-team/. They should be unchanged versus production.