### PR TITLE
Fix translation links when previewing new pages

### DIFF
--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -616,6 +616,38 @@ class TestCFGOVPageTranslations(TestCase):
         self.assertEqual(page_es.get_translations().first().pk, page_en.pk)
         self.assertEqual(page_es.get_translations().last().pk, page_es.pk)
 
+    def test_new_english_page_without_primary_key(self):
+        new_page_en = BrowsePage(language="en")
+        self.assertEqual(new_page_en.get_translations().count(), 1)
+        self.assertEqual(
+            new_page_en.get_translations().first().pk, new_page_en.pk
+        )
+        self.assertEqual(
+            new_page_en.get_translations(inclusive=False).count(), 0
+        )
+
+    def test_new_spanish_page_without_primary_key(self):
+        new_page_es = BrowsePage(language="es")
+        self.assertEqual(new_page_es.get_translations().count(), 1)
+        self.assertEqual(
+            new_page_es.get_translations().first().pk, new_page_es.pk
+        )
+        self.assertEqual(
+            new_page_es.get_translations(inclusive=False).count(), 0
+        )
+
+        page_en = self.make_page(language="en")
+        new_page_es.english_page = page_en
+        self.assertEqual(new_page_es.get_translations().count(), 2)
+        self.assertEqual(new_page_es.get_translations().first().pk, page_en.pk)
+        self.assertEqual(
+            new_page_es.get_translations().last().pk, new_page_es.pk
+        )
+        self.assertEqual(
+            new_page_es.get_translations(inclusive=False).count(), 1
+        )
+        self.assertEqual(new_page_es.get_translations().first().pk, page_en.pk)
+
     def test_page_get_translation_links(self):
         page_en = self.make_page(language="en")
         self.make_page(language="es", english_page=page_en)


### PR DESCRIPTION
Translation links are currently broken when you use the Wagtail 4+ live preview panel to preview new pages that have never been saved. A translation link is shown for almost every page on the site. This is because the current logic doesn't properly handle the case where a page's primary key is null.

This commit fixes that logic, while still ensuring that the links render properly both for new English and non-English pages.

Fixes internal D&CP#230.

## How to test this PR

Create a new page in Wagtail using a type that would show translation links, for example a BrowseFilterablePage. Fill in all the required fields but don't hit save yet. Open the live sidebar panel and note that the translation links don't appear.

Now set the page's language to something other than English, and select an English page. Still don't hit save. The live preview should update to properly show the translation links. You can even select an English page that you know has other non-English translations already, and those links should also appear.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)