### PR TITLE
Remove job listing CSS cruft

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_details.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_details.html
@@ -63,10 +63,9 @@
 
 <section class="block
                 block__flush-top
-                block__sub
-                vacancy-announcement_details">
+                block__sub">
     <h1>{{ value.title }}</h1>
-    <dl>
+    <dl class="vacancy-announcement_details">
         <dt>Division/Office:</dt>
         <dd>{{ value.division }}</dd>
         <dt>Closing date:</dt>
@@ -124,8 +123,7 @@
         <dt>Grade{{ value.grades | pluralize() }}:</dt>
         <dd>
             {{ value.grades | sort | join( ', ' ) }}
-            <a class="pay-grade-link"
-                href="/about-us/careers/pay-scales/">
+            <a href="/about-us/careers/pay-scales/">
                 See information on grades and base pay ranges</a>
         </dd>
         {% endif %}

--- a/cfgov/unprocessed/css/on-demand/job_listing_page.less
+++ b/cfgov/unprocessed/css/on-demand/job_listing_page.less
@@ -1,19 +1,6 @@
-@import (reference) '../main.less';
+@import (reference) 'cfpb-core.less';
 
-.pay-grade-link {
-  margin-top: 5px;
-  .respond-to-min( @bp-sm-min, {
-    margin: 0 0 0 unit( 5px / @base-font-size-px, em );
-  } );
-}
-
-.vacancy-announcement_details dt {
+dl.vacancy-announcement_details dt {
   margin-top: unit(12px / @base-font-size-px, em);
   margin-bottom: 0;
-}
-
-.vacancy-announcement_description .o-expandable_content__collapsed {
-  .respond-to-max( @bp-xs-max, {
-    max-height:  unit( @base-line-height-px * 10 / @base-font-size-px, em );
-  } );
 }


### PR DESCRIPTION
The vacancies had some CSS related to setting the max-height to create a summary for when these were customized expandables. However, they are summary components now, so that is unneeded.

The vacancies have a `vacancy-announcement_details` class that applies to the `dt` elements inside a `dl` element. The class should move to the `dl` element, not its parent.

The vacancies have a `pay-grade-link` bespoke CSS class, which adds some margin at desktop sizes.

Desktop:
<img width="473" alt="Screen Shot 2023-04-27 at 10 19 24 AM" src="https://user-images.githubusercontent.com/704760/234899158-048ea922-ca74-4bb4-818d-cb50fac407d8.png">

Tablet and below:
<img width="466" alt="Screen Shot 2023-04-27 at 10 19 39 AM" src="https://user-images.githubusercontent.com/704760/234899215-0b18b13d-cfc9-4953-94d5-155f9277c5f3.png">

This appears to be made to make the space around the grade value equal, but it's unclear why this was only applied at desktop sizes. It seems minor and unnecessary, and since the link is about the grade it would make sense it is closer.


## Removals

- Remove `.vacancy-announcement_description .o-expandable_content__collapsed` CSS.
- Remove `pay-grade-link` class.


## Changes

- Move `vacancy-announcement_details` to `dl` element.


## How to test this PR

1. `yarn build` and visit a job listing page via http://localhost:8000/about-us/careers/ and see that the pay grade link is slightly closer at desktop sizes.
