### PR TITLE
iRegs: Remove `application-footer` and `landing-footer` CSS classes

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-pagination.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-pagination.less
@@ -67,19 +67,6 @@
       font-size: 1.125em;
     }
   }
-
-  .application-footer {
-    .title-logo {
-      display: block;
-      margin-bottom: 1em;
-
-      h1 {
-        //display: inline-block;
-        font-size: 1em;
-        margin-bottom: 1em;
-      }
-    }
-  }
 }
 
 @media only screen and (max-width: 600px) {
@@ -102,25 +89,5 @@
 
   .previous {
     margin-left: -25px;
-  }
-}
-
-@media only screen and (max-width: 780px) {
-  .landing-footer {
-    .logo-wrap {
-      width: 100%;
-      float: none;
-    }
-
-    .footer-links {
-      width: 100%;
-      float: none;
-    }
-  }
-}
-
-@media only screen and (max-width: 1100px) {
-  .application-footer {
-    margin-left: 40px;
   }
 }


### PR DESCRIPTION
I can't find references to these classes outside of the less files (both in file search and search of the crawler).

## Removals

- iRegs: remove `application-footer` and `landing-footer` CSS classes

## How to test this PR

1. No change to iRegs browser.
