### PR TITLE
Form explainers: Update to fix issue with expandable overrides

### DIFF
--- a/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
+++ b/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
@@ -75,6 +75,7 @@
   } );
 
   // Expandable overrides
+  // TODO: Make this its own component.
 
   .o-expandable-group .o-expandable {
     border: 4px solid transparent;
@@ -96,7 +97,7 @@
       }
     }
 
-    .o-expandable_content__expanded:before {
+    .o-expandable_content[data-open='true']:before {
       border: none;
     }
 


### PR DESCRIPTION
Expandables changed their designator to when they are open from a class modifier to a data-open attribute in https://github.com/cfpb/design-system/pull/1600, but an override for this was missed in the form explainers.

## Changes

- Update form explainers expandable expanded override.


## How to test this PR

1. Visit http://localhost:8000/owning-a-home/loan-estimate/ and see there's no double line when the form explainer expandables are opened.


## Screenshots

Before:
<img width="500" alt="Screen Shot 2023-04-28 at 12 17 39 PM" src="https://user-images.githubusercontent.com/704760/235200652-20a3715d-39cb-41cc-9c55-a8b1cf88a419.png">

After:
<img width="514" alt="Screen Shot 2023-04-28 at 12 17 31 PM" src="https://user-images.githubusercontent.com/704760/235200680-86a3eeb2-ce9d-4faa-a70f-e920a020494d.png">
