### PR TITLE
Update docs: update outdated expandable and banner code

### DIFF
--- a/docs/atomic-structure.md
+++ b/docs/atomic-structure.md
@@ -114,13 +114,11 @@ Prefixed with `o-` in class names.
 ```html
 <div
   class="o-expandable
-            o-expandable__borders
-            o-expandable__midtone
-            o-expandable__expanded"
-  data-js-hook="state_atomic_init"
+         o-expandable__padded
+         o-expandable__midtone"
 >
-  <button class="o-expandable_target" aria-pressed="true">
-    <div class="o-expandable_header">…</div>
+  <button class="o-expandable_header">
+    <div class="o-expandable_label">…</div>
   </button>
 </div>
 ```
@@ -131,7 +129,7 @@ Prefixed with `o-` in class names.
 .o-expandable {
     position: relative;
 
-    &_target {
+    &_header {
         padding: 0;
         border: 0;
         …
@@ -155,7 +153,7 @@ Prefixed with `o-` in class names.
   // The Expandable element will directly be the Expandable
   // when used in an ExpandableGroup, otherwise it can be the parent container.
   const _dom = atomicHelpers.checkDom( element, BASE_CLASS );
-  const _target = _dom.querySelector( '.' + BASE_CLASS + '_target' );
+  const _target = _dom.querySelector( '.' + BASE_CLASS + '_header' );
   const _content = _dom.querySelector( '.' + BASE_CLASS + '_content' );
   …
 }

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -48,19 +48,17 @@ Most of consumerfinance.gov's templates are Jinja2. In these templates, two temp
 
 See [Enabling a flag](#enabling-a-flag) below for more on flag conditions.
 
-An example is [the `BETA_NOTICE flag` as implemented in `header.html`](https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/jinja2/v1/_includes/organisms/header.html#L28-L41):
+An example is [the `BETA_NOTICE flag` as implemented in `header.html`](https://github.com/cfpb/consumerfinance.gov/blob/d4879552d353198de4f24dd385fe8a48c04448d7/cfgov/v1/jinja2/v1/includes/organisms/header.html#L25-L38):
 
 ```jinja
 {% if flag_enabled('BETA_NOTICE') %}
 <div class="m-global-banner">
     <div class="wrapper
-                wrapper__match-content
-                o-expandable
-                o-expandable__expanded">
-        <div class="m-global-banner_head">
-            <span class="cf-icon
-                         cf-icon-error-round
-                         m-global-banner_icon"></span>
+                wrapper__match-content">
+        <div class="m-notification
+                    m-notification__warning
+                    m-notification__visible">
+            …
             This beta site is a work in progress.
         </div>
         …
@@ -88,13 +86,11 @@ The `BETA_NOTICE` [Jinja2](#jinja2) example above when implemented with Django t
 {% if beta_flag %}
 <div class="m-global-banner">
     <div class="wrapper
-                wrapper__match-content
-                o-expandable
-                o-expandable__expanded">
-        <div class="m-global-banner_head">
-            <span class="cf-icon
-                         cf-icon-error-round
-                         m-global-banner_icon"></span>
+                wrapper__match-content">
+        <div class="m-notification
+                    m-notification__warning
+                    m-notification__visible">
+            …
             This beta site is a work in progress.
         </div>
         …


### PR DESCRIPTION
The whole atomic structure docs needs revisiting, but this fixes some obvious erroneous examples.

## Changes

- Fix dead header.html link by converting it to a permalink.
- Fix some example markup to align with the current codebase.
