### PR TITLE
iRegs: Temp fix for missing icons

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -17,6 +17,18 @@
     border-top: 1px solid @gray-40;
     margin-bottom: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
   } );
+
+  // TODO - this will be updated to data-open='true' in newer expandables.
+  .o-expandable_target__expanded {
+    .o-expandable_cue-close {
+      display: block;
+    }
+  }
+  .o-expandable_target__collapsed {
+    .o-expandable_cue-open {
+      display: block;
+    }
+  }
 }
 
 // Regs3K secondary nav sections


### PR DESCRIPTION
This fixes the hidden secondary nav icons till the iregs secondary nav can be overhauled and untangled from expandables.

## Changes
 
- iRegs: Add temporary CSS to fix hidden icons on secondary navigation. 


## How to test this PR

1. visit http://localhost:8000/rules-policy/regulations/1002/ and resize to mobile and there should be an expand/collapse icon on the secondary navigation.


## Screenshots

Before:
<img width="535" alt="Screen Shot 2023-04-28 at 3 23 47 PM" src="https://user-images.githubusercontent.com/704760/235235789-8c2a584b-2bf9-47f2-be43-125b7e0eadf0.png">

After:
<img width="538" alt="Screen Shot 2023-04-28 at 3 23 36 PM" src="https://user-images.githubusercontent.com/704760/235235804-d67af096-d862-437e-9cdc-323802ecfda7.png">


