### PR TITLE
FIG: update expandable CSS to fix mobile scrolling issue

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.less
@@ -114,7 +114,7 @@
 
   // When the sidebar collapses into an expandable,
   // make the expandable's content scrollable
-  .o-expandable_content__expanded {
+  .o-expandable_content[data-open='true'] {
     overflow-y: auto;
     height: 100vh;
     &:after {


### PR DESCRIPTION
This expandable override needs to be updated to the latest expandable expanded code.

## Changes

- FIG: update expandable CSS


## How to test this PR

1. http://localhost:8000/data-research/small-business-lending/filing-instructions-guide/2024-guide/ and resize to mobile and expand menu and scroll down.
