### PR TITLE
Financial well-being: Use standard borders in expandable

### DIFF
--- a/cfgov/unprocessed/apps/financial-well-being/css/main.less
+++ b/cfgov/unprocessed/apps/financial-well-being/css/main.less
@@ -143,15 +143,6 @@
 }
 
 /* CF Enhancements */
-.u-left {
-  float: left;
-}
-
-.o-expandable {
-  border-top: 1px solid #b4b5b6;
-  border-bottom: 1px solid #b4b5b6;
-}
-
 @media all and (max-width: 37.5em) {
   .comparison-chart_toggle-button {
     display: block;

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -152,7 +152,8 @@
         </p>
     {% if user_score %}
         <div class="o-expandable
-                    o-expandable__padded">
+                    o-expandable__padded
+                    o-expandable__border">
             <button class="o-expandable_header o-expandable_target">
                 <span class="o-expandable_label">
                     {{ _('Review your answers') }}


### PR DESCRIPTION
## Removals

- Remove unused `u-left`.


## Changes

- Financial well-being: Use standard borders in expandable.


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/financial-well-being/ and fill out the form and get your results and see the expandable on the results page.

## Screenshots

Before:

<img width="526" alt="Screen Shot 2023-05-02 at 2 12 38 PM" src="https://user-images.githubusercontent.com/704760/235751464-8e678d41-17f5-46fa-bfd3-f87e4955a5c3.png">

After:

<img width="526" alt="Screen Shot 2023-05-02 at 2 12 48 PM" src="https://user-images.githubusercontent.com/704760/235751497-fa008b62-e3ba-4d8b-9602-c1af2b816dc2.png">
