### PR TITLE
Prepaid credit card agreements: Add JS initialization script

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
@@ -95,3 +95,12 @@
         {% include 'search_results.html' %}
     </div>
 {% endblock %}
+
+
+{% block javascript %}
+    {{ super() }}
+    <script>
+      jsl(['{{ static("apps/prepaid-agreements/js/common.js") }}']);
+    </script>
+{% endblock javascript %}
+

--- a/cfgov/unprocessed/apps/prepaid-agreements/css/main.less
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/main.less
@@ -72,14 +72,8 @@
 
   .search_results {
     .content_sidebar {
-      .o-expandable {
-        &:nth-child(4n) {
-          border-bottom: none;
-        }
-      }
-
-      .o-expandable_content__expanded {
-        padding-top: unit(@grid_gutter-width / 3 / @base-font-size-px, em);
+      .o-expandable:nth-child(4n) {
+        border-bottom: none;
       }
     }
 

--- a/cfgov/unprocessed/apps/prepaid-agreements/js/common.js
+++ b/cfgov/unprocessed/apps/prepaid-agreements/js/common.js
@@ -1,0 +1,2 @@
+import { ExpandableGroup } from '@cfpb/cfpb-expandables';
+ExpandableGroup.init();

--- a/esbuild/scripts.js
+++ b/esbuild/scripts.js
@@ -38,6 +38,7 @@ const jsPaths = [
   `${apps}/owning-a-home/js/mortgage-estimate/index.js`,
   `${apps}/paying-for-college/js/disclosures/index.js`,
   `${apps}/paying-for-college/js/college-costs.js`,
+  `${apps}/prepaid-agreements/js/common.js`,
   `${apps}/regulations3k/js/index.js`,
   `${apps}/regulations3k/js/permalinks.js`,
   `${apps}/regulations3k/js/recent-notices.js`,


### PR DESCRIPTION
Not totally sure how this was working before, but the expandables aren't initialized. This PR adds a script to initialize them.


## Additions

- Add prepaid script to initialize expandable group.

## How to test this PR

1. Compare filter expandables in http://localhost:8000/data-research/prepaid-accounts/search-agreements/ vs https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/


## Screenshots

Before:
<img width="530" alt="Screen Shot 2023-05-02 at 2 42 50 PM" src="https://user-images.githubusercontent.com/704760/235757152-360601e1-8659-455d-b825-62fc79802202.png">

After:
<img width="535" alt="Screen Shot 2023-05-02 at 2 42 33 PM" src="https://user-images.githubusercontent.com/704760/235757183-1819e73a-621d-48b3-8453-8ce2eeaa9bd3.png">