### PR TITLE
Simplify search-regulations.html no-js submit button

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -179,14 +179,10 @@
                     </fieldset>
                 </div>
                 {% endcall %}
-                <div class="o-form_group regs3k-js">
-                    <fieldset class="o-form_fieldset u-mt20">
-                        <div class="input-with-btn_btn">
-                            <button class="a-btn" type="submit">
-                                Update
-                            </button>
-                        </div>
-                    </fieldset>
+                <div class="regs3k-js u-mb20">
+                    <button class="a-btn" type="submit">
+                        Update
+                    </button>
                 </div>
             </form>
         </aside>


### PR DESCRIPTION
This button was missing bottom padding and had arguably overly complex nesting. 

## Changes

- Simplify search-regulations.html no-js submit button


## How to test this PR

1. Search http://localhost:8000/rules-policy/regulations/search-regulations/results/ and turn off JS in the browser and note an "Update" button appears and can be clicked to search the regs.


## Screenshots

Before:
<img width="533" alt="Screen Shot 2023-05-02 at 3 41 16 PM" src="https://user-images.githubusercontent.com/704760/235770472-15190c1b-4ac9-4d68-8abb-401768a2ca06.png">

After:
<img width="537" alt="Screen Shot 2023-05-02 at 3 43 17 PM" src="https://user-images.githubusercontent.com/704760/235770487-37a6b54c-7c11-42c9-befc-ac7958fe6ada.png">

