### PR TITLE
Fix aria role on expandable icons

### DIFF
--- a/cfgov/form_explainer/jinja2/form-explainer/blocks/explainer.html
+++ b/cfgov/form_explainer/jinja2/form-explainer/blocks/explainer.html
@@ -94,10 +94,10 @@
             {{ item.heading }}
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                 {{ svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/jinja2/rural-or-underserved/_templates/expandable.html
+++ b/cfgov/jinja2/rural-or-underserved/_templates/expandable.html
@@ -24,10 +24,10 @@
             {{ heading|safe }}
         </h3>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                 {{ svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -498,10 +498,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                             How should I format the addresses that I upload to the tool?
                                         </h3>
                                         <span class="o-expandable_link">
-                                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                                 {{ svg_icon('plus-round') }}
                                             </span>
-                                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                                 {{ svg_icon('minus-round') }}
                                             </span>
                                         </span>
@@ -721,10 +721,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                             How do I resolve the addresses that could not be identified?
                                         </h3>
                                         <span class="o-expandable_link">
-                                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                                 {{ svg_icon('plus-round') }}
                                             </span>
-                                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                                 {{ svg_icon('minus-round') }}
                                             </span>
                                         </span>
@@ -798,10 +798,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                             What is CSV?
                                         </h3>
                                         <span class="o-expandable_link">
-                                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                                 {{ svg_icon('plus-round') }}
                                             </span>
-                                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                                 {{ svg_icon('minus-round') }}
                                             </span>
                                         </span>
@@ -833,10 +833,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                             How do I fix the format?
                                         </h3>
                                         <span class="o-expandable_link">
-                                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                                 {{ svg_icon('plus-round') }}
                                             </span>
-                                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                                 {{ svg_icon('minus-round') }}
                                             </span>
                                         </span>
@@ -889,10 +889,10 @@ home price, down payment, and more can affect mortgage interest rates.
                                             Where can I find more information?
                                         </h3>
                                         <span class="o-expandable_link">
-                                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                                 {{ svg_icon('plus-round') }}
                                             </span>
-                                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                                 {{ svg_icon('minus-round') }}
                                             </span>
                                         </span>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-expandable.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/macros/financial-item-expandable.html
@@ -43,10 +43,10 @@
             <span class="financial-item_value" {{ value.data_attribute | safe if value.data_attribute else '' }} >
                {{ value.value }}
             </span>
-            <span class="o-expandable_cue-open" aria-label="{{ 'Edit' if value.is_editable else 'Show' }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ 'Edit' if value.is_editable else 'Show' }}">
                 {{ svg_icon('edit') if value.is_editable else svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ 'Save' if value.is_editable else 'Hide' }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ 'Save' if value.is_editable else 'Hide' }}">
                 {{ svg_icon('approved-round') if value.is_editable else svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/inline_interps.html
@@ -12,10 +12,10 @@
             Official interpretation {% if section_title %}of {{ section_title }}{% endif %}
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                 {{ svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations3k-secondary-navigation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations3k-secondary-navigation.html
@@ -20,10 +20,10 @@
                 Table of Contents
             </span>
             <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -15,10 +15,10 @@
                         </label><button class="a-btn a-btn__link u-hide-on-xs u-hide-on-sm o-expandable-facets_target" type="button">
                             <span class="u-visually-hidden">Expand children</span>
                             <span aria-hidden="true">{{ facet.title }}</span>
-                            <span class="o-expandable-facets_cue o-expandable-facets_cue-open" aria-label="{{ _('Show') }}">
+                            <span class="o-expandable-facets_cue o-expandable-facets_cue-open" role="img" aria-label="{{ _('Show') }}">
                                 {{ svg_icon('down') }}
                             </span>
-                            <span class="o-expandable-facets_cue o-expandable-facets_cue-close" aria-label="{{ _('Hide') }}">
+                            <span class="o-expandable-facets_cue o-expandable-facets_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                 {{ svg_icon('up') }}
                             </span>
                         </button>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/form-page.html
@@ -117,10 +117,10 @@
                     <button class="o-expandable_header o-expandable_target"
                             title="Expand content">
                         <span class="o-expandable_link">
-                            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                                 {{ svg_icon('plus-round') }}
                             </span>
-                            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                                 {{ svg_icon('minus-round') }}
                             </span>
                         </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-3-5.html
@@ -77,10 +77,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/planning.svg') }}" alt="planning icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -114,10 +114,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/habits.svg') }}" alt="habits icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -151,10 +151,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/knowledge.svg') }}" alt="knowledge icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-6-8.html
@@ -72,10 +72,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/planning.svg') }}" alt="planning icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -127,10 +127,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/habits.svg') }}" alt="habits icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -183,10 +183,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/knowledge.svg') }}" alt="knowledge icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/survey/results-9-12.html
@@ -72,10 +72,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/planning.svg') }}" alt="planning icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -127,10 +127,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/habits.svg') }}" alt="habits icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>
@@ -183,10 +183,10 @@
                         <img src="{{ static('apps/teachers-digital-platform/img/knowledge.svg') }}" alt="knowledge icon"> {{ bbs[bb].title }}
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                     {{ svg_icon('plus-round') }}
                 </span>
-                <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                     {{ svg_icon('minus-round') }}
                 </span>
             </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/tdp_expandable.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/tdp_expandable.html
@@ -45,10 +45,10 @@ TODO: Note that this is a copy of our standard expandable for TDP,
             {{ value.label }}
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                 {{ svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/unprocessed/css/organisms/secondary-navigation.less
+++ b/cfgov/unprocessed/css/organisms/secondary-navigation.less
@@ -16,10 +16,10 @@
                     Nav Button
                 </span>
                 <span class="o-expandable_link">
-                    <span class="o-expandable_cue-open" aria-label="Show">
+                    <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         {{ svg_icon('plus-round') }}
                     </span>
-                    <span class="o-expandable_cue-close" aria-label="Hide">
+                    <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         {{ svg_icon('minus-round') }}
                     </span>
                 </span>

--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -44,10 +44,10 @@
             {{ value.label }}
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+            <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                 {{ svg_icon('plus-round') }}
             </span>
-            <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+            <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                 {{ svg_icon('minus-round') }}
             </span>
         </span>

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -159,10 +159,10 @@
                     {{ _('Review your answers') }}
                 </span>
                 <span class="o-expandable_link">
-                    <span class="o-expandable_cue-open" aria-label="{{ _('Show') }}">
+                    <span class="o-expandable_cue-open" role="img" aria-label="{{ _('Show') }}">
                         {{ svg_icon('plus-round') }}
                     </span>
-                    <span class="o-expandable_cue-close" aria-label="{{ _('Hide') }}">
+                    <span class="o-expandable_cue-close" role="img" aria-label="{{ _('Hide') }}">
                         {{ svg_icon('minus-round') }}
                     </span>
                 </span>

--- a/test/unit_tests/apps/filing-instruction-guide/fixtures/sample-fig-page.js
+++ b/test/unit_tests/apps/filing-instruction-guide/fixtures/sample-fig-page.js
@@ -46,7 +46,7 @@ export default `<main class="content content__1-3 o-fig" id="main">
               Table of contents
             </span>
             <span class="o-expandable_link">
-              <span class="o-expandable_cue-open" aria-label="Show">
+              <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 17 20.4"
@@ -57,7 +57,7 @@ export default `<main class="content content__1-3 o-fig" id="main">
                   ></path>
                 </svg>
               </span>
-              <span class="o-expandable_cue-close" aria-label="Hide">
+              <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 17 20.4"

--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -25,8 +25,8 @@ const HTML_SNIPPET = `
         <span class="o-expandable_label">
         </span>
         <span class="o-expandable_link">
-          <span class="o-expandable_cue-open" aria-label="Show"></span>
-          <span class="o-expandable_cue-close" aria-label="Hide"></span>
+          <span class="o-expandable_cue-open" role="img" aria-label="Show"></span>
+          <span class="o-expandable_cue-close" role="img" aria-label="Hide"></span>
         </span>
       </div>
     </button>

--- a/test/unit_tests/apps/teachers-digital-platform/html/results-page-analytics.js
+++ b/test/unit_tests/apps/teachers-digital-platform/html/results-page-analytics.js
@@ -177,12 +177,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/planning.svg" alt="planning icon"> Planning and self-control
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
@@ -246,12 +246,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/habits.svg" alt="habits icon"> Money habits and values
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
@@ -316,12 +316,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/knowledge.svg" alt="knowledge icon"> Money knowledge and choices
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>

--- a/test/unit_tests/apps/teachers-digital-platform/html/results-page.js
+++ b/test/unit_tests/apps/teachers-digital-platform/html/results-page.js
@@ -149,10 +149,10 @@ const HTML_SNIPPET = `
                         <img src="/static/apps/teachers-digital-platform/img/planning.3d9110136aec.svg" alt="planning icon"> Planning and self-control
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="Show">
+                <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
-                <span class="o-expandable_cue-close" aria-label="Hide">
+                <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
             </span>
@@ -214,10 +214,10 @@ const HTML_SNIPPET = `
                         <img src="/static/apps/teachers-digital-platform/img/habits.b5e335a8247c.svg" alt="habits icon"> Money habits and values
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="Show">
+                <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
-                <span class="o-expandable_cue-close" aria-label="Hide">
+                <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
             </span>
@@ -280,10 +280,10 @@ const HTML_SNIPPET = `
                         <img src="/static/apps/teachers-digital-platform/img/knowledge.f4ecb7c4cd00.svg" alt="knowledge icon"> Money knowledge and choices
                     </h3>
                     <span class="o-expandable_link">
-                <span class="o-expandable_cue-open" aria-label="Show">
+                <span class="o-expandable_cue-open" role="img" aria-label="Show">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
-                <span class="o-expandable_cue-close" aria-label="Hide">
+                <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path></svg>
                 </span>
             </span>

--- a/test/unit_tests/apps/teachers-digital-platform/html/shared-results-page-analytics.js
+++ b/test/unit_tests/apps/teachers-digital-platform/html/shared-results-page-analytics.js
@@ -171,12 +171,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/planning.svg" alt="planning icon"> Planning and self-control
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
@@ -240,12 +240,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/habits.svg" alt="habits icon"> Money habits and values
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
@@ -310,12 +310,12 @@ const HTML_SNIPPET = `
                      <img src="/static/apps/teachers-digital-platform/img/knowledge.svg" alt="knowledge icon"> Money knowledge and choices
                   </h3>
                   <span class="o-expandable_link">
-                     <span class="o-expandable_cue-open" aria-label="Show">
+                     <span class="o-expandable_cue-open" role="img" aria-label="Show">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                         </svg>
                      </span>
-                     <span class="o-expandable_cue-close" aria-label="Hide">
+                     <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                            <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                         </svg>

--- a/test/unit_tests/apps/teachers-digital-platform/html/survey-page-analytics.js
+++ b/test/unit_tests/apps/teachers-digital-platform/html/survey-page-analytics.js
@@ -270,12 +270,12 @@ const HTML_SNIPPET = `
         <div class="tdp-survey-sidebar__mobile-control">
           <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" title="Expand content">
             <span class="o-expandable_link">
-              <span class="o-expandable_cue-open" aria-label="Show">
+              <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                   <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"></path>
                 </svg>
               </span>
-              <span class="o-expandable_cue-close" aria-label="Hide">
+              <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg">
                   <path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"></path>
                 </svg>

--- a/test/unit_tests/apps/teachers-digital-platform/html/survey-page.js
+++ b/test/unit_tests/apps/teachers-digital-platform/html/survey-page.js
@@ -404,10 +404,10 @@ const HTML_SNIPPET = `
                     <button class="o-expandable_header o-expandable_target"
                             title="Expand content">
                         <span class="o-expandable_link">
-                            <span class="o-expandable_cue-open" aria-label="Show">
+                            <span class="o-expandable_cue-open" role="img" aria-label="Show">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H9.284V6.12a.792.792 0 1 0-1.583 0V9.5H4.32a.792.792 0 0 0 0 1.584H7.7v3.382a.792.792 0 0 0 1.583 0v-3.382h3.382a.792.792 0 0 0 .792-.791z"/></svg>
                             </span>
-                            <span class="o-expandable_cue-close" aria-label="Hide">
+                            <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 20.4" class="cf-icon-svg"><path d="M16.416 10.283A7.917 7.917 0 1 1 8.5 2.366a7.916 7.916 0 0 1 7.916 7.917zm-2.958.01a.792.792 0 0 0-.792-.792H4.32a.792.792 0 0 0 0 1.583h8.346a.792.792 0 0 0 .792-.791z"/></svg>
                             </span>
                         </span>

--- a/test/unit_tests/apps/teachers-digital-platform/js/expandable-facets-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/expandable-facets-spec.js
@@ -20,10 +20,10 @@ const HTML_SNIPPET = `
         <button class="a-btn a-btn__link u-hide-on-xs u-hide-on-sm o-expandable-facets_target" type="button">
           <span class="u-visually-hidden">Expand children</span>
           <span aria-hidden="true">Earn</span>
-          <span class="o-expandable-facets_cue o-expandable-facets_cue-open" aria-label="Show">
+          <span class="o-expandable-facets_cue o-expandable-facets_cue-open" role="img" aria-label="Show">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 988.2 1200" class="cf-icon-svg"><path d="M494.1 967.2c-17.3 0-33.8-6.8-46-19L18.6 518.6c-25.1-25.6-24.8-66.8.8-91.9 25.3-24.8 65.8-24.8 91.1 0l383.6 383.6 383.6-383.6c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L540.1 948.1c-12.2 12.2-28.7 19.1-46 19.1z"></path></svg>
           </span>
-          <span class="o-expandable-facets_cue o-expandable-facets_cue-close" aria-label="Hide">
+          <span class="o-expandable-facets_cue o-expandable-facets_cue-close" role="img" aria-label="Hide">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 988.7 1200" class="cf-icon-svg"><path d="M923.6 967.6c-17.3 0-33.8-6.8-46-19L494.1 565 110.5 948.5c-25.6 25.1-66.8 24.8-91.9-.8-24.8-25.3-24.8-65.8 0-91.1l429.5-429.5c25.4-25.4 66.5-25.4 91.9 0l429.6 429.5c25.4 25.4 25.4 66.5.1 91.9-12.3 12.3-28.8 19.1-46.1 19.1z"></path></svg>
           </span>
         </button>

--- a/test/unit_tests/apps/teachers-digital-platform/js/expandable-mobile-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/expandable-mobile-spec.js
@@ -16,10 +16,10 @@ const HTML_SNIPPET = `
             Building block
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="Show">
+            <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"/></svg>
             </span>
-            <span class="o-expandable_cue-close" aria-label="Hide">
+            <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"/></svg>
             </span>
         </span>

--- a/test/unit_tests/apps/teachers-digital-platform/js/search-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/search-spec.js
@@ -28,10 +28,10 @@ const HTML_SNIPPET = `
           Building block
         </span>
         <span class="o-expandable_link">
-          <span class="o-expandable_cue-open" aria-label="Show">
+          <span class="o-expandable_cue-open" role="img" aria-label="Show">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
           </span>
-          <span class="o-expandable_cue-close" aria-label="Hide">
+          <span class="o-expandable_cue-close" role="img" aria-label="Hide">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
           </span>
         </span>
@@ -68,10 +68,10 @@ const HTML_SNIPPET = `
       <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" type="button">
         <span class="h4 o-expandable_label">Topic</span>
         <span class="o-expandable_link">
-          <span class="o-expandable_cue-open" aria-label="Show">
+          <span class="o-expandable_cue-open" role="img" aria-label="Show">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
           </span>
-          <span class="o-expandable_cue-close" aria-label="Hide">
+          <span class="o-expandable_cue-close" role="img" aria-label="Hide">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
           </span>
         </span>
@@ -88,10 +88,10 @@ const HTML_SNIPPET = `
               <button class="a-btn a-btn__link u-hide-on-xs u-hide-on-sm o-expandable-facets_target is-open" type="button">
                 <span class="u-visually-hidden">Expand children</span>
                 <span aria-hidden="true">Earn</span>
-                <span class="o-expandable-facets_cue o-expandable-facets_cue-open" aria-label="Show">
+                <span class="o-expandable-facets_cue o-expandable-facets_cue-open" role="img" aria-label="Show">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 988.2 1200" class="cf-icon-svg"><path d="M494.1 967.2c-17.3 0-33.8-6.8-46-19L18.6 518.6c-25.1-25.6-24.8-66.8.8-91.9 25.3-24.8 65.8-24.8 91.1 0l383.6 383.6 383.6-383.6c25.6-25.1 66.8-24.8 91.9.8 24.8 25.3 24.8 65.8 0 91.1L540.1 948.1c-12.2 12.2-28.7 19.1-46 19.1z"></path></svg>
                 </span>
-                <span class="o-expandable-facets_cue o-expandable-facets_cue-close" aria-label="Hide">
+                <span class="o-expandable-facets_cue o-expandable-facets_cue-close" role="img" aria-label="Hide">
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 988.7 1200" class="cf-icon-svg"><path d="M923.6 967.6c-17.3 0-33.8-6.8-46-19L494.1 565 110.5 948.5c-25.6 25.1-66.8 24.8-91.9-.8-24.8-25.3-24.8-65.8 0-91.1l429.5-429.5c25.4-25.4 66.5-25.4 91.9 0l429.6 429.5c25.4 25.4 25.4 66.5.1 91.9-12.3 12.3-28.8 19.1-46.1 19.1z"></path></svg>
                 </span>
               </button>

--- a/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
@@ -31,10 +31,10 @@ const HTML_SNIPPET = `
             Building block
           </span>
           <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="Show">
+            <span class="o-expandable_cue-open" role="img" aria-label="Show">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
             </span>
-            <span class="o-expandable_cue-close" aria-label="Hide">
+            <span class="o-expandable_cue-close" role="img" aria-label="Hide">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
             </span>
           </span>
@@ -71,10 +71,10 @@ const HTML_SNIPPET = `
         <button class="o-expandable_header o-expandable_target o-expandable_target__expanded" type="button">
           <span class="h4 o-expandable_label">Topic</span>
           <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="Show">
+            <span class="o-expandable_cue-open" role="img" aria-label="Show">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H549.6v213.6c0 27.6-22.4 50-50 50s-50-22.4-50-50V655.9H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h213.6V342.3c0-27.6 22.4-50 50-50s50 22.4 50 50v213.6h213.6c27.6 0 50 22.4 50 50s-22.5 50-50.1 50z"></path></svg>
             </span>
-            <span class="o-expandable_cue-close" aria-label="Hide">
+            <span class="o-expandable_cue-close" role="img" aria-label="Hide">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1200" class="cf-icon-svg"><path d="M500 105.2c-276.1 0-500 223.9-500 500s223.9 500 500 500 500-223.9 500-500-223.9-500-500-500zm263.1 550.7H236c-27.6 0-50-22.4-50-50s22.4-50 50-50h527.1c27.6 0 50 22.4 50 50s-22.4 50-50 50z"></path></svg>
             </span>
           </span>

--- a/test/unit_tests/js/organisms/FilterableListControls-spec.js
+++ b/test/unit_tests/js/organisms/FilterableListControls-spec.js
@@ -14,11 +14,11 @@ const HTML_SNIPPET = `
             Filter posts
         </span>
         <span class="o-expandable_link">
-            <span class="o-expandable_cue-open" aria-label="Show">
+            <span class="o-expandable_cue-open" role="img" aria-label="Show">
                 Show
                 filters
             </span>
-            <span class="o-expandable_cue-close" aria-label="Hide">
+            <span class="o-expandable_cue-close" role="img" aria-label="Hide">
                 Hide
                 filters
             </span>


### PR DESCRIPTION
Lighthouse reports that the icons that have `aria-label`s need the proper aria role. This PR adds a `role="img"` on the icons.


## Changes

- Add role="img" on expandable icons.


## How to test this PR

1.  Visit localhost:8000/about-us/blog/ and run lighthouse in the browser dev tools. Compare to production. Accessibility score should be higher.
