### PR TITLE
Remove unused forms CSS

### DIFF
--- a/cfgov/unprocessed/css/organisms/form.less
+++ b/cfgov/unprocessed/css/organisms/form.less
@@ -1,51 +1,3 @@
-/* topdoc
-  name: Forms
-  family: cf-organisms
-  patterns:
-  - name: Standard form
-    markup: |
-      <form>
-          <h3>Title of form</h3>
-          <p class="o-form-description">Intro text</p>
-          <h3>Description of section</h3>
-          <div class="o-form-section"></div>
-          <div class="o-form-action"></div>
-      </div>
-    codenotes:
-      - |
-        Pattern structure
-        -----------------
-        form
-          h2
-            .o-form-description
-          h3
-            .o-form-section
-          .o-form-actions
-  tags:
-  - cf-organisms
-*/
-
-.o-form-description {
-  margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-  margin-bottom: unit(@grid_gutter-width * 2 / @base-font-size-px, em);
-}
-
-.o-form-section {
-  margin: unit(@grid_gutter-width / @base-font-size-px, em)
-    unit(@grid_gutter-width / -2 / @base-font-size-px, em)
-    unit(@grid_gutter-width * 2 / @base-font-size-px, em)
-    unit(@grid_gutter-width / -2 / @base-font-size-px, em);
-  padding: unit(@grid_gutter-width / @base-font-size-px, em)
-    unit(@grid_gutter-width / @base-font-size-px, em);
-  background: @gray-5;
-  border: 1px solid @gray-40;
-
-  .respond-to-min(@bp-med-min, {
-    margin-left: unit( -@grid_gutter-width / @base-font-size-px, em );
-    margin-right: unit( -@grid_gutter-width / @base-font-size-px, em );
-  });
-}
-
 .o-form_fieldset {
   ul {
     list-style: none;
@@ -56,14 +8,4 @@
   input[type='radio'] {
     margin-right: 4px;
   }
-}
-
-.o-form-actions {
-  margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-
-  .respond-to-max(@bp-sm-max, {
-    .a-btn {
-      width: 100%;
-    }
-  });
 }


### PR DESCRIPTION
This forms CSS appears to be added in https://github.com/cfpb/consumerfinance.gov/pull/1273 and is no longer used.
I can't find these classes in a codebase search or in the crawler.

## Removals

- Removed unused CSS: `o-form-description`, `o-form-section`, `o-form-actions`.

## How to test this PR

1. PR checks should pass.
