### PR TITLE
Fix Financial well-being scale

### DIFF
--- a/cfgov/unprocessed/css/enhancements/forms.less
+++ b/cfgov/unprocessed/css/enhancements/forms.less
@@ -254,7 +254,6 @@ input {
    ========================================================================== */
 
 @scale-point-count: 5;
-@radio-button-diameter: 18px;
 
 .o-scale {
   + .o-scale {
@@ -278,9 +277,9 @@ input {
         border-top: 1px solid @gray-80;
 
         position: absolute;
-        top: ( @radio-button-diameter / 2 );
+        top: 11px;
         right: 0;
-        left: 0;
+        left: 22px;
 
         content: '';
       }


### PR DESCRIPTION
The line in the scale on the financial well-being tool is slightly off and sticks out of the left-hand radio button. 

## Changes

- Financial well-being: Adjust the line through the scale.


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/financial-well-being/ and compare the line behind the radio buttons to the version on production.


## Screenshots

Before:

<img width="557" alt="Screen Shot 2023-05-03 at 3 20 53 PM" src="https://user-images.githubusercontent.com/704760/236025581-16a97c9a-d39f-421f-9647-9af2085a28d0.png">

After:

<img width="551" alt="Screen Shot 2023-05-03 at 3 21 41 PM" src="https://user-images.githubusercontent.com/704760/236025638-57f001b6-d5e4-4af3-909f-3fb2583a1438.png">
