### PR TITLE
Remove `event-status_rsvp` class

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.less
+++ b/cfgov/unprocessed/css/on-demand/event.less
@@ -96,19 +96,6 @@
   }
 }
 
-// The spacing for the RSVP/Livestream aside on the event details.
-// Spacing should follow a 1/2/1 ratio (15px/30px/15px).
-.event-status_rsvp {
-  p:first-child {
-    line-height: 1;
-    margin-bottom: unit(15px / @base-font-size-px, em);
-  }
-
-  p:last-child {
-    margin-bottom: unit(30px / @base-font-size-px, em);
-  }
-}
-
 .event-status_livestream p:first-child {
   line-height: 1;
   // The margin is kept at 10px to accommodate the line-height


### PR DESCRIPTION
The markup for this class was removed in https://github.com/cfpb/consumerfinance.gov/pull/2139

## Removals

- Remove `event-status_rsvp` class

## How to test this PR

1. PR checks should pass.