### PR TITLE
Events: Consolidate `post_inset` with `post_inset__right`

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.less
+++ b/cfgov/unprocessed/css/on-demand/event.less
@@ -238,12 +238,10 @@
   margin: unit(30px / @base-font-size-px, em) 0;
   color: @black;
 
-  &__right {
-    .respond-to-min(@bp-sm-min, {
-      float: right;
-      width: unit(250px / @base-font-size-px, em);
-      margin-top: unit(5px / @base-font-size-px, em);
-      margin-left: unit(@grid_gutter-width / @base-font-size-px, em);
-    });
-  }
+  .respond-to-min(@bp-sm-min, {
+    float: right;
+    width: unit(250px / @base-font-size-px, em);
+    margin-top: unit(5px / @base-font-size-px, em);
+    margin-left: unit(@grid_gutter-width / @base-font-size-px, em);
+  });
 }

--- a/cfgov/v1/jinja2/v1/events/_event-detail.html
+++ b/cfgov/v1/jinja2/v1/events/_event-detail.html
@@ -31,7 +31,7 @@
     </header>
     <div class="post_body">
         {% if event_state == 'future' and page.live_stream_availability %}
-        <aside class="post_inset post_inset__right line-container event-status">
+        <aside class="post_inset line-container event-status">
             <div class="line-container_body">
                 <h1 class="u-visually-hidden">Event viewing details</h1>
                 <div class="event-status_livestream">
@@ -49,7 +49,7 @@
             </div>
         </aside>
         {% elif ( event_state == 'present' and page.live_stream_availability ) %}
-        <aside class="post_inset post_inset__right line-container event-status">
+        <aside class="post_inset line-container event-status">
             <div class="line-container_body">
                 <div class="event-status_livestream">
                     <p>


### PR DESCRIPTION
`post_inset` only appears in the templates along side `post_inset__right`, so best to just combine them.

## Changes

- Events: Consolidate `post_inset` with `post_inset__right`


## How to test this PR

1. Find "Live event test" in Wagtail and adjust the event dates to now-ish so that the livestream controls show up and see that nothing has changed.


<img width="721" alt="Screen Shot 2023-05-03 at 5 00 36 PM" src="https://user-images.githubusercontent.com/704760/236049231-eb8d1269-cc4d-425b-ba12-fa4178677e08.png">
