### PR TITLE
FAHC: Remove `m-form-field-with-button__inline-info` and `m-form-field-with-button_wrapper`

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -144,22 +144,24 @@
                                                    placeholder="Please enter a five-digit ZIP code">
                                         </div>
 
-                                        <div class="m-form-field-with-button_wrapper">
-                                            <button class="a-btn a-btn__full-on-xs" type="submit">Find a counselor</button>
-                                            <div class="m-form-field-with-button_info">
-                                                <p>
-                                                    This tool is powered by
-                                                    <a class="a-link a-link__icon"
-                                                       href="https://data.hud.gov/housing_counseling.html">
-                                                        <span class="a-link_text">HUD's</span>
-                                                        {{ svg_icon('external-link') }}</a>
-                                                    official list of housing counselors.
-                                                </p>
-                                                <p>
-                                                    If you notice errors in the housing counselor data,
-                                                    contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
-                                                </p>
-                                            </div>
+                                        <button class="a-btn a-btn__full-on-xs"
+                                                type="submit"
+                                                data-cy="btn-fahc-submit">
+                                            Find a counselor
+                                        </button>
+                                        <div class="m-form-field-with-button_info">
+                                            <p>
+                                                This tool is powered by
+                                                <a class="a-link a-link__icon"
+                                                    href="https://data.hud.gov/housing_counseling.html">
+                                                    <span class="a-link_text">HUD's</span>
+                                                    {{ svg_icon('external-link') }}</a>
+                                                official list of housing counselors.
+                                            </p>
+                                            <p>
+                                                If you notice errors in the housing counselor data,
+                                                contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+                                            </p>
                                         </div>
                                     </div>
                                 </form>

--- a/cfgov/unprocessed/css/molecules/form-field-with-button.less
+++ b/cfgov/unprocessed/css/molecules/form-field-with-button.less
@@ -42,27 +42,6 @@
   .a-btn {
     margin-top: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
   }
-
-  &__inline-info {
-    .respond-to-min( 321px, {
-      .m-form-field-with-button_wrapper {
-        width: 100%;
-        display: flex;
-        align-items: flex-start;
-        flex-wrap: wrap-reverse;
-        justify-content: space-between;
-      }
-
-      .m-form-field-with-button_info {
-        order: 1;
-      }
-
-      .a-btn {
-        width: auto;
-        margin-right: unit( ( @grid_gutter-width / 3 ) / @base-font-size-px, em );
-      }
-    } );
-  }
 }
 
 /* topdoc

--- a/test/cypress/integration/consumer-tools/find-a-housing-counselor/find-a-housing-counselor-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/find-a-housing-counselor/find-a-housing-counselor-helpers.cy.js
@@ -27,9 +27,7 @@ export class FindAHousingCounselor {
 
   searchZipCode(zipCode) {
     cy.get('#hud_hca_api_query').type(zipCode);
-    cy.get('.m-form-field-with-button_wrapper').within(() => {
-      cy.get('button').click();
-    });
+    cy.get('[data-cy=btn-fahc-submit]').click();
   }
 
   resultsSection() {


### PR DESCRIPTION
I can't find `m-form-field-with-button__inline-info` in the codebase or crawler.

`m-form-field-with-button_wrapper` only appears in the markup and has no styling. 

This PR removes both.

## Removals

- FAHC: Remove `m-form-field-with-button__inline-info` and `m-form-field-with-button_wrapper`.

## Additions 

- Adds `data-cy="btn-fahc-submit"` for Cypress test.

## How to test this PR

1. PR checks should pass. http://localhost:8000/find-a-housing-counselor/ should be unchanged vs production.
