### PR TITLE
Form Explainer: Remove older requestAnimationFrame fallbacks

### DIFF
--- a/cfgov/unprocessed/js/modules/util/scroll.js
+++ b/cfgov/unprocessed/js/modules/util/scroll.js
@@ -1,13 +1,3 @@
-const _requestAnimationFrame =
-  window.requestAnimationFrame ||
-  window.webkitRequestAnimationFrame ||
-  window.mozRequestAnimationFrame ||
-  function (callback) {
-    return setTimeout(function () {
-      callback(Number(new Date()));
-    }, 1000 / 60);
-  };
-
 /**
  * Easing.
  * @param {number} currentTime - current time.
@@ -67,14 +57,14 @@ function scrollTo(to, opts) {
     window.scroll(0, next);
 
     if (elapsed < duration) {
-      _requestAnimationFrame(scroll);
+      window.requestAnimationFrame(scroll);
     } else if (typeof opts.callback === 'function') {
       opts.callback();
     }
   }
 
   if (Math.abs(distance) > 3) {
-    _requestAnimationFrame(scroll);
+    window.requestAnimationFrame(scroll);
   } else if (typeof opts.callback === 'function') {
     opts.callback();
   }


### PR DESCRIPTION
`window.requestAnimationFrame` has a good level of support https://caniuse.com/requestanimationframe, and browsers that don't support it should get the no-js experience anyway.

## Removals

- Form Explainer: Remove older requestAnimationFrame fallbacks

## How to test this PR

1. Form explainers like http://localhost:8000/owning-a-home/loan-estimate/ should scroll when clicking around the image map.
