### PR TITLE
Financial Well-Being: Update fwb-results-spec.js expandables to enable skipped test

### DIFF
--- a/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-results-spec.js
@@ -20,19 +20,15 @@ const dataLayerEvent = {
 const HTML_SNIPPET = `
 <div class="content">
   <div class="o-expandable">
-    <button class="o-expandable_target">
-      <div class="o-expandable_header">
-        <span class="o-expandable_label">
-        </span>
-        <span class="o-expandable_link">
-          <span class="o-expandable_cue-open" role="img" aria-label="Show"></span>
-          <span class="o-expandable_cue-close" role="img" aria-label="Hide"></span>
-        </span>
-      </div>
+    <button class="o-expandable_header o-expandable_target">
+      <span class="o-expandable_label">
+      </span>
+      <span class="o-expandable_link">
+        <span class="o-expandable_cue-open" role="img" aria-label="Show"></span>
+        <span class="o-expandable_cue-close" role="img" aria-label="Hide"></span>
+      </span>
     </button>
-    <div class="o-expandable_content">
-      <div class="o-expandable_content-animated"></div>
-    </div>
+    <div class="o-expandable_content"></div>
   </div>
   <figure class="comparison-chart" id="comparison-chart">
     <div class="comparison-chart_toggle u-js-only">
@@ -114,15 +110,14 @@ describe('fwb-results', () => {
       '.comparison-chart_toggle-button'
     );
     dataPoint = document.querySelectorAll('.comparison_data-point');
+    expandableTarget = document.querySelector('.o-expandable_header');
     expandableContent = document.querySelector('.o-expandable_content');
-    expandableTarget = document.querySelector('.o-expandable_target');
     initFwbResults();
   });
 
-  // TODO: Add aria pressed states to cf-expandables
-  xit('initialize the expandables on page load', () => {
-    expect(expandableTarget.getAttribute('aria-pressed')).toBe('false');
-    expect(expandableContent.getAttribute('aria-expanded')).toBe('false');
+  it('initialize the expandables on page load', () => {
+    expect(expandableTarget.getAttribute('aria-expanded')).toBe('false');
+    expect(expandableContent.getAttribute('data-open')).toBe('false');
   });
 
   it('should submit the correct analytics when a toggle button is clicked', () => {


### PR DESCRIPTION
The financial well-being unit test had a `TODO` for `Add aria pressed states to cf-expandables`, however, [aria-pressed](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) does not appear to be appropriate for expandables, so I have removed the todo.

## Changes

- Financial Well-Being: Update fwb-results-spec.js expandables to enable skipped test


## How to test this PR

1. PR checks should pass.