### PR TITLE
iRegs: Remove expandable width settings

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -41,15 +41,6 @@
     padding-right: 0;
   }
 
-  .o-expandable_header {
-    &-label {
-      width: 88%;
-    }
-    &-link {
-      width: 12%;
-    }
-  }
-
   .o-expandable_content {
     padding: 0;
     .respond-to-min( @bp-med-min, {
@@ -90,15 +81,6 @@
     .o-expandable_label {
       text-transform: uppercase;
     }
-  }
-
-  .o-expandable_label {
-    width: 88%;
-  }
-
-  .o-expandable_link {
-    text-align: right;
-    width: 12%;
   }
 }
 


### PR DESCRIPTION
With flexbox in use in the expandable header, these settings do not appear to be needed.

## Removals

- iRegs: Remove expandable width settings

## How to test this PR

1. Compare the secondary nav expandable icon positioning in e.g. http://localhost:8000/rules-policy/regulations/1002/ vs production
