### PR TITLE
Remove unused `has_top_border` and `has_bottom_border`

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/templates/render_block.html
+++ b/cfgov/v1/jinja2/v1/includes/templates/render_block.html
@@ -2,13 +2,14 @@
    {%- import 'v1/includes/macros/accessible-languages.html' as accessible_languages with context -%}
    {% set block_classes = ['block'] %}
 
-   {% if block.value.has_top_border or block.value.has_top_rule_line %}
+   {% if block.value.has_top_rule_line %}
       {% do block_classes.append('block__padded-top block__border-top') %}
    {% elif index == 1 %}
       {% do block_classes.append('block__flush-top') %}
    {% endif %}
 
-   {% if block.value.has_rule or block.value.has_bottom_border %}
+   {# TODO: Rename `has_rule` to `has_bottom_rule_line` #}
+   {% if block.value.has_rule %}
       {% do block_classes.append('block__padded-bottom block__border-bottom') %}
    {% endif %}
 


### PR DESCRIPTION
These two variables appear on the `value.` object and are only referenced in the the `render_block` template.

## Removals

- Remove unused `has_top_border` and `has_bottom_border`

## How to test this PR

1. PR checks should pass.