### PR TITLE
Check for hidden attribute instead of class in regs3k

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/permalinks-utils.js
@@ -245,7 +245,7 @@ const updateParagraphPositions = () => {
   const visibleParagraphs = [];
   // IE doesn't support `forEach` w/ node lists
   for (let i = 0; i < paragraphs.length; i++) {
-    const hiddenParagraphContainer = paragraphs[i].closest('.u-hidden');
+    const hiddenParagraphContainer = paragraphs[i].closest('[hidden]');
     if (!hiddenParagraphContainer) {
       visibleParagraphs.push(paragraphs[i]);
     }


### PR DESCRIPTION
Fixes https://github.local/Design-Development/External-Products/issues/129

## Testing
 - Pull and build
 - Go to an ireg
 - Note that hidden expandables aren't being included in the wayfinder