### PR TITLE
Fix paths filtering

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,8 +2,8 @@ name: backend
 
 on:
   workflow_dispatch:
-  pull_request:
   merge_group:
+  pull_request:
     paths:
       - '**.py'
       - 'requirements/**.txt'

--- a/.github/workflows/filter-backend.yml
+++ b/.github/workflows/filter-backend.yml
@@ -1,7 +1,7 @@
 name: filter-backend
 on:
-  pull_request:
   merge_group:
+  pull_request:
     paths-ignore:
       - '**.py'
       - 'requirements/**.txt'

--- a/.github/workflows/filter-frontend.yml
+++ b/.github/workflows/filter-frontend.yml
@@ -1,7 +1,7 @@
 name: filter-frontend
 on:
-  pull_request:
   merge_group:
+  pull_request:
     paths-ignore:
       - '**.js'
       - '**/package.json'

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,8 +1,8 @@
 name: frontend
 
 on:
-  pull_request:
   merge_group:
+  pull_request:
     paths:
       - '**.js'
       - '**package.json'


### PR DESCRIPTION
Paths filtering doesn't actually work on `merge_group`. When this was added to the actions, it broke the paths filtering since the `paths` key became a subkey of `merge_group` instead of `pull_request`. This fixes that.