### PR TITLE
Remove `u-centered-on-mobile` from code comment

### DIFF
--- a/cfgov/unprocessed/css/organisms/sidebar-breakout.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-breakout.less
@@ -21,10 +21,8 @@
                                   block__flush-bottom">
                         <h3 class="o-sidebar-breakout_heading">
                         </h3>
-                        <div class="o-sidebar-breakout_img-container
-                                    u-centered-on-mobile">
-                            <div class="o-sidebar-breakout_img
-                                        u-centered-on-mobile"
+                        <div class="o-sidebar-breakout_img-container">
+                            <div class="o-sidebar-breakout_img"
                                  style="background-image:url()">
                             </div>
                         </div>


### PR DESCRIPTION
`u-centered-on-mobile` was removed in https://github.com/cfpb/consumerfinance.gov/pull/7621/, but these inclusions in a code comment were missed.

## Removals

- Remove `u-centered-on-mobile` from code comment
