### PR TITLE
Update wagtail-sharing to 2.9

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -34,7 +34,7 @@ wagtail-autocomplete==0.9.0
 wagtail-flags==5.3.0
 wagtail-inventory==2.0.0
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.8
+wagtail-sharing==2.9
 wagtail-treemodeladmin==1.7.0
 wagtailmedia==0.13
 


### PR DESCRIPTION
This brings in [wagtail-sharing#63](https://github.com/cfpb/wagtail-sharing/pull/63), which adds the "View sharing link" to the Wagtail 4 ellipsis menu in the header on the current page.

![The ellipsis menu in the page list view](https://github.com/cfpb/consumerfinance.gov/assets/10562538/43ca3c2d-e349-4c23-94c1-2240911a19f9)

![The ellipsis menu in the page edit view](https://github.com/cfpb/consumerfinance.gov/assets/10562538/9f343073-9eec-4505-a947-fc10394d4b7c)

Previously this was only available on child pages in the page list view "More" menu.


## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
