### PR TITLE
Simplify Wagtail block unescaping logic

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/templates/render_block.html
+++ b/cfgov/v1/jinja2/v1/includes/templates/render_block.html
@@ -19,9 +19,6 @@
 
    <div class="{{ block_classes | unique | join(' ') }}"
       {{- accessible_languages.render() -}}>
-      {{ render_stream_child(
-         block,
-         unescape=block.block.meta.unescape | default( true )
-      ) }}
+      {{ render_stream_child( block ) }}
    </div>
 {% endmacro %}

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -67,32 +67,23 @@ def is_filter_selected(context, fieldname, value):
     return value in query_string_values
 
 
-def render_stream_child(context, stream_child, unescape=True):
-    # Use the django_jinja to get the template content based on its name
-    try:
-        template = context.environment.get_template(
-            stream_child.block.meta.template
-        )
-    except Exception:
-        return stream_child
+def render_stream_child(context, stream_child):
+    rendered = stream_child.render(context=context)
 
-    # Create a new context based on the current one as we can't edit it
-    # directly
-    new_context = context.get_all()
-    # Add the value on the context (value is the keyword chosen by
-    # wagtail for the blocks context)
-    try:
-        new_context["value"] = stream_child.value
-    except AttributeError:
-        new_context["value"] = stream_child
+    # This logic is needed because historically we have supported the
+    # inclusion of raw HTML tags in any Wagtail text or rich text block.
+    # Ideally we could remove this logic, but before we do so we need to
+    # eliminate all such tags from our field content.
+    #
+    # By default all blocks are unescaped, but individual blocks can disable
+    # this behavior by setting unescape=False in their Meta class. Once all
+    # blocks have been audited for raw HTML tags, and all have unescape set
+    # to False, this logic can be removed, and we can simplify our templates
+    # to use {% include_block %} instead of {{ render_stream_child }}.
+    if getattr(stream_child.block.meta, "unescape", True):
+        rendered = html.unescape(rendered)
 
-    # Render the template with the context
-    html_result = template.render(new_context)
-
-    if unescape:
-        html_result = html.unescape(html_result)
-
-    return Markup(html_result)
+    return Markup(rendered)
 
 
 def unique_id_in_context(context):


### PR DESCRIPTION
Commit 11c6b8dfe86032bb4eea9c9e7f54cce0de3da509 introduced a bug where legacy page content wasn't being rendered properly (tracked internally at D&CT#241).

This commit tries to fix that and simplifies our unnecessarily custom render_stream_child logic. We have this custom logic because we have historically supported raw HTML tags in any Wagtail text or rich text field. Ideally we could remove this in future.

## How to test this PR

Verify that all of these pages render properly:

- http://localhost:8000/about-us/blog/join-us-in-making-mortgage-shopping-easier/
- http://localhost:8000/about-us/newsroom/consumer-financial-protection-bureau-releases-report-on-issues-facing-users-of-international-money-transfers/
- http://localhost:8000/about-us/careers/current-openings/
- http://localhost:8000/administrative-adjudication-proceedings/administrative-adjudication-docket/rmk-financial-corp-majestic-home-loan-mhl/

@csebianlander or any other pages you know of that have hardcoded raw HTML.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)