### PR TITLE
Fix "first page date" logic

### DIFF
--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -226,8 +226,11 @@ class FilterablePagesDocumentSearch:
         """
         search = self.search_obj[0 : self.count()]
 
-        # Also aggregate unique languages in the result.
-        search.aggs.bucket("languages", A("terms", field="language"))
+        # Aggregate unique languages in the result.
+        search.aggs.bucket("languages", "terms", field="language")
+
+        # Determine the earliest page date.
+        search.aggs.metric("min_start_date", "min", field="start_date")
 
         return search.execute()
 

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from datetime import date
-from operator import itemgetter
+from operator import attrgetter, itemgetter
 
 from django import forms
 from django.conf import settings
@@ -206,10 +206,12 @@ class FilterableListForm(forms.Form):
         return results
 
     def first_page_date(self):
-        if len(self.all_filterable_results) > 0:
-            first_post = self.all_filterable_results[0]
-            return first_post.start_date.date()
-        return date(2010, 1, 1)
+        if not self.all_filterable_results:
+            return date(2010, 1, 1)
+
+        return min(
+            map(attrgetter("start_date"), self.all_filterable_results)
+        ).date()
 
     def prepare_options(self, arr):
         """


### PR DESCRIPTION
Commit https://github.com/cfpb/consumerfinance.gov/commit/2d9839bfb1460c630a0d1de21bbe3e2f7b72b984 introduced a bug in how we determine the default "first page date" when rendering filterable list pages. Previously, we could assume that Elasticsearch results were always sorted from earliest to latest, and so the code used `all_filterable_results[0]` to get the earliest post. Now, we can't assume that, so we have to find the earliest post ourselves.

Additionally, this commit adds a new search aggregation that computes the earliest page date; we need to leave in some fallback code due to the way we use caches for our filterable list search but that code can be removed once this is deployed and caches are cleared.

## How to test this PR

To test, visit a URL like this:

http://localhost:8000/about-us/blog/?title=&from_date=&to_date=2021-01-15

If you don't specify a `from_date`, the code fills it in. On production, this is currently wrong:

https://www.consumerfinance.gov/about-us/blog/?title=&from_date=&to_date=2021-01-15

but this change fixes that.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)