### PR TITLE
Add run build action

### DIFF
--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,7 +1,3 @@
-run the centos image produced by the builder with the repo files mapped in a volume
-runs create.py inside this container
-pushes the results to S3. This thus fully replaces cf.gov-ansible-build
-
 name: 'Run build'
 
 on:
@@ -15,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2.27.0

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -1,0 +1,46 @@
+run the centos image produced by the builder with the repo files mapped in a volume
+runs create.py inside this container
+pushes the results to S3. This thus fully replaces cf.gov-ansible-build
+
+name: 'Run build'
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: frontend.yml
+          commit: ${{ github.sha }}
+          name: frontend_${{ github.sha }}.zip
+
+      - name: Unzip static files
+        run: unzip frontend_${{ github.sha }}.zip
+
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+            registry: gcr.io
+            image: ${{ github.repository }}-builder:latest
+            options: -v ${{ github.workspace }}:/cfgov
+            run: ./_build.sh
+
+      - name: Upload arifact
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: cfgov_current_build.zip
+          destination: s3://cf.gov-build/artifacts/${{ github.sha }}.zip
+          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1


### PR DESCRIPTION
With https://github.com/cfpb/consumerfinance.gov/pull/7732 and https://github.com/cfpb/consumerfinance.gov/pull/7735
Behavior:
- pulls in the frontend build artifact and unzips it
- uses the centos image produced by the builder with the repo files mapped in a volume
- runs create.py inside this container via _build.sh
- pushes the results to S3.