### PR TITLE
Cleanup unnecessary filterable list logic

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from datetime import date
-from operator import attrgetter, itemgetter
+from operator import itemgetter
 
 from django import forms
 from django.conf import settings
@@ -211,18 +211,9 @@ class FilterableListForm(forms.Form):
         if not self.all_filterable_results:
             return date(2010, 1, 1)
 
-        # TODO: The fallback case is only needed because we have a cache for
-        # all_filterable_results that may not contain the aggregation at
-        # the time this code goes live. Once all caches have been cleared and
-        # re-set with this aggegration, the fallback can be removed.
-        if min_start_date := getattr(
-            self.all_filterable_results.aggregations, "min_start_date", None
-        ):  # pragma: nocover
-            min_start_date = parser.parse(min_start_date.value_as_string)
-        else:
-            min_start_date = min(
-                map(attrgetter("start_date"), self.all_filterable_results)
-            )
+        min_start_date = parser.parse(
+            self.all_filterable_results.aggregations.min_start_date.value_as_string
+        )
 
         return min_start_date.date()
 


### PR DESCRIPTION
Commit 19e69581d2614fe6a2c5dff1485a6d1564c11725 introduced a new search aggregation for filterable lists to optimize computation of the earliest post date in search results. Because of the way we use Django caching as part of filterable search, this logic had to be deployed incrementally such that existing cache values would work even without having the aggregation value.

This code has been deployed and the cache has been cleared in all environments; thus, the fallback logic can now be removed. This change does so.

## Testing

Search a filterable list providing an end date but not a start date (example: http://localhost:8000/about-us/blog/?title=&from_date=&to_date=2023-05-17) and confirm that the start date gets set to the earliest post date.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)