### PR TITLE
Fix `prefooter` reference in browse-filterable/index.html

### DIFF
--- a/cfgov/v1/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/v1/jinja2/v1/browse-filterable/index.html
@@ -29,7 +29,7 @@
         {% endif %}
     {% endfor %}
     {% if page.sidefoot %}
-        <aside class="prefooter">
+        <aside class="o-prefooter">
             {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
         </aside>
     {% endif %}


### PR DESCRIPTION
Will you look at that. Six years ago `prefooter` was updated to `o-prefooter` in https://github.com/cfpb/consumerfinance.gov/pull/2787, however, the browse-filterable/index.html reference was missed, so all this time prefooters on those pages (62 pages) had an unstyled prefooter. 

This was pointed out in https://github.com/cfpb/consumerfinance.gov/pull/2787#issuecomment-285480919, but looks like the loop didn't get closed.

## Changes

- Fix `prefooter` reference in browse-filterable/index.html to be `o-prefooter`


## How to test this PR

1. Visit a browser-filterable page, such as localhost:8000/rules-policy/final-rules/ or localhost:8000/administrative-adjudication-proceedings/administrative-adjudication-docket/ and scroll to the prefooter at the bottom.


## Screenshots

Before:
<img width="936" alt="Screen Shot 2023-05-19 at 8 33 13 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/a4377b8f-0d15-4e2a-b1b1-737f5e1e06f8">

After:
<img width="926" alt="Screen Shot 2023-05-19 at 8 33 20 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/697e19d1-5a11-4ba0-8343-2552a4e80f14">


Before:
<img width="944" alt="Screen Shot 2023-05-19 at 8 38 08 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2290be12-2661-4417-9e5a-22ee3d1fe64e">

After:
<img width="923" alt="Screen Shot 2023-05-19 at 8 38 15 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/bb7f580c-59d2-40ef-ac5b-7588de2854b2">
