### PR TITLE
Minor cleanup to collapse whitespace on  `for block in page.header` loop

### DIFF
--- a/cfgov/v1/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/v1/jinja2/v1/browse-filterable/index.html
@@ -8,7 +8,7 @@
 {%- endblock %}
 
 {% block content_main %}
-    {% for block in page.header %}
+    {% for block in page.header -%}
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         {{ 'u-mt0' if loop.first }}">

--- a/cfgov/v1/jinja2/v1/campaign_page.html
+++ b/cfgov/v1/jinja2/v1/campaign_page.html
@@ -1,7 +1,7 @@
 {% extends "v1/layouts/layout-full.html" %}
 
 {% block hero %}
-    {% for block in page.header %}
+    {% for block in page.header -%}
         {% if block.block_type == 'features' %}
             <section class="wrapper
                             wrapper__match-content

--- a/cfgov/v1/jinja2/v1/newsroom/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/index.html
@@ -7,7 +7,7 @@
 {%- endblock %}
 
 {% block content_main %}
-    {% for block in page.header %}
+    {% for block in page.header -%}
         {% if 'featured_content' in block.block_type %}
             <div class="block
                         {{ 'u-mt0' if loop.first }}">

--- a/cfgov/v1/jinja2/v1/story_page.html
+++ b/cfgov/v1/jinja2/v1/story_page.html
@@ -1,7 +1,7 @@
 {% extends "v1/layouts/layout-full.html" %}
 
 {% block hero %}
-    {% for block in page.header %}
+    {% for block in page.header -%}
         {% if block.block_type == 'features' %}
             <section class="wrapper
                             wrapper__match-content


### PR DESCRIPTION
Most templates collapse the whitespace on the loop `for block in page.header`. This PR adds this for the four templates that weren't, for consistency across the codebase.

## Changes

- Collapse whitespace for four templates that weren't in their `for block in page.header` loop.


## How to test this PR

1. These pages should be unchanged (Note: omitted campaign pages, because they are unused):

- http://localhost:8000/about-us/newsroom/
- http://localhost:8000/rules-policy/final-rules/
- http://localhost:8000/about-us/racial-equity/