### PR TITLE
iRegs: refactor wayfinder to fix customizations and BEM

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -138,22 +138,20 @@
                         {{ regulation.short_name }}
                     </span>
                 </div>
-                <div class="o-regulations-wayfinder_main">
-                    <div class="o-regulations-wayfinder_content">
-                        <a href="#" class="h4 o-regulations-wayfinder_link">
-                            <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
-                        </a>
-                        <div class="o-regulations-wayfinder_version">
-                            {% if requested_version.effective_date < current_version.effective_date %}
-                                Previous version (effective
-                                {{ ap_date(requested_version.effective_date) }} to
-                                {{ ap_date(next_version.effective_date) }})
-                            {% endif %}
-                            {% if requested_version.effective_date > current_version.effective_date %}
-                                Future version (effective
-                                {{ ap_date(requested_version.effective_date) }})
-                            {% endif %}
-                        </div>
+                <div class="o-regulations-wayfinder_content">
+                    <a href="#" class="h4 o-regulations-wayfinder_link">
+                        <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
+                    </a>
+                    <div class="o-regulations-wayfinder_version">
+                        {% if requested_version.effective_date < current_version.effective_date %}
+                            Previous version (effective
+                            {{ ap_date(requested_version.effective_date) }} to
+                            {{ ap_date(next_version.effective_date) }})
+                        {% endif %}
+                        {% if requested_version.effective_date > current_version.effective_date %}
+                            Future version (effective
+                            {{ ap_date(requested_version.effective_date) }})
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -133,30 +133,26 @@
 
         <section class="block block__flush-top">
             <div class="o-regulations-wayfinder" aria-hidden="true" data-section="{{section.title}}">
-                <div class="content_wrapper">
-                    <div class="content_sidebar content__flush-top content__flush-bottom">
-                        <span class="h4">
-                            {{ regulation.short_name }}
-                        </span>
-                    </div>
-                    <div class="content_main content__flush-top content__flush-bottom">
-                        <div class="o-regulations-wayfinder__content">
-                            <div class="o-regulations-wayfinder__heading">
-                                <a href="#" class="h4 o-regulations-wayfinder_link">
-                                    <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
-                                </a>
-                            </div>
-                            <div class="o-regulations-wayfinder__version">
-                                {% if requested_version.effective_date < current_version.effective_date %}
-                                    Previous version (effective
-                                    {{ ap_date(requested_version.effective_date) }} to
-                                    {{ ap_date(next_version.effective_date) }})
-                                {% endif %}
-                                {% if requested_version.effective_date > current_version.effective_date %}
-                                    Future version (effective
-                                    {{ ap_date(requested_version.effective_date) }})
-                                {% endif %}
-                            </div>
+                <div class="o-regulations-wayfinder_sidebar">
+                    <span class="h4">
+                        {{ regulation.short_name }}
+                    </span>
+                </div>
+                <div class="o-regulations-wayfinder_main">
+                    <div class="o-regulations-wayfinder_content">
+                        <a href="#" class="h4 o-regulations-wayfinder_link">
+                            <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
+                        </a>
+                        <div class="o-regulations-wayfinder_version">
+                            {% if requested_version.effective_date < current_version.effective_date %}
+                                Previous version (effective
+                                {{ ap_date(requested_version.effective_date) }} to
+                                {{ ap_date(next_version.effective_date) }})
+                            {% endif %}
+                            {% if requested_version.effective_date > current_version.effective_date %}
+                                Future version (effective
+                                {{ ap_date(requested_version.effective_date) }})
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -133,25 +133,27 @@
 
         <section class="block block__flush-top">
             <div class="o-regulations-wayfinder" aria-hidden="true" data-section="{{section.title}}">
-                <div class="o-regulations-wayfinder_sidebar">
-                    <span class="h4">
-                        {{ regulation.short_name }}
-                    </span>
-                </div>
-                <div class="o-regulations-wayfinder_content">
-                    <a href="#" class="h4 o-regulations-wayfinder_link">
-                        <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
-                    </a>
-                    <div class="o-regulations-wayfinder_version">
-                        {% if requested_version.effective_date < current_version.effective_date %}
-                            Previous version (effective
-                            {{ ap_date(requested_version.effective_date) }} to
-                            {{ ap_date(next_version.effective_date) }})
-                        {% endif %}
-                        {% if requested_version.effective_date > current_version.effective_date %}
-                            Future version (effective
-                            {{ ap_date(requested_version.effective_date) }})
-                        {% endif %}
+                <div class="o-regulations-wayfinder_wrapper">
+                    <div class="o-regulations-wayfinder_sidebar">
+                        <span class="h4">
+                            {{ regulation.short_name }}
+                        </span>
+                    </div>
+                    <div class="o-regulations-wayfinder_content">
+                        <a href="#" class="h4 o-regulations-wayfinder_link">
+                            <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
+                        </a>
+                        <div class="o-regulations-wayfinder_version">
+                            {% if requested_version.effective_date < current_version.effective_date %}
+                                Previous version (effective
+                                {{ ap_date(requested_version.effective_date) }} to
+                                {{ ap_date(next_version.effective_date) }})
+                            {% endif %}
+                            {% if requested_version.effective_date > current_version.effective_date %}
+                                Future version (effective
+                                {{ ap_date(requested_version.effective_date) }})
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
@@ -1,7 +1,9 @@
 /* ==========================================================================
    Regulations 3000
    Wayfinder
-   ========================================================================== */
+========================================================================== */
+
+@regs-wayfinder-padding-top: unit(15px / @base-font-size-px, rem);
 
 .o-regulations-wayfinder {
   box-sizing: border-box;
@@ -13,6 +15,10 @@
   box-shadow: 0px 3px 8px -6px @black;
   transition: top 0.1s ease-in-out;
   z-index: 100;
+  padding-left: unit(15px / @base-font-size-px, rem);
+  padding-right: unit(15px / @base-font-size-px, rem);
+  padding-top: @regs-wayfinder-padding-top;
+  padding-bottom: unit(15px / @base-font-size-px, rem);
 
   &_link {
     display: inline-block;
@@ -24,23 +30,14 @@
     color: @link-text;
   }
 
-  &_main,
-  &_sidebar {
-    padding-left: unit(15px / @base-font-size-px, rem);
-    padding-top: unit(15px / @base-font-size-px, rem);
-    padding-bottom: unit(15px / @base-font-size-px, rem);
-  }
-
   &_sidebar {
     display: none;
   }
 
   // Tablet and above
   .respond-to-min(@bp-sm-min, {
-    &_main,
-    &_sidebar {
-      padding-left: unit(30px / @base-font-size-px, rem);
-    }
+    padding-left: unit(30px / @base-font-size-px, rem);
+    padding-right: unit(30px / @base-font-size-px, rem);
   });
 
   // Desktop
@@ -50,10 +47,20 @@
 
     &_sidebar {
       display: inline-block;
-      border-right: 1px solid @gray-40;
+      position: relative;
+
+      &:after {
+        border-right: 1px solid @gray-40;
+        content: '';
+        position: absolute;
+        right: -1px;
+        top: -@regs-wayfinder-padding-top;
+        height: calc( 100% + (@regs-wayfinder-padding-top * 2));
+      }
     }
 
     &_content {
+      padding-left: unit(30px / @base-font-size-px, rem);
       display: flex;
       justify-content: space-between;
     }

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
@@ -8,15 +8,11 @@
   width: 100%;
   border-bottom: 2px solid @green;
   position: fixed;
-  top: -80px;
   left: 0;
   background-color: @white;
   box-shadow: 0px 3px 8px -6px @black;
   transition: top 0.1s ease-in-out;
   z-index: 100;
-  .respond-to-min( @bp-med-min, {
-    top: -60px;
-  } );
 
   &_link {
     display: inline-block;
@@ -28,35 +24,44 @@
     color: @link-text;
   }
 
-  .content_main,
-  .content_sidebar {
-    padding-top: 15px;
-    padding-bottom: 15px;
+  &_main,
+  &_sidebar {
+    padding-left: unit(15px / @base-font-size-px, rem);
+    padding-top: unit(15px / @base-font-size-px, rem);
+    padding-bottom: unit(15px / @base-font-size-px, rem);
   }
 
-  .content_main:after {
-    top: 0;
-  }
-
-  .content_sidebar {
+  &_sidebar {
     display: none;
-    .respond-to-min( @bp-med-min, {
-      display: inline-block;
-    } );
   }
 
-  .o-regulations-wayfinder__content {
-    .respond-to-min( @bp-med-min, {
+  // Tablet and above
+  .respond-to-min(@bp-sm-min, {
+    &_main,
+    &_sidebar {
+      padding-left: unit(30px / @base-font-size-px, rem);
+    }
+  });
+
+  // Desktop
+  .respond-to-min( @bp-med-min, {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
+
+    &_sidebar {
+      display: inline-block;
+      border-right: 1px solid @gray-40;
+    }
+
+    &_content {
       display: flex;
       justify-content: space-between;
-    } );
-  }
+    }
 
-  .o-regulations-wayfinder__version {
-    .respond-to-min( @bp-med-min, {
+    &_version {
       text-align: right;
-    } );
-  }
+    }
+  } );
 }
 
 .show-wayfinder .o-regulations-wayfinder {

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
@@ -42,8 +42,12 @@
 
   // Desktop
   .respond-to-min( @bp-med-min, {
-    display: grid;
-    grid-template-columns: 1fr 3fr;
+    &_wrapper {
+      display: grid;
+      grid-template-columns: 1fr 3fr;
+      max-width: 1170px;
+      margin: 0 auto;
+    }
 
     &_sidebar {
       display: inline-block;

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -30,20 +30,16 @@ const HTML_SNIPPET2 = `
 const HTML_SNIPPET3 = `
   <div class="regulations3k">
     <div class="o-regulations-wayfinder" data-section="Comment for 1026.33 - Requirements for Reverse Mortgages">
-        <div class="content_wrapper">
-            <div class="content_sidebar content__flush-top content__flush-bottom">
-                <span class="h4">
-                    Regulation FOO
-                </span>
-            </div>
-            <div class="content_main content__flush-top content__flush-bottom">
-                <div class="o-regulations-wayfinder__content">
-                    <div class="o-regulations-wayfinder__heading">
-                        <a href="#NOPE" class="h4 o-regulations-wayfinder_link">
-                            <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
-                        </a>
-                    </div>
-                </div>
+        <div class="o-regulations-wayfinder_sidebar">
+            <span class="h4">
+                Regulation FOO
+            </span>
+        </div>
+        <div class="o-regulations-wayfinder_main">
+            <div class="o-regulations-wayfinder_content">
+                <a href="#NOPE" class="h4 o-regulations-wayfinder_link">
+                    <span class="o-regulations-wayfinder_section-title"></span><span class="o-regulations-wayfinder_marker"></span>
+                </a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The iRegs wayfinder includes its own component organism `o-regulations-wayfinder`. Inside this component, the layout is handled by `content_wrapper`, `content_main`, and `content_sidebar` to align the left/right columns with the rest of the page layout. However, these classes have styles specific to the page layout, so `o-regulations-wayfinder` overrides styles of these classes, which it should not do (outside of margin adjustments). Additionally, it mixes in `content__flush-top content__flush-bottom`, which is fine, but the combined mixing of utility classes and overrides makes this brittle. 

This PR rewrites the wayfinder to handle its own layout and not depend on external layout classes.

Additionally, the wayfinder contained two classes `o-regulations-wayfinder__content` and `o-regulations-wayfinder__version`, which are written as if they were modifiers in our flavor of BEM, but are actually treated as BEM elements. An additional class of this type, `o-regulations-wayfinder__heading`, was unused and was removed.

## Removals

- Remove `o-regulations-wayfinder__heading`


## Changes

- Refactors wayfinder to use `o-regulations-wayfinder_main` and `o-regulations-wayfinder_sidebar` in place of customized `content_main` and `content_sidebar`.


## How to test this PR

1. Visit a regulation, like http://localhost:8000/rules-policy/regulations/1002/2/ and scroll down till the wayfinder shows. It should appear like production. Resize to tablet and mobile.


## Screenshots
<img width="658" alt="Screen Shot 2023-05-19 at 10 29 33 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ab412946-dbc9-421f-966c-fb7d984e3e6d">
<img width="723" alt="Screen Shot 2023-05-19 at 10 29 42 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/618e9e31-29e3-433d-8ce5-ad2613b0743a">
<img width="453" alt="Screen Shot 2023-05-19 at 10 44 34 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/88ff31a6-4867-4a17-a66c-8c1e259a712d">

