### PR TITLE
Add new Page Preview Fields report

### DIFF
--- a/cfgov/v1/templates/v1/_list_page_preview_fields.html
+++ b/cfgov/v1/templates/v1/_list_page_preview_fields.html
@@ -7,6 +7,7 @@
     <th>Preview Title</th>
     <th>Preview Subheading</th>
     <th>Preview Description</th>
+    <th>Preview Image</th>
 {% endblock %}
 
 {% block extra_page_data %}
@@ -27,5 +28,12 @@
     </td>
     <td valign="top">
         {{ page.preview_description }}
+    </td>
+    <td valign="top">
+        {% if page.preview_image %}
+            {{ page.preview_image.filename }}
+        {% else %}
+            None
+        {% endif %}
     </td>
 {% endblock %}

--- a/cfgov/v1/templates/v1/_list_page_preview_fields.html
+++ b/cfgov/v1/templates/v1/_list_page_preview_fields.html
@@ -1,0 +1,31 @@
+{% extends 'wagtailadmin/reports/listing/_list_page_report.html' %}
+
+{% block extra_columns %}
+    <th>URL</th>
+    <th>SEO Title</th>
+    <th>Search Description</th>
+    <th>Preview Title</th>
+    <th>Preview Subheading</th>
+    <th>Preview Description</th>
+{% endblock %}
+
+{% block extra_page_data %}
+    <td valign="top">
+        {{ page.url }}
+    </td>
+    <td valign="top">
+        {{ page.seo_title }}
+    </td>
+    <td valign="top">
+        {{ page.search_description }}
+    </td>
+    <td valign="top">
+        {{ page.preview_title }}
+    </td>
+    <td valign="top">
+        {{ page.preview_subheading }}
+    </td>
+    <td valign="top">
+        {{ page.preview_description }}
+    </td>
+{% endblock %}

--- a/cfgov/v1/templates/v1/_list_page_preview_fields.html
+++ b/cfgov/v1/templates/v1/_list_page_preview_fields.html
@@ -27,7 +27,7 @@
         {{ page.preview_subheading }}
     </td>
     <td valign="top">
-        {{ page.preview_description }}
+        {{ page.preview_description | striptags }}
     </td>
     <td valign="top">
         {% if page.preview_image %}

--- a/cfgov/v1/templates/v1/page_preview_fields_report.html
+++ b/cfgov/v1/templates/v1/page_preview_fields_report.html
@@ -1,0 +1,5 @@
+{% extends 'wagtailadmin/reports/base_page_report.html' %}
+
+{% block listing %}
+    {% include "v1/_list_page_preview_fields.html" %}
+{% endblock %}

--- a/cfgov/v1/tests/views/test_reports_view.py
+++ b/cfgov/v1/tests/views/test_reports_view.py
@@ -22,6 +22,7 @@ from v1.models import (
     EnforcementActionPage,
     EnforcementActionProduct,
     EnforcementActionStatus,
+    LearnPage,
 )
 from v1.models.snippets import RelatedResource
 from v1.tests.wagtail_pages.helpers import save_new_page
@@ -33,6 +34,7 @@ from v1.views.reports import (
     DocumentsReportView,
     EnforcementActionsReportView,
     PageMetadataReportView,
+    PagePreviewFieldsReportView,
     construct_absolute_url,
     join_values_with_pipe,
     process_categories,
@@ -303,3 +305,20 @@ class TestActiveUsersReport(TestCase):
         report_users = ActiveUsersReportView().get_queryset()
         self.assertGreater(len(User.objects.all()), len(report_users))
         self.assertNotIn(test_user, report_users)
+
+
+class TestPagePreviewFieldsReport(TestCase):
+    def test_get_queryset(self):
+        root_page = Site.objects.get(is_default_site=True).root_page
+        page_no_preview = LearnPage(
+            title="no preview",
+            slug="no-preview",
+        )
+        root_page.add_child(instance=page_no_preview)
+        page_with_preview = LearnPage(
+            title="has preview", slug="has-preview", preview_title="Preview me"
+        )
+        root_page.add_child(instance=page_with_preview)
+
+        queryset = PagePreviewFieldsReportView().get_queryset()
+        self.assertQuerysetEqual(queryset, [page_with_preview])

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -5,6 +5,7 @@ from operator import itemgetter
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 from django.utils import html as html_util
 
 from wagtail.admin.filters import WagtailFilterSet
@@ -17,7 +18,7 @@ import django_filters
 from bs4 import BeautifulSoup
 
 from ask_cfpb.models.answer_page import AnswerPage
-from v1.models import CFGOVPage
+from v1.models import AbstractFilterPage, CFGOVPage
 from v1.models.enforcement_action_page import EnforcementActionPage
 from v1.util.ref import categories, get_category_icon
 
@@ -469,3 +470,36 @@ class ActiveUsersReportView(ReportView):
 
     def get_queryset(self):
         return get_user_model().objects.filter(is_active=True)
+
+
+class PagePreviewFieldsReportView(PageReportView):
+    title = "Page Preview Fields"
+    header_icon = "view"
+    template_name = "v1/page_preview_fields_report.html"
+
+    def get_queryset(self):
+        default_site = Site.objects.get(is_default_site=True)
+        return (
+            AbstractFilterPage.objects.in_site(default_site)
+            .exclude(
+                (Q(preview_title__isnull=True) | Q(preview_title=""))
+                & (
+                    Q(preview_subheading__isnull=True)
+                    | Q(preview_subheading="")
+                )
+                & (
+                    Q(preview_description__isnull=True)
+                    | Q(preview_description="")
+                )
+            )
+            .specific()
+        )
+
+    list_export = PageReportView.list_export + [
+        "url",
+        "seo_title",
+        "search_description",
+        "preview_title",
+        "preview_subheading",
+        "preview_description",
+    ]

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -1,7 +1,7 @@
 import html
 from datetime import date
 from functools import partial
-from operator import itemgetter
+from operator import attrgetter, itemgetter
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -18,7 +18,7 @@ import django_filters
 from bs4 import BeautifulSoup
 
 from ask_cfpb.models.answer_page import AnswerPage
-from v1.models import AbstractFilterPage, CFGOVPage
+from v1.models import AbstractFilterPage, CFGOVImage, CFGOVPage
 from v1.models.enforcement_action_page import EnforcementActionPage
 from v1.util.ref import categories, get_category_icon
 
@@ -491,6 +491,7 @@ class PagePreviewFieldsReportView(PageReportView):
                     Q(preview_description__isnull=True)
                     | Q(preview_description="")
                 )
+                & Q(preview_image__isnull=True)
             )
             .specific()
         )
@@ -502,4 +503,12 @@ class PagePreviewFieldsReportView(PageReportView):
         "preview_title",
         "preview_subheading",
         "preview_description",
+        "preview_image",
     ]
+
+    custom_value_preprocess = {
+        **PageReportView.custom_value_preprocess,
+        CFGOVImage: {
+            fmt: attrgetter("filename") for fmt in PageReportView.FORMATS
+        },
+    }

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -506,6 +506,12 @@ class PagePreviewFieldsReportView(PageReportView):
         "preview_image",
     ]
 
+    custom_field_preprocess = {
+        "preview_description": {
+            fmt: html_util.strip_tags for fmt in PageReportView.FORMATS
+        }
+    }
+
     custom_value_preprocess = {
         **PageReportView.custom_value_preprocess,
         CFGOVImage: {

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -47,6 +47,7 @@ from v1.views.reports import (
     EnforcementActionsReportView,
     ImagesReportView,
     PageMetadataReportView,
+    PagePreviewFieldsReportView,
     TranslatedPagesReportView,
 )
 
@@ -360,6 +361,26 @@ def register_active_users_report_url():
             r"^reports/active-users/$",
             ActiveUsersReportView.as_view(),
             name="active_users_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_page_preview_fields_report_menu_item():
+    return MenuItem(
+        "Page Preview Fields",
+        reverse("page_preview_fields_report"),
+        classnames="icon icon-" + PagePreviewFieldsReportView.header_icon,
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_page_preview_fields_report_url():
+    return [
+        re_path(
+            r"^reports/page-preview-fields/$",
+            PagePreviewFieldsReportView.as_view(),
+            name="page_preview_fields_report",
         ),
     ]
 


### PR DESCRIPTION
This commit adds a new Page Preview Fields report in Wagtail that lists all AbstractFilterPages in the main site that have non-empty page preview fields (`preview_title`, `preview_subheading`, `preview_description`).

See internal D&CP#234 for context.

## How to test this PR

To access the new report, visit http://localhost:8000/admin/reports/page-preview-fields/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)