### PR TITLE
Remove `post_content` block

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/content-base.html
+++ b/cfgov/v1/jinja2/v1/layouts/content-base.html
@@ -20,6 +20,5 @@
             {% endif %}
         {%- endblock %}
         {% block body_content scoped -%}{%- endblock %}
-        {% block post_content scoped -%}{%- endblock %}
     </main>
 {% endblock %}

--- a/cfgov/v1/jinja2/v1/layouts/layout-2-1-rtl.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-2-1-rtl.html
@@ -35,7 +35,6 @@
             {% block content_sidebar scoped -%}{%- endblock %}
         </aside>
         {% endblock %}
-        {% block post_content scoped -%}{%- endblock %}
         </div>
     </main>
 {% endblock %}


### PR DESCRIPTION
The `post_content` block does not appear to ever be overridden. 

## Removals

- The `post_content` block in `content_base.html` and `layout-2-1-rtl.html`.

## How to test this PR

1. PR checks should pass.
