### PR TITLE
Migrate Event.initEvent to native event creation

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/ClearableInput.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/ClearableInput.js
@@ -41,8 +41,7 @@ function ClearableInput(element) {
     _inputDom.value = _setClearBtnState('');
     _inputDom.focus();
     // Create custom clear event so we can automatically reset results after clear.
-    const customEvent = document.createEvent('Event');
-    customEvent.initEvent('clear', true, true);
+    const customEvent = new Event('clear', { bubbles: true, cancelable: true });
     _clearBtnDom.dispatchEvent(customEvent);
     // Prevent event bubbling up to the input, which would blur otherwise.
     event.preventDefault();

--- a/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/permalinks-utils-spec.js
@@ -60,8 +60,7 @@ describe('The Regs3K permalinks utils', () => {
     });
 
     it('should only call a function once within a given timespan', (done) => {
-      const event = document.createEvent('Event');
-      event.initEvent('resize', true, true);
+      const event = new Event('resize', { bubbles: true, cancelable: true });
       jest.spyOn(global, 'spy');
 
       debounce('resize', 100, global.spy);
@@ -79,8 +78,7 @@ describe('The Regs3K permalinks utils', () => {
     });
 
     it("should not call a function if the timespan hasn't passed", (done) => {
-      const event = document.createEvent('Event');
-      event.initEvent('scroll', true, true);
+      const event = new Event('scroll', { bubbles: true, cancelable: true });
       jest.spyOn(global, 'spy');
 
       debounce('scroll', 1000, global.spy);

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -54,8 +54,7 @@ describe('The Regs3K search page', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
   });
 

--- a/test/unit_tests/apps/teachers-digital-platform/js/expandable-facets-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/expandable-facets-spec.js
@@ -56,8 +56,7 @@ describe('Expandable facets', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     ef = document.querySelector('.o-expandable-facets');

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/grade-level-page-analytics-spec.js
@@ -13,8 +13,7 @@ describe('Custom analytics for the TDP survey grade-level page', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     const mockXHR = {

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/results-page-analytics-spec.js
@@ -15,8 +15,7 @@ describe('Custom analytics for the TDP survey results page', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     const mockXHR = {

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/shared-results-page-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/shared-results-page-analytics-spec.js
@@ -13,8 +13,7 @@ describe('Custom analytics for the TDP survey results page', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     const mockXHR = {

--- a/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/survey/survey-page-analytics-spec.js
@@ -13,8 +13,7 @@ describe('Custom analytics for the TDP survey form page', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     const mockXHR = {

--- a/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
@@ -197,8 +197,7 @@ describe('The TDP custom analytics', () => {
     // Load HTML fixture
     document.body.innerHTML = HTML_SNIPPET;
     // Fire `load` event
-    const event = document.createEvent('Event');
-    event.initEvent('load', true, true);
+    const event = new Event('load', { bubbles: true, cancelable: true });
     window.dispatchEvent(event);
 
     const mockXHR = {

--- a/test/util/simulate-event.js
+++ b/test/util/simulate-event.js
@@ -7,20 +7,34 @@
 function simulateEvent(eventType, target, eventOption = {}) {
   let event;
 
-  if (eventType === 'click') {
-    event = new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-    });
-    // TODO: migrate to KeyBoardEvent, etc.
-  } else {
-    event = window.document.createEvent('Event', eventOption.currentTarget);
-    event.initEvent(eventType, true, true);
+  // Add more event types here as required by tests.
+  switch (eventType) {
+    case 'click' || 'mousedown' || 'mouseup':
+      event = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+      break;
+    case 'keypress' || 'keydown' || 'keyup':
+      event = new KeyboardEvent(eventType, {
+        bubbles: true,
+        cancelable: true,
+      });
 
-    if (eventOption && eventOption.key) {
-      event.key = eventOption.key;
-    }
+      if (eventOption && eventOption.key) {
+        event.key = eventOption.key;
+      }
+      break;
+    default:
+      event = new Event(eventType, {
+        bubbles: true,
+        cancelable: true,
+      });
+
+      if (eventOption && eventOption.key) {
+        event.key = eventOption.key;
+      }
   }
 
   return target.dispatchEvent(event);


### PR DESCRIPTION
Event.initEvent is deprecated and should be replaced with creating event instances directly. 

## Changes

- Migrate Event.initEvent to native event creation


## How to test this PR

1. `yarn jest` should pass.
2. http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/ search clear button should still work.