### PR TITLE
Default PortalSearchPage results to alphabetical

### DIFF
--- a/cfgov/ask_cfpb/models/search.py
+++ b/cfgov/ask_cfpb/models/search.py
@@ -62,10 +62,14 @@ class AnswerPageSearch:
             )
         else:
             search = self.base_query.filter("term", language=self.language)
+
         if self.search_term != "":
             search = search.query(
                 "match", text={"query": self.search_term, "operator": "AND"}
             )
+        else:
+            search = search.sort("autocomplete.raw")
+
         total_results = search.count()
         search = search[0:total_results]
         self.results = search.execute()[0:total_results]


### PR DESCRIPTION
Currently the results on PortalSearchPages like https://www.consumerfinance.gov/consumer-tools/auto-loans/answers/basics/ default to a random order if the user hasn't entered a search query.

If they do enter a search query, the results are sorted by search relevance (the default behavior of OpenSearch, using the `_score` field).

This commit changes the default sort order to be alphabetical.

## How to test this PR

1. You'll need to reindex your search index, either with a fresh `./refresh-db.sh` or just by running [these two commands](https://github.com/cfpb/consumerfinance.gov/blob/6311c9d4be9f6cf8cff390b234edf7879b4045b1/refresh-data.sh#L73-L74) manually.
2. Visit http://localhost:8000/consumer-tools/auto-loans/answers/basics/ and observe alphabetical sorting.
3. Do a search, for example http://localhost:8000/consumer-tools/auto-loans/answers/basics/?search_term=equity, and observe sorting by relevance.

## Screenshots

|Before|After|
|-|-|
|<img width="1284" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/6027faea-4bd3-484e-85e2-093c54ddab5b">|<img width="1282" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/39a2f8c5-e06f-4306-b644-5e3e65008258">|

## Notes and todos

~~This is just a draft PR because we'll have to roll this out in two separate steps: first adding the new keyword field to the index & reindexing our cf.gov environments; and second deploying the modified search logic that uses the new field. I'll also need to write tests for the new behavior.~~ Done!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)