### PR TITLE
Optimize search tests that use `time.sleep()`

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -119,21 +119,15 @@ class ElasticsearchTestsMixin:
 
             raise SkipTest("Cannot connect to local Elasticsearch") from e
 
-        # The django-elasticsearch-dsl package we use to interface with
-        # Elasticsearch does not currently provide a way to make indexing
-        # blocking. This test case patches the Elasticsearch bulk API call
-        # to ensure that reindexes are immediately available in search results.
+        # Patch the Elasticsearch bulk API call to ensure that reindexes and
+        # individual document updates are immediately available in search results.
         #
         # See the Elasticsearch documentation on refresh:
         # https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-refresh.html
-        #
-        # See https://github.com/django-es/django-elasticsearch-dsl/pull/323
-        # for a proposed pull request to django-elasticsearch-dsl to support
-        # this blocking behavior.
         from opensearchpy.helpers import bulk as original_bulk
 
         def bulk_with_refresh(*args, **kwargs):
-            kwargs.setdefault("refresh", True)
+            kwargs["refresh"] = True
             return original_bulk(*args, **kwargs)
 
         cls.patched_es_bulk = patch(

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -1,6 +1,5 @@
 import json
 from io import StringIO
-from time import sleep
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -231,8 +230,6 @@ class FilterableSearchTests(ElasticsearchWagtailPageTreeTestCase):
         indexed_page = Page.objects.get(slug="child1").specific
         indexed_page.title = "child1 foo"
         indexed_page.save_revision().publish()
-        # wait for the index to update
-        sleep(1)
         self.assertEqual(search.search(title="foo").count(), 1)
 
 
@@ -498,7 +495,6 @@ class TestThatWagtailPageSignalsUpdateIndex(ElasticsearchTestsMixin, TestCase):
             # Moving a page out of the parent should update the index so that
             # a search there now returns only 2 results.
             blog2.move(root)
-            sleep(1)
             results = search.search(title="foo")
             self.assertEqual(results.count(), 2)
 
@@ -506,7 +502,6 @@ class TestThatWagtailPageSignalsUpdateIndex(ElasticsearchTestsMixin, TestCase):
             # now returns only 1 result.
             blog3.title = "bar"
             blog3.save_revision().publish()
-            sleep(1)
             results = search.search(title="foo")
             self.assertEqual(results.count(), 1)
 

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime
 from io import StringIO
-from time import sleep
 
 from django.test import TestCase, override_settings
 
@@ -222,8 +221,6 @@ class TestEventArchiveFilterForm(ElasticsearchTestsMixin, TestCase):
         )
         form.is_bound = True
         form.cleaned_data = {"categories": []}
-        # wait for cleaned_data to be updated before we query it
-        sleep(1)
         page_set = form.get_page_set()
         self.assertEqual(len(page_set), 1)
         self.assertEqual(page_set[0].specific, self.event)


### PR DESCRIPTION
Some of our search tests currently use `time.sleep()` to try to ensure that the search index updates after some operation in the test. This commit removes these sleeps by improving the way we patch the OpenSearch library so that updates always take effect immediately.

## How to test this PR

All tests should continue to pass successfully, just a bit faster.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)