### PR TITLE
Bump Wagtail version from 4.1.4 to 4.1.6

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==4.1.4
+wagtail==4.1.6


### PR DESCRIPTION
4.1.5 release notes: https://docs.wagtail.org/en/stable/releases/4.1.5.html
4.1.6 release notes: https://docs.wagtail.org/en/stable/releases/4.1.6.html

The change of most interest to us here is "Ensure that copying page correctly picks up the latest revision"; this fixes https://github.com/wagtail/wagtail/issues/10393 which I filed due to our internal D&CT#232.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)