### PR TITLE
Upgrade OpenSearch-related libraries

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -17,7 +17,7 @@ from wagtail.signals import (
 )
 
 from django_opensearch_dsl.signals import BaseSignalProcessor
-from opensearch_dsl import analyzer, token_filter, tokenizer
+from opensearchpy import analyzer, token_filter, tokenizer
 
 from search.models import Synonym
 

--- a/cfgov/search/management/commands/es_health.py
+++ b/cfgov/search/management/commands/es_health.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from opensearch_dsl import connections
+from opensearchpy import connections
 
 
 class Command(BaseCommand):

--- a/cfgov/search/tests/management/commands/test_es_health.py
+++ b/cfgov/search/tests/management/commands/test_es_health.py
@@ -11,7 +11,7 @@ class ESHealthTestCase(TestCase):
         with self.assertRaises(CommandError):
             call_command("es_health", "notarealconnection", stdout=StringIO())
 
-    @mock.patch("opensearch_dsl.connections.get_connection")
+    @mock.patch("opensearchpy.connections.get_connection")
     def test_foo(self, mock_es_get_connection):
         mock_elasticsearch = mock.MagicMock()
         mock_elasticsearch.cat.health.return_value = "health table"

--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -7,7 +7,7 @@ from django.db import models
 from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.fields import StreamField
 
-from opensearch_dsl import Q
+from opensearchpy import Q
 
 from teachers_digital_platform.documents import ActivityPageDocument
 from teachers_digital_platform.models.django import (

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -5,7 +5,7 @@ from django.utils.html import strip_tags
 
 from django_opensearch_dsl import Document, fields
 from django_opensearch_dsl.registries import registry
-from opensearch_dsl.query import MultiMatch
+from opensearchpy.helpers.query import MultiMatch
 
 from search.elasticsearch_helpers import environment_specific_index
 from v1.models.blog_page import BlogPage, LegacyBlogPage

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -6,7 +6,7 @@ django-autocomplete-light==3.9.4
 django-axes==5.41.0
 django-cors-headers==3.11.0
 django-csp==3.7
-django-opensearch-dsl==0.4.1
+django-opensearch-dsl==0.5.1
 django-extensions==3.1.5
 django-flags==5.0.9
 django-formtools==2.3
@@ -22,8 +22,7 @@ elasticsearch<7.11  # Keep pinned to the deployed ES version
 govdelivery==1.4.0
 Jinja2==3.1.2
 lxml==4.9.1
-opensearch-dsl==1.0.0
-opensearch-py==1.1.0
+opensearch-py==2.2.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.2
 regdown==1.0.7


### PR DESCRIPTION
This commit bumps the version of the opensearch-py package from 1.1.0 to [2.2.0](https://github.com/opensearch-project/opensearch-py/releases). This allows us to remove our dependence on opensearch-dsl, which was incorporated into opensearch-py in the latest version.

It also bumps the version of the django-opensearch-dsl from 0.4.1 to [0.5.1](https://github.com/Codoc-os/django-opensearch-dsl/releases).

## How to test this PR

All unit and functional tests continue to pass with these upgrades.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)