### PR TITLE
Fix warning from StoryPage breadcrumbs test

### DIFF
--- a/cfgov/v1/tests/models/test_story_page.py
+++ b/cfgov/v1/tests/models/test_story_page.py
@@ -9,11 +9,8 @@ class StoryPageTests(TestCase):
             return [1, 2, 3]
 
         page = StoryPage(title="test", slug="test")
-
         page.get_breadcrumbs = get_bread
 
         request = RequestFactory().get("/")
         response = page.serve(request)
-        response.render()
-
-        self.assertNotIn("breadcrumbs_text", str(response.content))
+        self.assertNotContains(response, "breadcrumbs_text")


### PR DESCRIPTION
The StoryPage breadcrumbs test added in commit defb5e59415a10a1ec176a47f15a1cb4c8925199 introduced a warning to our Python unit tests:

```
BytesWarning: str() on a bytes instance
  self.assertNotIn("breadcrumbs_text", str(response.content))
```

This commit fixes that warning by using Django's built-in [`assertNotContains`](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.SimpleTestCase.assertNotContains) on the page render response.

## How to test this PR

[Run our Python tests](https://cfpb.github.io/consumerfinance.gov/python-unit-tests/#running-tests) and observe that this warning no longer appears when compared to running them against the `main` branch.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)