### PR TITLE
Always report slowest Django tests

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -37,6 +37,7 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 TEST_RUNNER = os.environ.get(
     "TEST_RUNNER", "core.testutils.runners.TestRunner"
 )
+ALWAYS_GENERATE_SLOW_REPORT = True
 
 BAKER_CUSTOM_CLASS = "core.testutils.baker.ActualContentTypeBaker"
 

--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -8,12 +8,13 @@ from django.apps import apps
 from django.conf import settings
 from django.db import connection
 from django.db.migrations.loader import MigrationLoader
-from django.test.runner import DiscoverRunner
+
+from django_slowtests.testrunner import DiscoverSlowestTestsRunner
 
 from scripts import initial_data
 
 
-class TestRunner(DiscoverRunner):
+class TestRunner(DiscoverSlowestTestsRunner):
     def setup_test_environment(self, **kwargs):
         super().setup_test_environment(**kwargs)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 coverage==6.3.2
 diff_cover==6.5.0
+django-slowtests==1.1.1
 freezegun==1.2.1
 github3.py==3.2.0
 model-bakery==1.5.0


### PR DESCRIPTION
This PR adds the [django-slowtests](https://github.com/realpython/django-slow-tests) package to our Python test environment so that we can measure and report how long our Python tests take to run. Running Python tests (via `tox` or some other method) will now always report the 10 slowest tests:

```
10 slowest tests:
4.9607s test_index_reflects_page_moves_and_deletions (v1.tests.test_documents.TestThatWagtailPageSignalsUpdateIndex)
4.2827s test_page_matches_categories (v1.tests.models.test_browse_filterable_page.TestNewsroomLandingPage)
4.2764s test_page_in_other_site_not_included (v1.tests.models.test_browse_filterable_page.TestNewsroomLandingPage)
4.2064s test_no_pages_matching_categories (v1.tests.models.test_browse_filterable_page.TestNewsroomLandingPage)
3.4575s test_event_archive_elasticsearch (v1.tests.test_filterable_list_form.TestEventArchiveFilterForm)
3.3181s test_filter_by_nonexisting_category (v1.tests.test_filterable_list_form.TestFilterableListForm)
3.2756s test_clean_categories_converts_blog_subcategories_correctly (v1.tests.test_filterable_list_form.TestFilterableListForm)
3.2275s test_validate_date_after_1900_can_fail (v1.tests.test_filterable_list_form.TestFilterableListForm)
3.1613s test_filter_doesnt_return_drafts (v1.tests.test_filterable_list_form.TestFilterableListForm)
3.1601s test_clean_categories_converts_reports_subcategories_correctly (v1.tests.test_filterable_list_form.TestFilterableListForm)
```

## How to test this PR

Run the Django tests (skipping migrations to make it a little faster):

`SKIP_DJANGO_MIGRATIONS=1 tox -e unittest`

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets