### PR TITLE
HMDA: Remove hardcoded negative margin

### DIFF
--- a/cfgov/hmda/jinja2/hmda/hmda-explorer.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer.html
@@ -20,7 +20,7 @@
         {% endif %}
     {%- endfor %}
 
-    <div class="hmda-historic-data" style="margin-top: -20px">
+    <div class="hmda-historic-data">
 
         {{ controls.render(form) }}
 


### PR DESCRIPTION
For some reason this page moves the table -20px through a hardcoded negative margin.
If we want this, we could roughly approximate it by adding `block__flush-bottom block__padded-bottom` to the preceding sibling container, or clear the preceding sibling with `block__flush-bottom` and then add `u-mt20` to the table. But either way doesn't seem worth it.

## Removals

- HMDA: Remove hardcoded negative margin

## How to test this PR

1. Visit https://www.consumerfinance.gov/data-research/hmda/historic-data/ and compare the table position to https://localhost:8000/data-research/hmda/historic-data/


## Screenshots

Before:

<img width="866" alt="Screen Shot 2023-05-30 at 5 59 40 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ce6a56e7-43be-4977-921a-39174d79f7ed">

After: 

<img width="873" alt="Screen Shot 2023-05-30 at 5 59 34 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/83cf3aa2-9902-47e3-879f-c01dfcd0af96">
