### PR TITLE
Add keyword field index to PortalSearchPages

### DIFF
--- a/cfgov/ask_cfpb/documents.py
+++ b/cfgov/ask_cfpb/documents.py
@@ -11,7 +11,9 @@ from search.elasticsearch_helpers import (
 
 @registry.register_document
 class AnswerPageDocument(Document):
-    autocomplete = fields.TextField(analyzer=ngram_tokenizer)
+    autocomplete = fields.TextField(
+        analyzer=ngram_tokenizer, fields={"raw": fields.KeywordField()}
+    )
     portal_topics = fields.KeywordField()
     portal_categories = fields.TextField()
     text = fields.TextField(attr="text", analyzer=synonym_analyzer)

--- a/cfgov/ask_cfpb/tests/test_documents.py
+++ b/cfgov/ask_cfpb/tests/test_documents.py
@@ -173,6 +173,7 @@ class AnswerPageDocumentTest(TestCase):
                     "autocomplete": {
                         "analyzer": "ngram_tokenizer",
                         "type": "text",
+                        "fields": {"raw": {"type": "keyword"}},
                     },
                     "language": {"type": "text"},
                     "portal_categories": {"type": "text"},


### PR DESCRIPTION
We currently index PortalSearchPages into OpenSearch so they can be searched on pages like

https://www.consumerfinance.gov/consumer-tools/auto-loans/answers/basics/

The "autocomplete" field in the search index actually represents the page title. This is currently indexed as a text field so that fuzzy searches work against it.

But we also want to index this same title as a keyword field so that we can sort on the field, i.e. so that search results can be shown in alphabetical order.

This commit makes a change to the way this field is indexed so that it gets indexed both as a text field AND as a keyword field (under the name "raw").

A subsequent change will actually use this new field to add alphabetical ordering; this needs to be done in two steps so that we first ensure that all live environments get the new field before we try to use it.

(A draft version of this change was previously opened as #7768; that PR will be repurposed to do the second step if/when this one goes live and I reindex all of our environments.)

## How to test this PR

There's no real testing to be done besides trying this PR on an existing DB and search index and visiting pages like:

http://localhost:8000/consumer-tools/auto-loans/answers/basics/ http://localhost:8000/consumer-tools/auto-loans/answers/basics/?search_term=credit

You won't see any changes to search results. Reindexing with this change and then revisiting those URLs also won't show any differences.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)