### PR TITLE
Fix outdated references to molecules in College Costs nav styles

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/nav.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/nav.less
@@ -11,10 +11,10 @@
       border-left: 0;
       padding-left: 0;
 
-      > .m-list_item {
+      > .o-secondary-nav_list-item__parent {
         border-bottom: 1px solid @gray-20;
 
-        & > .m-nav_link {
+        & > .o-secondary-nav_link {
           font-size: unit( 18px / @base-font-size-px, em );
         }
       }
@@ -41,7 +41,7 @@
         display: none;
       }
 
-      li.m-list_item__parent[data-nav-is-active='True'] > a {
+      li.o-secondary-nav_list-item__parent[data-nav-is-active='True'] > a {
         font-weight: 600;
       }
 
@@ -52,7 +52,7 @@
         }
       }
 
-      .m-list_item li.m-list_item[data-nav-is-active='True'] {
+      .o-secondary-nav_list-item__parent li[data-nav-is-active='True'] {
         .active-section {
           border-left: 3px solid @green;
 


### PR DESCRIPTION
:wave: Looks like a small oversight from #7739 was causing some missing styling on the secondary nav for the Grad Path tool.

---

## Changes

- Updates instances of `.m-list_item` and `.m-nav_link` with the appropriate new classes.


## How to test this PR

1. Visit [Your financial path to graduation](https://www.consumerfinance.gov/paying-for-college/your-financial-path-to-graduation/) on production and click "Get started" to see the intended style. (#7739 has not been deployed yet.)
1. In your local env running `main`, [visit the tool](http://localhost:8000/paying-for-college/your-financial-path-to-graduation/), click "Get started", and observe the missing bold on "Your financial aid offer" and missing green border on the active item.
1. Pull this branch
1. Rebuild the styles
1. Reload your local version and see the restored styles


## Screenshots

### Current production (and on this branch)

![Grad Path nav with intended styling](https://github.com/cfpb/consumerfinance.gov/assets/1044670/4a38fefa-3485-41d2-8736-fdeec4110c6b)

### Current `main`

![Grad Path nav with missing styles](https://github.com/cfpb/consumerfinance.gov/assets/1044670/0d583fcd-fda9-42f6-ac8a-c264b6599ef1)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->
