### PR TITLE
Refer to python, not python3

### DIFF
--- a/cfgov/manage.py
+++ b/cfgov/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
Use `/usr/bin/env python`, not `/usr/bin/env python3`.

When working with @BrewCityBoy, we found that his pyenv setup was setting the global `python` executable but not `python3` for some reason. This commit fixes In a Python 3-only world, there's no need to refer to `python3` explicitly when we can just refer to `python`.

I'm not certain why his laptop setup doesn't set `python3` but it seemed easier to fix here than try to re-setup his pyenv. @willbarton does this seem reasonable?

I've confirmed that on real deployments, using `/usr/bin/env python` once the cf.gov virtualenv is activated still works properly.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)