### PR TITLE
Bugfix: Set mobile layout in layout-base to fix overlapping mobile layout

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout-1-3.less
+++ b/cfgov/unprocessed/css/enhancements/layout-1-3.less
@@ -3,14 +3,6 @@
   .u-layout-grid__1-3 {
     // Mobile
     .u-layout-grid {
-      &_wrapper {
-        grid-auto-rows: minmax(0, auto) auto-fit 1fr;
-        grid-template-areas:
-          'c-breadcrumbs'
-          'c-secondary-nav'
-          'c-main';
-      }
-
       &_breadcrumbs,
       &_secondary-nav {
         margin-left: unit(-15px / @base-font-size-px, rem);
@@ -98,9 +90,7 @@
   .u-layout-grid__1-3.u-layout-grid__rtl {
     // Desktop
     .respond-to-min( @bp-med-min, {
-
       .u-layout-grid {
-
         &_wrapper {
           grid-auto-rows: minmax(0, auto) minmax(0, auto) 1fr;
           grid-auto-columns: 3fr 1fr;

--- a/cfgov/unprocessed/css/enhancements/layout-base.less
+++ b/cfgov/unprocessed/css/enhancements/layout-base.less
@@ -7,6 +7,13 @@
       margin: 0 auto;
       padding-left: unit(15px / @base-font-size-px, rem);
       padding-right: unit(15px / @base-font-size-px, rem);
+      grid-template-areas:
+        'c-breadcrumbs'
+        'c-secondary-nav'
+        'c-hero'
+        'c-main'
+        'c-sidebar'
+        'c-prefooter';
     }
 
     // Name all possible content area elements (appearing inside <main>).


### PR DESCRIPTION
The RTL layout-2-1 layouts (such as https://www.consumerfinance.gov/about-us/blog/avoid-covid-19-government-imposter-scams-ar/) have a major bug at mobile where the grid layout is not being configured, so all blocks are overlapping on top of each other. This PR fixes this by moving a default mobile layout to the layout-base.less file.

## Changes

- Layouts: Move default mobile layout to the layout-base.less file.


## How to test this PR

1. At mobile, compare https://www.consumerfinance.gov/about-us/blog/avoid-covid-19-government-imposter-scams-ar/ to https://localhost:8000/about-us/blog/avoid-covid-19-government-imposter-scams-ar/


## Screenshots

Before: 😬😬😬😬😬
<img width="527" alt="Screen Shot 2023-06-07 at 10 46 23 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/acb68043-11ae-44fe-8db6-c31976892822">


After:

<img width="529" alt="Screen Shot 2023-06-07 at 10 46 37 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/9bcd8919-1e74-4b39-8e8f-e8432b52e792">


## Notes and todos

- Ignore breadcrumb indent for now.