### PR TITLE
Cypress: Enable screenshots on failure

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   video: false,
-  screenshotOnRunFailure: false,
+  screenshotOnRunFailure: true,
   fixturesFolder: 'test/cypress/fixtures',
   videosFolder: 'test/cypress/videos',
   screenshotsFolder: 'test/cypress/screenshots',


### PR DESCRIPTION
Screenshots on failure were disabled in https://github.com/cfpb/consumerfinance.gov/pull/6303, perhaps because it was causing issues in Jenkins. However, let's try it out again.

## Changes

- Cypress: Enable screenshots on failure
