### PR TITLE
Prototype preview fields audit tool

### DIFF
--- a/cfgov/v1/jinja2/v1/page_preview_comparison.html
+++ b/cfgov/v1/jinja2/v1/page_preview_comparison.html
@@ -1,0 +1,56 @@
+{% extends "v1/layouts/base.html" %}
+
+{% block title %}Page preview comparison{% endblock %}
+
+{% block header %}{% endblock %}
+
+{% block content %}
+{% import 'v1/includes/molecules/pagination.html' as pagination with context %}
+
+<div class="content_wrapper">
+    <div class="content_main">
+        {% if paginator.num_pages > 1 %}
+            <div class="block block__flush-top block__flush-bottom block__padded-bottom">
+                {{ pagination.render( paginator.num_pages, page_obj.number ) }}
+            </div>
+        {% endif %}
+
+        {% for page in page_obj %}
+        <div>
+            <h2>
+                <a href="{{ page.url }}">{{ page.url }}</a>
+                <small>
+                <a href="{{ url('wagtailadmin_pages:edit', args=[page.pk]) }}"
+                   target="_blank"
+                >({{ page.pk }})</a>
+                </small>
+            </h2>
+        </div>
+        <div class="content-l"
+            {% if changes_alter_preview( page ) %}
+            style="background-color: #f9e0e0"
+            {% endif %}
+        >
+            <div class="content-l_col content-l_col-1-2">
+                {{ render_snapshot( page ) }}
+            </div>
+
+            <div class="content-l_col content-l_col-1-2">
+                {{ render_snapshot( page, patch_fields=true ) }}
+            </div>
+        </div>
+        <hr>
+        {% endfor %}
+
+        {% if paginator.num_pages > 1 %}
+            <div class="block block__flush-top block__flush-bottom block__padded-top">
+                {{ pagination.render( paginator.num_pages, page_obj.number ) }}
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}
+
+{% block wagtailuserbar %}{% endblock %}
+
+{% block footer %}{% endblock %}

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -18,7 +18,7 @@ from wagtail.contrib.modeladmin.options import (
 )
 
 from ask_cfpb.models.snippets import GlossaryTerm
-from v1.admin_views import cdn_is_configured, manage_cdn
+from v1.admin_views import PagePreviewComparison, cdn_is_configured, manage_cdn
 from v1.models.banners import Banner
 from v1.models.portal_topics import PortalCategory, PortalTopic
 from v1.models.resources import Resource
@@ -381,6 +381,26 @@ def register_page_preview_fields_report_url():
             r"^reports/page-preview-fields/$",
             PagePreviewFieldsReportView.as_view(),
             name="page_preview_fields_report",
+        ),
+    ]
+
+
+@hooks.register("register_reports_menu_item")
+def register_page_preview_comparison_menu_item():
+    return MenuItem(
+        "Page Preview Comparison",
+        reverse("page_preview_comparison"),
+        classnames="icon icon-view",
+    )
+
+
+@hooks.register("register_admin_urls")
+def register_page_preview_comparison_url():
+    return [
+        re_path(
+            r"^reports/page-preview-comparison/$",
+            PagePreviewComparison.as_view(),
+            name="page_preview_comparison",
         ),
     ]
 


### PR DESCRIPTION
This commit adds a prototype tool for auditing a potential change to page post preview fields, as discussed on internal D&CP#234.

It makes the following changes to pages and allows for comparison of the post preview view:

- Remove `preview_title` in favor of `seo_title`
- Remove `preview_subheading` entirely
- Remove `preview_description` in favor of `search_description`
- Remove `preview_image` entirely, falling back on default CFGOVPage behavior.

To test, run locally and visit:

http://localhost:8000/admin/reports/page-preview-comparison/

Pages with differences will be highlighed in red; note there may be false alarms due to noise in the way that rich text data is stored.

This is just a first cut at a prototype tool and is far from polished. @csebianlander please let me know what kinds of changes would make this more useful. I realize it'd be nicer if the tool only showed pages with differences; that would make this kind of view significantly slower. For the record, there are 5,873 pages included in this view - all AbstractFilterPages under the main site.

Note also that this is just a draft and so doesn't include any tests, etc. We can merge this if it would be helpful to run on the content server directly.

## Screenshots

<img width="1347" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/dec5e7c6-b286-4194-809c-1e5e05175ac3">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets