### PR TITLE
Skip flaky FIG test on mobile

### DIFF
--- a/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
+++ b/test/cypress/integration/compliance/small-business-lending/filing-instruction-guide.cy.js
@@ -192,7 +192,7 @@ describe('1071 Filing Instruction Guide (FIG)', () => {
             expect(windowConsoleError).to.not.be.called;
           });
 
-          it('should be present', () => {
+          xit('should be present', () => {
             fig.open();
             fig.toc().should('be.visible');
           });


### PR DESCRIPTION
This change skips a test that is failing occasionally internally until we can fix the test/cause of the flakiness.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
