### PR TITLE
Margin adjustments for breadcrumbs and hero

### DIFF
--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -5,9 +5,9 @@
   gap: unit(10px / @base-font-size-px, rem);
   align-items: center;
   font-size: unit(14px / @base-font-size-px, rem);
-  padding-top: unit(15px / 14px, rem);
-  padding-bottom: unit(15px / 14px, rem);
-  margin-left: unit(40px / @base-font-size-px, rem);
+  padding-top: unit(15px / @base-font-size-px, rem);
+  padding-bottom: unit(15px / @base-font-size-px, rem);
+  margin-left: unit(20px / @base-font-size-px, rem);
   margin-right: unit(20px / @base-font-size-px, rem);
 
   .cf-icon-svg {
@@ -17,7 +17,7 @@
 
   // Desktop size.
   .respond-to-min( @bp-med-min, {
-    padding-top: unit(30px / 14px, rem);
+    padding-top: unit(30px / @base-font-size-px, rem);
     padding-bottom: 0;
   } );
 }
@@ -34,7 +34,7 @@ html[lang='ar'] {
   .breadcrumbs {
     flex-direction: row-reverse;
     // -40px
-    margin-right: unit(40px / @base-font-size-px, rem);
+    margin-right: unit(20px / @base-font-size-px, rem);
     margin-left: unit(20px / @base-font-size-px, rem);
 
     .cf-icon-svg {
@@ -42,4 +42,14 @@ html[lang='ar'] {
       margin-left: initial;
     }
   }
+}
+
+// TODO: When the layout-2-1 template is converted to use `u-layout-grid_wrapper`, this can be removed.
+.content_wrapper .breadcrumbs {
+  margin-left: unit(35px / @base-font-size-px, rem);
+
+  // Tablet size only.
+  .respond-to-range(@bp-sm-min, @bp-sm-max, {
+    margin-left: unit(50px / @base-font-size-px, rem);
+  });
 }

--- a/cfgov/unprocessed/css/enhancements/layout-1-3.less
+++ b/cfgov/unprocessed/css/enhancements/layout-1-3.less
@@ -3,13 +3,9 @@
   .u-layout-grid__1-3 {
     // Mobile
     .u-layout-grid {
-      &_breadcrumbs,
       &_secondary-nav {
         margin-left: unit(-15px / @base-font-size-px, rem);
         margin-right: unit(-15px / @base-font-size-px, rem);
-      }
-
-      &_secondary-nav {
         margin-bottom: unit(30px / @base-font-size-px, rem);
       }
     }
@@ -17,13 +13,9 @@
     // Tablet
     .respond-to-range( @bp-sm-min, @bp-sm-max, {
       .u-layout-grid {
-        &_breadcrumbs,
         &_secondary-nav {
           margin-left: unit(-30px / @base-font-size-px, rem);
           margin-right: unit(-30px / @base-font-size-px, rem);
-        }
-
-        &_secondary-nav {
           margin-bottom: unit(45px / @base-font-size-px, rem);
         }
       }
@@ -114,7 +106,6 @@
         }
 
         &_secondary-nav {
-          //padding-left: unit(30px / @base-font-size-px, rem);
           margin-left: unit(30px / @base-font-size-px, rem);
         }
       }

--- a/cfgov/unprocessed/css/enhancements/layout-2-1.less
+++ b/cfgov/unprocessed/css/enhancements/layout-2-1.less
@@ -24,6 +24,18 @@
 
   // Defaults shared in left-to-right (LTR) and right-to-left (RTL) layouts.
   .u-layout-grid__2-1 {
+    // Mobile
+    // TODO: The hero has a wrapper we need to ignore, so the direct reference to m-hero is a temp workaround.
+    .m-hero,
+    .u-layout-grid_hero {
+      position: relative;
+
+      // Create the hero background bleed.
+      &:after {
+        .u-hero-background();
+      }
+    }
+
     // Tablet and above
     .respond-to-min(@bp-sm-min, {
       .u-layout-grid {
@@ -37,17 +49,6 @@
         &_main,
         &_sidebar {
           padding-top: unit(45px / @base-font-size-px, rem);
-        }
-      }
-
-      // TODO: The hero has a wrapper we need to ignore, so the direct reference to m-hero is a temp workaround.
-      .m-hero,
-      .u-layout-grid_hero {
-        position: relative;
-
-        // Create the hero background bleed.
-        &:after {
-          .u-hero-background();
         }
       }
     });


### PR DESCRIPTION
## Changes

- Adjust margin of breadcrumbs across templates to align with main content area text.
- Remove margin on RTL page hero at mobile.


## How to test this PR

1. `yarn build` and visit the following pages and resize to mobile and see that the breadcrumb aligns with the content text and/or the C in the logo CFPB.

RTL layout-2-1 page with breadcrumbs:
http://localhost:8000/about-us/blog/hidden-cost-junk-fees-ar/
 
 LTR layout-2-1 page with breadcrumbs:
 http://localhost:8000/rules-policy/rules-under-development/registry-of-nonbank-covered-persons-subject-to-agency-court-orders/
 http://localhost:8000/consumer-tools/educator-tools/library-resources/program-ideas/money-as-you-grow-bookshelf/get-word-out-patrons/

RTL layout-1-3 with breadcrumbs:
http://localhost:8000/language/ar/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/

LTR layout-1-3 with breadcrumbs
 http://localhost:8000/rules-policy/final-rules/code-federal-regulations/