### PR TITLE
Header.cy.js: Swap order of globalsearch checks

### DIFF
--- a/test/cypress/integration/components/header/header.cy.js
+++ b/test/cypress/integration/components/header/header.cy.js
@@ -54,8 +54,8 @@ describe('Header', () => {
       menuDesktop.firstTab().click();
       menuDesktop.firstPanel().should('not.have.class', 'u-is-animating');
       // Then the global search content should not be visible.
-      globalSearch.content().should('not.have.class', 'u-is-animating');
       globalSearch.content().should('not.be.visible');
+      globalSearch.content().should('not.have.class', 'u-is-animating');
     });
   });
 


### PR DESCRIPTION
This test is flaky and often fails in CI when it expects the animation class to be absent and it is still present. This PR swaps the order of the test checks to first check that the global search is not visible and then checks that the animation class is absent.