### PR TITLE
Migration fixes

### DIFF
--- a/cfgov/ask_cfpb/migrations/0001_squashed_0047_add_use_json_field_to_streamfields.py
+++ b/cfgov/ask_cfpb/migrations/0001_squashed_0047_add_use_json_field_to_streamfields.py
@@ -26,14 +26,12 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0212_emailsignup_snippet'),
-        ('v1', '0234_clean_orphaned_revisions'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
         ('wagtailforms', '0005_alter_formsubmission_form_data'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('wagtailredirects', '0008_add_verbose_name_plural'),
         ('wagtailinventory', '0003_pageblock_id_bigautofield'),
         ('wagtailcore', '0069_log_entry_jsonfield'),
-        ('v1', '0198_recreated'),
     ]
 
     operations = [

--- a/cfgov/data_research/migrations/0001_squashed_0003_delete_conferenceregistration.py
+++ b/cfgov/data_research/migrations/0001_squashed_0003_delete_conferenceregistration.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0198_recreated'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/filing_instruction_guide/migrations/0001_squashed_0011_add_use_json_field_to_streamfields.py
+++ b/cfgov/filing_instruction_guide/migrations/0001_squashed_0011_add_use_json_field_to_streamfields.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0202_add_research_hub_filterable_page'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/filing_instruction_guide/migrations/0012_remove_content_image_bleed_option.py
+++ b/cfgov/filing_instruction_guide/migrations/0012_remove_content_image_bleed_option.py
@@ -15,7 +15,7 @@ import v1.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('filing_instruction_guide', '0011_add_use_json_field_to_streamfields'),
+        ('filing_instruction_guide', '0001_squashed_0011_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/form_explainer/migrations/0001_squashed_0006_add_use_json_field_to_streamfields.py
+++ b/cfgov/form_explainer/migrations/0001_squashed_0006_add_use_json_field_to_streamfields.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0199_2022_squash'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/form_explainer/migrations/0007_remove_content_image_bleed_option.py
+++ b/cfgov/form_explainer/migrations/0007_remove_content_image_bleed_option.py
@@ -13,7 +13,7 @@ import v1.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('form_explainer', '0006_add_use_json_field_to_streamfields'),
+        ('form_explainer', '0001_squashed_0006_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/hmda/migrations/0001_initial.py
+++ b/cfgov/hmda/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0198_recreated'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/jobmanager/migrations/0001_squashed_0020_hourly_salary.py
+++ b/cfgov/jobmanager/migrations/0001_squashed_0020_hourly_salary.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0198_recreated'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/paying_for_college/migrations/0001_squashed_0018_add_use_json_field_to_streamfields.py
+++ b/cfgov/paying_for_college/migrations/0001_squashed_0018_add_use_json_field_to_streamfields.py
@@ -20,12 +20,10 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailcore', '0060_fix_workflow_unique_constraint'),
-        ('v1', '0212_emailsignup_snippet'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
         ('wagtailinventory', '0001_initial'),
         ('wagtailforms', '0004_add_verbose_name_plural'),
         ('wagtailredirects', '0006_redirect_increase_max_length'),
-        ('v1', '0198_recreated'),
-        ('v1', '0199_2022_squash'),
     ]
 
     operations = [

--- a/cfgov/paying_for_college/migrations/0019_remove_content_image_bleed_option.py
+++ b/cfgov/paying_for_college/migrations/0019_remove_content_image_bleed_option.py
@@ -13,7 +13,7 @@ import v1.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('paying_for_college', '0018_add_use_json_field_to_streamfields'),
+        ('paying_for_college', '0001_squashed_0018_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/regulations3k/migrations/0001_squashed_0036_add_use_json_field_to_streamfields.py
+++ b/cfgov/regulations3k/migrations/0001_squashed_0036_add_use_json_field_to_streamfields.py
@@ -23,8 +23,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('v1', '0212_emailsignup_snippet'),
-        ('v1', '0198_recreated'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/regulations3k/migrations/0037_remove_content_image_bleed_option.py
+++ b/cfgov/regulations3k/migrations/0037_remove_content_image_bleed_option.py
@@ -13,7 +13,7 @@ import v1.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('regulations3k', '0036_add_use_json_field_to_streamfields'),
+        ('regulations3k', '0001_squashed_0036_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/teachers_digital_platform/migrations/0001_squashed_0005_add_use_json_field_to_streamfields.py
+++ b/cfgov/teachers_digital_platform/migrations/0001_squashed_0005_add_use_json_field_to_streamfields.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtaildocs', '0010_document_file_hash'),
-        ('v1', '0198_recreated'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
         ('wagtaildocs', '0007_merge'),
         ('wagtailimages', '0019_delete_filter'),
     ]

--- a/cfgov/v1/migrations/0001_squashed_0235_add_use_json_field_to_streamfields.py
+++ b/cfgov/v1/migrations/0001_squashed_0235_add_use_json_field_to_streamfields.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
         ('wagtailcore', '0040_page_draft_title'),
         ('taggit', '0002_auto_20150616_2121'),
         ('wagtaildocs', '0007_merge'),
-        ('login', '0002_populate_login_models'),
+        ('login', '0001_squashed_0003_simplify_password_logic'),
         ('wagtailcore', '0066_collection_management_permissions'),
     ]
 

--- a/cfgov/v1/migrations/0236_case_docket_table.py
+++ b/cfgov/v1/migrations/0236_case_docket_table.py
@@ -11,7 +11,7 @@ import wagtail.images.blocks
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('v1', '0235_add_use_json_field_to_streamfields'),
+        ('v1', '0001_squashed_0235_add_use_json_field_to_streamfields'),
     ]
 
     operations = [

--- a/cfgov/v1/migrations/0242_filterable_list_topics.py
+++ b/cfgov/v1/migrations/0242_filterable_list_topics.py
@@ -23,6 +23,10 @@ def migrate_filterable_list(page_or_revision, data):
 
 class Migration(migrations.Migration):
     dependencies = [
+        (
+            "wagtailcore",
+            "0075_populate_latest_revision_and_revision_object_str",
+        ),
         ("v1", "0241_remove_filterable_5050"),
     ]
 


### PR DESCRIPTION
This PR includes two unrelated fixes to our Django migration files:

1. In previous attempts to squash our migrations, we neglected to remove a few references to the old migration names. Per [the Django docs](https://docs.djangoproject.com/en/4.2/topics/migrations/#squashing-migrations) we need to
   
   > Updating all migrations that depend on the deleted migrations to depend on the squashed migration instead.
   
   but it seems like we missed a few of these.
   
   A way to check this is to try running something like
   
   ```
   cfgov/manage.py sqlmigrate v1 0001
   ```
   
   which is supposed to dump out the SQL for a migration; this won't work on main because of these bad references.
2. The v1 0242 migration does a StreamField data migration and depends on some Wagtail 4.x changes (specifically, that revision data is stored in a `Revision` model as JSON), but the migration didn't include a dependency on the relevant Wagtail migration. This could cause problems in certain scenarios, for example when running initial-data.sh to populate an empty database.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)