### PR TITLE
Fix incorrect template use of slugify

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/atoms/checkbox.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/checkbox.html
@@ -29,7 +29,7 @@
 
 {% macro render(value) -%}
 
-{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ slugify( value.label ) -%}
+{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ ( value.label | slugify ) -%}
 {%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
 {%- set val = value.value if value.value else id -%}
 {%- set name = value.name if value.name else id -%}

--- a/cfgov/v1/jinja2/v1/includes/atoms/radio-button.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/radio-button.html
@@ -27,7 +27,7 @@
 
 {% macro render(value) -%}
 
-{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ slugify( value.label ) -%}
+{%- set id = value.id or 'input_' ~ unique_id_in_context() ~ '_' ~ ( value.label | slugify ) -%}
 {%- set el = value.el_wrapper if value.el_wrapper else 'div' -%}
 {%- set val = value.value if value.value else id -%}
 {%- set name = value.name if value.name else id -%}


### PR DESCRIPTION
Commit 269c54c842debd5cf9d767377b4e7ee5b377dc8e broke some uses of slugify in Jinja templates. Previously you could call slugify in templates as a function, e.g. `slugify(value)` but it's actually only available in the global Jinja context as a filter, e.g. `value | slugify`.

This PR fixes those incorrect uses.

## How to test this PR

To test: http://localhost:8000/consumer-tools/educator-tools/buying-a-car/

This fails on main but works properly with this PR.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)