### PR TITLE
College Costs: Fix width of costs group headers with no `financial-item_note` inside

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
@@ -73,6 +73,7 @@
   }
 
   &.o-costs-group_header {
+    width: 100%;
     border: none;
     margin-bottom: unit(15px / @base-font-size-px, em);
     text-align: left;


### PR DESCRIPTION
Came across a tiny bug causing the PLUS loan button to be squished.

---

## Changes

- Sets an explicit `width: 100%` on `.financial-item.o-costs-group_header` to ensure they expand to fit the available width. Without that, only headers with a `.financial-item_note` of at least one full line of text inside would expand that far.


## How to test this PR

1. Running `main`, [visit the tool](http://localhost:8000/paying-for-college/your-financial-path-to-graduation/), navigate to the "Make a plan" section of the app and scroll near the bottom to observe the issue.
1. Pull this branch
1. Rebuild the styles
1. Reload your local version and see the restored styles


## Screenshots

Before | After
--------------------------------------- | --------------
![Squished button](https://github.com/cfpb/consumerfinance.gov/assets/1044670/2b0329eb-0984-4220-a8d9-664f8f63c0ac) | ![Nicely spaced button](https://github.com/cfpb/consumerfinance.gov/assets/1044670/de6de478-d3a7-4b79-8f8d-65ee78d6587b)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->
