### PR TITLE
Fix Post Preview Snapshot template

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview-snapshot.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview-snapshot.html
@@ -25,9 +25,8 @@
 {% for post in posts %}
     {{ post_preview.render(
         post,
-        controls=none,
         url=pageurl(post.get_parent().specific),
-        post_date_description=value.post_date_description
+        date_label=value.post_date_description
     ) }}
 {% endfor %}
 </div>


### PR DESCRIPTION
Commit 2f7168072262c4943443f53aa3d8310853bd2925 broke the template for the PostPreviewSnapshot module. This fixes that.

## How to test this PR

To test, visit this page that contains a PPS:

http://localhost:8000/compliance/amicus/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)