### PR TITLE
Add domains to Cypress ignore list

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -7,7 +7,14 @@ module.exports = defineConfig({
   videosFolder: 'test/cypress/videos',
   screenshotsFolder: 'test/cypress/screenshots',
   defaultCommandTimeout: 25000,
-  blockHosts: ['*google-analytics.com', '*googletagmanager.com'],
+  blockHosts: [
+    '*.federalregister.gov',
+    '*.geo.census.gov',
+    '*google-analytics.com',
+    '*googletagmanager.com',
+    '*.newrelic.com',
+    '*.nr-data.net',
+  ],
   e2e: {
     baseUrl: 'http://localhost:8000',
     specPattern: 'test/cypress/integration/**/*.cy.{js,jsx,ts,tsx}',


### PR DESCRIPTION
This commit adds some domains to Cypress' `blockHosts` setting so that we don't load third-party scripts when running functional tests.

I sourced these domains from [our list in Django base settings](https://github.com/cfpb/consumerfinance.gov/blob/867fcac24e2433ef637b826828f1f564b70741f0/cfgov/cfgov/settings/base.py#L514-L535).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)