### PR TITLE
i18n: Add getMessages method to FormSubmit for retrieving Form success and error messages

### DIFF
--- a/cfgov/unprocessed/js/organisms/FormSubmit.js
+++ b/cfgov/unprocessed/js/organisms/FormSubmit.js
@@ -9,11 +9,21 @@ import Notification from '../molecules/Notification.js';
 import { scrollIntoView } from '../modules/util/scroll.js';
 
 const FORM_MESSAGES = {
-  ERROR: 'There was an error in your submission. Please try again later.',
-  ERROR_ES:
-    'Había un error en su presentación. ' + 'Por favor, inténtelo más tarde.',
-  SUCCESS: 'Your submission was successfully received.',
-  SUCCESS_ES: 'Su presentación fue recibido con éxito.',
+  ERROR: {
+    en: 'There was an error in your submission. Please try again later.',
+    es: 'Había un error en su presentación. Por favor, inténtelo más tarde.',
+  },
+  SUCCESS: {
+    en: 'Your submission was successfully received.',
+    ar: 'تم استلام طلبك  بنجاح.',
+    ht: 'Nou byen resevwa sa ou soumèt la.',
+    ko: '신청이 접수되었습니다.',
+    ru: 'Мы успешно получили ваш запрос на подписку.',
+    es: 'Su presentación fue recibido con éxito.',
+    tl: 'Matagumpay na natanggap ang iyong isinumite.',
+    'zh-Hant': '您提交的資料已被成功接收。',
+    vi: 'Đã nhận thành công nội dung gửi của quý vị.',
+  },
 };
 const DONE_CODE = 4;
 const SUCCESS_CODES = {
@@ -138,10 +148,9 @@ function FormSubmit(element, baseClass, opts) {
         if (state === 'SUCCESS' && opts.replaceForm) {
           _replaceFormWithNotification(heading + ' ' + message);
         } else {
-          const key = opts.language === 'es' ? state + '_ES' : state;
           _displayNotification(
             Notification[state],
-            message || FORM_MESSAGES[key]
+            message || getMessage(state, opts.language)
           );
         }
         if (state === 'SUCCESS') {
@@ -209,6 +218,16 @@ function FormSubmit(element, baseClass, opts) {
   }
 
   /**
+   * @param {string} state - 'SUCCESS' or 'ERROR' form state flag.
+   * @param {string} lang - A language string.
+   * @returns {string} A success or error message.
+   */
+  function getMessage(state, lang) {
+    if (state !== 'SUCCESS' && state !== 'ERROR') return 'Error.';
+    return FORM_MESSAGES[state][lang] || FORM_MESSAGES[state]['en'];
+  }
+
+  /**
    * @param {string} fieldName - name of field
    * @param {string} fieldValue - value of field
    * @returns {string} representing field data.
@@ -249,6 +268,7 @@ function FormSubmit(element, baseClass, opts) {
   }
 
   this.init = init;
+  this.getMessage = getMessage;
 
   return this;
 }

--- a/test/unit_tests/js/organisms/FormSubmit-spec.js
+++ b/test/unit_tests/js/organisms/FormSubmit-spec.js
@@ -22,4 +22,32 @@ describe('FormSubmit', () => {
       expect(formSubmit.init()).toBeInstanceOf(FormSubmit);
     });
   });
+
+  describe('getMessage()', () => {
+    it('should return the correct messages based on the state', () => {
+      // Return generic error message if wrong state was passed.
+      expect(thisFormSubmit.getMessage('TYPO', 'en')).toEqual('Error.');
+
+      // Return error message.
+      expect(thisFormSubmit.getMessage('ERROR', 'es')).toEqual(
+        'Había un error en su presentación. Por favor, inténtelo más tarde.'
+      );
+
+      // Return success message.
+      expect(thisFormSubmit.getMessage('SUCCESS', 'en')).toEqual(
+        'Your submission was successfully received.'
+      );
+      expect(thisFormSubmit.getMessage('SUCCESS', 'ar')).toEqual(
+        'تم استلام طلبك  بنجاح.'
+      );
+      expect(thisFormSubmit.getMessage('SUCCESS', 'zh-Hant')).toEqual(
+        '您提交的資料已被成功接收。'
+      );
+
+      // Return english message by default if the language isn't found.
+      expect(thisFormSubmit.getMessage('SUCCESS', 'de')).toEqual(
+        'Your submission was successfully received.'
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Changes

- i18n: Add getMessages method to FormSubmit for retrieving Form success and error messages


## How to test this PR

1. `yarn jest` should pass.
1. Visit an english page and it should be in english (e.g. http://localhost:8000/about-us/newsroom/cfpb-takes-action-against-two-companies-for-charging-illegal-debt-relief-fees/)
2. Visit a non-english page and sign up with an example email in the sidebar and see that the success message is in the language of the page:

http://localhost:8000/language/ar/
http://localhost:8000/language/vi/
http://localhost:8000/language/ht/
http://localhost:8000/language/zh/
http://localhost:8000/language/ru/
http://localhost:8000/language/ko/
http://localhost:8000/language/tl/

## Screenshots

Before:
<img width="397" alt="Screen Shot 2023-06-20 at 5 53 13 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/0ff64d4a-2c97-4268-9184-d46e7ed688f6">

After:
<img width="399" alt="Screen Shot 2023-06-20 at 5 52 52 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/32ee9559-0a35-4eb8-8658-21d55f77c88d">
