### PR TITLE
ROUT: Prevent jsLoadMap SVG from preventing clicks of the "Show map" toggle

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/css/main.less
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/css/main.less
@@ -79,6 +79,11 @@ tr.data + tr[class=''] {
   width: 100%;
 }
 
+// Prevent clicking of the SVG in "Show map" from prevent clicks of the toggle.
+.jsLoadMap svg {
+  pointer-events: none;
+}
+
 // Print-related styling.
 /* stylelint-disable-next-line no-invalid-position-at-import-rule */
 @import (less) './print.less';

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/css/main.less
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/css/main.less
@@ -79,7 +79,7 @@ tr.data + tr[class=''] {
   width: 100%;
 }
 
-// Prevent clicking of the SVG in "Show map" from prevent clicks of the toggle.
+// Prevent clicking of the SVG in "Show map" from blocking clicks of the toggle.
 .jsLoadMap svg {
   pointer-events: none;
 }


### PR DESCRIPTION
The SVG in the "show map" toggle was preventing clicks of the toggle. This PR adds CSS to hide it from interactivity. 

See https://[GHE]/CFGOV/platform/issues/4314

## Changes

- Add CSS to hide show map SVG from interactivity. 


## How to test this PR

1. Visit http://localhost:8000/rural-or-underserved-tool/ and enter some addresses. Click the show/hide map in the result table. Clicks to the SVG should toggle. Compare to production where clicks to the SVG do not toggle.