### PR TITLE
Swap font-family order on Vietnamese pages

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -129,3 +129,10 @@
 body {
   -webkit-font-smoothing: antialiased;
 }
+
+// Make Arial the first-line font in Vietnamese pages' main content area.
+// This is used because Avenir Next does not contain all Vietnamese diacritics.
+// See https://[GHE]/Design-Development/Design-and-Content-Team/issues/175
+html[lang='vi'] body main {
+  font-family: Arial, 'Avenir Next', sans-serif;
+}


### PR DESCRIPTION
See https://[GHE]/Design-Development/Design-and-Content-Team/issues/175

## Changes

- Swap Arial and Avenir order in font-family on Vietnamese pages.


## How to test this PR

1. Visit http://localhost:8000/language/vi/ and see that Vietnamese characters do not have differing bolding.