### PR TITLE
Remove unnecessary tags.html and notification.html inclusion

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
@@ -1,5 +1,4 @@
 {% extends 'v1/layouts/layout-2-1.html' %}
-{% import 'v1/includes/tags.html' as tags with context %}
 {% import 'v1/includes/macros/util/format/datetime.html' as dt %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 {% import 'v1/includes/organisms/ask-search.html' as ask_search with context %}

--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
@@ -2,7 +2,6 @@
 {% import 'v1/includes/macros/util/format/datetime.html' as dt %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 {% import 'v1/includes/organisms/ask-search.html' as ask_search with context %}
-{% import 'v1/includes/molecules/notification.html' as notification %}
 
 {% block title -%}
     {{- seo_title or page.question or page.title | striptags }} | {{ _('Consumer Financial Protection Bureau') }}


### PR DESCRIPTION
The use of tags.html was removed from this file in commit 7d4745ca04130653d103c624ca75d55524c7ef22.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)