### PR TITLE
Retirement: Replace bespoke color with navy color variable | Update hardcoded gray-5 with variables

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -29,7 +29,7 @@
   .content_sidebar {
     padding: 45px 15px 0;
     border: 1px solid @gray-40;
-    background-color: #f7f8f9;
+    background-color: @gray-5;
 
     .o-expandable_content,
     .o-expandable_header {

--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -385,8 +385,7 @@
   }
 
   .step-two .lifestyle-btn__active {
-    // TODO: Replace hardcoded color with color variable from Capital Framework.
-    background-color: #33578e;
+    background-color: @navy;
   }
 
   .step-two + hr {

--- a/cfgov/unprocessed/css/search.less
+++ b/cfgov/unprocessed/css/search.less
@@ -22,7 +22,7 @@
   .content_sidebar {
     padding: 45px 15px 0;
     border: 1px solid @gray-40;
-    background-color: #f7f8f9;
+    background-color: @gray-5;
 
     .o-expandable-group {
       margin-bottom: 15px;


### PR DESCRIPTION
The active state for buttons in the retirement before you claim app are [this](https://www.color-hex.com/color/33578e), while the color for navy in the design system is [this](https://www.color-hex.com/color/254b87). So, it appears that navy was intended to be used here.


## Changes

- Change bespoke color `#33578e` with `@navy` color variable.
- Update regs and prepaid cards search hardcoded colors with `@gray-5` variable.

## How to test this PR

1. Visit http://localhost:8000/consumer-tools/retirement/before-you-claim/, enter the tool, and click one of the question's buttons and to see the active state color.


## Screenshots

Before:
<img width="120" alt="Screen Shot 2023-06-23 at 9 43 04 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/221bbe56-2b76-435b-97bd-2ea552558454">

After:
<img width="121" alt="Screen Shot 2023-06-23 at 9 42 57 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/fde95213-1c9a-4c29-bd33-2297beaf5ca7">
