### PR TITLE
Upgrade has_hero logic to use Wagtail 4 method

### DIFF
--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -137,11 +137,5 @@ class SublandingPage(CFGOVPage):
 
     @property
     def has_hero(self):
-        """Returns boolean indicating whether the page includes a hero module.
-
-        TODO: On Wagtail 4.0, this functionality can be removed in favor of
-        using the built-in page.header.first_block_by_name("hero"):
-
-        https://docs.wagtail.org/en/stable/topics/streamfield.html#streamfield-retrieving-blocks-by-name
-        """
-        return bool(len(self.header))
+        """Returns boolean indicating whether the page includes a hero."""
+        return bool(self.header.first_block_by_name("hero"))


### PR DESCRIPTION
Use `first_block_by_name`, which became [available in Wagtail 4](https://docs.wagtail.org/en/stable/topics/streamfield.html#streamfield-retrieving-blocks-by-name).

## How to test this PR

Existing unit tests should already cover this logic.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)