### PR TITLE
Category slug: remove `classes` and `use_blog_category` arguments

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-theme-overrides.less
@@ -210,10 +210,6 @@
 // .date
 @date-text: @gray-80;
 
-// .category-slug
-@category-slug-text: @black;
-@category-slug-hover: @link-text-hover;
-
 // .padded-header
 @padded-header-text: @gray-dark;
 @padded-header-bg: @gray-10;

--- a/cfgov/v1/jinja2/v1/includes/macros/category-slug.html
+++ b/cfgov/v1/jinja2/v1/includes/macros/category-slug.html
@@ -20,24 +20,14 @@
                        Path is used to create the filtered URL:
                        {{ href }}?category={{ category }}
 
-   classes (optional): Space separated list of class names.
-
-   use_blog_category (optional): Whether to use the blog category filter or not.
-                                 Defaults to false.
-
    ========================================================================== #}
 
-{% macro render(category, href, classes='', use_blog_category=false) %}
+{% macro render(category, href) %}
     {% if href %}
-        {# TODO: Remove use_blog_category parameter when this element becomes atomic. #}
-        {% if use_blog_category %}
-            {% set href = href + '?blog_category=' + category | urlencode | replace('%20', '+') %}
-        {% else %}
-            {% set href = href + '?categories=' + category | urlencode | replace('%20', '+') %}
-        {% endif %}
+        {% set href = href + '?categories=' + category | urlencode | replace('%20', '+') %}
     {% endif %}
 
-    {% call _category_link(href, classes) %}
+    {% call _category_link(href) %}
         {%- set cat = category_label(category) or category -%}
         {%- set icon_name = get_category_icon( cat ) -%}
         {%- if icon_name %}{{ svg_icon( icon_name ) }}{% endif %}
@@ -46,10 +36,10 @@
     {% endcall %}
 {% endmacro %}
 
-{% macro _category_link(href, classes) %}
+{% macro _category_link(href) %}
     {% if href %}
         <a href="{{ href }}"
-           class="a-heading a-heading__icon {{ classes }}">
+           class="a-heading a-heading__icon">
     {% endif %}
        {{ caller() }}
     {% if href %}


### PR DESCRIPTION
The three files that make calls to this macro do not use the `classes` and `use_blog_category` arguments:

https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/v1/jinja2/v1/activity-log/_activity-list.html#L22-L31

https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html#L39

https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html#L79

## Removals

- Category slug: remove `classes` and `use_blog_category` arguments.
- `@category-slug-text` and `@category-slug-hover` are not found in the codebase.

## How to test this PR

1. PR checks should pass.
