### PR TITLE
Refactor tags to support links and non-links | Make iregs search use tags macro

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
@@ -2,7 +2,7 @@
 {% set default_text = 'No information provided' %}
 <article class="results_item">
     <h4 class="h3">
-      <a href="detail/{{result.id}}">{{ result.name }}</a>
+        <a href="detail/{{result.id}}">{{ result.name }}</a>
     </h4>
     <div class="content-l">
         <div class="content-l_col content-l_col-1-2">

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations3k-search-result-item.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations3k-search-result-item.html
@@ -1,23 +1,16 @@
+{%- import 'v1/includes/tags.html' as tags %}
 {% macro render(result) %}
 
 {%- set reg_name = result.part ~ ' (' ~ result.reg ~ ')' -%}
 
 <article class="results_item">
     <h4>
-      <a href="{{ result.url }}">{{ result.label }}</a>
+        <a href="{{ result.url }}">{{ result.label }}</a>
     </h4>
     <p>{{ result.snippet }}</p>
-    {# TODO: Make this use the tags.render() macro. #}
-    <div class="m-tags">
-        <ul class="m-tags_list" aria-label="Topics">
-            <li class="m-tags_tag">
-                <span class="m-tags_link">
-                    <span class="m-tags_bullet" aria-hidden="true">•</span>
-                    {{ reg_name }}
-                </span>
-            </li>
-        </ul>
-    </div>
+
+    {% set tags_links=({ 'text': reg_name },) %}
+    {{ tags.render( tags_links, show_heading=false ) }}
 </article>
 
 {% endmacro %}

--- a/cfgov/unprocessed/css/molecules/tags.less
+++ b/cfgov/unprocessed/css/molecules/tags.less
@@ -11,119 +11,48 @@
   patterns:
     - name: Default example
       markup: |
-        <div class="tags">
-            <h4 class="tags_heading">Topics:</h4>
-            <ul class="tags_list">
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+        <div class="m-tags">
+            <span class="m-tags_heading">Topics:</span>
+            <ul class="m-tags_list">
+                <li class="m-tags_item">
+                    <span class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         Students
-                    </a>
+                    </span>
                 </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+                <li class="m-tags_item">
+                    <span class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         Consumers
-                    </a>
+                    </span>
                 </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+                <li class="m-tags_item">
+                    <span class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         College loans
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Students
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Consumers
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        College loans
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Students
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Consumers
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        College loans
-                    </a>
+                    </span>
                 </li>
             </ul>
         </div>
-    - name: Hide heading modifier
+    - name: Has links modifier
       markup: |
-        <div class="tags">
-            <ul class="tags_list">
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+        <div class="m-tags">
+            <span class="m-tags_heading">Topics:</span>
+            <ul class="m-tags_list">
+                <li class="m-tags_item">
+                    <a href="#" class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         Students
                     </a>
                 </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+                <li class="m-tags_item">
+                    <a href="#" class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         Consumers
                     </a>
                 </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        College loans
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Students
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Consumers
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        College loans
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Students
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
-                        <span class="tags_bullet" aria-hidden="true">&bull;</span>
-                        Consumers
-                    </a>
-                </li>
-                <li class="tags_tag">
-                    <a href="#" class="tags_link">
+                <li class="m-tags_item">
+                    <a href="#" class="m-tags_tag">
                         <span class="tags_bullet" aria-hidden="true">&bull;</span>
                         College loans
                     </a>
@@ -149,6 +78,7 @@
     flex-direction: column;
     flex-wrap: wrap;
     padding-left: 0;
+    padding-right: 0;
     list-style-type: none;
   }
 
@@ -156,27 +86,15 @@
     .h6();
     // Override h6 margin.
     margin: 0;
-    border-top: 1px dotted @gold-80;
-
-    &:last-child {
-      border-bottom: 1px dotted @gold-80;
-    }
-
-    &:hover {
-      cursor: pointer;
-      border-top: 1px solid @gold-80;
-      border-bottom: 1px solid @gold-80;
-    }
-  }
-
-  &_link {
+    box-sizing: border-box;
+    display: inline-block;
     position: relative;
     line-height: @bullet-font-size;
-    .u-link__colors(
-      @gray, @gray, @gray, @gray, @gray,
-      @gold-80, @gold-80, @gold-80, @gold-80, @gold-80
-    );
-    margin-left: @bullet-font-size;
+    color: @gray;
+  }
+
+  &_item {
+    margin: 0;
   }
 
   &_bullet {
@@ -185,17 +103,49 @@
     color: @gold-80;
     font-size: unit(@bullet-font-size / @base-font-size-px, rem);
     margin-right: unit(5px / @base-font-size-px, rem);
+    margin-left: @bullet-font-size;
+  }
+
+  a.m-tags_tag {
+    .u-link__colors(
+      @gray, @gray, @gray, @gray, @gray,
+      @gold-80, @gold-80, @gold-80, @gold-80, @gold-80
+    );
+  }
+
+  // Negate the border of the sibling when hovering.
+  &_item:hover + &_item {
+    a.m-tags_tag {
+      border-top: none;
+    }
   }
 
   // Mobile only.
   .respond-to-max( @bp-xs-max, {
     &_tag {
+      height: 100%;
+      width: 100%;
       padding-top: unit(10px / @base-font-size-px, rem);
       padding-bottom: unit(10px / @base-font-size-px, rem);
+      padding-left: @bullet-font-size;
+      border-top: 1px dotted @gold-80;
     }
 
-    &_link {
-      .u-link__no-border();
+    a.m-tags_tag {
+      border-bottom-width: 0;
+
+      &:hover {
+        border-top: 1px solid @gold-80;
+        border-bottom: 1px solid @gold-80;
+      }
+    }
+
+    // Add bottom border to last tag.
+    &_item:last-child {
+      // This needs to appear after border-bottom-width: 0;
+      .m-tags_tag {
+        border-bottom: 1px dotted @gold-80;
+      }
     }
   });
 
@@ -210,10 +160,12 @@
       gap: unit(15px / @base-font-size-px, rem);
     }
 
-    &_tag,
-    &_tag:last-child,
-    &_tag:hover {
-      border: none;
+    &_tag {
+      margin-left: @bullet-font-size;
+    }
+
+    &_bullet {
+      margin-left: 0;
     }
   } );
 
@@ -222,31 +174,38 @@
   });
 }
 
-// Negate the border of the sibling when hovering.
-.m-tags_tag:hover + .m-tags_tag {
-  border-top: none;
-}
-
 // Right-to-left (RTL) adjustments for arabic pages.
 html[lang='ar'] {
   .m-tags {
-    &_list {
-      padding-right: 0;
-    }
-
-    &_link {
-      margin-right: @bullet-font-size;
-      margin-left: 0;
-    }
-
     &_bullet {
       position: absolute;
-      right: -1em;
+      right: -1rem;
       left: initial;
       color: @gold-80;
-      margin-left: unit(5px / @base-font-size-px, rem);
-      margin-right: 0;
     }
+
+    // Mobile only.
+    .respond-to-max( @bp-xs-max, {
+      &_tag {
+        padding-right: @bullet-font-size;
+      }
+
+      &_bullet {
+        right: unit(-7px / @base-font-size-px, rem);
+      }
+    });
+
+    // Tablet and above.
+    .respond-to-min(@bp-sm-min, {
+      &_tag {
+        margin-left: 0;
+        margin-right: @bullet-font-size;
+      }
+
+      &_bullet {
+        margin-right: 0;
+      }
+    });
   }
 }
 

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -46,14 +46,14 @@
                 </div>
                 <div class="m-tags">
                     <ul class="m-tags_list">
-                        <li class="m-tags_tag">
-                            <a class="m-tags_link" href="/about-us/blog/?filter_tags=FOIA&amp;filter_topics=FOIA">
+                        <li class="m-tags_item">
+                            <a class="m-tags_tag" href="/about-us/blog/?filter_tags=FOIA&amp;filter_topics=FOIA">
                                 <span class="m-tags_bullet" aria-hidden="true">•</span>
                                 FOIA
                             </a>
                         </li>
-                        <li class="m-tags_tag">
-                            <a class="m-tags_link" href="/about-us/blog/?filter_tags=Mortgage&amp;filter_topics=Mortgage">
+                        <li class="m-tags_item">
+                            <a class="m-tags_tag" href="/about-us/blog/?filter_tags=Mortgage&amp;filter_topics=Mortgage">
                                 <span class="m-tags_bullet" aria-hidden="true">•</span>
                                 Mortgage
                             </a>

--- a/cfgov/v1/jinja2/v1/events/_event-detail.html
+++ b/cfgov/v1/jinja2/v1/events/_event-detail.html
@@ -80,7 +80,7 @@
     {% if page.tags.names() | length %}
     <footer>
         {%- import 'v1/includes/tags.html' as tags %}
-        {{ tags.render(page.related_metadata_tags()) }}
+        {{ tags.render(page.related_metadata_tags().links) }}
     </footer>
     {% endif %}
 </article>

--- a/cfgov/v1/jinja2/v1/includes/article.html
+++ b/cfgov/v1/jinja2/v1/includes/article.html
@@ -65,7 +65,7 @@
     </div>
     {% if page.tags.all() | length %}
         <footer>
-            {{ tags.render(page.related_metadata_tags()) }}
+            {{ tags.render(page.related_metadata_tags().links) }}
         </footer>
     {% endif %}
 </article>

--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
@@ -186,7 +186,7 @@
 
             {% if show_tags and post.tags.exists() %}
                 {%- import 'v1/includes/tags.html' as tags %}
-                {{ tags.render(post.related_metadata_tags(), show_heading=false) }}
+                {{ tags.render(post.related_metadata_tags().links, show_heading=false) }}
             {% endif %}
         </div>
         {% endcache %}

--- a/cfgov/v1/jinja2/v1/includes/tags.html
+++ b/cfgov/v1/jinja2/v1/includes/tags.html
@@ -20,7 +20,7 @@
 
    ========================================================================== #}
 
-{% macro render(tags, show_heading=true, has_links=true) %}
+{% macro render(tags, show_heading=true) %}
 <div class="m-tags">
     {% if show_heading %}
     <span class="m-tags_heading">

--- a/cfgov/v1/jinja2/v1/includes/tags.html
+++ b/cfgov/v1/jinja2/v1/includes/tags.html
@@ -9,18 +9,18 @@
 
    Render a tags list when given:
 
-   tags.links:    List of tags to render with:
+   tags:     List of tags to render with:
 
-       link.url:        The tag URL.
+       url:  (optional) The tag URL.
 
-       link.text:       The tag text.
+       text: The tag text.
 
-   show_heading:  The optional boolean flag to show the tags_heading element.
-                  Defaults to true.
+   show_heading: The optional boolean flag to show the tags_heading element.
+                 Defaults to true.
 
    ========================================================================== #}
 
-{% macro render(tags, show_heading=true) %}
+{% macro render(tags, show_heading=true, has_links=true) %}
 <div class="m-tags">
     {% if show_heading %}
     <span class="m-tags_heading">
@@ -28,12 +28,20 @@
     </span>
     {% endif %}
     <ul class="m-tags_list" aria-label="Topics">
-        {% for tag in tags.links if tag.url %}
-        <li class="m-tags_tag">
-            <a href="{{ tag.url }}" class="m-tags_link">
+        {% for tag in tags %}
+        <li class="m-tags_item">
+            {% if tag.url %}
+            <a href="{{ tag.url }}" class="m-tags_tag">
+            {% else %}
+            <span class="m-tags_tag">
+            {% endif %}
                 <span class="m-tags_bullet" aria-hidden="true">&bull;</span>
                 {{ tag.text }}
+            {% if tag.url %}
             </a>
+            {% else %}
+            </span>
+            {% endif %}
         </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
iRegs search has tags in the search results, but unlike elsewhere they are not links. https://github.com/cfpb/consumerfinance.gov/pull/7831 assumed topic tags would be links, so provided a hover state, which is erroneously shown on iregs topic tags. This PR refactors the tags macro to support both links and not for tags.

## Changes

- Refactor tags macro to support tag links or not.
- Update iregs search topic tags to use tags macro.


## How to test this PR

1. Visit the following pages and hover the topic tags and resize to mobile and hover:

http://localhost:8000/rules-policy/regulations/search-regulations/results/?q=mortgage&regs=1002&regs=1003&results=25&order=relevance

http://localhost:8000/about-us/blog/we-are-extending-the-deadline-for-comments-about-data-brokers/

http://localhost:8000/about-us/blog/?filter1_topics=bureau-milestones

http://localhost:8000/rules-policy/regulations/search-regulations/results/?regs=1002&q=mortgage

http://localhost:8000/about-us/events/cfpb-finex-webinar-identity-theft-scams-older-adults/

http://localhost:8000/about-us/blog/?filter1_topics=know-before-you-owe

http://localhost:8000/about-us/blog/whats-ahead-for-wells-fargo-and-its-customers-ar/