### PR TITLE
Remove unused tag.html code

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -1,7 +1,6 @@
 {% extends 'v1/layouts/layout-full.html' %}
 {% import 'v1/includes/atoms/checkbox.html' as checkbox %}
 {% import 'v1/includes/atoms/radio-button.html' as radio with context %}
-{% import 'v1/includes/atoms/tag.html' as tag %}
 {% import 'regulations3k/regulations3k-search-bar.html' as search_bar %}
 {% import 'regulations3k/regulations3k-search-result-item.html' as search_item %}
 {% import 'v1/includes/molecules/pagination.html' as pagination with context %}

--- a/cfgov/unprocessed/css/atoms/tag.less
+++ b/cfgov/unprocessed/css/atoms/tag.less
@@ -21,17 +21,4 @@
   a {
     color: inherit;
   }
-
-  &__info {
-    background: @gold-10;
-    border: 1px solid @gold;
-    font-weight: 500;
-  }
-
-  &__dark {
-    background: @teal-mid-dark;
-    border: 1px solid @teal-mid-dark;
-    color: @white;
-    font-weight: 500;
-  }
 }

--- a/cfgov/v1/jinja2/v1/includes/atoms/tag.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/tag.html
@@ -9,11 +9,15 @@
 
    Renders a small visual tag with an X icon.
 
-   options.label:  The tag's text content.
+   options:
 
-   value:          The tag's underlying value. Optional.
+     label:    The tag's text content.
 
-   behavior:       The checkbox's JS behavior. Optional.
+     href:     The tag's X icon click URL. Optional.
+
+     value:    The tag's underlying value. Optional.
+
+     behavior: The checkbox's JS behavior. Optional.
 
    ========================================================================== #}
 
@@ -26,6 +30,6 @@
 <div class="a-tag"
      {{ value }}
      {{ behavior }}>
-    {{ options.label }} {% if href %}<a {{href}}>{% endif %}{{ svg_icon('error') }}{% if href %}</a>{% endif %}
+   {{ options.label }} {% if href %}<a {{href}}>{% endif %}{{ svg_icon('error') }}{% if href %}</a>{% endif %}
 </div>
 {% endmacro %}


### PR DESCRIPTION
This is the "pill" pattern on e.g. https://www.consumerfinance.gov/rules-policy/regulations/search-regulations/results/?q=mortgage&regs=1002&regs=1003&results=25&order=relevance

## Additions

- Add missing code comment for `href` argument.


## Removals

- Remove unused tag.html template import
- Remove `a-tag__info` and `a-tag__dark`, which are delivered site-wide and are unused.


## How to test this PR

1. The filter "pills" on these pages should be unchanged:

http://localhost:8000/data-research/prepaid-accounts/search-agreements/?prepaid_type=GPR+%28General+Purpose+Reloadable%29

http://localhost:8000/rules-policy/regulations/search-regulations/results/?q=mortgage&regs=1002&regs=1003&results=25&order=relevance

https://www.consumerfinance.gov/consumer-tools/educator-tools/youth-financial-education/teach/activities/?q=&school_subject=3

