### PR TITLE
Cypress: Do not chain further commands

### DIFF
--- a/cypress.config.cjs
+++ b/cypress.config.cjs
@@ -1,6 +1,7 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
+  experimentalMemoryManagement: true,
   video: true,
   screenshotOnRunFailure: true,
   fixturesFolder: 'test/cypress/fixtures',

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -63,21 +63,13 @@ export class AdminPage {
   }
 
   searchContact(contact_heading) {
-    cy.get('#changelist-search')
-      .type(contact_heading)
-      .type('{enter}')
-      .then(() => {
-        // we need to wait for results to be populated
-        cy.wait(1000);
-      });
+    cy.get('#changelist-search').type(contact_heading);
+    cy.get('#changelist-search').type('{enter}');
   }
 
   removeContact() {
-    cy.get('a[href^="/admin/v1/contact/delete/"]:first')
-      .click({ force: true })
-      .then(() => {
-        cy.get('[value="Yes, delete"]').click();
-      });
+    cy.get('a[href^="/admin/v1/contact/delete/"]:first').click({ force: true });
+    cy.get('[value="Yes, delete"]').click();
   }
 
   addMortgageData(name) {
@@ -126,7 +118,8 @@ export class AdminPage {
   }
 
   setRegulationEffectiveDate(name) {
-    cy.get('#id_effective_date').clear().type(name);
+    cy.get('#id_effective_date').clear();
+    cy.get('#id_effective_date').type(name);
   }
 
   openMegaMenu() {
@@ -150,7 +143,8 @@ export class AdminPage {
 
   clickBlock(name) {
     const block = `.action-add-block-${name}`;
-    cy.get(block).scrollIntoView().should('be.visible');
+    cy.get(block).scrollIntoView();
+    cy.get(block).should('be.visible');
     return cy.get(block).click();
   }
 
@@ -253,10 +247,8 @@ export class AdminPage {
 
   selectTableEditorButton(name) {
     // Type a slash to open the popup menu.
-    cy.get('@tableEditor')
-      .find('.public-DraftEditor-content')
-      .focus()
-      .type('/');
+    cy.get('@tableEditor').find('.public-DraftEditor-content').focus();
+    cy.get('@tableEditor').find('.public-DraftEditor-content').type('/');
 
     // Then click on the item we want.
     cy.get('.Draftail-ComboBox__option-text').contains(name).click();
@@ -273,14 +265,10 @@ export class AdminPage {
   }
 
   typeTableEditorTextbox(text) {
-    return (
-      cy
-        .get('@tableEditor')
-        .find('.public-DraftEditor-content')
-        .focus()
-        .type(text)
-        // We need to wait for a bit or the typed text won't be captured
-        .wait(500)
-    );
+    cy.get('@tableEditor').find('.public-DraftEditor-content').focus();
+    return cy
+      .get('@tableEditor')
+      .find('.public-DraftEditor-content')
+      .type(text);
   }
 }

--- a/test/cypress/integration/admin/admin.cy.js
+++ b/test/cypress/integration/admin/admin.cy.js
@@ -114,9 +114,9 @@ describe('Admin', () => {
       admin.editFirstTableCell();
     });
 
-    it('should be able to create and edit a table', () => {
+    it('should be able to create and edit a table', async () => {
       const text = 'test cell text';
-      admin.typeTableEditorTextbox(text);
+      await admin.typeTableEditorTextbox(text);
       admin.closeTableEditor();
       admin.searchFirstTableCell(text).should('be.visible');
     });
@@ -130,8 +130,8 @@ describe('Admin', () => {
       admin.closeTableEditor();
     });
 
-    it('should be able to save an empty cell', () => {
-      admin.typeTableEditorTextbox('{selectall} ');
+    it('should be able to save an empty cell', async () => {
+      await admin.typeTableEditorTextbox('{selectall} ');
       admin.closeTableEditor();
       admin.getFirstTableCell().should('be.empty');
     });

--- a/test/cypress/integration/components/pagination/pagination-helpers.cy.js
+++ b/test/cypress/integration/components/pagination/pagination-helpers.cy.js
@@ -4,7 +4,8 @@ export class Pagination {
   }
 
   enter(name) {
-    cy.get('#m-pagination_current-page-0').clear({ force: true }).type(name);
+    cy.get('#m-pagination_current-page-0').clear({ force: true });
+    cy.get('#m-pagination_current-page-0').type(name);
     cy.get('.m-pagination').within(() => {
       cy.get('.m-pagination_form').submit();
     });

--- a/test/cypress/integration/paying-for-college/your-financial-path-to-graduation/financial-path-helpers.cy.js
+++ b/test/cypress/integration/paying-for-college/your-financial-path-to-graduation/financial-path-helpers.cy.js
@@ -34,7 +34,8 @@ export class PfcFinancialPathToGraduation {
   }
 
   setText(name, value) {
-    cy.get(`#${name}`).clear().type(value);
+    cy.get(`#${name}`).clear();
+    cy.get(`#${name}`).type(value);
   }
 
   selectProgram(program, name) {


### PR DESCRIPTION
I ran https://github.com/cypress-io/eslint-plugin-cypress on the tests and it flags to not chain further commands onto `cy` commands. It also flags having arbitrary waits, so I've tried removing them.

## Changes

- Split chained `cy` commands into multiple commands.
- Remove arbitrary waits.


## How to test this PR

1. Cypress functional tests should pass.