### PR TITLE
Automatically assign IDs to rendered HeadingBlocks

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/blocks/heading.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/heading.html
@@ -26,8 +26,8 @@
 {% if value.text -%}
 
 <{{ value.level }}
-{%- if value.level_class %} class="{{ value.level_class }}"{% endif -%}
->
+{%- if value.level_class %} class="{{ value.level_class }}"
+{%- endif %} id="{{ value.text | slugify_unique }}">
     {%- if value.icon %}{{ svg_icon( value.icon ) }} {% endif %}
     {{- value.text | safe -}}
 </{{ value.level }}>


### PR DESCRIPTION
This change alters the template for the existing HeadingBlock so that the heading tag (e.g. `<h2>`) always gets an `id` attribute with a slugified version of the heading text.

This uses our existing `slugify_unique` method that avoids duplicate IDs by enforcing unique IDs for a single Django request. For example, if there are two headings with the same text ("Example"), the first will will be given the ID "example" and the second "example-1".

## How to test this PR

1. Locally visit the template debug view for the heading module at http://localhost:8000/admin/template_debug/v1/heading/, and inspect source to see the heading IDs.
2. Visit a page with headings like http://localhost:8000/consumer-tools/educator-tools/your-money-your-goals/toolkit/ and notice that headings have IDs, for example "Access the full toolkit" gets `id="access-the-full-toolkit"`.

## Notes and todos

@csebianlander I'm implementing this as support for the ongoing table work; I've noticed on tables and elsewhere that some Wagtail pages have their heading text as `<div id="something">Heading text</div>`. It'd be better (a) not to have to do this and (b) not to be using raw HTML in heading blocks like this.

Unfortunately with this change it is possible that we will end up with duplicate headings in places where we use a HeadingBlock (or another block that embeds that) AND an editor has added a manual heading using a div. This doesn't happen now with tables because the existing AtomicTableBlock doesn't use a HeadingBlock.

Also, this solution doesn't apply headings everywhere -- only where HeadingBlock is used. Note on [the example page above](http://localhost:8000/consumer-tools/educator-tools/your-money-your-goals/toolkit/) the h1 doesn't get a heading for this reason. This makes me wonder whether it would be better to try to apply this globally, e.g. as part of our middleware that rewrites links to add icons.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)