### PR TITLE
Fix linting failures with latest Ruff

### DIFF
--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -418,7 +418,7 @@ class RegModelTests(DjangoTestCase):
         mock_hit.short_name = "Regulation DD"
         mock_hit.paragraph_id = "2-a-Interp-2-i"
         mock_hit.meta.highlight.text = ["<strong>Mortgage</strong> highlight"]
-        mock_search().query().highlight().filter().sort().__getitem__().execute.return_value = [  # noqa:
+        mock_search().query().highlight().filter().sort().__getitem__().execute.return_value = [  # noqa: E501
             mock_hit
         ]
         mock_count = mock.Mock(return_value=1)

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -393,7 +393,9 @@ def clean_up_report_menu_items(request, report_menu_items):
     for index, item in enumerate(report_menu_items):
         item.label = item.label.title()
         if re.search(cfpb_re, item.label, re.IGNORECASE):
-            item.label = re.sub(cfpb_re, "CFPB", item.label, 0, re.IGNORECASE)
+            item.label = re.sub(
+                cfpb_re, "CFPB", item.label, count=0, flags=re.IGNORECASE
+            )
         item.order = index
 
 


### PR DESCRIPTION
Ruff now correctly flags a line in `regulations3/test/test_models.py` where we have `# noqa: ` but do not specify an error or errors.

It also now correctly flags a call to `re.sub` that uses keyword arguments positionally.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
