### PR TITLE
Bump wagtail-inventory from 2.0.0 to 2.1

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -31,7 +31,7 @@ s3transfer==0.5.2
 setuptools>=65.5.1
 wagtail-autocomplete==0.9.0
 wagtail-flags==5.3.0
-wagtail-inventory==2.0.0
+wagtail-inventory==2.1
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.9
 wagtail-treemodeladmin==1.7.0


### PR DESCRIPTION
Upgrade wagtail-inventory version to latest release 2.1:

https://github.com/cfpb/wagtail-inventory/releases/tag/2.1

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)