### PR TITLE
Fix: Properly refresh empty filterable list caches

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -161,7 +161,7 @@ class FilterableListForm(forms.Form):
         all_filterable_results = cache.get(
             f"{self.cache_key_prefix}-all_filterable_results"
         )
-        if all_filterable_results is None:
+        if not all_filterable_results:
             all_filterable_results = self.filterable_search.get_raw_results()
             cache.set(
                 f"{self.cache_key_prefix}-all_filterable_results",
@@ -172,7 +172,7 @@ class FilterableListForm(forms.Form):
     def get_all_page_ids(self):
         """Return a list of all possible filterable page ids"""
         page_ids = cache.get(f"{self.cache_key_prefix}-page_ids")
-        if page_ids is None:
+        if not page_ids:
             page_ids = [
                 result.meta.id for result in self.all_filterable_results
             ]


### PR DESCRIPTION
This commit fixes an issue with the Django cache logic used for filterable list results. Currently a cache is used to store both (a) the full set of search results for a page and (b) the list of page IDs from those search results.

There is an edge case in the current logic that can result in incorrect empty results or a blank list of topic options:

1. Assume the search index is empty to start, perhaps due to a manual refresh or due to some network or configuration issue.
2. A request to a filterable list page with an empty cache returns an empty list of results.
3. This gets stored in both caches as an empty list (`[]`).
4. Now assume the search index has been repopulated. This doesn't automatically reset the Django caches, unfortunately.
5. Subsequent requests will check the cache, and the current logic checks e.g. `if page_ids is None` to see if there is anything in the cache.
6. This condition will fail - the cache doesn't have `None`, it has `[]`, and so the cache won't be repopulated.

This commit changes the logic so that if the cache result is Falsy (either `None` or `[]`), it will be repopulated. This has the slight potential for duplicate queries in cases where the index is truly empty, but this should never happen in practice.

Fixes internal D&CP#311.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)