### PR TITLE
CCDB: remove @tablet variable

### DIFF
--- a/cfgov/unprocessed/apps/ccdb-search/css/main.less
+++ b/cfgov/unprocessed/apps/ccdb-search/css/main.less
@@ -1,4 +1,4 @@
-@import '../node_modules/@cfpb/ccdb5-ui/dist/ccdb5.css';
+@import url('../node_modules/@cfpb/ccdb5-ui/dist/ccdb5.css');
 @import (reference) 'cfpb-core.less';
 
 // TODO: !important's are added for styles that are overriding ccdb5-ui styles.
@@ -6,10 +6,9 @@
   max-width: 1200px !important;
 }
 
-@tablet: ~'only screen and (min-width: 600px) and (max-width: 900px)';
-
 .wrapper__match-content {
-  @media @tablet {
+  // Tablet size.
+  @media only screen and (min-width: 600px) and (max-width: 900px) {
     padding-left: 30px !important;
     padding-right: 30px !important;
   }


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- CCDB: remove @tablet variable
- Use url syntax for import


## How to test this PR

1. `yarn build` and visit http://localhost:8000/data-research/consumer-complaints/search/ and resize to tablet and there should be no change from production in terms of left/right padding on `wrapper__match-content`.
