### PR TITLE
FAHC: Adjust CSS | drop IE8 support

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
@@ -25,14 +25,14 @@
   }
 
   /* Spell out abbreviations. */
-  abbr[title]:after {
+  abbr[title]::after {
     content: ' (' attr(title) ')';
   }
 
   /*
      * Don't show links.
      */
-  a:after {
+  a::after {
     content: '';
   }
 
@@ -60,7 +60,7 @@
 
   @page {
     size: letter;
-    margin: 0.5in 0.5in 0.5in 0.5in;
+    margin: 0.5in;
     padding: 0;
   }
 
@@ -95,11 +95,11 @@
     display: inline;
   }
 
-  ul li:after {
+  ul li::after {
     content: ', ';
   }
 
-  ul li:last-child:after {
+  ul li:last-child::after {
     content: '.';
   }
 

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/main.less
@@ -1,6 +1,5 @@
 // Import required CF components.
 @import (reference) 'cfpb-core.less';
 @import (reference) 'cfpb-grid.less';
-
 @import (less) './hud.less';
 @import (less) './hud_print.css';


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Double colon pseudoelements
- Consolidate margin shorthand.
- Minor newline removal.


## How to test this PR

1. Visit http://localhost:8000/find-a-housing-counselor/ and compare to production. There should be no change.

## Notes and todos

- Double colon pseudoelements drops IE8 support.
