### PR TITLE
Form Explainers: double colon pseudoelements to drop IE8 support

### DIFF
--- a/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
+++ b/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
@@ -97,7 +97,7 @@
       }
     }
 
-    .o-expandable_content[data-open='true']:before {
+    .o-expandable_content[data-open='true']::before {
       border: none;
     }
 


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Form Explainers: double colon pseudoelements to drop IE8 support


## How to test this PR

1. Visit these pages and compare to production. There should be no difference.

http://localhost:8000/consumer-tools/prepaid-cards/understand-fees/
http://localhost:8000/es/herramientas-del-consumidor/tarjetas-prepagadas/entienda-las-tarifas/
http://localhost:8000/owning-a-home/closing-disclosure/
http://localhost:8000/owning-a-home/loan-estimate/

## Notes and todos

- Double colon pseudoelement drops IE8 support.