### PR TITLE
KBYO: Remove browser prefixed box-sizing

### DIFF
--- a/cfgov/unprocessed/apps/know-before-you-owe/css/main.less
+++ b/cfgov/unprocessed/apps/know-before-you-owe/css/main.less
@@ -51,8 +51,6 @@
 
   .kbyo-compare-col {
     display: inline-block;
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
     border: solid transparent;
     border-width: 0 15px;


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- KBYO: Remove browser prefixed box-sizing


## How to test this PR

1. Visit http://localhost:8000/know-before-you-owe/compare/ and compare to production. It should be unchanged.