### PR TITLE
OAH/BAH: Drop IE8 support, browser prefixes, and deprecated min-device-pixel-ratio

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/a-range.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/a-range.less
@@ -63,13 +63,12 @@
 
 .a-range_input:focus + .rangeslider .rangeslider__handle {
   border: 1px solid #0072ce;
-  -webkit-box-shadow: none;
   box-shadow: none;
   outline: 1px solid #0072ce;
   outline-offset: 0;
 }
 
-@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+@media (min-resolution: 192dpi) {
   .rangeslider__handle {
     width: 22px;
     height: 21px;

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -85,12 +85,12 @@
     }
 
     input[type='number'] {
-      -moz-appearance: textfield;
+      appearance: textfield;
     }
 
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {
-      -webkit-appearance: none;
+      appearance: none;
     }
 
     .calc-subsection {
@@ -405,7 +405,7 @@
     }
   }
 
-  .next-steps-list > li:before {
+  .next-steps-list > li::before {
     position: absolute;
     top: 1px;
     left: -30px;

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -8,8 +8,6 @@
 }
 
 .clear {
-  /* IE 8 */
-  -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=0)';
   opacity: 0;
 }
 
@@ -32,8 +30,6 @@
 }
 
 .loading {
-  /* IE 8 */
-  -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=30)';
   opacity: 0.3;
 }
 

--- a/cfgov/unprocessed/apps/owning-a-home/css/main.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/main.less
@@ -7,7 +7,6 @@
 @image_path: '/static/apps/owning-a-home/img/';
 
 @import (reference) '../../../css/main.less';
-
 @import (less) './brand-header.less';
 @import (less) './brand-footer.less';
 @import (less) './explore-rates.less';


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

See min-device-pixel-ratio guidance on https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-webkit-device-pixel-ratio

## Changes

- Remove min-device-pixel-ratio in favor of resolution media query.
- Remove CSS browser prefixes.
- Double quote pseudoelements to drop IE8 support.
- Remove IE8 filter rules.

## How to test this PR

1. Compare http://localhost:8000/owning-a-home/explore-rates/ to production. It should be unchanged.