### PR TITLE
Prepaid agreements: Double colon pseudoelements to drop IE8 support

### DIFF
--- a/cfgov/unprocessed/apps/prepaid-agreements/css/search-bar.less
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/search-bar.less
@@ -65,7 +65,7 @@ button.a-btn.flex-fixed {
     display: none;
   }
 
-  &:after {
+  &::after {
     height: 100%;
     content: '\25BE';
     width: unit(@select-height / @base-font-size-px, em);


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Prepaid agreements: Double colon pseudoelements to drop IE8 support


## How to test this PR

1. Compare http://localhost:8000/data-research/prepaid-accounts/search-agreements/ to production. It should be unchanged in regard to the search bar.