### PR TITLE
iRegs: Double colon pseudoelements to drop IE8 support | Consolidate CSS shorthand

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -47,13 +47,13 @@
       background: none;
       border: none;
     } );
-    &:before {
+    &::before {
       border: 0;
       padding: 0;
     }
   }
 
-  &:before {
+  &::before {
     .respond-to-max( @bp-sm-max, {
       border-bottom: 1px solid @gray-40;
       content: ' ';

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-pagination.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-pagination.less
@@ -26,7 +26,7 @@
 
 .previous {
   float: left;
-  padding: 0 15px 0 15px;
+  padding: 0 15px;
   margin-left: -15px;
 
   .cf-icon-svg {
@@ -38,7 +38,7 @@
 .next {
   float: right;
   text-align: right;
-  padding: 0 15px 0 15px;
+  padding: 0 15px;
 
   .cf-icon-svg {
     margin-right: -15px;
@@ -50,7 +50,7 @@
 
 .next-prev-link {
   display: block;
-  margin: 16px 0 0 0;
+  margin: 16px 0 0;
 }
 
 .next-prev-link:link,

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -35,8 +35,8 @@
     .o-expandable_header {
       border: 0;
       padding: 0;
-      &:before,
-      &:after {
+      &::before,
+      &::after {
         border: 0;
         padding: 0;
       }
@@ -65,7 +65,7 @@
     }
   }
   .content_main {
-    &:after {
+    &::after {
       border: 0;
     }
     border: 0;

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-wayfinder.less
@@ -14,7 +14,7 @@
   position: fixed;
   left: 0;
   background-color: @white;
-  box-shadow: 0px 3px 8px -6px @black;
+  box-shadow: 0 3px 8px -6px @black;
   transition: top 0.1s ease-in-out;
   z-index: 100;
   padding-left: unit(15px / @base-font-size-px, rem);


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Double colon pseudoelements to drop IE8 support
- Consolidate CSS shorthand


## How to test this PR

1. Compare http://localhost:8000/rules-policy/regulations/1002/ to production. It should be unchanged.

