### PR TITLE
Use url imports | double colon pseudoelements to drop IE8 support

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/main.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/main.less
@@ -18,10 +18,10 @@
 @import (reference) 'cfpb-tables.less';
 
 // Project specific Less goes here or you can break it up into discrete files.
-@import 'atoms/icon.less';
-@import 'molecules/form-fields.less';
-@import 'molecules/search-hero.less';
-@import 'organisms/expandable.less';
-@import 'organisms/expandable-facets.less';
-@import 'pages/activity-search.less';
-@import 'utilities/hide-on.less';
+@import url('atoms/icon.less');
+@import url('molecules/form-fields.less');
+@import url('molecules/search-hero.less');
+@import url('organisms/expandable.less');
+@import url('organisms/expandable-facets.less');
+@import url('pages/activity-search.less');
+@import url('utilities/hide-on.less');

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/molecules/form-fields.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/molecules/form-fields.less
@@ -4,7 +4,7 @@
 
 .m-form-field__checkbox {
   .a-checkbox + .a-label.indeterminate {
-    &:before {
+    &::before {
       background-image: url('/static/apps/teachers-digital-platform/img/square-gray.png');
       background-size: auto 0.875em auto unit(15px / @base-font-size-px, em);
       background-position: center;

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
@@ -54,12 +54,12 @@
       padding: 0;
       overflow: hidden;
 
-      &:before,
-      &:after {
+      &::before,
+      &::after {
         border: 0;
       }
 
-      &:before {
+      &::before {
         padding: 0;
       }
     }
@@ -99,7 +99,7 @@
   .content_main {
     border: 0;
 
-    &:after {
+    &::after {
       display: none;
     }
   }


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Use url imports 
- Double colon pseudoelements to drop IE8 support


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/ and it should be unchanged from production.