### PR TITLE
Charting: CSS consolidation

### DIFF
--- a/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
@@ -1,6 +1,6 @@
 // Import external cfpb-chart-builder stylesheet
 // This is also imported by the chart block (in chart.less)
-@import 'cfpb-chart-builder.less';
+@import url('cfpb-chart-builder.less');
 
 .o-mp-map {
   border: 1px solid @gray-40;
@@ -182,7 +182,7 @@
 
 #mp-line-chart-controls,
 #mp-map-controls {
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 #mp-line-chart-geo,

--- a/cfgov/unprocessed/css/on-demand/simple-chart.less
+++ b/cfgov/unprocessed/css/on-demand/simple-chart.less
@@ -100,6 +100,7 @@
   .highcharts-xaxis-grid.highcharts-navigator-xaxis > .highcharts-grid-line {
     stroke: @gray-40;
   }
+
   /* Testing line patterns
   .highcharts-line-series.highcharts-series-0 {
     stroke-dasharray: 45, 7;
@@ -183,7 +184,7 @@
 
     .a-link {
       color: @link-text;
-      border-width: 0 0 1px 0;
+      border-width: 0 0 1px;
       border-style: dotted;
       display: inline-block;
       text-overflow: ellipsis;


### PR DESCRIPTION
Spun out of https://github.com/cfpb/consumerfinance.gov/pull/7881

## Changes

- Use url for imports.
- Consolidate CSS shorthand.
- Remove units for zero value.


## How to test this PR

1. Compare these charts to production and they should be unchanged.

http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/
http://localhost:8000/data-research/research-reports/data-spotlight-medical-debt-among-older-adults-before-pandemic/full-report/
