### PR TITLE
Move prettier config to package.json

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,0 @@
-{
-  "singleQuote": true
-}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,9 @@
     "watch": "yarn build watch",
     "build": "node ./esbuild/build.js"
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "snyk": true,
   "type": "module"
 }


### PR DESCRIPTION
When moving between Prettier@2 and Prettier@3 in different projects, the prettier config location in VSCode can cause issues. Our Prettier config is very light, so this PR moves it to the `package.json`. See background in https://github.com/prettier/prettier-vscode/issues/3007

## Changes

- Move prettier config to package.json


## How to test this PR

1. PR checks should pass.