### PR TITLE
Deprecate reliance on Wagtail's testapp

### DIFF
--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -41,38 +41,6 @@ ALWAYS_GENERATE_SLOW_REPORT = True
 
 BAKER_CUSTOM_CLASS = "core.testutils.baker.ActualContentTypeBaker"
 
-INSTALLED_APPS += (
-    "wagtail.contrib.settings",
-    "wagtail.test.snippets",
-    "wagtail.test.testapp",
-)
-
-WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    "default": {
-        "WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea",
-        "OPTIONS": {
-            "features": [
-                "h2",
-                "h3",
-                "h4",
-                "h5",
-                "blockquote",
-                "hr",
-                "ol",
-                "ul",
-                "bold",
-                "italic",
-                "link",
-                "document-link",
-                "image",
-            ]
-        },
-    },
-    "custom": {
-        "WIDGET": "wagtail.test.testapp.rich_text.CustomRichTextArea",
-    },
-}
-
 GOVDELIVERY_API = "core.govdelivery.MockGovDelivery"
 
 STATICFILES_FINDERS += [

--- a/cfgov/v1/models/__init__.py
+++ b/cfgov/v1/models/__init__.py
@@ -38,7 +38,12 @@ from v1.models.portal_topics import (
     PortalTopicTag,
 )
 from v1.models.resources import Resource, ResourceTag, TaggableSnippetManager
-from v1.models.snippets import Contact, ReusableText
+from v1.models.snippets import (
+    Contact,
+    EmailSignUp,
+    RelatedResource,
+    ReusableText,
+)
 from v1.models.story_page import StoryPage
 from v1.models.sublanding_filterable_page import (
     ActivityLogPage,

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -2,14 +2,14 @@
 from django.test import TestCase
 
 from wagtail.models import Site
-from wagtail.test.testapp.models import SimplePage
 
 from v1.blocks import ReusableTextChooserBlock
-from v1.models.snippets import (
+from v1.models import (
     Contact,
     EmailSignUp,
     RelatedResource,
     ReusableText,
+    SublandingPage,
 )
 
 
@@ -63,7 +63,7 @@ class TestModelStrings(TestCase):
 
 class TestReusableTextRendering(TestCase):
     def test_links_get_expanded(self):
-        page = SimplePage(title="foo", slug="foo", content="content")
+        page = SublandingPage(title="foo", slug="foo")
         default_site = Site.objects.get(is_default_site=True)
         default_site.root_page.add_child(instance=page)
 

--- a/cfgov/v1/tests/test_query.py
+++ b/cfgov/v1/tests/test_query.py
@@ -4,31 +4,31 @@ from django.core.exceptions import FieldDoesNotExist
 from django.test import TestCase
 
 from wagtail.models import Page, Site
-from wagtail.test.testapp.models import DefaultStreamPage
 
+from v1.models import SublandingPage
 from v1.query import StreamBlockPageQuerySet
 
 
 class StreamBlockPageQuerySetTestCase(TestCase):
     def setUp(self):
         root_page = Site.objects.get(is_default_site=True).root_page
-        test_page = DefaultStreamPage(
+        test_page = SublandingPage(
             title="Test page",
             live=True,
-            body=json.dumps(
+            sidebar_breakout=json.dumps(
                 [
-                    {"type": "text", "value": "Test text"},
+                    {"type": "heading", "value": "Test text"},
                 ]
             ),
         )
         root_page.add_child(instance=test_page)
-        other_page = DefaultStreamPage(
+        other_page = SublandingPage(
             title="Other page",
             live=True,
-            body=json.dumps(
+            sidebar_breakout=json.dumps(
                 [
-                    {"type": "rich_text", "value": "rich text"},
-                    {"type": "rich_text", "value": "another rich text"},
+                    {"type": "paragraph", "value": "rich text"},
+                    {"type": "paragraph", "value": "another rich text"},
                 ]
             ),
         )
@@ -37,13 +37,15 @@ class StreamBlockPageQuerySetTestCase(TestCase):
     def test_block_in_field(self):
         """Ensure that block_in_field finds an appropriate number of expected
         results."""
-        queryset = StreamBlockPageQuerySet(DefaultStreamPage)
+        queryset = StreamBlockPageQuerySet(SublandingPage)
         self.assertEqual(queryset.count(), 2)
 
-        text_queryset = queryset.block_in_field("text", "body")
-        self.assertEqual(text_queryset.count(), 1)
+        heading_queryset = queryset.block_in_field(
+            "heading", "sidebar_breakout"
+        )
+        self.assertEqual(heading_queryset.count(), 1)
 
-        image_queryset = queryset.block_in_field("image", "body")
+        image_queryset = queryset.block_in_field("image", "sidebar_breakout")
         self.assertEqual(image_queryset.count(), 0)
 
     def test_block_in_field_wrong_fields(self):
@@ -55,40 +57,42 @@ class StreamBlockPageQuerySetTestCase(TestCase):
         # If we ask for a block in a field the model doesn't have, it should
         # raise a FieldDoesNotExist
         with self.assertRaises(FieldDoesNotExist):
-            queryset.block_in_field("text", "field_that_doesnt_exist")
+            queryset.block_in_field("heading", "field_that_doesnt_exist")
 
         # If we ask for a block in a field that isn't a StreamField, it should
         # raise a TypeError
         with self.assertRaises(TypeError):
-            queryset.block_in_field("text", "title")
+            queryset.block_in_field("heading", "title")
 
     def test_annotate_block_in(self):
         """Ensure we get an annotation for a target block"""
-        queryset = StreamBlockPageQuerySet(DefaultStreamPage)
+        queryset = StreamBlockPageQuerySet(SublandingPage)
 
         annotated_queryset = queryset.block_in_field(
-            "text", "body"
-        ).annotate_block_in("text", "body")
+            "heading", "sidebar_breakout"
+        ).annotate_block_in("heading", "sidebar_breakout")
         self.assertEqual(annotated_queryset.count(), 1)
-        self.assertEqual(annotated_queryset[0].text_value, "Test text")
+        self.assertEqual(annotated_queryset[0].heading_value, "Test text")
 
     def test_annotate_block_in_multiple_blocks(self):
         """If we have multiple target_blocks in a StreamField, ensure we only
         get an annotation for the first one."""
-        queryset = StreamBlockPageQuerySet(DefaultStreamPage)
+        queryset = StreamBlockPageQuerySet(SublandingPage)
 
         annotated_queryset = queryset.block_in_field(
-            "rich_text", "body"
-        ).annotate_block_in("rich_text", "body")
+            "paragraph", "sidebar_breakout"
+        ).annotate_block_in("paragraph", "sidebar_breakout")
         self.assertEqual(annotated_queryset.count(), 1)
-        self.assertEqual(annotated_queryset[0].rich_text_value, "rich text")
+        self.assertEqual(annotated_queryset[0].paragraph_value, "rich text")
 
     def test_annotate_block_in_when_block_doesnt_exist(self):
         """If asked to annotate with a block that doesn't exist in the
         streamfield in the queryset, the annotation should be None"""
-        queryset = StreamBlockPageQuerySet(DefaultStreamPage)
+        queryset = StreamBlockPageQuerySet(SublandingPage)
 
-        annotated_queryset = queryset.annotate_block_in("foo", "body")
+        annotated_queryset = queryset.annotate_block_in(
+            "foo", "sidebar_breakout"
+        )
         self.assertTrue(annotated_queryset.count() > 0)
         self.assertEqual(annotated_queryset[0].foo_value, None)
 
@@ -101,9 +105,9 @@ class StreamBlockPageQuerySetTestCase(TestCase):
         # If we ask for a block in a field the model doesn't have, it should
         # raise a FieldDoesNotExist
         with self.assertRaises(FieldDoesNotExist):
-            queryset.annotate_block_in("text", "field_that_doesnt_exist")
+            queryset.annotate_block_in("heading", "field_that_doesnt_exist")
 
         # If we ask for a block in a field that isn't a StreamField, it should
         # raise a TypeError
         with self.assertRaises(TypeError):
-            queryset.annotate_block_in("text", "title")
+            queryset.annotate_block_in("heading", "title")

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -12,13 +12,16 @@ from wagtail import hooks
 from wagtail.admin.views.pages.bulk_actions.delete import DeleteBulkAction
 from wagtail.admin.views.pages.delete import delete
 from wagtail.models import Page, Site
-from wagtail.test.testapp.models import SimplePage
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.whitelist import Whitelister as Allowlister
 
-from v1.models.base import CFGOVPage, CFGOVPageCategory
-from v1.models.blog_page import BlogPage
-from v1.models.resources import Resource
+from v1.models import (
+    BlogPage,
+    CFGOVPage,
+    CFGOVPageCategory,
+    Resource,
+    SublandingPage,
+)
 from v1.tests.wagtail_pages.helpers import publish_page
 from v1.wagtail_hooks import (
     get_resource_tags,
@@ -30,7 +33,7 @@ from v1.wagtail_hooks import (
 class TestServeLatestDraftPage(TestCase):
     def setUp(self):
         self.default_site = Site.objects.get(is_default_site=True)
-        self.page = SimplePage(title="live", slug="test", content="test")
+        self.page = SublandingPage(title="live", slug="test")
         self.default_site.root_page.add_child(instance=self.page)
         self.page.title = "draft"
         self.page.save_revision()

--- a/cfgov/v1/tests/util/test_migrations.py
+++ b/cfgov/v1/tests/util/test_migrations.py
@@ -5,9 +5,8 @@ from django.test import SimpleTestCase, TestCase
 
 from wagtail import blocks
 from wagtail.models import Page, Site
-from wagtail.test.testapp.models import StreamPage
 
-from v1.models.snippets import EmailSignUp
+from v1.models import EmailSignUp, SublandingPage
 from v1.tests.wagtail_pages.helpers import save_new_page
 from v1.util.migrations import (
     convert_emailsignup_block_to_snippet,
@@ -24,10 +23,12 @@ from v1.util.migrations import (
 class MigrationsUtilTestCase(TestCase):
     def setUp(self):
         self.root = Page.objects.get(slug="cfgov")
-        self.page = StreamPage(title="Test Page", slug="testpage")
+        self.page = SublandingPage(title="Test Page", slug="testpage")
         save_new_page(self.page, self.root)
         set_streamfield_data(
-            self.page, "body", [{"type": "text", "value": "some text"}]
+            self.page,
+            "sidebar_breakout",
+            [{"type": "heading", "value": "some text"}],
         )
 
         self.revision = self.page.save_revision()
@@ -44,39 +45,39 @@ class MigrationsUtilTestCase(TestCase):
     def test_get_streamfield_data_page(self):
         """Test that get_streamfield_data fetches the data correctly
         from a page object."""
-        data = get_streamfield_data(self.page, "body")
+        data = get_streamfield_data(self.page, "sidebar_breakout")
 
-        self.assertEqual(data[0]["type"], "text")
+        self.assertEqual(data[0]["type"], "heading")
         self.assertEqual(data[0]["value"], "some text")
 
     def test_get_streamfield_data_revision(self):
         """Test that get_streamfield_data fetches the data correctly
         from a revision object."""
-        data = get_streamfield_data(self.revision, "body")
+        data = get_streamfield_data(self.revision, "sidebar_breakout")
 
-        self.assertEqual(data[0]["type"], "text")
+        self.assertEqual(data[0]["type"], "heading")
         self.assertEqual(data[0]["value"], "some text")
 
     def test_get_streamfield_data_revision_no_field(self):
         """Test that get an empty list for fields that don't exist on
         revisions"""
-        data = get_streamfield_data(self.revision, "notbody")
+        data = get_streamfield_data(self.revision, "not_a_field")
         self.assertEqual(data, [])
 
     def test_set_streamfield_data_page(self):
         """Test that set_streamfield_data correctly sets data for a
         given page and saves the page."""
-        new_data = [{"type": "text", "value": "new text"}]
-        set_streamfield_data(self.page, "body", new_data)
-        data = self.page.body.raw_data
+        new_data = [{"type": "heading", "value": "new text"}]
+        set_streamfield_data(self.page, "sidebar_breakout", new_data)
+        data = self.page.sidebar_breakout.raw_data
         self.assertEqual(data[0]["value"], "new text")
 
     def test_set_streamfield_data_revision(self):
         """Test that set_streamfield_data correctly sets data for a
         given revision and saves the page."""
-        new_data = [{"type": "text", "value": "new text"}]
-        set_streamfield_data(self.revision, "body", new_data)
-        data = self.revision.as_object().body.raw_data
+        new_data = [{"type": "heading", "value": "new text"}]
+        set_streamfield_data(self.revision, "sidebar_breakout", new_data)
+        data = self.revision.as_object().sidebar_breakout.raw_data
         self.assertEqual(data[0]["value"], "new text")
 
     def test_set_streamfield_data_page_without_committing(self):
@@ -84,8 +85,10 @@ class MigrationsUtilTestCase(TestCase):
         given page and saves the page."""
         self.page.save = mock.Mock()
 
-        new_data = [{"type": "text", "value": "new text"}]
-        set_streamfield_data(self.page, "body", new_data, commit=False)
+        new_data = [{"type": "heading", "value": "new text"}]
+        set_streamfield_data(
+            self.page, "sidebar_breakout", new_data, commit=False
+        )
 
         self.assertEqual(self.page.save.mock_calls, [])
 
@@ -98,10 +101,10 @@ class MigrationsUtilTestCase(TestCase):
         # set_streamfield_data.
         mapper = mock.Mock(return_value="new text")
 
-        migrate_stream_field(self.page, "body", "text", mapper)
+        migrate_stream_field(self.page, "sidebar_breakout", "heading", mapper)
 
         mapper.assert_called_with(self.page, "some text")
-        data = self.page.body.raw_data
+        data = self.page.sidebar_breakout.raw_data
         self.assertEqual(data[0]["value"], "new text")
 
     def test_migrate_stream_field_revision(self):
@@ -113,10 +116,12 @@ class MigrationsUtilTestCase(TestCase):
         # set_streamfield_data.
         mapper = mock.Mock(return_value="new text")
 
-        migrate_stream_field(self.revision, "body", "text", mapper)
+        migrate_stream_field(
+            self.revision, "sidebar_breakout", "heading", mapper
+        )
 
         mapper.assert_called_with(self.revision, "some text")
-        data = self.revision.as_object().body.raw_data
+        data = self.revision.as_object().sidebar_breakout.raw_data
         self.assertEqual(data[0]["value"], "new text")
 
     @mock.patch("v1.util.migrations.set_streamfield_data")
@@ -128,7 +133,9 @@ class MigrationsUtilTestCase(TestCase):
         shouldn't be migrated."""
         mapper = mock.Mock()
 
-        migrate_stream_field(self.page, "body", "other_type", mapper)
+        migrate_stream_field(
+            self.page, "sidebar_breakout", "other_type", mapper
+        )
 
         # The mapper should not be called
         mapper.assert_not_called()
@@ -145,19 +152,19 @@ class MigrationsUtilTestCase(TestCase):
         mapper = mock.Mock()
 
         page_types_and_fields = [
-            ("tests", "StreamPage", "body", "text"),
+            ("v1", "SublandingPage", "sidebar_breakout", "heading"),
         ]
         migrate_page_types_and_fields(apps, page_types_and_fields, mapper)
 
         # Check that migrate_stream_field was correct called with the page
         mock_migrate_stream_field.assert_any_call(
-            self.page, "body", "text", mapper
+            self.page, "sidebar_breakout", "heading", mapper
         )
 
         # Check that the revision lookup happened correctly and that the
         # revision stream field was correctly migrated.
         mock_migrate_stream_field.assert_any_call(
-            self.revision, "body", "text", mapper
+            self.revision, "sidebar_breakout", "heading", mapper
         )
 
 


### PR DESCRIPTION
Currently we use Wagtail's wagtail.test.testapp as part of our test settings in order to use some of its test models, for example SimplePage.

There's no need to use Wagtail's test models if we have a model that can work just as well. Additionally, there's an issue with the migrations for the testapp in Wagtail 4.2.4, and this avoids needing to deal with that -- see [wagtail#10724](https://github.com/wagtail/wagtail/issues/10724).

Theoretically we could maintain our own test models, for example using the method documented [here](https://docs.djangoproject.com/en/4.2/topics/testing/tools/#isolating-apps), but for now using our own models works just as well and avoids the dependency on Wagtail's testapp.

## How to test this PR

All tests should pass; there is no user-facing impact to this change.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)