### PR TITLE
Deprecate SERVE_LATEST_DRAFT_PAGES setting

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -643,15 +643,6 @@ FLAGS = {
     "ROBOTS_TXT_SEARCH_GOV_ONLY": [("environment is", "beta")],
 }
 
-# We want the ability to serve the latest drafts of some pages on beta
-# This value is read by v1.wagtail_hooks
-SERVE_LATEST_DRAFT_PAGES = []
-
-# To expose a previously-published page's latest draft version on beta,
-# add its primary key to the list below
-if DEPLOY_ENVIRONMENT == "beta":
-    SERVE_LATEST_DRAFT_PAGES = []
-
 # Email popup configuration. See v1.templatetags.email_popup.
 EMAIL_POPUP_URLS = {
     "debt": [

--- a/cfgov/v1/tests/test_wagtail_hooks.py
+++ b/cfgov/v1/tests/test_wagtail_hooks.py
@@ -1,17 +1,12 @@
 from django.contrib.auth.models import Permission, User
 from django.core.exceptions import PermissionDenied
-from django.test import (
-    RequestFactory,
-    SimpleTestCase,
-    TestCase,
-    override_settings,
-)
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 
 from wagtail import hooks
 from wagtail.admin.views.pages.bulk_actions.delete import DeleteBulkAction
 from wagtail.admin.views.pages.delete import delete
-from wagtail.models import Page, Site
+from wagtail.models import Page
 from wagtail.test.utils import WagtailTestUtils
 from wagtail.whitelist import Whitelister as Allowlister
 
@@ -21,7 +16,6 @@ from v1.models import (
     CFGOVPageCategory,
     InternalDocsSettings,
     Resource,
-    SublandingPage,
 )
 from v1.tests.wagtail_pages.helpers import publish_page
 from v1.wagtail_hooks import (
@@ -29,27 +23,6 @@ from v1.wagtail_hooks import (
     raise_bulk_delete_error,
     raise_delete_error,
 )
-
-
-class TestServeLatestDraftPage(TestCase):
-    def setUp(self):
-        self.default_site = Site.objects.get(is_default_site=True)
-        self.page = SublandingPage(title="live", slug="test")
-        self.default_site.root_page.add_child(instance=self.page)
-        self.page.title = "draft"
-        self.page.save_revision()
-
-    @override_settings(SERVE_LATEST_DRAFT_PAGES=[])
-    def test_not_serving_draft_serves_published_revision(self):
-        response = self.client.get("/test/")
-        self.assertContains(response, "live")
-        self.assertIsNone(response.get("Serving-Wagtail-Draft"))
-
-    def test_serving_draft_serves_latest_revision_and_adds_header(self):
-        with override_settings(SERVE_LATEST_DRAFT_PAGES=[self.page.pk]):
-            response = self.client.get("/test/")
-            self.assertContains(response, "draft")
-            self.assertEqual(response["Serving-Wagtail-Draft"], "1")
 
 
 class TestGetResourceTags(TestCase):

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -184,15 +184,6 @@ def register_cdn_url():
     ]
 
 
-@hooks.register("before_serve_page")
-def serve_latest_draft_page(page, request, args, kwargs):
-    if page.pk in settings.SERVE_LATEST_DRAFT_PAGES:
-        latest_draft = page.get_latest_revision_as_object()
-        response = latest_draft.serve(request, *args, **kwargs)
-        response["Serving-Wagtail-Draft"] = "1"
-        return response
-
-
 @hooks.register("register_reports_menu_item")
 def register_page_metadata_report_menu_item():
     return MenuItem(


### PR DESCRIPTION
This commit deprecates the `SERVE_LATEST_DRAFT_PAGES` that allows for arbitrary serving of draft Wagtail page content by primary key. This functionality was added in 2017 in commit e8902bd10ea01b7cac5f4a8b1924ffbf271f9e56 for a few pages and then turned off for those pages in 2018 in commit ae0156d29b5b099d38b1d6af7cfa88d982d13543. It hasn't been used since.

We now use wagtail-sharing to provide this functionality instead.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)