### PR TITLE
Retirement: Convert small font sizes to use <small> HTML element

### DIFF
--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -81,7 +81,7 @@
                                 autocomplete="off" autocorrect="off" spellcheck="false"></label>
                         <div class="tooltip-content" id="salary-tooltip" data-tooltip-name="salary" role="tooltip"
                             aria-haspopup="true">
-                            <p>{{ _("Enter your total work income before taxes and other deductions. If your work income is 0 (zero) because you are now retired or unemployed, enter the income for the last full year in which you worked.") }}</p>
+                            <small>{{ _("Enter your total work income before taxes and other deductions. If your work income is 0 (zero) because you are now retired or unemployed, enter the income for the last full year in which you worked.") }}</small>
                         </div>
                     </div>
                     <div class="content-l_col content-l_col-1-3">
@@ -99,9 +99,9 @@
                 </div>
             </form>
             <div class="content-l_col content-l_col-1-3 estimate-info">
-                <p>
+                <small>
                     {{ _("The calculator bases your benefit estimate on current formulas from the Social Security Administration. Your answers are anonymous. Because we do not access or use your Social Security earnings record, these are rough estimates.") }}
-                </p>
+                </small>
             </div>
         </div>
     </div>
@@ -128,14 +128,14 @@
                         {{ _("is your full benefit claiming age.") }}
                     </span>
                 </p>
-                <p class="compared-to-full explainer">{{ _("Compared to claiming at your full benefit claiming age.") }}
-                </p>
+                <small class="compared-to-full">{{ _("Compared to claiming at your full benefit claiming age.") }}
+                </small>
             </div>
             <div class="total-benefits-container">
                 <p class="total-benefits-text h4"><strong>{{ _("By age 85, an average lifespan, your total benefits will be") }}</strong></p>
                 <p>
-                    <span id="lifetime-benefits-value" class="lifetime-benefits-value h3"></span>&nbsp;<span
-                        class="todays-dollars explainer">({{ _("in today's dollars") }})</span>
+                    <span id="lifetime-benefits-value" class="lifetime-benefits-value h3"></span>&nbsp;<small
+                        class="todays-dollars">({{ _("in today's dollars") }})</small>
                 </p>
             </div>
             <div class="graph-content">
@@ -456,16 +456,16 @@
                 </p>
             </div>
             <div class="tooltip-content" data-tooltip-name="working-longer" role="tooltip" aria-haspopup="true">
-                <p>{{ _("Once you reach your full retirement benefits claiming age, you can work and earn as much as you want and your benefits will not be reduced. If you claim before this age and continue to work, your benefits could be temporarily reduced if you earn over a certain limit, but any reductions you receive will be credited back to you once you reach full retirement age.") }}</p>
+                <small>{{ _("Once you reach your full retirement benefits claiming age, you can work and earn as much as you want and your benefits will not be reduced. If you claim before this age and continue to work, your benefits could be temporarily reduced if you earn over a certain limit, but any reductions you receive will be credited back to you once you reach full retirement age.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="401k" role="tooltip" aria-haspopup="true">
-                <p>{{ _("A type of retirement savings account offered by employers to help their employees save for retirement.") }}</p>
+                <small>{{ _("A type of retirement savings account offered by employers to help their employees save for retirement.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="iras" role="tooltip" aria-haspopup="true">
-                <p>{{ _("IRAs are types of retirement savings plans with special tax incentives. In these plans, your savings equal the contributions that you make to the account plus the gains or losses of your investments.") }}</p>
+                <small>{{ _("IRAs are types of retirement savings plans with special tax incentives. In these plans, your savings equal the contributions that you make to the account plus the gains or losses of your investments.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="claim_early_and_work" role="tooltip" aria-haspopup="true">
-                <p>{{ _("If you claim before full retirement age and continue to work, your benefits could be temporarily reduced if you earn over a certain amount. Any reductions you receive will be credited back to you once you reach full retirement age.") }}</p>
+                <small>{{ _("If you claim before full retirement age and continue to work, your benefits could be temporarily reduced if you earn over a certain amount. Any reductions you receive will be credited back to you once you reach full retirement age.") }}</small>
             </div>
         </div>
     </div>
@@ -799,19 +799,19 @@
                 </p>
             </div>
             <div class="tooltip-content" data-tooltip-name="working-longer" role="tooltip" aria-haspopup="true">
-                <p>{{ _("Once you reach your full retirement benefits claiming age, you can work and earn as much as you want and your benefits will not be reduced. If you claim before this age and continue to work, your benefits could be temporarily reduced if you earn over a certain limit, but any reductions you receive will be credited back to you once you reach full retirement age.") }}</p>
+                <small>{{ _("Once you reach your full retirement benefits claiming age, you can work and earn as much as you want and your benefits will not be reduced. If you claim before this age and continue to work, your benefits could be temporarily reduced if you earn over a certain limit, but any reductions you receive will be credited back to you once you reach full retirement age.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="pensions" role="tooltip" aria-haspopup="true">
-                <p>{{ _("Your Social Security benefits could be reduced if you receive federal, state, or local government pensions that are based on work where you did not pay Social Security taxes.") }}</p>
+                <small>{{ _("Your Social Security benefits could be reduced if you receive federal, state, or local government pensions that are based on work where you did not pay Social Security taxes.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="401k" role="tooltip" aria-haspopup="true">
-                <p>{{ _("A type of retirement savings account offered by employers to help their employees save for retirement.") }}</p>
+                <small>{{ _("A type of retirement savings account offered by employers to help their employees save for retirement.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="iras" role="tooltip" aria-haspopup="true">
-                <p>{{ _("IRAs are types of retirement savings plans with special tax incentives. In these plans, your savings equal the contributions that you make to the account plus the gains or losses of your investments.") }}</p>
+                <small>{{ _("IRAs are types of retirement savings plans with special tax incentives. In these plans, your savings equal the contributions that you make to the account plus the gains or losses of your investments.") }}</small>
             </div>
             <div class="tooltip-content" data-tooltip-name="catchup-contributions" role="tooltip" aria-haspopup="true">
-                <p>{{ _("Catch-up contributions are additional contributions that individuals who are age 50 or older can make to their 401(k) or IRA accounts to help them boost their savings as they approach retirement.") }}</p>
+                <small>{{ _("Catch-up contributions are additional contributions that individuals who are age 50 or older can make to their 401(k) or IRA accounts to help them boost their savings as they approach retirement.") }}</small>
             </div>
         </div>
         <div class="content-l_col content-l_col-1-3 question question-longevity">
@@ -898,10 +898,11 @@
             <h3 id="retirement-selector-label">
                 {{ _("Select the age you plan to start collecting your Social Security retirement benefits.") }}
             </h3>
-            <p class="explainer step-three-note">
-                {{ _("(This will not affect your Social Security account or eligibility and it will not begin an application.)") }}
+            <p class="step-three-note">
+                <small>
+                    {{ _("(This will not affect your Social Security account or eligibility and it will not begin an application.)") }}
+                </small>
             </p>
-
             <div class="m-form-field m-form-field__select">
                 <div class="a-select">
                     <select id="retirement-age-selector" aria-labelledby="retirement-selector-label">

--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -230,10 +230,6 @@
     font-weight: bolder;
   }
 
-  .explainer {
-    font-size: 0.875em;
-  }
-
   .estimated-benefits-input label {
     display: inline;
     margin-left: 15px;
@@ -271,7 +267,6 @@
 
   .step-one .estimate-info {
     vertical-align: bottom;
-    font-size: 0.875em;
     margin-top: 0;
   }
 
@@ -798,7 +793,6 @@
     cursor: auto;
     border-bottom: none;
     color: @pacific;
-    font-size: 0.9rem;
   }
 
   #tooltip-container {
@@ -806,7 +800,6 @@
     border: 0 solid #000;
     display: none;
     font-style: normal;
-    font-size: 0.8em;
     padding: 15px;
     position: absolute;
     width: 20em;


### PR DESCRIPTION
The retirement before you claim tool has some small text that unnecessarily sets the font size smaller, when it could use a `<small>` HTML element instead.

This was a change decided with discussion with @natalia-fitzgerald 

## Changes

- Retirement: Convert small font sizes to use <small> HTML element


## How to test this PR

1. `yarn build` and compare http://localhost:8000/consumer-tools/retirement/before-you-claim/ to https://www.consumerfinance.gov/consumer-tools/retirement/before-you-claim/ The small text should be consistently 14px (0.875em). Small text appears in these places:

- text block to the right of the form inputs on the tool landing page.
- tooltips (button and popup)
- Smaller parentheses text, such as "(in today's dollars)" to the left of the graph, and the text that appears under the claiming age to the left of the graph when adjusting the graph slider.
- The note on step three.


## Screenshots

Before:
<img width="637" alt="Screenshot 2023-08-11 at 10 26 04 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/14eef32d-1447-4be9-87da-0ddbd492de1d">

<img width="493" alt="Screenshot 2023-08-11 at 10 46 49 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/6762acda-7b53-4f74-8cb5-0a1e197f4564">


After:
<img width="593" alt="Screenshot 2023-08-11 at 10 26 35 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/6bca3499-ece2-4138-ad1e-adf88a6c5c87">

<img width="487" alt="Screenshot 2023-08-11 at 10 52 09 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/49c62441-5e4a-4d24-a369-3da7c63d44fe">

