### PR TITLE
Deprecate PRIVACY_FORMS feature flag

### DIFF
--- a/cfgov/privacy/tests/test_views.py
+++ b/cfgov/privacy/tests/test_views.py
@@ -3,10 +3,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 
 
-@override_settings(
-    FLAGS={"PRIVACY_FORMS": [("boolean", True)]},
-    PRIVACY_EMAIL_TARGET="email@foia.gov",
-)
+@override_settings(PRIVACY_EMAIL_TARGET="email@foia.gov")
 class TestRecordsAccessForm(TestCase):
     def test_get_the_form(self):
         response = self.client.get(reverse("privacy:records_access"))
@@ -53,10 +50,7 @@ class TestRecordsAccessForm(TestCase):
         self.assertRedirects(response, reverse("privacy:form_submitted"))
 
 
-@override_settings(
-    FLAGS={"PRIVACY_FORMS": [("boolean", True)]},
-    PRIVACY_EMAIL_TARGET="email@foia.gov",
-)
+@override_settings(PRIVACY_EMAIL_TARGET="email@foia.gov")
 class TestDisclosureConsentForm(TestCase):
     def test_get_the_form(self):
         response = self.client.get(reverse("privacy:disclosure_consent"))

--- a/cfgov/privacy/urls.py
+++ b/cfgov/privacy/urls.py
@@ -1,24 +1,21 @@
+from django.urls import re_path
 from django.views.generic import TemplateView
 
-from flags.urls import flagged_re_path
 from privacy.views import GetDisclosureConsentForm, GetRecordsAccessForm
 
 
 urlpatterns = [
-    flagged_re_path(
-        "PRIVACY_FORMS",
+    re_path(
         r"^disclosure-consent/$",
         GetDisclosureConsentForm.as_view(),
         name="disclosure_consent",
     ),
-    flagged_re_path(
-        "PRIVACY_FORMS",
+    re_path(
         r"^records-access/$",
         GetRecordsAccessForm.as_view(),
         name="records_access",
     ),
-    flagged_re_path(
-        "PRIVACY_FORMS",
+    re_path(
         r"^form-submitted/$",
         TemplateView.as_view(template_name="privacy/form-submitted.html"),
         name="form_submitted",


### PR DESCRIPTION
In November 2021 in commit 2007ac860ec7dfff0f94517f1a69e75299b97d20 we added some new forms related to FOIA and privacy. At the time, these were added behind a PRIVACY_FORMS feature flag. The flag is no longer needed since the logic has been enabled in production since that time (see <internal domain>/admin/flags/PRIVACY_FORMS/ to confirm). This commit removes it.

To test locally, confirm that the forms on these pages work locally:

- http://localhost:8000/privacy/disclosure-consent/
- http://localhost:8000/privacy/records-access/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)