### PR TITLE
Always alphabetize filterable category options

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
@@ -100,7 +100,9 @@
                             class="o-multiselect"
                             data-placeholder="Search for categories"
                             multiple>
-                    {% for slug, name in choices_for_page_type(value.category_choices) %}
+                    {% for slug, name in choices_for_page_type(
+                        value.category_choices
+                    )  | sort(attribute="1") %}
                         <option value="{{ slug }}"
                                 {{ 'selected' if is_filter_selected('categories', slug) else '' }}>
                             {{ name }}


### PR DESCRIPTION
This commit modifies how category options are sorted on filterable list controls. Instead of being sorted arbitrarily by how they are currently defined in code, this change makes it so that filterable categories are always alphabetized.

This addresses internal D&CP#313.

## How to test this PR

To test, compare http://localhost:8000/data-research/research-reports/ with the version in production at
https://www.consumerfinance.gov/data-research/research-reports/. Expand "Filter reports" and look at the sorting under "Category".

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)