### PR TITLE
Fix deprecation warnings in Wagtail 4.2

### DIFF
--- a/cfgov/v1/tests/models/test_browse_page.py
+++ b/cfgov/v1/tests/models/test_browse_page.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory, TestCase
 
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from v1.models import BrowseFilterablePage, BrowsePage, CFGOVPage
 

--- a/docs/editing-components.md
+++ b/docs/editing-components.md
@@ -190,7 +190,7 @@ and associating it with the block type.
 A custom block definition can specify the template path in its `Meta` class:
 
 ```python
-from wagtail.core import blocks
+from wagtail import blocks
 
 
 class PersonBlock(blocks.StructBlock):

--- a/docs/wagtail-pages.md
+++ b/docs/wagtail-pages.md
@@ -54,7 +54,7 @@ For example, our `LandingPage` page model
 that can have a hero and/or a text introduction:
 
 ```python
-from wagtail.core.fields import StreamField
+from wagtail.fields import StreamField
 
 from v1.atomic_elements import molecules
 from v1.models import CFGOVPage
@@ -124,7 +124,7 @@ the `header` StreamField
 
 ```python
 from wagtail.admin.edit_handlers import StreamFieldPanel
-from wagtail.core.fields import StreamField
+from wagtail.fields import StreamField
 
 from v1.atomic_elements import molecules
 from v1.models import CFGOVPage


### PR DESCRIPTION
(This PR is to the upgrade/wagtail-4.2 branch.)

This commit fixes some deprecation warnings that appear when you run the Python tests against the upgrade/wagtail-4.2 branch. It also updates some references in the documentation.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)