### PR TITLE
Remove unused filterable list authors cache

### DIFF
--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -73,7 +73,6 @@ def invalidate_filterable_list_caches(sender, **kwargs):
         cache.delete(f"{cache_key_prefix}-all_filterable_results")
         cache.delete(f"{cache_key_prefix}-page_ids")
         cache.delete(f"{cache_key_prefix}-topics")
-        cache.delete(f"{cache_key_prefix}-authors")
 
         # Add the filterable list's slug to the list of cache tags to purge
         cache_tags_to_purge.append(filterable_list_page.slug)

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -35,12 +35,10 @@ class TestFilterableListForm(ElasticsearchTestsMixin, TestCase):
         self.blog1.categories.add(CFGOVPageCategory(name="foo"))
         self.blog1.categories.add(CFGOVPageCategory(name="bar"))
         self.blog1.tags.add("foo")
-        self.blog1.authors.add("richa-agarwal")
         self.blog1.language = "es"
         self.blog2 = BlogPage(title="another test page")
         self.blog2.categories.add(CFGOVPageCategory(name="bar"))
         self.blog2.tags.add("blah")
-        self.blog2.authors.add("richard-cordray")
         self.category_blog = BlogPage(title="Category Test")
         self.category_blog.categories.add(
             CFGOVPageCategory(name="info-for-consumers")

--- a/cfgov/v1/tests/test_signals.py
+++ b/cfgov/v1/tests/test_signals.py
@@ -60,7 +60,6 @@ class FilterableListInvalidationTestCase(TestCase):
             )
             mock_cache.delete.assert_any_call(f"{cache_key_prefix}-page_ids")
             mock_cache.delete.assert_any_call(f"{cache_key_prefix}-topics")
-            mock_cache.delete.assert_any_call(f"{cache_key_prefix}-authors")
 
         mock_purge.assert_called_once()
         self.assertIn(


### PR DESCRIPTION
Filterable lists don't index or search on post authors, but there are a few references to deleting a cache for searched authors. These were added at some point in the past where filterable list design included filtering by authors, but this functionality was removed in commit b02713f4d2773c76a6a28725afd59a0f4aa013a3.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)