### PR TITLE
Bump wagtail-sharing to version 2.10

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -33,7 +33,7 @@ wagtail-autocomplete==0.9.0
 wagtail-flags==5.3.0
 wagtail-inventory==2.1
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.9
+wagtail-sharing==2.10
 wagtail-treemodeladmin==1.7.0
 wagtailmedia==0.13
 


### PR DESCRIPTION
This commit bumps wagtail-sharing from 2.9 to 2.10.

https://github.com/cfpb/wagtail-sharing/releases/tag/2.10

This addresses internal D&CP#266.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)