### PR TITLE
fix missing margin on mobile

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_list.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_list.html
@@ -20,7 +20,7 @@
 
    ========================================================================== #}
 
-<aside class="m-jobs-list">
+<div class="m-jobs-list">
     {% if value.jobs %}
     <h3>Current openings</h3>
     <ul class="m-list m-list__unstyled m-list__links">
@@ -45,4 +45,4 @@
     {% else %}
     <h3 class='short-desc'>There are no current openings at this time.</h3>
     {% endif %}
-</aside>
+</div>

--- a/cfgov/unprocessed/css/on-demand/job_listing_list.less
+++ b/cfgov/unprocessed/css/on-demand/job_listing_list.less
@@ -14,3 +14,12 @@
     font-weight: normal;
   }
 }
+
+//adjust white space in job listing area on mobile
+.respond-to-max(@bp-xs-max, {
+  .o-sidebar-breakout_col {
+    .block.block__flush-top {
+      margin-bottom: 0
+    }
+  }
+});

--- a/cfgov/unprocessed/css/on-demand/job_listing_list.less
+++ b/cfgov/unprocessed/css/on-demand/job_listing_list.less
@@ -14,12 +14,3 @@
     font-weight: normal;
   }
 }
-
-//adjust white space in job listing area on mobile
-.respond-to-max(@bp-xs-max, {
-  .o-sidebar-breakout_col {
-    .block.block__flush-top {
-      margin-bottom: 0
-    }
-  }
-});

--- a/cfgov/unprocessed/css/organisms/sidebar-breakout.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-breakout.less
@@ -113,7 +113,6 @@
       width: 100%;
       &:last-child {
         padding-top: @margin__em;
-        border-top: 1px solid @gray-40;
       }
     }
 

--- a/cfgov/unprocessed/css/organisms/sidebar-breakout.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-breakout.less
@@ -109,11 +109,9 @@
 
     margin-bottom: @margin__em;
 
-    &_col {
+    &_col:last-child {
       width: 100%;
-      &:last-child {
-        padding-top: @margin__em;
-      }
+      margin-top: unit( (@grid_gutter-width * 2) / @base-font-size-px, em );
     }
 
     &_img-container {

--- a/cfgov/unprocessed/css/organisms/sidebar-breakout.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-breakout.less
@@ -109,9 +109,11 @@
 
     margin-bottom: @margin__em;
 
-    &_col:last-child {
+    &_col {
       width: 100%;
-      margin-top: unit( (@grid_gutter-width * 2) / @base-font-size-px, em );
+      &:last-child {
+        margin-top: unit( (@grid_gutter-width * 2) / @base-font-size-px, em );
+      }
     }
 
     &_img-container {

--- a/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
@@ -87,9 +87,7 @@
                             {% endif %}
                         {% endif %}
                     {% elif block.block_type in ['job_listing_list', 'related_posts'] %}
-                        <div class="block{{ ' block__flush-top' if loop.first else '' }}">
                             {% include_block block %}
-                        </div>
                     {% elif 'slug' in block.block_type %}
                         <header class="m-slug-header">
                             <h2 class="a-heading">

--- a/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/sidebar-breakout.html
@@ -51,7 +51,6 @@
                           content-l_col
                           content-l_col-1-3
                           block
-                          block__flush-top
                           block__flush-bottom">
                 {% for block in page.sidebar_breakout %}
                     {% if 'heading' in block.block_type %}


### PR DESCRIPTION
**Bug - Enterprise Issue 4502 (o-sidebar-breakout eliminates necessary margin on mobile between columns)**

------

o-sidebar-breakout is used on three pages:

https://www.consumerfinance.gov/about-us/careers/
https://www.consumerfinance.gov/find-a-housing-counselor/
https://www.consumerfinance.gov/rules-policy/

At mobile, there is a border between the items that stack at mobile, however, on two of these pages (housing counselor seems ok) block__flush-top is also applied, the margin is negated and the border sits against the block above it.

![image](https://github.com/cfpb/consumerfinance.gov/assets/130792942/c539b818-8131-4bda-95a9-968f1176101c)

![image](https://github.com/cfpb/consumerfinance.gov/assets/130792942/cc5a1562-8a57-432f-9bb3-8b704e235ed6)

-------

Note: CSS class "block__flush-top" is negating top margin at all times with the use of an !important tag. With flush-top removed, top margin is still applied via class .content-l_col. 

To test:

yarn build
visit previous urls and verify margin on mobile and no margin on desktop for element in question "aside.0-sidebar-breakout_col" 

http://localhost:8000/about-us/careers/
http://localhost:8000/rules-policy/