### PR TITLE
Retirement: hide tool on no-js

### DIFF
--- a/cfgov/retirement_api/jinja2/retirement_api/_templates/no_js.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/_templates/no_js.html
@@ -1,0 +1,11 @@
+<div class="m-notification
+            m-notification__error
+            u-hide-if-js">
+    {{ svg_icon('error-round') }}
+    <div class="m-notification_content">
+        <div class="h4 m-notification_message">
+            This tool is not supported in your browser.
+            Please try a newer browser or confirm that JavaScript is enabled.
+        </div>
+     </div>
+</div>

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -44,14 +44,14 @@
             </div>
         </div>
     </div>
+    {% include "_templates/no_js.html" %}
     <div class="step-one
               block
               block__padded-top
               block__border-top
-              block__flush-bottom">        
-
-              {% include "_templates/no_js.html" %}
-              <div class="content-l u-js-only">
+              block__flush-bottom
+              u-js-only">        
+              <div class="content-l">
                 <h2 class="content-l_col content-l_col-2-3"><strong>{{STEP}} 1: </strong>{{ _("Explore how the age you start collecting Social Security affects your retirement benefits") }}</h2>
                 <form id="step-one-form" name="step-one-form" action="#" class="content-l_col content-l_col-2-3">
                     <p class="h3 step-one-instructions">{{ _("Enter your information below to calculate your estimated benefits.") }}</p>

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -48,62 +48,64 @@
               block
               block__padded-top
               block__border-top
-              block__flush-bottom">
-        <div class="content-l">
-            <h2 class="content-l_col content-l_col-2-3"><strong>{{STEP}} 1: </strong>{{ _("Explore how the age you start collecting Social Security affects your retirement benefits") }}</h2>
-            <form id="step-one-form" name="step-one-form" action="#" class="content-l_col content-l_col-2-3">
-                <p class="h3 step-one-instructions">{{ _("Enter your information below to calculate your estimated benefits.") }}</p>
-                <div class="m-notification m-notification__warning">
-                    {{ svg_icon('warning-round') }}
-                    <div class="m-notification_content">
-                        <div class="h4 m-notification_message">Error message.</div>
-                    </div>
-                </div>
-                <div class="content-l">
-                    <div class="content-l_col content-l_col-1-3 birthdate-inputs">
-                        <p>{{ _("Date of birth") }}</p>
-                        <label for="bd-month" class="input-labels"><input id="bd-month" type="text" maxlength="2"
-                                placeholder="{{ _('MM') }}" value="" autocapitalize="none" autocomplete="off"
-                                autocorrect="off" spellcheck="false"></label>
-                        <label for="bd-day" class="input-labels"><input id="bd-day" type="text" maxlength="2"
-                                placeholder="{{ _('DD') }}" value="" autocapitalize="none" autocomplete="off"
-                                autocorrect="off" spellcheck="false"></label>
-                        <label for="bd-year" class="input-labels"><input id="bd-year" type="text" maxlength="4"
-                                placeholder="{{ _('YYYY') }}" value="" autocapitalize="none" autocomplete="off"
-                                autocorrect="off" spellcheck="false"></label>
-                    </div>
-                    <div class="content-l_col content-l_col-1-3">
-                        <label for="salary-input" class="input-labels">
-                            <span class="input-labels_block">{{ _("Highest annual work income") }} <span
-                                    data-tooltip-target="salary" aria-describedby="salary-tooltip">{{
-                                    svg_icon('help-round') }}</span></span>
-                            <input id="salary-input" type="text" placeholder="$" value="" autocapitalize="none"
-                                autocomplete="off" autocorrect="off" spellcheck="false"></label>
-                        <div class="tooltip-content" id="salary-tooltip" data-tooltip-name="salary" role="tooltip"
-                            aria-haspopup="true">
-                            <small>{{ _("Enter your total work income before taxes and other deductions. If your work income is 0 (zero) because you are now retired or unemployed, enter the income for the last full year in which you worked.") }}</small>
+              block__flush-bottom">        
+
+              {% include "_templates/no_js.html" %}
+              <div class="content-l u-js-only">
+                <h2 class="content-l_col content-l_col-2-3"><strong>{{STEP}} 1: </strong>{{ _("Explore how the age you start collecting Social Security affects your retirement benefits") }}</h2>
+                <form id="step-one-form" name="step-one-form" action="#" class="content-l_col content-l_col-2-3">
+                    <p class="h3 step-one-instructions">{{ _("Enter your information below to calculate your estimated benefits.") }}</p>
+                    <div class="m-notification m-notification__warning">
+                        {{ svg_icon('warning-round') }}
+                        <div class="m-notification_content">
+                            <div class="h4 m-notification_message">Error message.</div>
                         </div>
                     </div>
-                    <div class="content-l_col content-l_col-1-3">
-                        <button
-                            type="submit"
-                            id="get-your-estimates"
-                            class="get-your-estimates a-btn a-btn__disabled"
-                            disabled>
-                            {{ _("Get your estimates") }}
-                            <span id="api-data-loading-indicator">
-                                {{ svg_icon('updating') }}
-                            </span>
-                        </button>
+                    <div class="content-l">
+                        <div class="content-l_col content-l_col-1-3 birthdate-inputs">
+                            <p>{{ _("Date of birth") }}</p>
+                            <label for="bd-month" class="input-labels"><input id="bd-month" type="text" maxlength="2"
+                                    placeholder="{{ _('MM') }}" value="" autocapitalize="none" autocomplete="off"
+                                    autocorrect="off" spellcheck="false"></label>
+                            <label for="bd-day" class="input-labels"><input id="bd-day" type="text" maxlength="2"
+                                    placeholder="{{ _('DD') }}" value="" autocapitalize="none" autocomplete="off"
+                                    autocorrect="off" spellcheck="false"></label>
+                            <label for="bd-year" class="input-labels"><input id="bd-year" type="text" maxlength="4"
+                                    placeholder="{{ _('YYYY') }}" value="" autocapitalize="none" autocomplete="off"
+                                    autocorrect="off" spellcheck="false"></label>
+                        </div>
+                        <div class="content-l_col content-l_col-1-3">
+                            <label for="salary-input" class="input-labels">
+                                <span class="input-labels_block">{{ _("Highest annual work income") }} <span
+                                        data-tooltip-target="salary" aria-describedby="salary-tooltip">{{
+                                        svg_icon('help-round') }}</span></span>
+                                <input id="salary-input" type="text" placeholder="$" value="" autocapitalize="none"
+                                    autocomplete="off" autocorrect="off" spellcheck="false"></label>
+                            <div class="tooltip-content" id="salary-tooltip" data-tooltip-name="salary" role="tooltip"
+                                aria-haspopup="true">
+                                <small>{{ _("Enter your total work income before taxes and other deductions. If your work income is 0 (zero) because you are now retired or unemployed, enter the income for the last full year in which you worked.") }}</small>
+                            </div>
+                        </div>
+                        <div class="content-l_col content-l_col-1-3">
+                            <button
+                                type="submit"
+                                id="get-your-estimates"
+                                class="get-your-estimates a-btn a-btn__disabled"
+                                disabled>
+                                {{ _("Get your estimates") }}
+                                <span id="api-data-loading-indicator">
+                                    {{ svg_icon('updating') }}
+                                </span>
+                            </button>
+                        </div>
                     </div>
+                </form>
+                <div class="content-l_col content-l_col-1-3 estimate-info">
+                    <small>
+                        {{ _("The calculator bases your benefit estimate on current formulas from the Social Security Administration. Your answers are anonymous. Because we do not access or use your Social Security earnings record, these are rough estimates.") }}
+                    </small>
                 </div>
-            </form>
-            <div class="content-l_col content-l_col-1-3 estimate-info">
-                <small>
-                    {{ _("The calculator bases your benefit estimate on current formulas from the Social Security Administration. Your answers are anonymous. Because we do not access or use your Social Security earnings record, these are rough estimates.") }}
-                </small>
             </div>
-        </div>
     </div>
 
     <div id="estimated-benefits-description" class="estimated-benefits-description h3 step-one-hidden">


### PR DESCRIPTION
If the [before you claim retirement tool](https://www.consumerfinance.gov/consumer-tools/retirement/before-you-claim/) is in the no-js state the user can fill in the form inputs but can't click the "Get your estimates" button.

**PR TEST**
yarn build
http://localhost:8000/consumer-tools/retirement/before-you-claim/

![Screenshot 2023-08-18 at 2 48 38 PM](https://github.com/cfpb/consumerfinance.gov/assets/130792942/48d7be90-9555-45eb-b723-8c7f2aa3dc1e)
_**--disable javascript, reload and verify warning is displayed and that the retirement tool is hidden.**_