### PR TITLE
Mega Menu: Adjust icon width

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -430,7 +430,6 @@ body {
         display: inline;
         color: @pacific;
         margin-right: 6px;
-        width: 100%;
       }
     }
   }
@@ -1048,6 +1047,7 @@ body {
         & .cf-icon-svg {
           color: @gold;
           width: 100%;
+          max-width: unit( 16px / @base-font-size-px, rem );
         }
       }
 


### PR DESCRIPTION
In https://github.com/cfpb/design-system/pull/1699/files, we removed the max-width of the icons.
In the mega-menu we set the width of the icons to 100% https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/mega-menu.less#L433
Before the update to the DS, that was being constrained by the max-width of 1em (16px max). Without the max-width, it expanded out to 100% of the available area.

## Changes

- Mega Menu: Adjust icon width.


## How to test this PR

1. Pull branch, `yarn build`
2. Visit any page and check that the icons in the mega menu are correct across desktop and mobile.


## Screenshots

Before:

<img width="960" alt="Screenshot 2023-08-24 at 1 44 16 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d67e6ead-c7eb-44c7-b03f-854774d884d4">

<img width="607" alt="Screenshot 2023-08-24 at 1 43 46 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/4f59cecd-443b-43c0-97e2-8cfc0ab2e205">

After:

<img width="976" alt="Screenshot 2023-08-24 at 1 44 11 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/fe0f76d9-6ca2-4400-9fe7-1cdef035a6f1">

<img width="614" alt="Screenshot 2023-08-24 at 1 43 55 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/18c94f69-3362-4630-8b5e-a5d0b5dccc28">
