### PR TITLE
Fix missing jsdoc param

### DIFF
--- a/cfgov/unprocessed/js/modules/util/format.js
+++ b/cfgov/unprocessed/js/modules/util/format.js
@@ -65,7 +65,7 @@ function commaSeparate(numberString) {
 /**
  * @param {object} opts - The options object
  * @param {number|string} opts.amount - The number or string to be formatted
- * @param {number} decimalPlaces - Optionally specify the number of decimal places
+ * @param {number} opts.decimalPlaces - Optionally specify the number of decimal places
  *   you'd like in the returned string
  * @returns {string}      The number in USD format.
  */


### PR DESCRIPTION
Removes one linter warning.

## Changes

- Fix missing jsdoc param


## How to test this PR

1. `yarn lint` has 100 warnings vs 101 on `main`.
