### PR TITLE
Clarify comment about fallback database backend

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -303,10 +303,7 @@ WAGTAIL_USER_EDIT_FORM = "login.forms.UserEditForm"
 
 WAGTAILDOCS_SERVE_METHOD = "direct"
 
-# This is needed to maintain autocomplete search behavior in the Wagtail admin.
-# See https://github.com/wagtail/wagtail/issues/7720.
-# TODO: Remove once we're on Wagtail 4.2, where this should be fixed in
-# https://github.com/wagtail/wagtail/pull/9900.
+# This is used for easy autocomplete search behavior in the Wagtail admin.
 WAGTAILSEARCH_BACKENDS = {
     "default": {
         "BACKEND": "wagtail.search.backends.database.fallback",


### PR DESCRIPTION
(This PR is to the upgrade/wagtail-4.2 branch.)

We have a TODO comment in the code about something that can be removed in Wagtail 4.2, but it turns out that we can't actually remove this setting. If we want to maintain the easy (meaning: we don't need to worry about running a search index update job) substring search matching behavior in Wagtail admin search, we need to keep this setting even on Wagtail 4.2.

Instead of removing, I've instead clarified the comment.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)