### PR TITLE
Add "live" field to filterable search index

### DIFF
--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -23,6 +23,7 @@ class FilterablePagesDocument(Document):
     path = fields.KeywordField()
     depth = fields.IntegerField()
     title = fields.TextField(fields={"raw": fields.KeywordField()})
+    live = fields.BooleanField()
 
     start_date = fields.DateField()
     end_date = fields.DateField()

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -51,6 +51,7 @@ class FilterablePagesDocumentTest(TestCase):
                 "path",
                 "depth",
                 "title",
+                "live",
                 "start_date",
                 "end_date",
                 "language",


### PR DESCRIPTION
Currently the search index used for filterable pages does not include the `live` field which indicates whether a page is live or not. This means that search results could potentially include pages that aren't currently live.

We encountered this on internal issue D&CP#324, where unpublished pages appear in search results.

This commit adds the `live` field to the search index; a subsequent commit will actually use the field to filter pages once we have ensured that all environment indexes have been rebuilt.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)