### PR TITLE
Fix custom domain for S3 URLs

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -374,6 +374,7 @@ if os.environ.get("S3_ENABLED", "False") == "True":
     AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
     AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    AWS_S3_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN")
     MEDIA_URL = os.path.join(
         AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com", AWS_LOCATION, ""
     )


### PR DESCRIPTION
This commit restores the Django AWS_S3_CUSTOM_DOMAIN setting which was incorrectly removed in commit 853c948248b96850d20961e1e6569c6429f7f437.

Without this setting, S3 URLs are constructed like:

https://s3.amazonaws.com/files.consumerfinance.gov/something

where we want them to be instead constructed like:

https://files.consumerfinance.gov/something

This fix makes that happen.

Addresses internal D&CP#325.

## How to test this PR

To test this, you can run this command at the command line:

```sh
S3_ENABLED=True AWS_STORAGE_BUCKET_NAME=files.consumerfinance.gov AWS_ACCESS_KEY_ID=x AWS_SECRET_ACCESS_KEY=x AWS_S3_CUSTOM_DOMAIN=files.consumerfinance.gov cfgov/manage.py shell -c "from wagtail.documents import get_document_model; Document = get_document_model(); print(Document.objects.last().file.url)"
```

This prints out the URL of the most recent Wagtail document; on the main branch this will use the incorrect URL structure. With this commit the URL will be https://files.cf.gov as desired.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)