### PR TITLE
Wagtail data tables

### DIFF
--- a/cfgov/unprocessed/apps/admin/js/table.js
+++ b/cfgov/unprocessed/apps/admin/js/table.js
@@ -1,0 +1,122 @@
+class TableDefinition extends window.wagtailStreamField.blocks
+  .StructBlockDefinition {
+  render(placeholder, prefix, initialState, initialError) {
+    const block = super.render(placeholder, prefix, initialState, initialError);
+    const table = block.childBlocks.data;
+
+    // Create a new element with paste buttons.
+    const html = `
+        <div>
+            <label class="w-field__label">
+                Paste from clipboard
+            </label>
+            <div class="w-field__wrapper data-field-wrapper">
+                <button class="button button-small button-secondary paste-as-text">
+                    Create as text
+                </button>
+                <button class="button button-small button-secondary paste-as-rich-text">
+                    Create as rich text
+                </button>
+            </div>
+        </div>
+    `.trim();
+
+    const elem = document.createElement('template');
+    elem.innerHTML = html;
+
+    // Add the new buttons below the options block.
+    const optionsField = document.getElementById(prefix + '-options');
+    const optionsWrapper = optionsField.closest(
+      'div[data-contentpath="options"]',
+    );
+
+    const inserted = optionsWrapper.parentNode.insertBefore(
+      elem.content.firstChild,
+      optionsWrapper.nextSibling,
+    );
+
+    // Add click handlers to the buttons.
+    const buttonText = inserted.querySelector('.paste-as-text');
+    buttonText.addEventListener('click', this.getClickHandler(table, 'text'));
+
+    const buttonRichText = inserted.querySelector('.paste-as-rich-text');
+    buttonRichText.addEventListener(
+      'click',
+      this.getClickHandler(table, 'rich_text'),
+    );
+
+    return block;
+  }
+
+  getClickHandler(table, cellType) {
+    const that = this;
+
+    return function (event) {
+      navigator.clipboard.readText().then((clipText) => {
+        that.pasteFromClipboard(clipText, table, cellType);
+      });
+      event.preventDefault();
+    };
+  }
+
+  pasteFromClipboard(clipText, table, cellType) {
+    const rows = (clipText || '')
+      .replace(/^\n+|\n+$/g, '')
+      .split('\n')
+      .map((line) => line.split('\t'));
+
+    const numColumns = rows[0].length;
+
+    // There needs to be at least 2 rows and 2 columns.
+    if (rows.length < 2 || numColumns < 2) {
+      return;
+    }
+
+    if (!rows.every((row) => row.length == numColumns)) {
+      return;
+    }
+
+    table.clear();
+
+    // First add headings, then add data.
+    const newColumn = table.childBlockDefsByName[cellType];
+
+    const converters = {
+      text: function (text) {
+        return text;
+      },
+      rich_text: this.convertTextToDraftail,
+    };
+
+    const converter = converters[cellType];
+
+    for (let i = 0; i < numColumns; i++) {
+      table.insertColumn(i, newColumn);
+      table.columns[i].headingInput.value = rows[0][i];
+    }
+
+    for (let i = 1; i < rows.length; i++) {
+      table.insertRow(i - 1);
+      for (let j = 0; j < numColumns; j++) {
+        table.rows[i - 1].blocks[j].setState(converter(rows[i][j]));
+      }
+    }
+  }
+
+  convertTextToDraftail(text) {
+    return window.Draftail.createEditorStateFromRaw({
+      blocks: [
+        {
+          type: 'unstyled',
+          depth: 0,
+          text: text,
+          inlineStyleRanges: [],
+          entityRanges: [],
+        },
+      ],
+      entityMap: {},
+    });
+  }
+}
+
+window.telepath.register('v1.atomic_elements.tables.Table', TableDefinition);

--- a/cfgov/v1/atomic_elements/tables.py
+++ b/cfgov/v1/atomic_elements/tables.py
@@ -1,8 +1,11 @@
 from django import forms
+from django.utils.functional import cached_property
 
 from wagtail import blocks
+from wagtail.blocks.struct_block import StructBlockAdapter
 from wagtail.contrib.typed_table_block.blocks import TypedTableBlock
 from wagtail.documents.blocks import DocumentChooserBlock
+from wagtail.telepath import register
 
 from v1.blocks import HeadingBlock
 
@@ -101,3 +104,18 @@ class Table(blocks.StructBlock):
         icon = "table"
         template = "v1/includes/organisms/tables/base.html"
         unescape = False
+
+
+class TableAdapter(StructBlockAdapter):
+    js_constructor = "v1.atomic_elements.tables.Table"
+
+    @cached_property
+    def media(self):
+        media = super().media
+        return forms.Media(
+            js=media._js + ["apps/admin/js/table.js"],
+            css=media._css,
+        )
+
+
+register(TableAdapter(), Table)

--- a/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_tables.py
@@ -1,7 +1,7 @@
 from django.test import SimpleTestCase
 from django.utils.html import escape
 
-from v1.atomic_elements.tables import ContactUsTable
+from v1.atomic_elements.tables import ContactUsTable, TableAdapter
 
 
 class ContactUsTableTests(SimpleTestCase):
@@ -21,3 +21,10 @@ class ContactUsTableTests(SimpleTestCase):
 
         self.assertNotIn("<script>", html)
         self.assertIn("&lt;script&gt;", html)
+
+
+class TableTests(SimpleTestCase):
+    def test_table_adapter_media(self):
+        media = TableAdapter().media
+        self.assertFalse(media._css)
+        self.assertIn("apps/admin/js/table.js", media._js)

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -196,4 +196,46 @@ export class AdminPage {
     this.selectSubMenu('Page Metadata');
     return cy.get('.listing').find('tr');
   }
+
+  addSublandingPage() {
+    cy.visit('/admin/pages/add/v1/sublandingpage/1/');
+    cy.url().should('include', 'sublandingpage');
+  }
+
+  clickBlock(name) {
+    const block = `.action-add-block-${name}`;
+    cy.get(block).scrollIntoView();
+    cy.get(block).should('be.visible');
+    return cy.get(block).click();
+  }
+
+  addTable() {
+    cy.get('input[value="table"]', { timeout: 1000 }).should('not.exist');
+    this.clickBlock('table');
+    cy.get('input[value="table"]', { timeout: 1000 }).should('exist');
+  }
+
+  setClipboard(text) {
+    cy.window().its('navigator.clipboard').invoke('writeText', text);
+  }
+
+  getTableHeadingCell() {
+    return cy.get('input[name="content-0-value-data-column-0-heading"]');
+  }
+
+  getTableDataCell() {
+    return cy.get('input[name="content-0-value-data-cell-0-1"]');
+  }
+
+  getTableData() {
+    return '00\t01\n10\t11\n';
+  }
+
+  pasteTableAsText() {
+    cy.get('button.paste-as-text').click();
+  }
+
+  pasteTableAsRichText() {
+    cy.get('button.paste-as-rich-text').click();
+  }
 }


### PR DESCRIPTION
This commit adds the ability to create a Wagtail table by pasting data from the clipboard. It supports data copied from applications like Microsoft Word or Excel, or any table data delimited by newlines and tab characters. It adds two clickable buttons to our custom Table block in Wagtail: one to paste the table as text columns, and one to paste as rich text columns.

This feature requires use of the clipboard.read browser permission, which is supported in Google Chrome but not currently in Firefox. The first time you try to use this feature on a new domain, Chrome will pop up a permissions request asking users to confirm clipboard read permission.

This implements internal D&CP#314.

## Screenshots

![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/bd69225b-6755-4bdd-ad49-ed95ea40a048)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets