### PR TITLE
Customize JobListingPage admin display title

### DIFF
--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.db import models
+from django.template.defaultfilters import pluralize
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
@@ -216,6 +217,15 @@ class JobListingPage(CFGOVPage):
     objects = JobListingPageManager()
 
     template = "jobmanager/job_listing_page.html"
+
+    def get_admin_display_title(self):
+        title = super().get_admin_display_title()
+        grades = list(map(str, self.grades.all()))
+
+        if grades:
+            title += f" [Grade{pluralize(grades)} {', '.join(grades)}]"
+
+        return title
 
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)

--- a/cfgov/jobmanager/tests/models/test_pages.py
+++ b/cfgov/jobmanager/tests/models/test_pages.py
@@ -241,3 +241,18 @@ class JobListingPageTests(TestCase):
 
     def test_page_includes_extra_js(self):
         self.assertIn("summary.js", JobListingPage().page_js)
+
+    def test_get_admin_display_title(self):
+        page = JobListingPage(title="Director")
+        self.assertEqual(page.get_admin_display_title(), "Director")
+
+        grade53 = Grade(grade="53", salary_min=1, salary_max=2)
+        grade60 = Grade(grade="60", salary_min=1, salary_max=2)
+
+        page.grades = [grade53]
+        self.assertEqual(page.get_admin_display_title(), "Director [Grade 53]")
+
+        page.grades = [grade53, grade60]
+        self.assertEqual(
+            page.get_admin_display_title(), "Director [Grades 53, 60]"
+        )


### PR DESCRIPTION
This commit modifies the Wagtail admin display title of JobListingPages.

If a page has no grades assigned, its display title is unchanged. With one grade, the title will appear like "Title [Grade 53]". With multiple, it will appear like "Title [Grades 53, 60]".

Note that because of the way that Wagtail drafts work, this display title will unfortunately not always show the grades as of the latest Wagtail draft. It will show the _title_ as of the latest Wagtail draft, but the _grades_ portion will be fixed to the latest published version, or the first draft if the page has never been published.

Addresses internal D&CP#333.

## Screenshots

![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/fe7b6320-45d0-4ced-ada1-6a9313433821)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)