### PR TITLE
Don't strip file extensions from document and image titles

### DIFF
--- a/cfgov/unprocessed/apps/admin/js/global.js
+++ b/cfgov/unprocessed/apps/admin/js/global.js
@@ -12,3 +12,11 @@ const env = location.hostname.split('.')[0];
 
 const body = document.querySelector('body');
 body.setAttribute('data-env', env);
+
+// Modify default document title generation to keep file extensions.
+// See https://docs.wagtail.org/en/stable/advanced_topics/documents/title_generation_on_upload.html
+window.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener('wagtail:documents-upload', function (event) {
+    event.detail.data.title = event.detail.filename;
+  });
+});

--- a/cfgov/unprocessed/apps/admin/js/global.js
+++ b/cfgov/unprocessed/apps/admin/js/global.js
@@ -13,10 +13,14 @@ const env = location.hostname.split('.')[0];
 const body = document.querySelector('body');
 body.setAttribute('data-env', env);
 
-// Modify default document title generation to keep file extensions.
+// Modify default document/image title generation to keep file extensions.
 // See https://docs.wagtail.org/en/stable/advanced_topics/documents/title_generation_on_upload.html
+// and https://docs.wagtail.org/en/stable/advanced_topics/images/title_generation_on_upload.html.
 window.addEventListener('DOMContentLoaded', function () {
-  document.addEventListener('wagtail:documents-upload', function (event) {
+  const keepFilename = function (event) {
     event.detail.data.title = event.detail.filename;
-  });
+  };
+
+  document.addEventListener('wagtail:documents-upload', keepFilename);
+  document.addEventListener('wagtail:images-upload', keepFilename);
 });


### PR DESCRIPTION
By default Wagtail strips filename extensions when setting a document's title when it is first created. For example, uploading a file named "something-else.pdf" will create a document entitled "something-else".

As discussed on internal D&CP#323, we want to remove this behavior, and have document titles exactly match the original filename.

This commit makes that change, following the approach documented at https://docs.wagtail.org/en/stable/advanced_topics/documents/title_generation_on_upload.html.

Edit: after further internal discussion, I've added similar logic to image uploads, per the documentation at https://docs.wagtail.org/en/stable/advanced_topics/images/title_generation_on_upload.html.

## How to test this PR

To test locally, first rebuild your frontend assets using `./frontend.sh`. Then navigate to
http://localhost:8000/admin/documents/multiple/add/ and upload one or more files. Note that their extensions get persisted in the document title.

## Notes

Note that if Wagtail changes the underlying filename upon upload, for example because a file with the same exact name exists, the title field will be populated with the _original_ filename, not the modified one.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)