### PR TITLE
Disable verbose logging for django-axes

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -455,6 +455,7 @@ AUTHENTICATION_BACKENDS = (
     "django.contrib.auth.backends.ModelBackend",
 )
 AXES_ENABLED = True
+AXES_VERBOSE = False
 AXES_FAILURE_LIMIT = 5
 AXES_COOLOFF_TIME = 2  # Hours
 AXES_ONLY_USER_FAILURES = True


### PR DESCRIPTION
Our current configuration for [the django-axes package](https://github.com/jazzband/django-axes) uses its default setting for the `AXES_VERBOSE` Django setting, which is `True` if django-axes is enabled via `AXES_ENABLED`.

The verbose logging generates the following message every single time Django starts up, on every single management command, etc:

```
AXES: BEGIN version 5.41.0, blocking by username only
```

Verbose logging also logs failed/successful login attempts with greater level of detail, for example on failure:

```
AXES: User login failed, running database handler for failure.
AXES: Cleaned up 0 expired access attempts from database that were older than 2023-09-14 12:47:43.162182+00:00
AXES: New login failure by {username: "admin", ip_address: "127.0.0.1", user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36", path_info: "/admin/login/"}. Created new record in the database.
```

and on success:

```
AXES: Cleaned up 0 expired access attempts from database that were older than 2023-09-14 12:47:47.300292+00:00
AXES: Successful login by {username: "admin", ip_address: "127.0.0.1", user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36", path_info: "/admin/login/"}.
```

This PR disables verbose logging to keep our consoles a little tidier. This changes the above messages to remove the startup message and look like this on failure:

```
AXES: User login failed, running database handler for failure.
AXES: Cleaned up 0 expired access attempts from database that were older than 2023-09-14 12:48:08.292728+00:00
AXES: Repeated login failure by {username: "admin", path_info: "/admin/login/"}. Updated existing record in the database
```

and this on success:

```
AXES: Cleaned up 0 expired access attempts from database that were older than 2023-09-14 12:48:11.853921+00:00
AXES: Successful login by {username: "admin", path_info: "/admin/login/"}.
```

Note that the only difference is that the login details (IP address and user agent) are redacted from the log messages. These are still persisted in the Django database and can be reviewed in the admin, for example locally at http://localhost:8000/django-admin/axes/:

![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/0c66c468-9c58-476e-a068-401f18164797)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)