### PR TITLE
Build deployable artifact in GHA

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,6 +1,7 @@
 name: 'Build cf.gov artifact'
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -10,39 +11,43 @@ jobs:
   Build:
     if: github.repository == 'cfpb/consumerfinance.gov'
     runs-on: ubuntu-latest
+    env:
+      ARTIFACT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-            node-version: '16.x'
-
-      - name: Install dependencies
-        run: yarn
-
-      - name: Build frontend
-        run: yarn run build
-
-      - name: Run the build process with Docker
-        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
-        with:
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
-            image: ghcr.io/${{ github.repository }}-builder:main
-            options: -v ${{ github.workspace }}:/cfgov
-            run: |
-              source scl_source enable rh-python38
-              ./call_create.sh
-
-      - name: Upload arifact
-        uses: keithweaver/aws-s3-github-action@46dd0263ee582cbb2e81ad88209198d26d7a67c6
-        with:
-          command: cp
-          source: cfgov_current_build.zip
-          destination: s3://${{ secrets.BUCKET }}/cfgov_${{ github.sha }}_build.zip
-          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
-          aws_region: us-east-1
+      - name: echo
+        run: echo "$GITHUB_SHA / $ARTIFACT_SHA"
+      #      - name: Check out the repo
+      #        uses: actions/checkout@v3
+      #
+      #      - name: Set up Node
+      #        uses: actions/setup-node@v3
+      #        with:
+      #            node-version: '16.x'
+      #
+      #      - name: Install dependencies
+      #        run: yarn
+      #
+      #      - name: Build frontend
+      #        run: yarn run build
+      #
+      #      - name: Run the build process with Docker
+      #        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
+      #        with:
+      #            registry: ghcr.io
+      #            username: ${{ github.actor }}
+      #            password: ${{ secrets.GITHUB_TOKEN }}
+      #            image: ghcr.io/${{ github.repository }}-builder:main
+      #            options: -v ${{ github.workspace }}:/cfgov
+      #            run: |
+      #              source scl_source enable rh-python38
+      #              ./call_create.sh
+      #
+      #      - name: Upload arifact
+      #        uses: keithweaver/aws-s3-github-action@46dd0263ee582cbb2e81ad88209198d26d7a67c6
+      #        with:
+      #          command: cp
+      #          source: cfgov_current_build.zip
+      #          destination: s3://${{ secrets.BUCKET }}/cfgov_${{ github.sha }}_build.zip
+      #          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
+      #          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
+      #          aws_region: us-east-1

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   Build:
+    if: github.repository == 'cfpb/consumerfinance.gov'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn run build
 
       - name: Run the build process with Docker
-        uses: addnab/docker-run-action@v3
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
         with:
             registry: ghcr.io
             username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
               ./call_create.sh
 
       - name: Upload arifact
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@46dd0263ee582cbb2e81ad88209198d26d7a67c6
         with:
           command: cp
           source: cfgov_current_build.zip

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,47 @@
+name: 'Build cf.gov artifact'
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+            node-version: '16.x'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build frontend
+        run: yarn run build
+
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+            image: ghcr.io/${{ github.repository }}-builder:main
+            options: -v ${{ github.workspace }}:/cfgov
+            run: |
+              source scl_source enable rh-python38
+              ./call_create.sh
+
+      - name: Upload arifact
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: cfgov_current_build.zip
+          destination: s3://${{ secrets.BUCKET }}/cfgov_${{ github.sha }}_build.zip
+          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -14,40 +14,38 @@ jobs:
     env:
       ARTIFACT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
     steps:
-      - name: echo
-        run: echo "$GITHUB_SHA / $ARTIFACT_SHA"
-      #      - name: Check out the repo
-      #        uses: actions/checkout@v3
-      #
-      #      - name: Set up Node
-      #        uses: actions/setup-node@v3
-      #        with:
-      #            node-version: '16.x'
-      #
-      #      - name: Install dependencies
-      #        run: yarn
-      #
-      #      - name: Build frontend
-      #        run: yarn run build
-      #
-      #      - name: Run the build process with Docker
-      #        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
-      #        with:
-      #            registry: ghcr.io
-      #            username: ${{ github.actor }}
-      #            password: ${{ secrets.GITHUB_TOKEN }}
-      #            image: ghcr.io/${{ github.repository }}-builder:main
-      #            options: -v ${{ github.workspace }}:/cfgov
-      #            run: |
-      #              source scl_source enable rh-python38
-      #              ./call_create.sh
-      #
-      #      - name: Upload arifact
-      #        uses: keithweaver/aws-s3-github-action@46dd0263ee582cbb2e81ad88209198d26d7a67c6
-      #        with:
-      #          command: cp
-      #          source: cfgov_current_build.zip
-      #          destination: s3://${{ secrets.BUCKET }}/cfgov_${{ github.sha }}_build.zip
-      #          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
-      #          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
-      #          aws_region: us-east-1
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+            node-version: '16.x'
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build frontend
+        run: yarn run build
+
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+            image: ghcr.io/${{ github.repository }}-builder:main
+            options: -v ${{ github.workspace }}:/cfgov
+            run: |
+              source scl_source enable rh-python38
+              ./call_create.sh
+
+      - name: Upload arifact
+        uses: keithweaver/aws-s3-github-action@46dd0263ee582cbb2e81ad88209198d26d7a67c6
+        with:
+          command: cp
+          source: cfgov_current_build.zip
+          destination: s3://${{ secrets.BUCKET }}/cfgov_${{ env.ARTIFACT_SHA }}_build.zip
+          aws_access_key_id: ${{ secrets.BUILD_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.BUILD_SECRET_ACCESS_KEY }}
+          aws_region: us-east-1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -17,22 +17,7 @@ jobs:
             node-version: '16.x'
 
       - name: Install dependencies
-        run: |
-          yarn
+        run: yarn
 
       - name: Test Javascript
         run: yarn run test
-
-      - name: Build Javascript
-        run: yarn build
-
-      - name: Zip static files
-        uses: montudor/action-zip@v1
-        with:
-          args: zip -q -r frontend.zip ./cfgov/static_built
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: frontend_${{ github.sha }}
-          path: frontend.zip


### PR DESCRIPTION
This uses the centos package built in https://github.com/cfpb/consumerfinance.gov/pull/7732 to build our deployable zipfile and push it to S3, replacing the cf.gov-ansible-build and cf.gov-ansible-upload jenkins jobs. As such, this is blocked by #7732.

Testing is best done on a fork, where you will need to provide the appropriate secrets.