### PR TITLE
TDP: No results view should match results view

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -53,25 +53,23 @@
 
 <a class="skip-filters u-visually-hidden{% if not activities %} skip-filters__hidden{% endif %}" href="#tdp-search-results">Skip to search results</a>
 
-{% if page.results.total_results and page.results.total_results > 0 %}
-    <div class="results_count block__padded-bottom u-hide-on-med u-hide-on-lg u-hide-on-xl" data-results-count="{{ page.results.total_results }}">
-        <h3>
-            {% if page.results.total_activities > page.results.total_results %}
-                Showing {{ page.results.total_results }}
-                match{% if page.results.total_results > 1 %}es{% endif %}
-                out of
-            {% endif %}
-            {{ page.results.total_activities }} activities
-        </h3>
-    </div>
-{% else %}
-    <div class="results_count results_count__empty u-hide-on-med u-hide-on-lg u-hide-on-xl" data-results-count="0">
-        <h3>No results match your search.</h3>
-        <p class="u-mb15">Try a <a href="/consumer-tools/educator-tools/youth-financial-education/teach/activities/">new search</a> with different terms or filters.</p>
-    </div>
-{% endif %}
+<div class="results_count block__padded-bottom u-hide-on-med u-hide-on-lg u-hide-on-xl" data-results-count="{{ page.results.total_results }}">
+    {% if page.results.total_results %}
+    <h3>
+        {% if page.results.total_activities > page.results.total_results %}
+            Showing {{ page.results.total_results }}
+            match{% if page.results.total_results > 1 %}es{% endif %}
+            out of
+        {% endif %}
+        {{ page.results.total_activities }} activities
+    </h3>
+    {% else %}
+    <h3>No results match your search.</h3>
+    <p class="u-mb15">Try a new search with different terms or filters.</p>
+    {% endif %}
+</div>
 
-<aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters{% if not activities %} filters__hidden{% endif %}">
+<aside class="content_sidebar content__flush-top-on-small content__flush-sides-on-small filters">
     <h3 class="h2">Filter results by</h3>
     <form action="." method="get" data-js-hook="behavior_change-filter">
         <input type="hidden" name="q" value="{% if search_query: %}{{ search_query }}{% endif %}">
@@ -104,8 +102,7 @@
     </form>
 
 </aside>
-<section id="tdp-search-results" class="content_main content__flush-all-on-small content__flush-bottom results{% if not activities %} results__full{% endif %}" tabindex="-1">
-    <a class="u-visually-hidden" id="content_main"></a>
+<section id="tdp-search-results" class="content_main content__flush-all-on-small content__flush-bottom results" tabindex="-1">
     <div class="results_header">
         {% if page.results.total_results and page.results.total_results > 0 %}
             <div class="results_count u-hide-on-sm u-hide-on-xs" data-results-count="{{ page.results.total_results }}">
@@ -121,7 +118,7 @@
         {% else %}
             <div class="results_count results_count__empty u-hide-on-sm u-hide-on-xs" data-results-count="0">
                 <h3>No results match your search.</h3>
-                <p class="u-mb15">Try a <a href="/consumer-tools/educator-tools/youth-financial-education/teach/activities/">new search</a> with different terms or filters.</p>
+                <p class="u-mb15">Try a new search with different terms or filters.</p>
             </div>
         {% endif %}
         {% if show_filters %}

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
@@ -92,10 +92,6 @@
     }
   }
 
-  .filters__hidden {
-    display: none;
-  }
-
   .content_main {
     border: 0;
 


### PR DESCRIPTION
To address internal D&CP#347, this change modifies the TDP activity search view so that it has the same layout whether there are results or not. Specifically, if there are no results, this change keeps the facet sidebar and moves the "no results" text where the results would otherwise go.

## How to test this PR

To test locally, rebuild the frontend with `./frontend.sh`, make sure you have an up-to-date database and search index, and visit

http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/?grade_level=5&activity_duration=3&topic=8

Try the page on desktop and mobile; when on mobile, the UI is unchanged, as is the behavior when you tab through the page elements - the "Skip to search results" jump link does not appear when there are no results even though it does when there are results.

## Screenshots

|Before|After|
|-|-|
|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/638d4ea5-7885-4d21-97a6-d40feb76fec5)|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/157c1075-20df-415d-9e24-7ceaf56e0fa3)|

## Notes

I made the executive decision to remove the link from the "Try a new search" text since there's no need or reason to navigate to a different page, since all of the controls now appear right there.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)