### PR TITLE
Fix-up grid-based layout for mobile, 1-3, and 2-1

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout-1-3.less
+++ b/cfgov/unprocessed/css/enhancements/layout-1-3.less
@@ -36,7 +36,9 @@
       .u-layout-grid {
         &_wrapper {
           grid-auto-rows: minmax(0, auto) minmax(0, auto) 1fr;
-          grid-auto-columns: 1fr 3fr;
+          // Numbers below are 870 split into four parts
+          // 870 is the 900px breakpoint - 30px of gutters
+          grid-auto-columns: minmax(217.5px, 1fr) minmax(652.5px, 3fr);
           grid-template-areas:
             'c-breadcrumbs c-breadcrumbs'
             'c-secondary-nav c-main';
@@ -58,7 +60,9 @@
       .u-layout-grid {
         &_wrapper {
           grid-auto-rows: minmax(0, auto) minmax(0, auto) 1fr;
-          grid-auto-columns: 1fr 3fr;
+          // Numbers below are 870 split into four parts
+          // 870 is the 900px breakpoint - 30px of gutters
+          grid-auto-columns: minmax(217.5px, 1fr) minmax(652.5px, 3fr);
           grid-template-areas:
             'c-breadcrumbs c-breadcrumbs'
             'c-secondary-nav c-main';

--- a/cfgov/unprocessed/css/enhancements/layout-2-1.less
+++ b/cfgov/unprocessed/css/enhancements/layout-2-1.less
@@ -56,7 +56,9 @@
     // Desktop
     .respond-to-min( @bp-med-min, {
       .u-layout-grid_wrapper {
-          grid-auto-columns: 2fr 1fr;
+          // Numbers below are 870 split into three parts
+          // 870 is the 900px breakpoint - 30px of gutters
+          grid-auto-columns: minmax(580px, 2fr) minmax(290, 1fr);
           grid-template-areas:
             'c-hero c-hero'
             'c-breadcrumbs c-sidebar'

--- a/cfgov/unprocessed/css/enhancements/layout-base.less
+++ b/cfgov/unprocessed/css/enhancements/layout-base.less
@@ -14,6 +14,7 @@
         'c-main'
         'c-sidebar'
         'c-prefooter';
+      grid-auto-columns: 100%;
     }
 
     // Name all possible content area elements (appearing inside <main>).


### PR DESCRIPTION
## Changes:
### Adds mobile grid-auto-columns to keep wide content from breaking the grid

#### Before:
<img width="637" alt="Screenshot 2023-09-18 at 5 09 21 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/deba7eb9-e218-479e-833e-2a4e0499a0ac">

-----

#### After:
<img width="631" alt="Screenshot 2023-09-18 at 5 09 49 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/966a964c-52fe-41d7-9440-43b2eb52da46">

### Sets a minimum width on the column layouts to auto prevent grid breakage in either the sidebar or the main content

#### Before:
<img width="1665" alt="Screenshot 2023-09-18 at 4 59 09 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/ebefd35b-f359-4486-89c1-f1b981ac41db">
<img width="1442" alt="Screenshot 2023-09-18 at 5 00 36 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/5c1485bd-67fe-40df-ab55-46d579c7e4af">

-----

#### After:
<img width="1119" alt="Screenshot 2023-09-18 at 5 01 50 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/ccba4b42-c863-4ecc-b3e3-72b466328665">
<img width="1537" alt="Screenshot 2023-09-18 at 5 03 31 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/ad243bc1-879d-408a-a787-6087d84aaff9">

