### PR TITLE
Grid columns typo

### DIFF
--- a/cfgov/unprocessed/css/enhancements/layout-2-1.less
+++ b/cfgov/unprocessed/css/enhancements/layout-2-1.less
@@ -58,7 +58,7 @@
       .u-layout-grid_wrapper {
           // Numbers below are 870 split into three parts
           // 870 is the 900px breakpoint - 30px of gutters
-          grid-auto-columns: minmax(580px, 2fr) minmax(290, 1fr);
+          grid-auto-columns: minmax(580px, 2fr) minmax(290px, 1fr);
           grid-template-areas:
             'c-hero c-hero'
             'c-breadcrumbs c-sidebar'


### PR DESCRIPTION
Missed a stray `px` that is causing layout breakage.

Before:
<img width="1539" alt="Screenshot 2023-09-20 at 8 13 54 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/80d0db84-3a3e-493b-802d-1df653eb0905">

After:
<img width="1476" alt="Screenshot 2023-09-20 at 8 14 01 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/5d9c0a99-25dd-4a2c-91ea-a67467abce56">
