### PR TITLE
Add new domain for dap script to csp

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -519,6 +519,7 @@ CSP_SCRIPT_SRC = (
     "'unsafe-inline'",
     "'unsafe-eval'",
     "*.consumerfinance.gov",
+    "dap.digitalgov.gov",
     "*.googleanalytics.com",
     "*.google-analytics.com",
     "*.googletagmanager.com",


### PR DESCRIPTION
The move from GA4 to UA has come with a new domain, which is currently blocked by our CSP
<img width="700" alt="Screenshot 2023-09-22 at 9 04 35 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/942d63c1-3a6e-498d-a365-ceae5b83804b">

This fixes that.