### PR TITLE
Create sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+# Exclude SonarCloud scans of django auto-generated migration files.
+sonar.exclusions = cfgov/**/migrations/*.py


### PR DESCRIPTION
Add a config file for SonarCloud that excludes django auto-generated migration files from scans.

## Additions

- Create sonar-project.properties
 
## How to test this PR

1. Merge and we'll see…
