### PR TITLE
Remove `a-heading`

### DIFF
--- a/cfgov/ask_cfpb/tests/models/test_snippets.py
+++ b/cfgov/ask_cfpb/tests/models/test_snippets.py
@@ -27,7 +27,7 @@ class TestGlossaryTerm(TestCase):
         html = "<p>This is the text of the reusable snippet.</p>"
         block = ReusableTextChooserBlock(ReusableText)
         self.assertIn(
-            '<h2 class="a-heading">',
+            '<h2 class="h4">',
             block.render({"sidefoot_heading": sidefoot_heading, "text": html}),
         )
 
@@ -36,6 +36,6 @@ class TestGlossaryTerm(TestCase):
         html = "<p>This is the text of the reusable snippet.</p>"
         block = ReusableTextChooserBlock(ReusableText)
         self.assertNotIn(
-            '<h2 class="a-heading">',
+            '<h2 class="h4">',
             block.render({"sidefoot_heading": sidefoot_heading, "text": html}),
         )

--- a/cfgov/unprocessed/css/organisms/post-preview.less
+++ b/cfgov/unprocessed/css/organisms/post-preview.less
@@ -17,11 +17,8 @@
                     </span>
                 </div>
                 <div class="m-meta-header_left">
-                    <a href="/about-us/blog/?filter_blog_category=Info+for+Consumers" class="a-heading a-heading__icon">
-                        {{ svg_icon('information') }}
-                        <span class="u-visually-hidden">Category:</span>
-                        Info for Consumers
-                    </a>
+                    {{ svg_icon('information') }}
+                    Info for Consumers
                 </div>
             </div>
             <div class="o-post-preview_image-container">

--- a/cfgov/v1/jinja2/v1/includes/macros/category-slug.html
+++ b/cfgov/v1/jinja2/v1/includes/macros/category-slug.html
@@ -38,8 +38,7 @@
 
 {% macro _category_link(href) %}
     {% if href %}
-        <a href="{{ href }}"
-           class="a-heading a-heading__icon">
+        <a href="{{ href }}" class="h4">
     {% endif %}
        {{ caller() }}
     {% if href %}


### PR DESCRIPTION
`a-heading` was essentially just an h4 with different coloring. We should make heading links look like links.

## Removals

- Remove `a-heading`


## How to test this PR

1. Visit http://localhost:8000/activity-log/ and compare category links to production.
2. Visit http://localhost:8000/rules-policy/notice-opportunities-comment/open-notices/statement-of-policy-regarding-prohibition-on-abusive-acts-or-practices/ and compare category link to production.


## Screenshots

Before:
<img width="1358" alt="Screenshot 2023-09-27 at 4 51 52 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/7e8f9ba3-5513-43fb-a29a-65ecdfaa3fff">

After:
<img width="1240" alt="Screenshot 2023-09-27 at 4 51 44 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8efa3454-ff4a-470a-a0d4-d8c31ed8328c">
