### PR TITLE
Bump Wagtail version from 4.1.6 to 4.1.8

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==4.1.6
+wagtail==4.1.8


### PR DESCRIPTION
This change bumps the version of Wagtail from 4.1.6 to [4.1.8](https://docs.wagtail.org/en/v4.1.8/releases/4.1.8.html). This new patch release allows for a newer version of Pillow ([10.0.1](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.1.html)) that addresses [CVE-2023-4863](https://github.com/advisories/GHSA-j7hp-h8jx-5ppr).

This version was just released today.

This closes internal platform#4524.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)