### PR TITLE
Fix duplicate HTTP headers for Django responses

### DIFF
--- a/cfgov/apache/conf.d/headers.conf
+++ b/cfgov/apache/conf.d/headers.conf
@@ -5,8 +5,8 @@ LimitRequestFieldSize 8190
 KeepAlive On
 MaxKeepAliveRequests 500
 
-Header always set X-Frame-Options SAMEORIGIN
-Header always set X-Content-Type-Options: nosniff
+Header always setifempty X-Frame-Options SAMEORIGIN
+Header always setifempty X-Content-Type-Options nosniff
 
 # In prod, LIMIT_REQUEST_BODY is set to 100KB. In all other envs,
 # it is set to 0, meaning no limit.


### PR DESCRIPTION
Currently when Apache serves responses that come from Django, we see duplicate HTTP headers:

```
% curl -I https://www.consumerfinance.gov
...
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
...
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
```
...

When responses are served directly by Apache, we don't see this:

```
% curl -I https://www.consumerfinance.gov/code.json ...
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
...
```

This change modifies the Apache configuration to ensure that Apache only sets these headers if they are unset.

See https://httpd.apache.org/docs/2.4/mod/mod_headers.html for Apache documentation.

This fixes internal platform#4522.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)