### PR TITLE
Deprecate URL option for post preview template

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview-snapshot.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview-snapshot.html
@@ -23,10 +23,6 @@
 {% set num_posts = value.limit | int %}
 {% set posts = page.get_browsefilterable_posts(num_posts) if page else [] %}
 {% for post in posts %}
-    {{ post_preview.render(
-        post,
-        url=pageurl(post.get_parent().specific),
-        date_label=value.post_date_description
-    ) }}
+    {{ post_preview.render(post, date_label=value.post_date_description) }}
 {% endfor %}
 </div>

--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
@@ -42,9 +42,6 @@
    post.preview_link_text:  A string with the description text of an external link.
    post.preview_link_url:   A string with the url of an external link.
 
-   url: A string with the path for the homepage of the pagetype
-                              `/about-us/blog/`, `/about-us/newsroom/`
-
    show_categories: Whether to render categories for this post.
 
    show_date: Whether to render a date for this post.
@@ -59,7 +56,6 @@
 
 {% macro render(
     post,
-    url='',
     show_categories=true,
     show_date=true,
     date_label='',


### PR DESCRIPTION
~~As discussed on https://github.com/cfpb/consumerfinance.gov/pull/7974#issuecomment-1740989439, we want to deprecate the use of hyperlinked category labels in the header of the post preview template. That PR deprecated their use on most post previews; this change takes care of the remaining case in the PostPreviewSnapshot module template.~~

In  https://github.com/cfpb/consumerfinance.gov/pull/7974#issuecomment-1740989439 we deprecated the use of hyperlinked category labels in the header of the post preview template. That PR left behind an unused parameter in the template, which is cleaned up here.

## How to test this PR

~~This only impacts two pages on the production site:~~

~~https://www.consumerfinance.gov/compliance/amicus/~~
~~https://www.consumerfinance.gov/rules-policy/notice-opportunities-comment/~~

~~Compare locally:~~

~~http://localhost:8000/compliance/amicus/~~
~~http://localhost:8000/rules-policy/notice-opportunities-comment/~~

~~With this change, page categories will no longer be hyperlinks~~

Edit: my mistake; this change already happened in #7974. This is just cleaning up a parameter that now has no effect.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)