### PR TITLE
Show only last breadcrumb at mobile width

### DIFF
--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -15,6 +15,24 @@
     margin-left: unit(-20px / @base-font-size-px, rem);
   }
 
+  a:not(:last-of-type) {
+    display: none;
+  }
+
+  span {
+    display: none;
+  }
+
+  //Tablet and above
+  .respond-to-min( @bp-sm-min, {
+    a:not(:last-of-type) {
+      display: inline;
+    }
+    span {
+      display: inline;
+    }
+  } );
+
   // Desktop size.
   .respond-to-min( @bp-med-min, {
     padding-top: unit(30px / @base-font-size-px, rem);

--- a/cfgov/v1/jinja2/v1/includes/molecules/breadcrumbs.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/breadcrumbs.html
@@ -26,9 +26,9 @@
             {% endif %}
             {% if not loop.last %}
                 {% if language == 'ar' %}
-                \
+                <span>\</span>
                 {% else %}
-                /
+                <span>/</span>
                 {% endif %}
             {% endif %}
         {% endfor %}


### PR DESCRIPTION
[USWDS suggests](https://designsystem.digital.gov/components/breadcrumb/) that "a mobile-friendly breadcrumb may show only a page’s direct parent". This helps keep important content above the fold which is otherwise pushed down on some deeply nested pages with breadcrumbs.

Before:
<img width="199" alt="Screenshot 2023-10-04 at 3 46 18 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/96e68201-a6ac-4446-a7b8-2fea00eb92cf">

After:
<img width="194" alt="Screenshot 2023-10-04 at 3 45 40 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/442da1a9-7341-4dbd-b43c-1967b8a65892">

Breadcrumbs otherwise function identically to the status quo on tablet sizes and above.