### PR TITLE
Bump wagtail-inventory version from 2.1 to 2.3

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -31,7 +31,7 @@ s3transfer==0.5.2
 setuptools>=65.5.1
 wagtail-autocomplete==0.9.0
 wagtail-flags==5.3.0
-wagtail-inventory==2.1
+wagtail-inventory==2.3
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.10
 wagtail-treemodeladmin==1.7.0


### PR DESCRIPTION
This change bumps the version of our wagtail-inventory package from 2.1 to 2.3. This includes these releases:

- https://github.com/cfpb/wagtail-inventory/releases/tag/2.2
- https://github.com/cfpb/wagtail-inventory/releases/tag/2.3

This adds support for Django 4.2, adds ability to filter the block inventory report by page type, and adds the ability to grant access to the block inventory report to non-admins (which addresses internal D&CP#349).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)