### PR TITLE
Make multiselect expand to occupy space in filterable list control

### DIFF
--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -87,6 +87,7 @@
 @import (less) 'organisms/audio-player.less';
 @import (less) 'organisms/footer.less';
 @import (less) 'organisms/form.less';
+@import (less) 'organisms/filterable-list-controls.less';
 @import (less) 'organisms/full-width-text-group.less';
 @import (less) 'organisms/header.less';
 @import (less) 'organisms/info-unit-group.less';

--- a/cfgov/unprocessed/css/organisms/filterable-list-controls.less
+++ b/cfgov/unprocessed/css/organisms/filterable-list-controls.less
@@ -1,0 +1,18 @@
+.o-filterable-list-controls {
+  // The filterable list controls is an expandable, which uses a max-height
+  // transition that has the properties overflow:hidden and contain:paint set.
+  // This means nothing outside of the expandable bounds will be painted,
+  // which is good for performance, but is bad for things like drop-down menus
+  // that overflow the expandable bounds.
+  //
+  // The solution below makes the multiselect drop-down not "float", like it
+  // normally does, so that it expands to occupy space in the filterable list
+  // controls expandable, and therefore will not float outside of the controls'
+  // bounds.
+  // TODO: While this fixes the multiselect drop-down being cropped, it does
+  //       change the UX. A method to support overflowing the expandable bounds
+  //       while still retaining performance optimizations should be explored.
+  .o-multiselect_fieldset {
+    position: static;
+  }
+}


### PR DESCRIPTION
The multiselect was being cropped when it tried to expand outside the bounds of the filterable list controls. This PR makes it so that the expanded multiselect occupies space and therefore pushes the height of the filterable list control and does not spill outside of its bounds.


## Changes

- Make multiselect expand to occupy space in filterable list control


## How to test this PR

1. `yarn build` and run branch locally.
2. Visit a filterable list control with a multiselect, such as http://localhost:8000/data-research/cfpb-researchers/ or http://localhost:8000/blog/ and expand a multiselect and see that it increases the filterable list control height.

## Notes

This should probably be moved to the DS multiselect codebase.

## Screenshots

Before:

<img width="817" alt="Screenshot 2023-10-11 at 9 15 22 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/fa0f3d66-8c30-4f6d-90f7-5f7d9de0baae">

After:

<img width="787" alt="Screenshot 2023-10-11 at 9 19 43 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/36e4b814-c195-4be6-8f99-d0c0cc476954">


---


Before:
![filterable-list-before](https://github.com/cfpb/consumerfinance.gov/assets/704760/1f8e9435-d597-46bf-9789-01497b79feff)

After **(cropping is just the cropping of the gif, not the actual filterable list control)**:
![filterable-list](https://github.com/cfpb/consumerfinance.gov/assets/704760/40b22e5e-e9ba-4fac-963f-a29c9a779620)
