### PR TITLE
Shrink simple chart footnote to align with cct styles

### DIFF
--- a/cfgov/unprocessed/css/on-demand/simple-chart.less
+++ b/cfgov/unprocessed/css/on-demand/simple-chart.less
@@ -259,6 +259,7 @@
     max-width: unit(670 / @size-vi, rem);
     margin-top: unit(45 / @size-vi, em);
     padding-top: unit(15 / @size-vi, em);
+    font-size: 0.75em;
   }
 
   .cct {


### PR DESCRIPTION
Before:
![Screenshot 2023-10-17 at 9 54 47 AM](https://github.com/cfpb/consumerfinance.gov/assets/1558033/1aba3f35-b398-480a-9e4c-0870f6f3c8be)

After:
![Screenshot 2023-10-17 at 9 54 40 AM](https://github.com/cfpb/consumerfinance.gov/assets/1558033/9707a060-d21b-4d07-9bdc-b6f7c9a15fde)
