### PR TITLE
Fix: Prepaid agreement detail link redirects

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
@@ -2,7 +2,7 @@
 {% set default_text = 'No information provided' %}
 <article class="results_item">
     <h4 class="h3">
-        <a href="detail/{{result.id}}">{{ result.name }}</a>
+        <a href="{{ result.get_absolute_url() }}">{{ result.name }}</a>
     </h4>
     <div class="content-l">
         <div class="content-l_col content-l_col-1-2">

--- a/cfgov/prepaid_agreements/models.py
+++ b/cfgov/prepaid_agreements/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.urls import reverse
 
 
 class PrepaidProductQuerySet(models.QuerySet):
@@ -23,6 +24,11 @@ class PrepaidProduct(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse(
+            "prepaid_agreements:detail", kwargs={"product_id": self.pk}
+        )
 
     @property
     def most_recent_agreement(self):

--- a/cfgov/prepaid_agreements/tests/test_models.py
+++ b/cfgov/prepaid_agreements/tests/test_models.py
@@ -14,6 +14,13 @@ class TestPrepaidProducts(TestCase):
         self.assertIn(product1, valid_products)
         self.assertNotIn(product2, valid_products)
 
+    def test_get_absolute_url(self):
+        product = PrepaidProduct.objects.create()
+        self.assertEqual(
+            product.get_absolute_url(),
+            f"/data-research/prepaid-accounts/search-agreements/detail/{product.pk}/",
+        )
+
 
 class TestMostRecentAgreement(TestCase):
     """Test that the latest agreement is based on effective date.


### PR DESCRIPTION
Currently on [the prepaid agreements search page](https://www.consumerfinance.gov/data-research/prepaid-accounts/search-agreements/), detail links are rendered without a trailing slash, like:

/data-research/prepaid-accounts/search-agreements/detail/1234

These detail URLs are constructed manually in the page template. Because our site uses trailing slashes by default, all clicks to these detail URLs result in a redirect.

This commit modifies how those URLs are generated, using Django's get_absolute_url pattern, documented here:

https://docs.djangoproject.com/en/4.2/ref/models/instances/#get-absolute-url

This also adds a unit test for this behavior.

After this change, those detail links will render with a trailing slash, and users won't have to redirect to the actual detail page.

## How to test this PR

Visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and enjoy the trailing slashes on the detail page links.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)