### PR TITLE
Rate-checker chart label bugfixes

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -217,17 +217,8 @@
     }
   }
 
-  .data-label {
-    text-align: center;
-  }
-
   .data-label_number {
     background-color: @white;
-
-    .respond-to-max( @bp-xs-max, {
-      display: block;
-      transform: rotate( -90deg );
-    } );
   }
 
   .chart-caption {

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/RateCheckerChart.js
@@ -54,67 +54,12 @@ function RateCheckerChart() {
         type: 'column',
         animation: false,
       },
-      title: {
-        text: '',
-      },
-      xAxis: {
-        categories: [1, 2, 3, 4, 5],
-      },
-      yAxis: [
-        {
-          title: {
-            text: '',
-          },
-          labels: {
-            formatter: function () {
-              return this.value > 9 ? this.value + '+' : this.value;
-            },
-          },
-          max: 10,
-          min: 0,
-        },
-        {
-          title: {
-            text: 'Number of lenders offering rate',
-          },
-        },
-      ],
       series: [
         {
           name: 'Number of Lenders',
-          data: [1, 1, 1, 1, 1],
           showInLegend: false,
-          dataLabels: {
-            enabled: true,
-            useHTML: true,
-            crop: false,
-            overflow: 'none',
-            defer: true,
-            color: '#919395',
-            x: 2,
-            y: 2,
-            formatter: function () {
-              const point = this.point;
-              window.setTimeout(function () {
-                if (point.y > 9) {
-                  point.dataLabel.attr({
-                    y: -32,
-                    x: point.plotX - 24,
-                  });
-                }
-              });
-              return (
-                '<div class="data-label"><span class="data-label_number">' +
-                this.x +
-                '</span><br>|</div>'
-              );
-            },
-          },
         },
       ],
-      credits: {
-        text: '',
-      },
       tooltip: {
         useHTML: true,
         formatter: function () {

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
@@ -49,11 +49,7 @@ const HIGHCHARTS_SETTINGS = {
   xAxis: {
     minorTickInterval: null,
     labels: {
-      rotation: 0,
-      formatter: function () {
-        const val = this.value.slice(0, -1);
-        return Math.round(val * 10) / 10 + '%';
-      },
+      rotation: -90,
     },
     title: {
       style: {

--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/highcharts-theme.js
@@ -8,16 +8,28 @@ const HIGHCHARTS_SETTINGS = {
     backgroundColor: '#FFFFFF',
     marginRight: 25,
   },
+  title: {
+    text: '',
+  },
+  credits: {
+    enabled: false,
+  },
   yAxis: {
     labels: {
+      formatter: function () {
+        return this.value > 9 ? this.value + '+' : this.value;
+      },
       style: {
         color: '#BABBBD',
       },
     },
+    max: 10,
+    min: 0,
     minorTickInterval: null,
     gridLineColor: '#E3E4E5',
     tickWidth: 0,
     title: {
+      text: 'Number of lenders offering rate',
       style: {
         color: '#101820',
         fontSize: '16px',
@@ -35,11 +47,14 @@ const HIGHCHARTS_SETTINGS = {
     ],
   },
   xAxis: {
-    labels: {
-      enabled: false,
-    },
     minorTickInterval: null,
-    tickWidth: 0,
+    labels: {
+      rotation: 0,
+      formatter: function () {
+        const val = this.value.slice(0, -1);
+        return Math.round(val * 10) / 10 + '%';
+      },
+    },
     title: {
       style: {
         color: '#BABBBD',


### PR DESCRIPTION
This updates the rate-checker chart such that the labels have been moved to x-axis. This prevents reported disappearing of these labels and wonkiness on print.

<img width="807" alt="Screenshot 2023-11-07 at 2 45 16 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/8c34facf-5edd-43f3-99c5-9329c1f99cdc">


Testing:
 - Pull and build
 - Visit http://localhost:8000/owning-a-home/explore-rates/
 - Note that all bars have a label and that it's consistent at every screen size
 - Note that using "download chart" to get a PNG results in an image consistent with what's included in the webpage.