### PR TITLE
Remove frontend coverage action

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Test Javascript
         run: yarn run test
 
-      - name: Store test coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: frontend_coverage
-          path: ./test/unit_test_coverage/clover.xml
-
       - name: Build Javascript
         run: yarn build
 
@@ -42,33 +36,3 @@ jobs:
         with:
           name: frontend_${{ github.sha }}
           path: frontend.zip
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs:
-      - frontend
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.8
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/ci.txt
-
-      - name: Retrieve frontend coverage
-        uses: actions/download-artifact@v3
-        with:
-          name: frontend_coverage
-          path: frontend_coverage
-
-      - name: Check frontend test coverage
-        run: |
-          diff-cover frontend_coverage/clover.xml --compare-branch=origin/main --fail-under=100


### PR DESCRIPTION
We don't actually respect this or pay much attention to it. It isn't a blocker to merges, it's just noisy and adds time to CI.

I propose we remove the frontend coverage action until we have a specific reason for re-instituting it.