### PR TITLE
Fix: Prepaid agreement result link (again)

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_result_item.html
@@ -29,7 +29,7 @@
             </p>
             <div class="block block__sub">
                 <h5 class="h4 u-mb5">View all agreement files</h5>
-            <p><a href="detail/{{result.id}}">View all agreements for {{ result.name }}</a></p>
+            <p><a href="{{ result.get_absolute_url() }}">View all agreements for {{ result.name }}</a></p>
             </div>
         </div>
     </div>


### PR DESCRIPTION
As a follow up to commit fa1cebd6d02f54e7bb89a65423c71ae70e04dc88, this commit fixes one of the links on the prepaid agreements result view so that it uses better URL logic that ends in a trailing slash.

See #8000 for additional detail.

## How to test this PR

Run a local server and visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/. Confirm that the search results links "View all agreement files" goes to the same place as the result heading, and ends in a trailing slash. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)