### PR TITLE
Bugfix: Breadcrumbs, remove width

### DIFF
--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -10,13 +10,12 @@
   padding-top: unit(15px / @base-font-size-px, rem);
   padding-bottom: unit(15px / @base-font-size-px, rem);
   min-height: 33px;
-  width: calc(100vw - 65px);
 
   &_crumbs {
+    display: block;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    display: block;
   }
 
   // Desktop size.


### PR DESCRIPTION
The original breadcrumb update had breadcrumbs that could be collapsed down into an ellipsis. The width property was causing an issue where a horizontal scrollbar was appearing.

## Removals

- Breadcrumbs: remove width

## How to test this PR

1. Check some pages with breadcrumbs and they should wrap at smaller screen sizes and should not have a horizontal scrollbar:

http://localhost:8000/language/ar/coronavirus/mortgage-and-housing-assistance/help-for-homeowners/
http://localhost:8000/es/herramientas-del-consumidor/prestamos-para-vehiculos/respuestas/conozca-sus-derechos/
http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/


## Screenshots

Before: 

Can scroll to the right :(

<img width="1775" alt="Screenshot 2023-11-09 at 11 56 50 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/0316290b-f30e-4025-bd8c-aa23de6c08c2">

After: you can't scroll to the right.