### PR TITLE
TDP: convert category to event

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-analytics.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/tdp-analytics.js
@@ -4,12 +4,14 @@ import { analyticsSendEvent } from '@cfpb/cfpb-analytics';
  * Sends the user interaction to Analytics
  * @param {string} action - The user's action
  * @param {string} label - The label associated with the action
- * @param {string} category - Optional category if it's not eRegs-related
  * @returns {object} Event data
  */
-let sendEvent = (action, label, category) => {
-  category = category || 'TDP Search Tool';
-  const payload = { action, label, category };
+let sendEvent = (action, label) => {
+  const payload = {
+    event: 'TDP Search Tool',
+    action: action,
+    label: label,
+  };
   analyticsSendEvent(payload);
   return payload;
 };


### PR DESCRIPTION
Analytics reports that this should be an `event` instead of a `category`. Also, `sendEvent` never has a different category (event) sent in, so that doesn't need to be a parameter.


## Changes

- TDP: convert category to event


## How to test this PR

1. PR checks should pass. This will need to go to production and then the analytics team will need to check if it's working.
