### PR TITLE
Fix table Cypress tests against Wagtail 4.2

### DIFF
--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -209,14 +209,14 @@ export class AdminPage {
     addBlockButton.should('be.visible');
     addBlockButton.click();
 
-    const addTableOption = cy.contains('div.w-combobox__option', 'Table');
+    const addTableOption = cy.contains('div.w-combobox__option', name);
     addTableOption.should('be.visible');
     return addTableOption.click();
   }
 
   addTable() {
     cy.get('input[value="table"]', { timeout: 1000 }).should('not.exist');
-    this.clickBlock('table');
+    this.clickBlock('Table');
     cy.get('input[value="table"]', { timeout: 1000 }).should('exist');
   }
 

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -203,10 +203,15 @@ export class AdminPage {
   }
 
   clickBlock(name) {
-    const block = `.action-add-block-${name}`;
-    cy.get(block).scrollIntoView();
-    cy.get(block).should('be.visible');
-    return cy.get(block).click();
+    const addBlockButton = cy.get(
+      'div[data-contentpath="content"] .c-sf-add-button',
+    );
+    addBlockButton.should('be.visible');
+    addBlockButton.click();
+
+    const addTableOption = cy.contains('div.w-combobox__option', 'Table');
+    addTableOption.should('be.visible');
+    return addTableOption.click();
   }
 
   addTable() {


### PR DESCRIPTION
(This PR is to the upgrade/wagtail-4.2 branch.)

The Wagtail 4.2 release made changes to how the StreamField block UI is rendered, which broke our table-related Cypress tests that relied on a particular DOM structure.

This commit fixes those tests. To verify, run a local server and run:

`yarn cypress run --spec=test/cypress/integration/admin/admin.cy.js`

## Screenshots

|Wagtail 4.1 editing interface|Wagtail 4.2 editing interface|
|-|-|
|<img width="729" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/3531dc02-2c21-4810-ae29-41c9cb78a3be">|<img width="438" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/02bb92f5-df79-4ee6-9702-d65974bd1ecd">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)