### PR TITLE
Update VSCode Python formatter setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": false,
   "[python]": {
-    "editor.defaultFormatter": "ms-python.python"
+    "editor.defaultFormatter": "ms-python.black-formatter"
   }
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,7 +128,7 @@ to support easier code formatting.
 This repository includes a `.vscode/settings.json` file that sets the
 [Prettier extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 as the default code formatter. It also sets the
-[Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+[Black extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter)
 as the formatter for Python files.
 
 ### Install pre-commit


### PR DESCRIPTION
This repository's VSCode settings include specification of a default Python formatter. This points to the Python extension, which no longer includes formatters as per this change:

https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions

The black Python formatter is available through its own VSCode extension.

This change updates the VSCode settings along with our related documentation.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)