### PR TITLE
Broken link fixes from internal crawl

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -40,7 +40,7 @@
                             by calling 1-855-411-CFPB (2372).
                             You can also access a list of nationwide
                             HUD-approved counseling agencies at:
-                            https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm
+                            https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home
                         </p>
                     </div><!-- end .hud_hca_api_print-header -->
 
@@ -65,7 +65,7 @@
                                     offer independent advice, often at little or
                                     no cost to you. There is also a
                                     <a class="a-link a-link__icon"
-                                       href="https://apps.hud.gov/offices/hsg/sfh/hcc/hcs.cfm">
+                                       href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
                                         <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span></a>.
                                 </p>
                                 <p>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -88,7 +88,7 @@
         <h2 class="u-mt45">Explore related resources</h2>
         <ul>
             <li><a href="{{ page.get_related_activities_url() }}">Search for related CFPB activities</a></li>
-            <li><a href="https://www.fdic.gov/consumers/consumer/moneysmart/young.html" target="_blank" rel="noopener noreferrer">Find financial education lessons from FDIC</a></li>
+            <li><a href="https://www.fdic.gov/resources/consumers/money-smart/index.html" target="_blank" rel="noopener noreferrer">Find financial education lessons from FDIC</a></li>
             <li><a href="https://www.federalreserveeducation.org/" target="_blank" rel="noopener noreferrer">View financial education resources from the Federal Reserve</a></li>
         </ul>
     </div>


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
Our internal crawl tool revealed a couple of broken links that were hardcoded into HTML files. This PR corrects those. (Specifics in the "Changes" section below)

---

## Changes

- Updating the link to "Find financial education lessons from FDIC" on all TDP activity pages
- Updating the link to "list of nationwide HUD-approved counseling agencies" on the Housing Counselor tool


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance