### PR TITLE
Cleanup obsolete template-related settings

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -153,12 +153,9 @@ wagtail_extensions = [
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        # Look for Django templates in these directories
-        "DIRS": [PROJECT_ROOT.joinpath("templates")],
         # Look for Django templates in each app under a templates subdirectory
         "APP_DIRS": True,
         "OPTIONS": {
-            "builtins": [],
             "context_processors": [
                 "django.template.context_processors.debug",
                 "django.template.context_processors.request",


### PR DESCRIPTION
With the commits in PRs #8022 and #8024, this project no longer has a cfgov/templates directory. This allows us to remove its reference in the Django settings.

This commit also makes an unrelated bit of cleanup by removing the empty "builtins" option to the Django template engine.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)