### PR TITLE
Wrap expandable links in paragraph tag

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -63,6 +63,10 @@
                 {% for block in value.content %}
                     {% if 'paragraph' in block.block_type %}
                         {{ block.value | safe }}
+                    {% elif block.block_type == 'links' %}
+                        <p>
+                            {{ render_stream_child(block) }}
+                        </p>
                     {% else %}
                         {{ render_stream_child(block) }}
                     {% endif %}


### PR DESCRIPTION
This change alters the rendering of the Expandable block so that link tags are rendered inside of a `<p>..</p>` element. This prevents elements from incorrectly rendering directly next to each other.

See internal D&CP#392 for context.

## How to test this PR

To test, visit this page with a production dump to compare spacing around link elements with the production version:

http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/resources-research/building-block-activities-resources/

|Before|After|
|-|-|
|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/318391e3-fc5f-4f8a-bde2-67299889f085)|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/e76c4e76-1816-44b6-ae36-3942f3bb8445)|

Additionally, try adding two Links inside an Expandable to see that they are properly spaced.

|Before|After (ignore link visited color)|
|-|-|
|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/0a833188-93b4-4481-97c5-b7938be7979d)|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/f952c09b-ca60-455b-b218-403f6df29d94)|
|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/8fd7b544-d9d2-4c54-8329-c28e301f72ac)|![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/ffff3a88-8894-4109-8e89-f09530a21734)|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)