### PR TITLE
Post with fetch and load fetch data from post verify

### DIFF
--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -317,10 +317,18 @@ class VerifyViewTest(django.test.TestCase):
     url = reverse("paying_for_college:disclosures:verify")
 
     def test_verify_view(self):
-        resp = self.client.post(self.url, data=self.post_data)
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.post_data),
+            content_type="application/json",
+        )
         self.assertEqual(resp.status_code, 200)
         self.assertIn(b"Verification", resp.content)
-        resp2 = self.client.post(self.url, data=self.post_data)
+        resp2 = self.client.post(
+            self.url,
+            json.dumps(self.post_data),
+            content_type="application/json",
+        )
         self.assertEqual(resp2.status_code, 400)
         self.assertIn(b"already", resp2.content)
 
@@ -328,21 +336,35 @@ class VerifyViewTest(django.test.TestCase):
         post_data = copy.copy(self.post_data)
         post_data["iped"] = "408039"
         post_data["oid"] = "f38283b5b7c939a058889f997949efa566c616c4"
-        resp = self.client.post(self.url, data=post_data)
+        resp = self.client.post(
+            self.url, json.dumps(post_data), content_type="application/json"
+        )
         self.assertEqual(resp.status_code, 400)
 
     def test_verify_view_bad_id(self):
         self.post_data["iped"] = ""
-        resp = self.client.post(self.url, data=self.post_data)
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.post_data),
+            content_type="application/json",
+        )
         self.assertEqual(resp.status_code, 400)
 
     def test_verify_view_bad_oid(self):
         self.post_data["iped"] = "243197"
         self.post_data["oid"] = "f38283b5b7c939a058889f997949efa566script"
-        resp = self.client.post(self.url, data=self.post_data)
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.post_data),
+            content_type="application/json",
+        )
         self.assertEqual(resp.status_code, 400)
 
     def test_verify_view_no_data(self):
         self.post_data = {}
-        resp = self.client.post(self.url, data=self.post_data)
+        resp = self.client.post(
+            self.url,
+            json.dumps(self.post_data),
+            content_type="application/json",
+        )
         self.assertEqual(resp.status_code, 400)

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -301,7 +301,7 @@ def school_autocomplete(request):
 
 class VerifyView(View):
     def post(self, request):
-        data = json.loads(request.body.decode("utf-8"))
+        data = json.loads(request.body)
         timestamp = timezone.now()
         if data.get("oid") and validate_oid(data["oid"]):
             OID = data["oid"]

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -301,7 +301,7 @@ def school_autocomplete(request):
 
 class VerifyView(View):
     def post(self, request):
-        data = request.POST
+        data = json.loads(request.body)
         timestamp = timezone.now()
         if data.get("oid") and validate_oid(data["oid"]):
             OID = data["oid"]

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -301,7 +301,7 @@ def school_autocomplete(request):
 
 class VerifyView(View):
     def post(self, request):
-        data = json.loads(request.body)
+        data = json.loads(request.body.decode("utf-8"))
         timestamp = timezone.now()
         if data.get("oid") and validate_oid(data["oid"]):
             OID = data["oid"]

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/dispatchers/post-verify.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/dispatchers/post-verify.js
@@ -28,19 +28,19 @@ const postVerify = {
       URL: window.location.href,
     };
     const urlBase = document.querySelector('main').getAttribute('data-context');
-    const urlPath =
-      '/' + urlBase + '/understanding-your-financial-aid-offer/api/verify/';
+    const urlPath = `/${urlBase}/understanding-your-financial-aid-offer/api/verify/`;
     if (error === true) {
       postdata.errors =
         'INVALID: student indicated the offer information is wrong';
     }
 
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', urlPath, true);
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    xhr.send(JSON.stringify(postdata));
-
-    // $.post(urlPath, postdata);
+    fetch(urlPath, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(postdata),
+    });
   },
 };
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/utils/dollar-sign.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/utils/dollar-sign.js
@@ -111,7 +111,6 @@ Query.prototype.siblings = function (selector) {
   this.elements.forEach( ( elem)  => {
     let node = elem.parentNode.firstElementChild;
     for ( node; node !== null; node = node.nextElementSibling ) {
-      console.log( node );
       if ( node.matches( selector ) && node !== elem ) {
         elemArr.push( node );
       }


### PR DESCRIPTION
jquery does some magic massaging of post data which we tried to get around with xhr. However, django was expecting form-encoded data instead of post data. This PR:
 - loads the json data posted to the post-verify view (instead of trying to access form data on the `request.POST` object)
 - `POST`s with `fetch` for consistency with the other dispatchers
 - Removes a stray log
 
 ## Testing
 - Get a valid querystring and go through the step 1 -> step 2 flow
 - When confirming that ,you better understand your finances', note that there is no longer a `400` on `POST`ing