### PR TITLE
Fix data selector for negative cost

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -261,7 +261,9 @@ const financialView = {
     if (gap > 0) {
       positiveRemainingCost.show();
     } else if (overborrowing > 0) {
-      const $span = negativeRemainingCost.find('[data-financial="gap"]');
+      const $span = negativeRemainingCost.find(
+        '[data-financial="overborrowing"]',
+      );
       $span.text($span.text().replace('-', ''));
       negativeRemainingCost.show();
     }


### PR DESCRIPTION
Looks like there was a copy/paste error when converting from jquery. The correct selector when there is negative "remaining cost" is `'[data-financial="overborrowing"]'`