### PR TITLE
Change urlProgramLength presence check

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -279,10 +279,7 @@ const financialView = {
    */
   updateViewWithProgram: function (values, urlValues) {
     // Update program length
-    const lengthExists = Object.prototype.hasOwnProperty.call(
-      urlValues,
-      'urlProgramLength',
-    );
+    const lengthExists = !!urlValues.urlProgramLength;
     if (lengthExists) {
       this.$programLength.val(urlValues.urlProgramLength / 12).change();
     } else {


### PR DESCRIPTION
Previously, this check would allow program lengths of `0` provided in the URL to flow to the dropdown, which doesn't make sense and was causing the dropdown to be blank. This fixes that.

## Testing

 - With a valid url, add a `leng=0` and note it falls back to the default program value