### PR TITLE
[Dynamic Disclosures] FIx a currency formatting issue

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -55,7 +55,7 @@ const financialView = {
   $bigQuestion: $('.question'),
   $degreeType: $('.question [data-section="degreeType"]'),
   keyupDelay: null,
-  currentInput: null,
+  currentInput: 'none',
 
   /**
    * Initiates the object
@@ -200,12 +200,13 @@ const financialView = {
    * @param {object} $leftovers - jQuery object of the "leftover" elements
    */
   updateLeftovers: function (values, $leftovers) {
-    $leftovers.not('#' + financialView.currentInput).each((elem) => {
+    $leftovers.each((elem) => {
       const $ele = $(elem);
+      const elemId = $ele.attr('id') || 'noId';
       let currency = true;
       const name = $ele.attr('data-financial');
 
-      if (financialView.currentInput === $ele.attr('id')) {
+      if (financialView.currentInput === elemId) {
         currency = false;
       }
       if ($ele.attr('data-currency') === 'false') {
@@ -533,7 +534,7 @@ const financialView = {
   inputChangeListener: function () {
     const callback = function (elem) {
       clearTimeout(financialView.keyupDelay);
-      financialView.currentInput = $(elem).attr('id');
+      financialView.currentInput = $(elem).attr('id') || 'none';
       if (document.activeElement === elem) {
         financialView.keyupDelay = setTimeout(function () {
           financialView.inputHandler(financialView.currentInput);


### PR DESCRIPTION
There was a `null` case which caused some currency values to be improperly formatted. This should address the issue!

## Changes
  - Change code so that the `currentInput` value is not `null` and should not be assigned `null`
  - Change checks against the `currentInput` so that they will check properly against the current value

## How to test this PR
1. Check the values in Step 2 to make sure the currency values show with dollar signs and commas.

## Screenshots
This is what the app should look like with proper formatting:

<img width="422" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1490703/e399ea43-ed17-4d9c-8759-6d44e13cf31c">

<img width="827" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1490703/c2647ca8-7f2a-4b21-82a7-c36f1e14f17c">
