### PR TITLE
Pin Pillow to 10.1.0 to make Snyk happy

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -23,6 +23,7 @@ govdelivery==1.4.0
 Jinja2==3.1.2
 lxml==4.9.1
 opensearch-py==2.2.0
+Pillow==10.1.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.2
 regdown==1.0.7


### PR DESCRIPTION
Snyk reports a vulnerability in Pillow versions < 10.0.0. We don't pin Pillow, which means that Wagtail in practice pulls in the most recent version, which is greater than 10.0.0, BUT for some reason this doesn't satisfy Snyk.

Snyk keeps reporting this vulnerability on all of our cf.gov PRs. In order to make Snyk happy, let's pin Pillow to the currently installed version, which is 10.1.0.

## Screenshots

Here's what Snyk reports:

![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/0a76d050-e7ac-4baf-ada6-d4419f655cf3)

Even though in practice we are already getting Snyk 10.1.0:

```sh
$ /srv/cfgov/current/venv/bin/pip freeze | grep illow
Pillow @ file:///srv/cfgov/versions/20231129110504/wheels/Pillow-10.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl#sha256=fa1d323703cfdac2036af05191b969b910d8f115cf53093125e4058f62012c9a
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)