### PR TITLE
Remove unused ask_cfpb.views.annotate_links

### DIFF
--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -16,7 +16,6 @@ from ask_cfpb.models import (
     AnswerLandingPage,
     AnswerPage,
 )
-from ask_cfpb.views import annotate_links
 
 
 now = timezone.now()
@@ -156,30 +155,3 @@ class AnswerPagePreviewTestCase(TestCase):
     def test_redirect_view_with_no_recognized_facet(self):
         response = self.client.get("/askcfpb/search/?selected_facets=hoodoo")
         self.assertEqual(response.status_code, 404)
-
-
-class AnswerViewTestCase(TestCase):
-    def test_annotate_links(self):
-        mock_answer = (
-            '<p>Answer with a <a href="http://fake.com">fake link.</a></p>'
-        )
-        (annotated_answer, links) = annotate_links(mock_answer)
-        self.assertEqual(
-            annotated_answer,
-            '<html><body><p>Answer with a <a href="http://fake.com">fake '
-            "link.</a><sup>1</sup></p></body></html>",
-        )
-        self.assertEqual(links, [(1, str("http://fake.com"))])
-
-    def test_annotate_links_no_href(self):
-        mock_answer = "<p>Answer with a <a>fake link.</a></p>"
-        (annotated_answer, links) = annotate_links(mock_answer)
-        self.assertEqual(links, [])
-
-    def test_annotate_links_no_site(self):
-        site = Site.objects.get(is_default_site=True)
-        site.is_default_site = False
-        site.save()
-        with self.assertRaises(RuntimeError) as context:
-            annotate_links("answer")
-        self.assertIn("no default wagtail site", str(context.exception))

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -1,48 +1,15 @@
 import json
-from urllib.parse import urljoin
 
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import slugify
 
-from wagtail.models import Site
 from wagtailsharing.models import SharingSite
 from wagtailsharing.views import ServeView
 
-from bs4 import BeautifulSoup as bs
-
 from ask_cfpb.forms import AutocompleteForm, SearchForm, legacy_facet_validator
 from ask_cfpb.models import AnswerPage, AnswerPageSearch, AnswerResultsPage
-
-
-def annotate_links(answer_text):
-    """
-    Parse and annotate links from answer text.
-
-    Return the annotated answer
-    and an enumerated list of links as footnotes.
-    """
-    try:
-        _site = Site.objects.get(is_default_site=True)
-    except Site.DoesNotExist as err:
-        raise RuntimeError("no default wagtail site configured") from err
-
-    footnotes = []
-    soup = bs(answer_text, "lxml")
-    links = soup.findAll("a")
-    index = 1
-    for link in links:
-        if not link.get("href"):
-            continue
-        footnotes.append((index, urljoin(_site.root_url, link.get("href"))))
-        parent = link.parent
-        link_location = parent.index(link)
-        super_tag = soup.new_tag("sup")
-        super_tag.string = str(index)
-        parent.insert(link_location + 1, super_tag)
-        index += 1
-    return (str(soup), footnotes)
 
 
 def view_answer(request, slug, language, answer_id):


### PR DESCRIPTION
This commit removes the `ask_cfpb.views.annotate_links` view. It appears at some point this was intended to automatically generate footnote links for Ask CFPB answer text, but it was never fully implemented.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)