### PR TITLE
Add charset for js and css files in apache

### DIFF
--- a/cfgov/apache/conf/httpd.conf
+++ b/cfgov/apache/conf/httpd.conf
@@ -249,6 +249,8 @@ LogLevel info
     #
     AddType text/html .shtml
     AddOutputFilter INCLUDES .shtml
+
+    AddCharset UTF-8 .js .css
 </IfModule>
 
 #


### PR DESCRIPTION
This will make apache serve `Content-Type: application/javascript; charset=utf-8` (and similar for css) which will make some of our security scanning tools happy.