### PR TITLE
Don't index the constants object when initializing the financial model

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
@@ -41,7 +41,7 @@ const app = {
     getApiValues.initialData().then((resp) => {
       if (!resp) return;
       const [constants, expenses] = resp;
-      financialModel.init(constants[0]);
+      financialModel.init(constants);
       financialView.init();
       if (location.href.indexOf('about-this-tool') === -1) {
         expensesModel.init(expenses);


### PR DESCRIPTION
This fixes a bug that is causing the `$percent` elements to be rendered with incorrect values (any really anything depending on constants). I believe this crept in when merging the fetch branch into the big dynamic disclosures PR.

Before:
<img width="670" alt="Screenshot 2023-12-06 at 7 21 36 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/f7ed1634-6763-4992-8466-60707f141916">

After:
<img width="668" alt="Screenshot 2023-12-06 at 7 19 51 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/7273a872-e2aa-4b73-ae43-8c7266aa73d2">
