### PR TITLE
Move `u-reset` mixin to rate checker CSS

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -2,6 +2,13 @@
    "Rate checker" custom styles
    ========================================================================== */
 
+// Mixin to remove any default spacing or borders on an element.
+.u-reset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
 .rate-checker {
   position: relative;
 

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -3,7 +3,7 @@
    ========================================================================== */
 
 // Mixin to remove any default spacing or borders on an element.
-.u-reset {
+.u-reset() {
   border: 0;
   margin: 0;
   padding: 0;

--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -30,12 +30,6 @@
   width: 5%;
 }
 
-.u-reset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
 /* Used for cropping views in multi-level menus. */
 
 .u-hidden-overflow {


### PR DESCRIPTION
This class was intended as a general utility class, but was only used as a mixin in the rate checker. This PR moves it alongside the rest of the rate checker CSS.

## Changes

- Move `u-reset` mixin to rate checker CSS


## How to test this PR

1. Rate checker `.chart figure` and `next-steps-list` should be reset as before.
