### PR TITLE
Remove unused m-quote class

### DIFF
--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -67,8 +67,7 @@
     border-bottom: 1px solid @horizontal-rule;
   }
 
-  .m-full-width-text,
-  .m-quote {
+  .m-full-width-text {
     padding-top: unit(@grid_gutter-width / @base-font-size-px, em);
     padding-bottom: unit((@grid_gutter-width / 2) / @base-font-size-px, em);
     border-top: 1px solid @horizontal-rule;


### PR DESCRIPTION
As @anselmbradford pointed out to me, this is unused in markup and should be eliminated