### PR TITLE
Remove unused u-link__disabled utility

### DIFF
--- a/cfgov/unprocessed/css/enhancements/utilities.less
+++ b/cfgov/unprocessed/css/enhancements/utilities.less
@@ -44,13 +44,3 @@
 .u-invisible {
   visibility: hidden;
 }
-
-.u-link__disabled {
-  border: none !important;
-  color: @gray-40 !important;
-  cursor: not-allowed !important;
-
-  &.btn {
-    background-color: @gray-20 !important;
-  }
-}

--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -279,10 +279,6 @@ body {
     &-overview {
       display: block;
       border-bottom: 1px solid @gray-40;
-
-      .u-link__disabled {
-        color: @gray !important;
-      }
     }
 
     &-link,
@@ -495,16 +491,6 @@ body {
         padding-right: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
       }
 
-      // TODO: Remove when Consumer Tools and Ed Resources links are in.
-      // Overrides disabled link styles.
-      &-link.u-link__disabled {
-        color: @pacific !important;
-
-        &:hover {
-          color: @pacific-60 !important;
-          cursor: pointer !important;
-        }
-      }
     }
 
     // 2nd-level menu - Tablet/Mobile.


### PR DESCRIPTION
`u-link__disabled` is not used in any markup and so these rules should be removed.