### PR TITLE
Deprecate 3 unused Django settings

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -460,14 +460,7 @@ LOGOUT_REDIRECT_URL = "wagtailadmin_login"
 # override this based on the SAML_AUTH environment variable.
 SAML_AUTH = False
 
-# When we generate an full HTML version of the regulation, we want to
-# write it out somewhere. This is where.
-OFFLINE_OUTPUT_DIR = ""
-
 DATE_FORMAT = "n/j/Y"
-
-GOOGLE_ANALYTICS_ID = ""
-GOOGLE_ANALYTICS_SITE = ""
 
 # CDNs
 WAGTAILFRONTENDCACHE = {}


### PR DESCRIPTION
This commit deprecates 3 unused Django settings:

```
OFFLINE_OUTPUT_DIR = ''
GOOGLE_ANALYTICS_ID = ''
GOOGLE_ANALYTICS_SITE = ''
```

These were all added back in April 2016 (in commit b859cc8bce8e62666f4a8677186d63d2d04cd092) but as far as I can tell are not used anywhere. Therefore we can remove them.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)