### PR TITLE
Fix map not visible issue with Mortgage Performance Trends Cypress test

### DIFF
--- a/test/cypress/integration/data-research/mortgage-performance-trends/mortgage-performance-trends.cy.js
+++ b/test/cypress/integration/data-research/mortgage-performance-trends/mortgage-performance-trends.cy.js
@@ -15,6 +15,7 @@ onlyOn('local-machine', () => {
 
     it('should display delinquency rates by month for a given state', () => {
       trends.open();
+      cy.get('#mp-map').should('be.visible');
       trends.selectStateForDelinquencyRatesPerMonth('Virginia');
       trends.selectMonth('January');
       trends.selectYear('2017');


### PR DESCRIPTION
This test only runs on localhost and fails because the map has not loaded before the tests starts interacting with the controls. Ideally, the controls should probably not be actionable before the map shows up, but this test accommodates the status quo of how it currently works.

## Additions

- MPT test: Add check for the map before interacting with map drop-downs.

## How to test this PR

1. Pull branch and run `yarn cypress open` and run the mortgage performance trends test.
