### PR TITLE
Fix incorrect isort config

### DIFF
--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -6,9 +6,9 @@ from django.test import RequestFactory, TestCase
 from django.utils import timezone
 
 from wagtail.models import Site
-from wagtailsharing.models import SharingSite
 
 from model_bakery import baker
+from wagtailsharing.models import SharingSite
 
 from ask_cfpb.models import (
     ENGLISH_PARENT_SLUG,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -12,14 +12,14 @@ from django.views.generic.base import RedirectView, TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.contrib.sitemaps.views import sitemap
 from wagtail.documents import urls as wagtaildocs_urls
-from wagtailsharing import urls as wagtailsharing_urls
-from wagtailsharing.views import ServeView
 
 from flags.urls import flagged_re_path
 from flags.views import FlaggedTemplateView
 from wagtailautocomplete.urls.admin import (
     urlpatterns as autocomplete_admin_urls,
 )
+from wagtailsharing import urls as wagtailsharing_urls
+from wagtailsharing.views import ServeView
 
 from ask_cfpb.views import (
     ask_autocomplete,

--- a/cfgov/filing_instruction_guide/import_data_points.py
+++ b/cfgov/filing_instruction_guide/import_data_points.py
@@ -1,4 +1,5 @@
 import requests
+
 from filing_instruction_guide.data_point_models import DataFieldJson, DataPoint
 
 

--- a/cfgov/filing_instruction_guide/models.py
+++ b/cfgov/filing_instruction_guide/models.py
@@ -15,6 +15,8 @@ from wagtail.blocks import StreamBlock
 from wagtail.fields import StreamField
 
 import requests
+from modelcluster.models import ClusterableModel
+
 from filing_instruction_guide import import_data_points
 from filing_instruction_guide.blocks import (
     FigLevel3Subsection,
@@ -22,8 +24,6 @@ from filing_instruction_guide.blocks import (
     FigSubsection,
     content_block_options,
 )
-from modelcluster.models import ClusterableModel
-
 from v1.models.base import CFGOVPage
 
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -17,11 +17,11 @@ from django.template.response import TemplateResponse
 from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtail.fields import StreamField
-from wagtailsharing.models import ShareableRoutablePageMixin
 
 import requests
 from markupsafe import Markup
 from regdown import regdown
+from wagtailsharing.models import ShareableRoutablePageMixin
 
 from regulations3k.blocks import RegulationsListingFullWidthText
 from regulations3k.documents import SectionParagraphDocument

--- a/cfgov/retirement_api/urls.py
+++ b/cfgov/retirement_api/urls.py
@@ -1,6 +1,5 @@
-from retirement_api.views import estimator
-
 from core.views import TranslatedTemplateView
+from retirement_api.views import estimator
 
 
 try:

--- a/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
@@ -10,6 +10,7 @@ from unittest import mock
 from django.test import TestCase
 
 from bs4 import BeautifulSoup as bs
+
 from retirement_api import utils
 from retirement_api.utils.ss_update_stats import (
     make_soup,

--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -9,6 +9,7 @@ from unittest import mock
 import requests
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
+
 from retirement_api.utils.ss_calculator import (
     calculate_lifetime_benefits,
     clean_comment,

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 
 from wagtail.models import Page, Site
+
 from wagtailsharing.models import SharingSite
 
 from v1.models import HomePage

--- a/cfgov/v1/models/filterable_page.py
+++ b/cfgov/v1/models/filterable_page.py
@@ -4,6 +4,7 @@ from django.db import models
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.contrib.routable_page.models import route
 from wagtail.models import Site
+
 from wagtailsharing.models import ShareableRoutablePageMixin
 
 from v1.documents import FilterablePagesDocumentSearch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,35 +16,10 @@ line_length = 79
 lines_after_imports = 2
 skip = ["f", ".tox", "migrations", ".venv", "venv"]
 known_django = ["django"]
-known_wagtail = ["wagtail", "wagtailsharing"]
-known_first_party = [
-    "agreements",
-    "alerts",
-    "ask_cfpb",
-    "cfgov",
-    "core",
-    "data_research",
-    "deployable_zipfile",
-    "diversity_inclusion",
-    "form_explainer",
-    "hmda",
-    "housing_counselor",
-    "jobmanager",
-    "legacy",
-    "login",
-    "mega_menu",
-    "paying_for_college",
-    "permissions_viewer",
-    "prepaid_agreements",
-    "regulations3k",
-    "scripts",
-    "search",
-    "teachers_digital_platform",
-    "v1",
-    "wellbeing",
-    "youth_employment",
-]
-default_section = "THIRDPARTY"
+known_wagtail = ["wagtail"]
+src_paths = ["cfgov"]
+# Necessary due to the conflicting cfgov/jinja2 top-level template directory.
+known_third_party = ["jinja2"]
 sections = [
     "STDLIB",
     "DJANGO",


### PR DESCRIPTION
Our current isort config has a few issues:

1. `wagtailsharing` is classified as "known Wagtail" along with the `wagtail` package, but none of our other third-party Wagtail packages (like `wagtailinventory`) are similarly classified.
2. Our "first party" classification relies on a hardcoded list which is out of date, and doesn't include our `filing_instruction_guide` or `retirement_api` packages.

To address these and simplify in future, this commit migrates our isort configuration to use a new `src_paths` option that automatically treats any library under `/cfgov` as being first-party.

This does have one unfortunate complication, which is that the presence of our `/cfgov/jinja2` path would then shadow the third-party `jinja2` package that we use. For that reason we now have to explicily classify `jinja2` as being third-party.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)