### PR TITLE
Switch to dummyimage.com for local placeholder images

### DIFF
--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -108,10 +108,13 @@ if not os.environ.get("GOVDELIVERY_BASE_URL"):
     GOVDELIVERY_API = "core.govdelivery.LoggingMockGovDelivery"
 
 # Use a placeholder image service to replace images that are uploaded to S3
+_placeholder_domain = "dummyimage.com"
 WAGTAIL_PLACEHOLDERIMAGES_DUMMY = True
-WAGTAIL_PLACEHOLDERIMAGES_SOURCE = "//placekitten.com/{width}/{height}"
+WAGTAIL_PLACEHOLDERIMAGES_SOURCE = (
+    f"//{_placeholder_domain}/{{width}}x{{height}}/addc91/1fa040"
+)
 
-CSP_IMG_SRC += ("placekitten.com",)
+CSP_IMG_SRC += (_placeholder_domain,)
 
 # Add django-cprofile-middleware to enable lightweight local profiling.
 # The middleware's profiling is only available if DEBUG=True


### PR DESCRIPTION
This morning https://placekitten.com reports a DreamHost "site not found" error. This commit switches our local placeholder image service to https://dummyimage.com, which generates boxes of text with the image size overlaid.

This service has fewer kittens but does have the benefit of generating the same image each time the same URL is requested, unlike placekitten which generates a random kitten. This makes dummyimage nicer for visual regression testing.

## Screenshots

![image](https://github.com/cfpb/consumerfinance.gov/assets/654645/887b9bc8-8cc0-4723-8e37-d9f3b2754f8b)

## Notes and todos

I used Green 60 and Mid Dark Green from the design system palette [here](https://cfpb.github.io/design-system/foundation/color#data-visualization-palettes-1); please suggest a better combination if one is preferred!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)