### PR TITLE
Converts use of substr to slice, as substr has been deprecated

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/college-costs/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/college-costs/views/financial-view.js
@@ -48,9 +48,9 @@ const financialView = {
     this._financialItems.forEach((elem) => {
       if (!selectorMatches(elem, ':focus')) {
         const prop = elem.dataset.financialItem;
-        const isRate = prop.substr(0, 5) === 'rate_';
-        const isFee = prop.substr(0, 4) === 'fee_';
-        const isHours = prop.substr(-5, 5) === 'Hours';
+        const isRate = prop.slice(0, 5) === 'rate_';
+        const isFee = prop.slice(0, 4) === 'fee_';
+        const isHours = prop.slice(-5) === 'Hours';
         const isNumber = elem.dataset.isNumber === 'true';
         let val = getFinancialValue(prop);
 
@@ -123,8 +123,8 @@ function _handleInputChange(event) {
   clearTimeout(financialView._inputChangeTimeout);
   const elem = event.target;
   const name = elem.dataset.financialItem;
-  const isRate = name.substr(0, 5) === 'rate_';
-  const isFee = name.substr(0, 4) === 'fee_';
+  const isRate = name.slice(0, 5) === 'rate_';
+  const isFee = name.slice(0, 4) === 'fee_';
   let value = convertStringToNumber(elem.value);
 
   financialView._currentInput = elem;

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
@@ -81,7 +81,7 @@ const app = {
             questionView.init();
 
             // Update expenses model bases on region and salary
-            const region = schoolValues.BLSAverage.substr(0, 2);
+            const region = schoolValues.BLSAverage.slice(0, 2);
             $('#bls-region-select').val(region).change();
           });
       }

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -230,7 +230,7 @@ const financialView = {
 
       $fields.not('#' + financialView.currentInput).each((elem) => {
         const $ele = $(elem);
-        const index = Number(elem.getAttribute('id').substr(-1, 1));
+        const index = Number(elem.getAttribute('id').slice(-1));
         const key = $ele.attr('data-private-loan_key');
         let val = values.privateLoanMulti[index][key];
         const id = $ele.attr('id');
@@ -458,7 +458,7 @@ const financialView = {
         const elem = event.target;
         const $ele = elem.closest('[data-private-loan]');
 
-        const index = Number(elem.getAttribute('id').substr(-1, 1));
+        const index = Number(elem.getAttribute('id').slice(-1));
         $ele.remove();
         financialView.enumeratePrivateLoanIDs();
         publish.dropPrivateLoan(index);
@@ -521,7 +521,7 @@ const financialView = {
     if (privateLoanKey === null) {
       publish.financialData(key, value);
     } else {
-      const index = Number(elem.getAttribute('id').substr(-1, 1));
+      const index = Number(elem.getAttribute('id').slice(-1));
       publish.updatePrivateLoan(index, privateLoanKey, value);
     }
   },

--- a/cfgov/unprocessed/apps/retirement/js/data/index.js
+++ b/cfgov/unprocessed/apps/retirement/js/data/index.js
@@ -40,7 +40,7 @@ export function fetchApiData(birthdate, salary, dataLang) {
  */
 export function updateDataFromApi(resp) {
   const data = resp.data;
-  let fullAge = Number(data['full retirement age'].substr(0, 2));
+  let fullAge = Number(data['full retirement age'].slice(0, 2));
   if (resp.current_age > fullAge) {
     fullAge = resp.current_age;
   }
@@ -57,6 +57,6 @@ export function updateDataFromApi(resp) {
   benefits['fullRetirementAge'] = data['full retirement age'];
   benefits['earlyRetirementAge'] = data['early retirement age'];
   benefits['fullAge'] = Number(fullAge);
-  benefits['earlyAge'] = Number(data['early retirement age'].substr(0, 2));
+  benefits['earlyAge'] = Number(data['early retirement age'].slice(0, 2));
   benefits['monthsPastBirthday'] = Number(data.months_past_birthday);
 }

--- a/cfgov/unprocessed/apps/retirement/js/utils/num-to-money.js
+++ b/cfgov/unprocessed/apps/retirement/js/utils/num-to-money.js
@@ -1,5 +1,6 @@
 /**
  * Converts a number to a money string.
+ *
  * @param {number} num - A number to be converted.
  * @returns {string} money A string representing currency.
  */
@@ -17,7 +18,7 @@ function numToMoney(num) {
   const sign = num < 0 ? '-' : '';
 
   const numProc = String(
-    parseInt((num = Math.abs(Number(num) || 0).toFixed(0)), 10),
+    parseInt((num = Math.abs(Number(num) || 0).toFixed(0)), 10)
   );
   let groups = 0;
   if (numProc.length > 3) {
@@ -28,9 +29,9 @@ function numToMoney(num) {
 
   const separator = ',';
   if (groups > 0) {
-    money += numProc.substr(0, groups) + separator;
+    money += numProc.slice(0, groups) + separator;
   }
-  money += numProc.substr(groups).replace(/(\d{3})(?=\d)/g, '$1' + separator);
+  money += numProc.slice(groups).replace(/(\d{3})(?=\d)/g, '$1' + separator);
 
   return money;
 }

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
@@ -9,6 +9,7 @@ function resetFileName() {
 
 /**
  * Set a filename for a file input.
+ *
  * @param {string} fileName - A filename.
  */
 function setFileName(fileName) {
@@ -26,6 +27,7 @@ function resetError() {
 
 /**
  * Display an error message.
+ *
  * @param {string} message - An error message.
  */
 function setError(message) {
@@ -52,7 +54,7 @@ function getUploadName(fileName) {
  * @returns {boolean} - True if the file is a CSV, false otherwise.
  */
 function isCSV(fileName) {
-  return fileName.substr(fileName.lastIndexOf('.') + 1) === 'csv';
+  return fileName.slice(fileName.lastIndexOf('.') + 1) === 'csv';
 }
 
 export {

--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/AtomicComponent.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/AtomicComponent.js
@@ -23,6 +23,7 @@ const TAG_NAME = 'div';
  * Function as the constrcutor for the AtomicComponent.
  * Sets up initial instance properties and calls
  * necessary methods to properly instantiatie component.
+ *
  * @param {HTMLElement} element - The element to set as the base element.
  * @param {object} attributes - Hash of attributes to set on base element.
  */
@@ -41,6 +42,7 @@ function AtomicComponent(element, attributes) {
 Object.assign(AtomicComponent.prototype, new EventObserver(), {
   /**
    * Run through and call the component's initializers.
+   *
    * @returns {AtomicComponent} An instance.
    */
   init: function () {
@@ -76,6 +78,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to render a template in Single Page Applications.
+   *
    * @returns {AtomicComponent} An instance.
    */
   render: function () {
@@ -101,6 +104,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to set the base DOM element.
+   *
    * @param {HTMLElement} element - The element to set as the base element.
    * @returns {AtomicComponent} An instance.
    */
@@ -118,6 +122,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
   /* eslint-disable complexity */
   /**
    * Function used to set the cached DOM elements.
+   *
    * @returns {object} Hash of event names and cached elements.
    */
   setCachedElements: function () {
@@ -146,6 +151,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
   /**
    * Function used to remove the base element from the DOM
    * and unbind events.
+   *
    * @returns {boolean} True if successful in tearing down component.
    */
   destroy: function () {
@@ -162,6 +168,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to set the attributes on an element.
+   *
    * @param {object} attributes - Hash of attributes to set on base element.
    */
   setElementAttributes: function (attributes) {
@@ -179,6 +186,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
   /**
    * Function used to up event delegation on the base element.
    * Using Dom-delegate library to enable this functionality.
+   *
    * @param {object} events - Hash of events to bind to the dom element.
    * @returns {AtomicComponent} An instance.
    */
@@ -215,6 +223,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to set the attributes on an element.
+   *
    * @param {string} eventName - Event in which to listen for.
    * @param {string} selector - CSS selector.
    * @param {Function} listener - Callback for event.
@@ -228,6 +237,7 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to remove events from the base element.
+   *
    * @returns {AtomicComponent} An instance.
    */
   undelegateEvents: function () {
@@ -241,11 +251,12 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 
   /**
    * Function used to set the attributes on an element.
+   *
    * @param {string} prefix - String to use a prefix.
    * @returns {string} Prefixed unique id string.
    */
   uniqueId: function (prefix) {
-    return prefix + '_' + Math.random().toString(36).substr(2, 9);
+    return prefix + '_' + Math.random().toString(36).slice(2);
   },
 });
 
@@ -254,12 +265,14 @@ Object.assign(AtomicComponent.prototype, new EventObserver(), {
 /**
  * Function used to set the attributes on an element.
  * and unbind events.
+ *
  * @param {object} attributes - Hash of attributes to set on base element.
  * @returns {Function} Extended child constructor function.
  */
 function extend(attributes) {
   /**
    * Function used as constructor in order to establish inheritance chain.
+   *
    * @returns {AtomicComponent} An instance.
    */
   function child() {
@@ -286,6 +299,7 @@ function extend(attributes) {
 /**
  * Function used to instantiate all instances of the particular
  * atomic component on a page.
+ *
  * @param {HTMLElement} scope - Where to search for components within.
  * @returns {Array} List of AtomicComponent instances.
  */

--- a/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
+++ b/cfgov/unprocessed/js/organisms/MortgagePerformanceTrends/utils.js
@@ -133,7 +133,7 @@ const utils = {
    */
   getCountyState: (fips) => {
     // Grab the first two digits of the county's FIPS code.
-    fips = fips.substr(0, 2);
+    fips = fips.slice(0, 2);
     const usStates = {
       '01': 'AL',
       '02': 'AK',


### PR DESCRIPTION
All code is functionally equivalent except the uniqueId generated in the tdp atomic component, which will generate a uniqueId of variable length instead of always 9 chars (this doesn't matter in context though).