### PR TITLE
TDP: Remove redundant page title

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -1,9 +1,5 @@
 {% extends 'v1/layouts/layout-2-1.html' %}
 
-{% block title -%}
-    {{ page.title }} | Consumer Financial Protection Bureau
-{%- endblock title %}
-
 {% block css -%}
     {{ super() }}
 


### PR DESCRIPTION
`activity_page` extends `layout-2-1`, which extends `base`, which has an existing title section at https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/v1/jinja2/v1/layouts/base.html#L46-L51

The section removed in this PR appears redundant to that defined in the base template.

## Removals

- TDP: Remove redundant page title from activity_page template

## How to test this PR

1. Search `activity_page` in the crawler and see that pages from that result set viewed in this PR have an unchanged title.