### PR TITLE
Update oah-api version to include 2024 loan limit data

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -38,5 +38,5 @@ wagtail-treemodeladmin==1.8.0
 wagtailmedia==0.13
 
 # These packages are installed from GitHub.
-https://github.com/cfpb/owning-a-home-api/releases/download/0.17.3/owning_a_home_api-0.17.3-py3-none-any.whl
+https://github.com/cfpb/owning-a-home-api/releases/download/0.18.1/owning_a_home_api-0.18.1-py3-none-any.whl
 https://github.com/cfpb/ccdb5-api/releases/download/1.7.0/ccdb5_api-1.7.0-py3-none-any.whl


### PR DESCRIPTION
So that we have the correct values for 2024