### PR TITLE
Fix `test_get_retire_data_too_old` test: Change date of birth to 1/1

### DIFF
--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -570,7 +570,10 @@ class UtilitiesTests(unittest.TestCase):
 
     def test_get_retire_data_too_old(self):
         params = {}
-        params["yob"] = self.today.year - 71
+        too_old_birthday = self.today - relativedelta(years=71, days=1)
+        params["dobmon"] = too_old_birthday.month
+        params["dobday"] = too_old_birthday.day
+        params["yob"] = too_old_birthday.year
         results = self._get_retire_data(param_overrides=params)
         self.assertTrue("older than 70" in results["note"])
 

--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -81,7 +81,7 @@ class UtilitiesTests(unittest.TestCase):
             },
             "params": {
                 "dobmon": 1,
-                "dobday": 5,
+                "dobday": 1,
                 "yob": sample_year,
                 "earnings": 40000,
                 "lastYearEarn": "",

--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -81,7 +81,7 @@ class UtilitiesTests(unittest.TestCase):
             },
             "params": {
                 "dobmon": 1,
-                "dobday": 1,
+                "dobday": 5,
                 "yob": sample_year,
                 "earnings": 40000,
                 "lastYearEarn": "",


### PR DESCRIPTION
 This test was failing in the New Year.

## Changes

- Fix `test_get_retire_data_too_old` test: Change date of birth to 1/1


## How to test this PR

1. PR checks should pass.

