### PR TITLE
Fix Bandit linter warning

### DIFF
--- a/cfgov/v1/migrations/0015_grouppagepermission_index_fix.py
+++ b/cfgov/v1/migrations/0015_grouppagepermission_index_fix.py
@@ -22,7 +22,7 @@ DO $$ BEGIN
         ALTER TABLE {table_name} ADD CONSTRAINT {index_name} UNIQUE(group_id, page_id, permission_type);
     END IF;
 END $$;
-""".strip()  # nosec B608
+""".strip()  # nosec
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
We need "#nosec" here to prevent Bandit complaining about raw SQL. For some reason, probably because this is a multi-line string, this doesn't work right if we are more specific using "#nosec B608" instead.

As is this generates the following Bandit warning when you run "tox -e lint":

> WARNING nosec encountered (B608), but no failed test on line 18

Changing this to just "#nosec" correctly suppresses the warning.

## How to test this PR

`tox -e lint` -- note no Bandit warnings.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)