### PR TITLE
Fix Wagtail template override for 5.1 upgrade

### DIFF
--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,22 +1,15 @@
 {% load wagtailadmin_tags %}
-<div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %} {{ classes|join:' ' }}" data-dropdown>
-    <a href="javascript:void(0)" aria-label="{{ title }}" class="c-dropdown__button u-btn-current {{button_classes|join:' ' }}">
-        {{ label }}
-        <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon">
-            {% icon name="arrow-down" %}{% icon name="arrow-up" %}
-        </div>
-    </a>
-    <div class="t-dark">
-        <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
-            {% for button in buttons %}
-                {% if button.label != "Delete" %}
-                <li class="c-dropdown__item ">
-                    <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
-                        {{ button.label }}
-                    </a>
-                </li>
-                {% endif %}
-            {% endfor %}
-        </ul>
-    </div>
-</div>
+{% fragment as toggle_classname %}{{ classes|join:' ' }} {{ button_classes|join:' ' }}{% endfragment %}
+
+{% dropdown attrs=self.attrs toggle_icon="arrow-down" toggle_label=label toggle_aria_label=title toggle_classname=toggle_classname %}
+    {% for button in buttons %}
+    {% if button.label != "Delete" %}
+        <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="{{ button.classes|join:' ' }}">
+            {% if button.icon_name %}
+                {% icon name=button.icon_name %}
+            {% endif %}
+            {{ button.label }}
+        </a>
+    {% endif %}
+    {% endfor %}
+{% enddropdown %}


### PR DESCRIPTION
The recent upgrade to Wagtail 5.1 missed an update to one of their admin templates that we override. This new content comes from:

https://github.com/wagtail/wagtail/blob/v5.1.3/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html

To test, run a local server and visit http://localhost:8000/admin/pages/319/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)