### PR TITLE
Bugfix: Add `block content_modifiers`

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
@@ -16,7 +16,7 @@
 {% extends 'v1/layouts/base.html' %}
 
 {% block content scoped %}
-    <main class="content content__2-1 content__bleedbar"
+    <main class="content content__2-1 content__bleedbar {% block content_modifiers -%}{%- endblock %}"
           id="main">
         {% block hero -%}{%- endblock %}
         {% block pre_content scoped -%}


### PR DESCRIPTION
Follow up to https://github.com/cfpb/consumerfinance.gov/pull/8076/

The `block content_modifiers` didn't get carried over from `content-base.html` to `layout-2-1.html`, which broke some styling on the ask CFPB pages.


## Changes

- Adds `block content_modifiers` to `layout-2-1.html`.


## How to test this PR

1. Ask CFPB pages should have a properly styled "Last viewed" sections (see screenshots).


## Screenshots

Before:
<img width="759" alt="Screenshot 2024-01-09 at 11 47 12 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/b3e77337-b270-4962-bb5f-e5487d38b464">

After:
<img width="870" alt="Screenshot 2024-01-09 at 11 47 15 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/47fc7dd5-cf1c-4b3e-bf6b-7a1fb29156ec">

