### PR TITLE
Fix use of SKIP_DJANGO_MIGRATIONS without a DB

### DIFF
--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -35,14 +35,17 @@ class TestRunner(DiscoverSlowestTestsRunner):
     def setup_databases(self, **kwargs):
         dbs = super().setup_databases(**kwargs)
 
-        # Some required Wagtail data (like the default site) are created in
-        # Wagtail migrations. If we're skipping migrations when running tests,
-        # we need to create this data ourselves.
-        if settings.SKIP_DJANGO_MIGRATIONS:
-            self.initial_wagtail_data()
+        # If dbs is empty, it means we don't have a test database; this can
+        # happen if e.g. we're only running tests that don't require one.
+        if dbs:
+            # Some required Wagtail data (like the default site) are created in
+            # Wagtail migrations. If we're skipping migrations when running
+            # tests, we need to create this data ourselves.
+            if settings.SKIP_DJANGO_MIGRATIONS:
+                self.initial_wagtail_data()
 
-        # Set up our own additional required test data.
-        initial_data.run()
+            # Set up our own additional required test data.
+            initial_data.run()
 
         return dbs
 


### PR DESCRIPTION
Running `SKIP_DJANGO_MIGRATIONS=1 tox -e unittest` runs the Python unit tests without running migrations, as documented [here](https://cfpb.github.io/consumerfinance.gov/python-unit-tests/#running-tests).

If you try this to run a subset of tests that don't require a database (for example because they inherit from Django SimpleTestCase), you'll get a Django IntegrityError.

This commit fixes that by confirming that we're using a test database before trying to populate it with test data.

## Notes

This also fixes a bit of a bug here -- currently if you run with `SKIP_DJANGO_MIGRATIONS=1` against tests that don't require a database, the `initial_data` script gets run against _your local database_ -- not a test database (since one wasn't created). In practice this is usually a noop but this is still not a good thing to be doing when running tests!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)