### PR TITLE
Remove `m-related-posts__half-width`

### DIFF
--- a/cfgov/form_explainer/jinja2/form-explainer/index.html
+++ b/cfgov/form_explainer/jinja2/form-explainer/index.html
@@ -34,7 +34,7 @@
 
 {% if page.sidefoot %}
     <aside class="o-prefooter">
-        {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+        {{ streamfield_sidefoot.render(page.sidefoot) }}
     </aside>
 {% endif %}
 

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -295,7 +295,7 @@
     {% else %}
         {% if page.sidefoot %}
             <aside class="o-prefooter">
-                {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+                {{ streamfield_sidefoot.render(page.sidefoot) }}
             </aside>
         {% endif %}
     {% endif %}

--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -1,36 +1,16 @@
-@margin_half__em: unit(15px / @base-font-size-px, em);
-
-@list_half-width: {
-  .grid_nested-col-group();
-
-  .m-list_item {
-    .grid_column(6);
-  }
-
-  // Using .m-list__spaced items within a grid column causes unwanted
-  // extra margins because grid columns suppress margin collapsing.
-  // To counteract that we need to use a negative margin on the list.
-  // This means we also need to add a top margin to the first list
-  // item since the default .m-list__spaced only applies margins to
-  // .m-list_item + .m-list_item.
-  &.m-list__spaced {
-    margin-top: @margin_half__em * -1;
-
-    .m-list_item {
-      margin-top: @margin_half__em;
-    }
-  }
-};
-
-.m-related-posts__half-width {
-  .m-related-posts_list {
-    .respond-to-min(@bp-sm-min, {
-      @list_half-width();
-    });
-  }
-}
+@gap: unit(15px / @base-font-size-px, rem);
 
 .m-related-posts_list {
+  display: grid;
+  column-gap: @gap * 2;
+  row-gap: @gap;
+
+  grid-template-columns: repeat(
+    auto-fit,
+    // 230px is an arbitrary width for small screens.
+    minmax(230px, calc(50% - @gap))
+  );
+
   .m-list_link {
     .u-link__colors(@pacific, @pacific, @pacific-60, @pacific, @navy);
     .u-link__no-border();
@@ -42,25 +22,30 @@
 
   .m-list_item .a-date {
     margin-bottom: 0;
-    margin-top: unit(10px / @base-font-size-px, em);
+    margin-top: unit(10px / @base-font-size-px, rem);
   }
-  // Tablet only.
-  .respond-to-range(@bp-sm-min, @bp-sm-max, {
-    @list_half-width();
-  });
 }
 
 .m-related-posts_list-container {
-  margin-bottom: @margin_half__em * 2;
+  margin-bottom: @gap * 2;
 
   &:last-child {
     margin-bottom: 0;
   }
-
-  // Tablet only.
-  .respond-to-range(@bp-sm-min, @bp-sm-max, {
-    .m-related-posts_list {
-      .grid_nested-col-group();
-    }
-  });
 }
+// Mobile only.
+.respond-to-max(@bp-xs-max, {
+  // Always remove columns at mobile size.
+  .m-related-posts_list {
+    grid-template-columns: initial;
+  }
+});
+
+// Desktop and above.
+.respond-to-min(@bp-med-min, {
+  // If in the sidebar at desktop sizes, do not break into columns.
+  // Related posts also appear in the pre-footer, so we exclude that here.
+  .o-sidebar-content .m-related-posts_list {
+    grid-template-columns: initial;
+  }
+});

--- a/cfgov/v1/jinja2/v1/browse-basic/index.html
+++ b/cfgov/v1/jinja2/v1/browse-basic/index.html
@@ -38,7 +38,7 @@
 
     {% if page.sidefoot %}
         <aside class="o-prefooter">
-            {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+            {{ streamfield_sidefoot.render(page.sidefoot) }}
         </aside>
     {% endif %}
 

--- a/cfgov/v1/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/v1/jinja2/v1/browse-filterable/index.html
@@ -31,7 +31,7 @@
 
     {% if page.sidefoot %}
         <aside class="o-prefooter">
-            {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+            {{ streamfield_sidefoot.render(page.sidefoot) }}
         </aside>
     {% endif %}
 {% endblock %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-posts.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-posts.html
@@ -18,8 +18,7 @@
     {% if limit %}{% set posts = posts[ :limit | int ] %}{% endif %}
     <ul class="m-related-posts_list
                m-list
-               m-list__unstyled
-               m-list__spaced">
+               m-list__unstyled">
         {% for post in posts %}
             {% set post_url = post.url or '' %}
             <li class="m-list_item">
@@ -74,14 +73,10 @@
                             icon for each post sublist will be shown.
                             Optional, default false.
 
-   value.half_width:        Boolean indicating whether the posts should be at
-                            half width. Optional, default false.
-
    ========================================================================== #}
 
 {% macro render( value ) %}
-<div class="m-related-posts
-    {{'m-related-posts__half-width' if value.half_width else '' }}">
+<div class="m-related-posts">
     <header class="m-slug-header">
         <h2 class="m-slug-header_heading">
             {{ value.header_title }}
@@ -112,10 +107,6 @@
 {%- if value %}
 
 {# Consolidate additional context variables into the single "value" dict. #}
-
-{% if half_width is defined and not "half_width" in value %}
-    {% do value.update( { "half_width": half_width } ) %}
-{% endif %}
 
 {% if posts is defined and not "posts" in value %}
     {% do value.update( { "posts": posts } ) %}

--- a/cfgov/v1/jinja2/v1/includes/templates/streamfield-sidefoot.html
+++ b/cfgov/v1/jinja2/v1/includes/templates/streamfield-sidefoot.html
@@ -2,7 +2,7 @@
 {% import 'v1/includes/molecules/social-media.html' as social_media with context %}
 
 
-{% macro render(streamfield, half_width=false) %}
+{% macro render(streamfield) %}
     {% for block in streamfield %}
         {% if 'related_posts' in block.block_type %}
             <div class="block{{ ' block__flush-top' if loop.first else '' }}">

--- a/cfgov/v1/jinja2/v1/newsroom/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/index.html
@@ -34,7 +34,7 @@
 
     <aside class="o-prefooter">
         {% if page.sidefoot %}
-            {{ streamfield_sidefoot.render(page.sidefoot, half_width=true) }}
+            {{ streamfield_sidefoot.render(page.sidefoot) }}
         {% endif %}
         <div class="block
                     block__bg


### PR DESCRIPTION
Refactors the related posts to break into columns at (mostly) tablet width.

## Removals

- Remove `m-related-posts__half-width`


## Changes

- Refactor related posts CSS to use a responsive grid.


## How to test this PR

1. Visit a page with related posts in the pre footer, like http://localhost:8000/rules-policy/final-rules/
2. Scroll down till you see the related posts ("Further reading"). They should be two columns at tablet/desktop sizes, and a single column at mobile.
3. Visit a page with a related posts molecule in the sidefoot, such as http://localhost:8000/about-us/
2. Resize the page and observe that the related posts are a single column at desktop, two columns at tablet, and a single column again at mobile.


## Screenshots

Mobile:
<img width="287" alt="Screenshot 2024-01-09 at 5 28 54 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f8f54c27-6599-441e-a133-564da3f6d3ef">

Tablet:
<img width="830" alt="Screenshot 2024-01-09 at 5 29 04 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/13773ee5-0906-46a5-9564-f17c4316757c">

Desktop:
<img width="393" alt="Screenshot 2024-01-09 at 5 29 12 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/65f93815-cc91-4040-bc2a-eb982786c6d3">
