### PR TITLE
Reintroduce puerto rico and exclude it from aggregations

### DIFF
--- a/cfgov/data_research/data/states.csv
+++ b/cfgov/data_research/data/states.csv
@@ -38,6 +38,7 @@ fips,abbr,name
 40,OK,Oklahoma
 41,OR,Oregon
 42,PA,Pennsylvania
+72,PR,Puerto Rico
 44,RI,Rhode Island
 45,SC,South Carolina
 46,SD,South Dakota

--- a/cfgov/data_research/jinja2/data_research/mortgage-performance-downloads.html
+++ b/cfgov/data_research/jinja2/data_research/mortgage-performance-downloads.html
@@ -16,7 +16,7 @@
 <div class="o-full-width-text-group">
     <div class="m-full-width-text">
         <h2>The most recent data</h2>
-        <p>We recommend using the most recent data, which include the full time series and all revisions. These data cover {{ from_month_formatted }}&ndash;{{ thru_month_formatted }}.</p>
+        <p>We recommend using the most recent data, which include the full time series and all revisions. These data cover {{ from_month_formatted }}&ndash;{{ thru_month_formatted }}. In this update we use Connecticut’s new FIPS codes that changed in 2022 to nine county-equivalent boundaries.</p>
     </div>
 </div>
 

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -4,7 +4,7 @@ from django.db import models
 
 from dateutil import parser
 
-from data_research.mortgage_utilities.fips_meta import NON_STATES
+from data_research.mortgage_utilities.non_states import NON_STATES
 from v1.models import BrowsePage
 
 

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -4,6 +4,7 @@ from django.db import models
 
 from dateutil import parser
 
+from data_research.mortgage_utilities.fips_meta import NON_STATES
 from v1.models import BrowsePage
 
 
@@ -325,8 +326,9 @@ class NationalMortgageData(MortgageBase):
         }
         state_records = StateMortgageData.objects.filter(date=self.date)
         for state in state_records:
-            for field in count_fields:
-                count_fields[field] += getattr(state, field)
+            if state.state.abbr not in NON_STATES:
+                for field in count_fields:
+                    count_fields[field] += getattr(state, field)
         for field in count_fields:
             setattr(self, field, count_fields[field])
         self.save()

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -342,15 +342,14 @@ def load_states():
     with open("{}/states.csv".format(FIPS_DATA_PATH), "r") as f:
         reader = csv.DictReader(f)
         for row in list(reader):
-            if row["abbr"] not in NON_STATES:
-                states[row["abbr"]] = {
-                    "fips": row["fips"],
-                    "abbr": row["abbr"],
-                    "name": row["name"],
-                    "counties": [],
-                    "msas": [],
-                    "non_msa_counties": [],
-                }
+            states[row["abbr"]] = {
+                "fips": row["fips"],
+                "abbr": row["abbr"],
+                "name": row["name"],
+                "counties": [],
+                "msas": [],
+                "non_msa_counties": [],
+            }
 
     with open("{}/state_county_fips.csv".format(FIPS_DATA_PATH), "r") as f:
         reader = csv.DictReader(f)

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -6,20 +6,11 @@ from django.db import transaction
 
 from data_research.models import County, State
 
+from .non_states import NON_STATES
+
 
 PROJECT_ROOT = settings.PROJECT_ROOT
 FIPS_DATA_PATH = "{}/data_research/data".format(PROJECT_ROOT)
-
-# We have minimal data for smaller territories, so we exclude them.
-# For project launch, we also excluded Puerto Rico (72) as out of scope.
-NON_STATES = {
-    "AA": "00",
-    "MP": "69",
-    "AS": "60",
-    "VI": "78",
-    "GU": "66",
-    "PR": "72",
-}
 
 # Census no longer uses these FIPS codes, but they show up in the NMDB data.
 # For more details on stale FIPS and FIPS for territories, see

--- a/cfgov/data_research/mortgage_utilities/non_states.py
+++ b/cfgov/data_research/mortgage_utilities/non_states.py
@@ -1,0 +1,10 @@
+# We have minimal data for smaller territories, so we exclude them.
+# For project launch, we also excluded Puerto Rico (72) as out of scope.
+NON_STATES = {
+    "AA": "00",
+    "MP": "69",
+    "AS": "60",
+    "VI": "78",
+    "GU": "66",
+    "PR": "72",
+}

--- a/cfgov/data_research/scripts/update_county_msa_meta.py
+++ b/cfgov/data_research/scripts/update_county_msa_meta.py
@@ -1,11 +1,8 @@
 import logging
 
 from data_research.models import County, MetroArea, MortgageMetaData, State
-from data_research.mortgage_utilities.fips_meta import (
-    FIPS,
-    NON_STATES,
-    load_fips_meta,
-)
+from data_research.mortgage_utilities.fips_meta import FIPS, load_fips_meta
+from data_research.mortgage_utilities.non_states import NON_STATES
 
 
 logger = logging.getLogger(__name__)

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -41,7 +41,7 @@ class GeoValidationTests(django.test.TestCase):
             msas=["45300", "35840", "45220"],
         )
 
-        baker.make(
+        nj = baker.make(
             State,
             fips="34",
             name="New Jersey",
@@ -187,6 +187,7 @@ class GeoValidationTests(django.test.TestCase):
         baker.make(
             StateMortgageData,
             date=datetime.date(2016, 1, 1),
+            state=nj,
             fips="12",
             total="1000000",
             current="0",


### PR DESCRIPTION
Puerto Rico was excluded from the data list, but this was causing strange off-by-on errors in prod due to how data gets loaded between the load/deploy steps.

This reintroduces Puerto Rico but specifically guards against it in the aggregation, so https://github.com/cfpb/consumerfinance.gov/pull/8081#issuecomment-1881182258 should be avoided.

Also sneaks in a change to some language in a template.