### PR TITLE
Adjust `o-item-introduction`

### DIFF
--- a/cfgov/unprocessed/css/organisms/item-introduction.less
+++ b/cfgov/unprocessed/css/organisms/item-introduction.less
@@ -1,8 +1,8 @@
 .o-item-introduction {
-  margin-bottom: unit(@grid_gutter-width * 2 / @base-font-size-px, em);
+  margin-bottom: unit(@grid_gutter-width * 2 / @base-font-size-px, rem);
 
-  .short-desc {
-    padding-bottom: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
+  &_intro {
+    padding-bottom: unit(@grid_gutter-width / 2 / @base-font-size-px, rem);
   }
 
   .lead-paragraph {
@@ -10,7 +10,7 @@
   }
 
   .meta {
-    margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
+    margin-bottom: unit(@grid_gutter-width / @base-font-size-px, rem);
 
     .byline {
       .heading-4();

--- a/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
@@ -36,7 +36,9 @@
 
 <div class="o-item-introduction">
     {% if filter_page_url and page.categories.count() > 0 and value.show_category %}
-        {{ category_slug.render(category=page.categories.first().name, href=filter_page_url) }}
+        <div class="o-item-introduction_intro">
+            {{ category_slug.render(category=page.categories.first().name, href=filter_page_url) }}
+        </div>
     {% endif %}
 
     {% if value.heading -%}


### PR DESCRIPTION
`o-item-introduction` had a reference to an internal `short-desc`. If you check in the crawler, this class doesn't appear on pages with an item introduction (instead it's mostly used on charts). I believe once upon a time this was used to target the text above the heading in an item introduction. I converted it to an element of `o-item-introduction`. 


## Changes

- Change `.o-item-introduction .short-desc` to `.o-item-introduction_intro`


## How to test this PR

1. Check out localhost:8000/data-research/research-reports/financial-well-being-technical-report/ and see that the text above the heading is spaced out nicer.


## Screenshots

Before:
<img width="602" alt="Screenshot 2024-01-11 at 3 43 33 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d5fcf90d-8d5b-4084-8693-bf37f85bd591">

After:
<img width="602" alt="Screenshot 2024-01-11 at 3 43 22 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/9e6c1ea1-889e-41c3-a527-2596322be6b8">


