### PR TITLE
Retirement: Move language links to standard translation links module

### DIFF
--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -31,13 +31,20 @@
                 <p class="lead-paragraph">
                     {{ _("The age you claim Social Security affects your lifetime income. We’ll help you think through this decision.") }}
                 </p>
-                <p>
-                    {% if current_language == 'es' %}
-                    <a href="../">View page in English</a>
-                    {% else %}
-                    <a href="es/">Ver página en español</a>
-                    {% endif %}
-                </p>
+                {% set value = {
+                    'links': [
+                    {
+                        'href': '../',
+                        'language': 'en',
+                        'text': 'English'
+                    },{
+                        'href': 'es/',
+                        'language': 'es',
+                        'text': 'Spanish'
+                    }]
+                } %}
+                {% set temp = value.update({'language':'en'} if (current_language == 'en') else {'language':'es'} )%}
+                {% include "v1/includes/molecules/translation-links.html" %}
                 <div class="o-well">
                     {% if current_language == 'en' %}
                     <p>The Social Security Administration offers
@@ -65,7 +72,7 @@
               block__padded-top
               block__border-top
               block__flush-bottom
-              u-js-only">        
+              u-js-only">
               <div class="content-l">
                 <h2 class="content-l_col content-l_col-2-3"><strong>{{STEP}} 1: </strong>{{ _("Explore how the age you start collecting Social Security affects your retirement benefits") }}</h2>
                 <form id="step-one-form" name="step-one-form" action="#" class="content-l_col content-l_col-2-3">


### PR DESCRIPTION
Use standard language links module for language links in planning for retirement app.

## Changes

- Retirement: Move language links to standard translation links module


## How to test this PR

1. http://localhost:8000/consumer-tools/retirement/before-you-claim/ should have standard language links


## Screenshots

Before:
<img width="818" alt="Screenshot 2024-01-19 at 11 28 42 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/dfad331b-0d46-4eff-bec0-72fba58cab44">

After:
<img width="856" alt="Screenshot 2024-01-19 at 11 28 31 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8507124b-a0ad-460f-8d4c-816bd374e56c">


