### PR TITLE
Replace prop function

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -946,8 +946,9 @@ const financialView = {
         const $toggles = $('[data-repayment-section] input');
         const term = $ele.val();
         publish.financialData('repaymentTerm', term);
-        $toggles.prop('checked', false);
-        $toggles.filter('[value="' + term + '"]').prop('checked', true);
+        $toggles.elements.forEach((v) => {
+          v.value == term ? (v.checked = true) : (v.checked = false);
+        });
         financialView.updateView(getFinancial.values());
         expensesView.updateView(getExpenses.values());
         analyticsSendEvent({


### PR DESCRIPTION
There was a latent reference to the jquery `.prop` function, now replaced.

## Testing:
 - Go to a relevant page.
 - Click between 10 and 25yr loan terms in the sidebar
 - Values should update