### PR TITLE
Upgrade Wagtail from version 5.2.2 to version 5.2.3

### DIFF
--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==5.2.2
+wagtail==5.2.3


### PR DESCRIPTION
See release notes here:

https://docs.wagtail.org/en/latest/releases/5.2.3.html

Both of these changes are for Django 5.0 support so don't affect us, but it's good to stay on the latest patch version.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)