### PR TITLE
Fix admin/users error with UserListingButton

### DIFF
--- a/cfgov/permissions_viewer/wagtail_hooks.py
+++ b/cfgov/permissions_viewer/wagtail_hooks.py
@@ -40,7 +40,7 @@ def user_listing_buttons(context, user):
     yield UserListingButton(
         "View Permissions",
         reverse("permissions:user", args=[user.pk]),
-        classes={"button-secondary"},
+        classname="button-secondary",
         attrs={"title": "View permissions for this user"},
         priority=15,
     )


### PR DESCRIPTION
Wagtail 5.2 [removed the `classes` keyword argument to `UserListingButton`](https://github.com/wagtail/wagtail/commit/f3adefe362f1f5a13812ab57ec414f9add19591b). The `classname` argument is now used. This fixes this minor problem that's causing a 500 for /admin/users.

It looks like this is a tiny thing that we missed with the Wagtail 5.2 upgrade.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
