### PR TITLE
Raise anchors

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -667,6 +667,7 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
         "WIDGET": "wagtail.admin.rich_text.DraftailRichTextArea",
         "OPTIONS": {
             "features": [
+                "anchor-identifier",
                 "h2",
                 "h3",
                 "h4",
@@ -679,7 +680,6 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
                 "superscript",
                 "blockquote",
                 "link",
-                "anchor-identifier",
                 "document-link",
                 "image",
             ]


### PR DESCRIPTION
The `anchor-identifier` Draftail feature was not high up enough in the list of features. This meant that, when reading the HTML from the database and converting into Draftail's data format, anchors were being identified as regular links and presented as such in the rich text editor. Ultimately, this means that anchors were just becoming regular links *to* the anchor they used to be.

This fixes it by promoting the `anchor-identifier` feature to the top of the list; or, by raising the anchor.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)