### PR TITLE
Privacy: Remove inline styles

### DIFF
--- a/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
+++ b/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
@@ -40,7 +40,7 @@
 	    {% endfor %}
 	</div>
     {% endif %}
-    <div class="block block__flush-top">
+    <div class="block block__flush-top block__flush-bottom">
         <h1>Consent for disclosure of records protected under the Privacy Act</h1>
         <div class="lead-paragraph">
             <p>This form may be used to provide consent and authorize the CFPB to disclose your records to another person or entity. Please provide the information requested below and submit.</p>
@@ -71,12 +71,12 @@
         <p>This information is required for the CFPB to be able to match the individual's information provided in this request with the record that pertains to that individual.</p>
         <p><a class="a-btn a-btn__link" href="/privacy/system-records-notices/">See list of CFPB System of Records Notices (SORNs)</a></p>
     </div>
-    <div class="block" style="margin-top:-2em;margin-bottom:.9375em">
+    <div class="block block__flush-top block__padded-top">
         <form id="privacy-form"
               action="{{ url('privacy:disclosure_consent') }}"
               enctype="multipart/form-data"
               method="POST">
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                     <div class="m-form-field">
                         <label class="a-label a-label__heading"
@@ -121,7 +121,7 @@
 
             <h2>Contact information</h2>
             <p>Please provide your contact information so that we can correspond with you regarding the request.</p>
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <h3>Requestor contact information</h3>
                 <div class="o-form_group">
                     <div class="m-form-field">
@@ -144,7 +144,7 @@
                         {{ form.requestor_email }}
                     </div>
                 </div>
-                <h3 style="margin-top:45px;">Recepient contact information</h3>
+                <h3 class="u-mt45">Recepient contact information</h3>
                 <div class="o-form_group">
                     <div class="m-form-field">
                         <label class="a-label a-label__heading"
@@ -224,13 +224,13 @@
             </div>
 
             <h2>Supporting documentation (optional)</h2>
-            <p style="margin-bottom:15px">Identity verification documents:</p>
+            <p class="u-mb15">Identity verification documents:</p>
             <ul class="m-list">
                 <li class="m-list_item">A photocopy of two forms of identification, including one form of identification that bears your photograph, and one form of identification that bears your signature; or</li>
                 <li class="m-list_item">A photocopy of a single form of identification that bears both your photograph and signature</li>
             </ul>
             <p>If you are the parent consenting to and authorizing disclosure of the records of a minor or the legal guardian consenting to and authorizing disclosure of the records of an incompetent, you will be required to provide adequate proof of your legal relationship before action will be taken on any request.</p>
-            <div style="padding-bottom:30px" class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                   {% for error in form.supporting_documentation.errors %}
                       {{- notification.render( 'error', true, error ) }}
@@ -257,7 +257,7 @@
             </div>
 
             <h2>Consent for disclosure of records</h2>
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                     <div class="m-form-field m-form-field__checkbox">
                         {{ form.consent }}

--- a/cfgov/privacy/jinja2/privacy/records-access-form.html
+++ b/cfgov/privacy/jinja2/privacy/records-access-form.html
@@ -40,7 +40,7 @@
             {% endfor %}
         </div>
     {% endif %}
-    <div class="block block__flush-top">
+    <div class="block block__flush-top block__flush-bottom">
         <h1>Request for individual access to records protected under the Privacy Act</h1>
         <div class="lead-paragraph">
             <p>This form may be used to seek access to your records pursuant to the Privacy Act. Please provide the information requested below and submit.</p>
@@ -71,12 +71,12 @@
         <p>This information is required for the CFPB to be able to match the individual's information provided in this request with the records that pertain to that individual.</p>
         <p><a class="a-btn a-btn__link" href="/privacy/system-records-notices/">See list of CFPB System of Records Notices (SORNs)</a></p>
     </div>
-    <div class="block" style="margin-top:-2em;margin-bottom:.9375em">
+    <div class="block block__flush-top block__padded-top">
         <form id="privacy-form"
               action="{{ url('privacy:records_access') }}"
               enctype="multipart/form-data"
               method="POST">
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                     <div class="m-form-field">
                         <label class="a-label a-label__heading"
@@ -121,7 +121,7 @@
 
             <h2>Contact information</h2>
             <p>Please provide your contact information so that we can correspond with you regarding the request.</p>
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <h3>Requestor contact information</h3>
                 <div class="o-form_group">
                     <div class="m-form-field">
@@ -198,13 +198,13 @@
             </div>
 
             <h2>Supporting documentation (optional)</h2>
-            <p style="margin-bottom:15px">Identity verification documents:</p>
+            <p class="u-mb15">Identity verification documents:</p>
             <ul class="m-list">
                 <li class="m-list_item">A photocopy of two forms of identification, including one form of identification that bears your photograph, and one form of identification that bears your signature; or</li>
                 <li class="m-list_item">A photocopy of a single form of identification that bears both your photograph and signature</li>
             </ul>
             <p>If you are a parent seeking access to the records of a minor or a legal guardian seeking access to the records of an incompetent, you will be required to provide adequate proof of your legal relationship.</p>
-            <div style="padding-bottom:30px" class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                   {% for error in form.supporting_documentation.errors %}
                       {{- notification.render( 'error', true, error ) }}
@@ -230,7 +230,7 @@
                 </div>
             </div>
             <h2>Consent for release of records</h2>
-            <div class="o-well u-mb30">
+            <div class="o-well">
                 <div class="o-form_group">
                     <div class="m-form-field m-form-field__checkbox">
                         {{ form.consent }}


### PR DESCRIPTION
## Changes

- Privacy: Remove inline styles and replace with utility classes, where needed.


## How to test this PR

1. Visit these two pages and compare to production. 

http://localhost:8000/privacy/disclosure-consent/
http://localhost:8000/privacy/records-access/

Only difference should the increased gap at the bottom of the main content area.