### PR TITLE
Fix black linter issues

### DIFF
--- a/cfgov/paying_for_college/disclosures/scripts/api_utils.py
+++ b/cfgov/paying_for_college/disclosures/scripts/api_utils.py
@@ -12,6 +12,7 @@ from https://api.data.gov/signup/
 - api_key usage:
     https://api.data.gov/docs/api-key/
 """
+
 import os
 
 import requests

--- a/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
@@ -3,6 +3,7 @@ Update college data using the Dept. of Education's College Scorecard API.
 
 Scorecard documentation: https://collegescorecard.ed.gov/data/documentation/
 """
+
 import datetime
 import logging
 import os

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -1,4 +1,5 @@
 """Test the deployment http and static resource smoke tests."""
+
 import unittest
 from unittest import mock
 


### PR DESCRIPTION
`black` was autoupdated and led to linter failures on `main` https://black.readthedocs.io/en/stable/change_log.html#id1

## Changes

- Fix black linter issues
 

## How to test this PR

1. PR checks should pass.
