### PR TITLE
Update translation-links to use macro

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
@@ -35,7 +35,8 @@
             {{ page.question | striptags }}
         </h1>
 
-        {% include "v1/includes/molecules/translation-links.html" %}
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render() }}
     </div>
     <div class="block
                 block__flush-top">

--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
@@ -24,10 +24,12 @@
     <div class="content-l
                 block
                 block__flush-top">
+
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render({'modifier_classes': 'block__flush-top'}) }}
+
         <section class="ask-search block__sub block__flush-top">
             {{ ask_search.render( language=page.language, is_subsection=False ) }}
-
-            {% include "v1/includes/molecules/translation-links.html" %}
         </section>
 
         <section class="ask-categories">

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -31,7 +31,10 @@
                 <p class="lead-paragraph">
                     {{ _("The age you claim Social Security affects your lifetime income. We’ll help you think through this decision.") }}
                 </p>
-                {% set value = {
+
+                {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+                {{ translation_links.render({
+                    'language': 'en' if current_language == 'en' else 'es',
                     'links': [
                     {
                         'href': '../',
@@ -42,9 +45,7 @@
                         'language': 'es',
                         'text': 'Spanish'
                     }]
-                } %}
-                {% set temp = value.update({'language':'en'} if (current_language == 'en') else {'language':'es'} )%}
-                {% include "v1/includes/molecules/translation-links.html" %}
+                }) }}
                 <div class="o-well">
                     {% if current_language == 'en' %}
                     <p>The Social Security Administration offers

--- a/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
@@ -40,7 +40,8 @@
 {% if value.heading -%}
     <h1>{{ value.heading }}</h1>
 
-    {% include "v1/includes/molecules/translation-links.html" %}
+    {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+    {{ translation_links.render(value) }}
 {%- endif %}
 
 {% if value.intro.source %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -6,6 +6,8 @@
 
     value.links:    A list of translation links.
 
+    value.modifier_classes: classes to add to the translation links container.
+
     Each translation link should have:
 
     link.href:      Link URL.
@@ -26,31 +28,38 @@
 
     ======================================================================== #}
 
-{%- if page %}
-    {% set value = {
-        "language": ( language or page.language )| default( "en" ),
-        "links": page.get_translation_links( request ),
-    } %}
-{% endif -%}
+{% macro render(value={}) %}
 
-{%- if value.links and value.links|length > 1 %}
-<div class="block block__sub">
-    <ul dir="ltr" class="m-translation-links">
-        {%- for link in value.links %}
-            {%- set render_link = value.language and link.language != value.language %}
-            <li>
-            {%- if render_link %}
-                <a href="{{ link.href }}"
-                lang="{{ link.language }}"
-                hreflang="{{ link.language }}"
-                translate="no">
-            {%- endif %}
-            {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
-            {% if render_link %}
-                </a>
-            {% endif -%}
-            </li>
-        {% endfor -%}
-    </ul>
-</div>
-{%- endif %}
+    {%- if page is defined and not value.language or not value.links %}
+        {%- if value is not defined %}
+            {% set value = {} %}
+        {%- endif %}
+
+        {% set temp = value.update({
+            'language': ( language or page.language )| default( "en" ),
+            'links': page.get_translation_links( request ),
+        }) %}
+    {%- endif %}
+
+    {%- if value.links and value.links|length > 1 %}
+    <div class="block block__sub {{ value.modifier_classes }}">
+        <ul dir="ltr" class="m-translation-links">
+            {%- for link in value.links %}
+                {%- set render_link = value.language and link.language != value.language %}
+                <li>
+                {%- if render_link %}
+                    <a href="{{ link.href }}"
+                    lang="{{ link.language }}"
+                    hreflang="{{ link.language }}"
+                    translate="no">
+                {%- endif %}
+                {%- language link.language %}{{- _( link.text ) -}}{% endlanguage -%}
+                {% if render_link %}
+                    </a>
+                {% endif -%}
+                </li>
+            {% endfor -%}
+        </ul>
+    </div>
+    {%- endif %}
+{% endmacro %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -31,10 +31,6 @@
 {% macro render(value={}) %}
 
     {%- if page is defined and not value.language or not value.links %}
-        {%- if value is not defined %}
-            {% set value = {} %}
-        {%- endif %}
-
         {% set temp = value.update({
             'language': ( language or page.language )| default( "en" ),
             'links': page.get_translation_links( request ),

--- a/cfgov/v1/jinja2/v1/includes/organisms/ask-search.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/ask-search.html
@@ -50,7 +50,7 @@
 
         <div class="o-search-bar_input">
             <div class="o-form__input-w-btn">
-                <div class="o-form__input-w-btn_input-container u-mb0">
+                <div class="o-form__input-w-btn_input-container">
                     <div class="m-btn-inside-input
                                 input-contains-label
                                 {% if autocomplete %}m-autocomplete{% endif %}"
@@ -87,7 +87,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="o-form__input-w-btn_btn-container u-mb0">
+                <div class="o-form__input-w-btn_btn-container">
                     <button class="a-btn"
                             type="submit"
                             aria-label="{{ _('Search Ask CFPB for your question') }}">

--- a/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
@@ -44,7 +44,8 @@
     {% if value.heading -%}
         <h1>{{ value.heading | safe }}</h1>
 
-        {% include "v1/includes/molecules/translation-links.html" %}
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render(value) }}
     {%- endif %}
 
     {% if value.paragraph %}

--- a/cfgov/v1/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/v1/jinja2/v1/sublanding-page/index.html
@@ -20,7 +20,8 @@
 
 {% block content_main %}
     {% if page.has_hero -%}
-        {% include "v1/includes/molecules/translation-links.html" %}
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render() }}
     {%- endif %}
 
     {% for block in page.content -%}

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -27,7 +27,9 @@
 {% block content_main %}
     <h1>{{ _('Why financial well-being?') }}</h1>
 
-    {% set value = {
+    {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+    {{ translation_links.render({
+        'language': 'en' if current_language == 'en' else 'es',
         'links': [
         {
             'href': url('fwb_about_en'),
@@ -38,9 +40,7 @@
             'language': 'es',
             'text': 'Spanish'
         }]
-    } %}
-    {% set temp = value.update({'language':'en'} if (current_language == 'en') else {'language':'es'} )%}
-    {% include "v1/includes/molecules/translation-links.html" %}
+    }) }}
 
     <p class="lead-paragraph">
         {{ _('At the CFPB, we work to help consumers like you take control of your financial life to reach your own life goals,') }}

--- a/cfgov/wellbeing/jinja2/wellbeing/error.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/error.html
@@ -21,7 +21,9 @@
     <div class="block block__flush-top">
         <h1>{{ _('There was a problem with your submission') }}</h1>
 
-        {% set value = {
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render({
+            'language': 'en' if current_language == 'en' else 'es',
             'links': [
             {
                 'href': url('fwb_error_en'),
@@ -32,9 +34,7 @@
                 'language': 'es',
                 'text': 'Spanish'
             }]
-        } %}
-        {% set temp = value.update({'language':'en'} if (current_language == 'en') else {'language':'es'} )%}
-        {% include "v1/includes/molecules/translation-links.html" %}
+        }) }}
 
         <p class="lead-paragraph">
             {{ _('Please use your browser’s back button to return to the questionnaire and retake it to receive your score.') }}

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -61,7 +61,9 @@
 
         <h2>{{ _('Here’s how it works:') }}</h2>
 
-        {% set value = {
+        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+        {{ translation_links.render({
+            'language': 'en' if current_language == 'en' else 'es',
             'links': [
             {
                 'href': url('fwb_home_en'),
@@ -72,9 +74,7 @@
                 'language': 'es',
                 'text': 'Spanish'
             }]
-        } %}
-        {% set temp = value.update({'language':'en'} if (current_language == 'en') else {'language':'es'} )%}
-        {% include "v1/includes/molecules/translation-links.html" %}
+        }) }}
 
         <p>
             <b>{{ _('Answer the questions and get your score.') }}</b>


### PR DESCRIPTION
Small error in https://github.com/cfpb/consumerfinance.gov/pull/8115. When the translation links move below the ask search, the search needs its bottom margin removed. Turns out the bottom margin is used at mobile to space the button and search input apart. This PR turns the whole translation-links template into a macro and adds the option to pass in a modifier class. 

## Changes

- Update translation-links to use macro and allow passing in of a container CSS class.


## How to test this PR

1. Visit the following translation link pages:

http://localhost:8000/ask-cfpb/
http://localhost:8000/ask-cfpb/what-should-i-know-before-i-shop-for-auto-loan-at-a-bank-credit-union-dealership-or-other-lender-en-755/
http://localhost:8000/language/ru/
http://localhost:8000/consumer-tools/financial-well-being/
http://localhost:8000/consumer-tools/financial-well-being/about/
http://localhost:8000/consumer-tools/financial-well-being/error/
http://localhost:8000/consumer-tools/retirement/before-you-claim/
