### PR TITLE
Allow projected simple chart values to work for column charts

### DIFF
--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -219,7 +219,7 @@ function addProjectedMonths(chartObject, numMonths) {
      at the projected data starting point */
   chartObject.series = chartObject.series.map((singluarSeries) => {
     let projectedStyle = { dashStyle: 'dot' };
-    if (chartObject.chart && chartObject.chart.type === 'column') {
+    if (chartObject.chart?.type === 'column') {
       projectedStyle = { color: '#addc91' };
     }
     singluarSeries.zoneAxis = 'x';

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/simple-chart.js
@@ -218,14 +218,16 @@ function addProjectedMonths(chartObject, numMonths) {
   /* Add a zone to each series with a dotted line starting
      at the projected data starting point */
   chartObject.series = chartObject.series.map((singluarSeries) => {
+    let projectedStyle = { dashStyle: 'dot' };
+    if (chartObject.chart && chartObject.chart.type === 'column') {
+      projectedStyle = { color: '#addc91' };
+    }
     singluarSeries.zoneAxis = 'x';
     singluarSeries.zones = [
       {
         value: projectedDate.timestamp,
       },
-      {
-        dashStyle: 'dot',
-      },
+      projectedStyle,
     ];
     return singluarSeries;
   });


### PR DESCRIPTION
This adds a little check off the chart type to make the styling for projected data in column-type simple charts better.

Before:
![Screenshot 2024-01-29 at 11 30 23 AM](https://github.com/cfpb/consumerfinance.gov/assets/1558033/1f61bc38-5e28-46d2-90d1-3a4bfc897750)

After:
![Screenshot 2024-01-29 at 11 57 17 AM](https://github.com/cfpb/consumerfinance.gov/assets/1558033/61a6dc3b-ea87-414c-92c0-dd1c958f7887)
