### PR TITLE
Retirement: Clean up CSS and remove unused selectors

### DIFF
--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -111,7 +111,7 @@
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
 
-    & p {
+    p {
       margin-bottom: 0;
     }
   }
@@ -145,21 +145,21 @@
       color: #919395;
     }
 
-    & .graph__bar {
+    .graph__bar {
       cursor: pointer;
     }
 
-    & .graph__element {
+    .graph__element {
       position: absolute;
     }
 
-    & .graph__background {
+    .graph__background {
       background: #e3e4e5;
       height: 1px;
       left: 0;
     }
 
-    & .graph_slider {
+    .graph_slider {
       width: 100%;
       position: absolute;
       bottom: 0;
@@ -167,13 +167,13 @@
       z-index: 100;
     }
 
-    & input[type='range'] {
+    input[type='range'] {
       height: 49px;
       padding: 0;
       margin: 0;
     }
 
-    & .age-text {
+    .age-text {
       color: #919395;
       cursor: pointer;
       position: absolute;
@@ -184,7 +184,7 @@
       &.selected-age {
         height: 25px;
 
-        & p {
+        p {
           color: #000;
           font-weight: bolder;
         }
@@ -273,7 +273,7 @@
     height: 77px;
     margin-bottom: 30px;
 
-    & p {
+    p {
       margin-bottom: 0;
     }
   }
@@ -290,7 +290,7 @@
   .total-benefits-container {
     margin-bottom: 30px;
 
-    & p {
+    p {
       margin: 0;
     }
   }
@@ -405,14 +405,14 @@
     padding-top: 20px;
     margin-bottom: 60px;
 
-    & li {
+    li {
       background-repeat: no-repeat;
       background-position: 0 0;
       padding-left: 34px;
     }
 
-    & li.next-step-one,
-    & li.next-step-three {
+    li.next-step-one,
+    li.next-step-three {
       background-image: url('/static/apps/retirement/img/step_check.png');
     }
   }
@@ -764,18 +764,19 @@
     position: absolute;
     width: 20em;
     z-index: 3000;
-    & .content {
+
+    .content {
       padding: 0;
       margin: 0;
     }
 
-    & .content p:last-child {
+    .content p:last-child {
       margin-bottom: 0;
     }
 
     /* These elements, .outertip and .innertip, make the little speech-balloon
      styled tip appear along the top of the tooltip. */
-    & .outertip {
+    .outertip {
       border: 0 solid transparent;
       border-bottom-color: #000;
       content: ' ';
@@ -786,7 +787,7 @@
       width: 0;
     }
 
-    & .innertip {
+    .innertip {
       border: 7px solid transparent;
       border-bottom-color: #e4e2e0;
       content: ' ';

--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -30,6 +30,7 @@
 
   .intro {
     margin-bottom: 30px;
+
     .content-l_col + .content-l_col {
       margin-top: 0;
     }
@@ -90,13 +91,6 @@
     margin-right: 5px;
   }
 
-  #claiming-social-security
-    .step-one
-    .birthdate-inputs
-    label.input-labels:last-child {
-    margin-right: 0;
-  }
-
   .step-one label.input-labels .input-labels_block {
     display: block;
     margin-bottom: 8px;
@@ -116,10 +110,10 @@
     padding: 1em 0;
     border-top: 1px solid #ccc;
     border-bottom: 1px solid #ccc;
-  }
 
-  .estimated-benefits-description p {
-    margin-bottom: 0;
+    & p {
+      margin-bottom: 0;
+    }
   }
 
   .estimated-benefits-input {
@@ -143,46 +137,6 @@
     line-height: 6px;
   }
 
-  #claim-canvas .graph__bar {
-    cursor: pointer;
-  }
-
-  #claim-canvas .age-text {
-    color: #919395;
-    cursor: pointer;
-    position: absolute;
-    top: 292px;
-    height: 75px;
-    text-align: center;
-  }
-
-  #claim-canvas .age-text.selected-age {
-    height: 25px;
-  }
-
-  #claim-canvas .age-text.selected-age p {
-    color: #000;
-    font-weight: bolder;
-  }
-
-  #claim-canvas #min-age-text {
-    left: 5px;
-  }
-
-  #claim-canvas #selected-age-text {
-    color: black;
-  }
-
-  #claim-canvas #max-age-text {
-    left: 443px;
-  }
-
-  #claim-canvas #benefits-text,
-  #claim-canvas #full-age-benefits-text {
-    position: absolute;
-    font-weight: bolder;
-  }
-
   #claim-canvas {
     position: relative;
     left: 40px;
@@ -191,17 +145,21 @@
       color: #919395;
     }
 
-    .graph__element {
+    & .graph__bar {
+      cursor: pointer;
+    }
+
+    & .graph__element {
       position: absolute;
     }
 
-    .graph__background {
+    & .graph__background {
       background: #e3e4e5;
       height: 1px;
       left: 0;
     }
 
-    .graph_slider {
+    & .graph_slider {
       width: 100%;
       position: absolute;
       bottom: 0;
@@ -209,11 +167,35 @@
       z-index: 100;
     }
 
-    input[type='range'] {
+    & input[type='range'] {
       height: 49px;
       padding: 0;
       margin: 0;
     }
+
+    & .age-text {
+      color: #919395;
+      cursor: pointer;
+      position: absolute;
+      top: 292px;
+      height: 75px;
+      text-align: center;
+
+      &.selected-age {
+        height: 25px;
+
+        & p {
+          color: #000;
+          font-weight: bolder;
+        }
+      }
+    }
+  }
+
+  #benefits-text,
+  #full-age-benefits-text {
+    position: absolute;
+    font-weight: bolder;
   }
 
   .claim-canvas__no-slider {
@@ -290,10 +272,10 @@
   .selected-retirement-age-container {
     height: 77px;
     margin-bottom: 30px;
-  }
 
-  .selected-retirement-age-container p {
-    margin-bottom: 0;
+    & p {
+      margin-bottom: 0;
+    }
   }
 
   .selected-retirement-age {
@@ -307,22 +289,15 @@
 
   .total-benefits-container {
     margin-bottom: 30px;
+
+    & p {
+      margin: 0;
+    }
   }
 
-  .total-benefits-container p {
-    margin: 0;
-  }
-
-  .benefit-selection p.selected-full-retirement,
   #age-selector-response,
   #age-selector-response .thank-you {
     display: none;
-  }
-
-  .benefit-selection button.selected-remove {
-    background: none;
-    border: none;
-    float: right;
   }
 
   #graph-container + hr {
@@ -429,21 +404,17 @@
     padding-left: 0;
     padding-top: 20px;
     margin-bottom: 60px;
-  }
 
-  #age-selector-response .next-steps li {
-    background-repeat: no-repeat;
-    background-position: 0 0;
-    padding-left: 34px;
-  }
+    & li {
+      background-repeat: no-repeat;
+      background-position: 0 0;
+      padding-left: 34px;
+    }
 
-  #age-selector-response .next-steps li.next-step-one,
-  #age-selector-response .next-steps li.next-step-two,
-  #claiming-social-security
-    #age-selector-response
-    .next-steps
-    li.next-step-three {
-    background-image: url('/static/apps/retirement/img/step_check.png');
+    & li.next-step-one,
+    & li.next-step-three {
+      background-image: url('/static/apps/retirement/img/step_check.png');
+    }
   }
 
   .step-three .helpful-btn {
@@ -482,30 +453,22 @@
 
     .estimated-benefits-input {
       padding-left: 40px;
-    }
 
-    #estimated-benefits-input span {
-      display: block;
-    }
+      & span {
+        display: block;
+      }
 
-    .estimated-benefits-input label {
-      margin-left: 15px;
-    }
+      & label {
+        margin-left: 15px;
 
-    #estimated-benefits-input label:first-of-type {
-      margin-left: 0;
+        &:first-of-type {
+          margin-left: 0;
+        }
+      }
     }
 
     .step-two .lifestyle-response > p:last-child {
       margin-bottom: 0;
-    }
-  }
-
-  @media (max-width: 940px) {
-    .hero_image,
-    [lang='en'] .hero_image,
-    [lang='es'] .hero_image {
-      display: none;
     }
   }
 
@@ -638,19 +601,6 @@
       max-width: 236px;
     }
 
-    #claiming-social-security
-      #step-one-form
-      .content-l_col.content-l_col-1-3
-      + .content-l_col.content-l_col-1-3 {
-      margin-top: 1.875em;
-    }
-
-    #claiming-social-security
-      .content-l_col.content-l_col-1-3
-      + .content-l_col.content-l_col-1-3 {
-      margin-top: 0;
-    }
-
     .birthdate-inputs p,
     .step-one label.input-labels .input-labels_block {
       margin-bottom: 0;
@@ -662,17 +612,17 @@
 
     .estimated-benefits-input {
       padding-left: 0;
-    }
 
-    #estimated-benefits-input label {
-      display: block;
-      margin-left: 0;
-      height: 30px;
-    }
+      & label {
+        display: block;
+        margin-left: 0;
+        height: 30px;
 
-    #estimated-benefits-input label:first-of-type {
-      margin-top: 8px;
-      margin-left: 0;
+        &:first-of-type {
+          margin-top: 8px;
+          margin-left: 0;
+        }
+      }
     }
 
     #graph-container .content-l_col {
@@ -687,6 +637,16 @@
     p.y-axis-label {
       top: 240px;
       left: -57px;
+    }
+
+    #step-one-form
+      .content-l_col.content-l_col-1-3
+      + .content-l_col.content-l_col-1-3 {
+      margin-top: 1.875em;
+    }
+
+    .content-l_col.content-l_col-1-3 + .content-l_col.content-l_col-1-3 {
+      margin-top: 0;
     }
 
     .canvas-container .x-axis-label {
@@ -804,39 +764,38 @@
     position: absolute;
     width: 20em;
     z-index: 3000;
-  }
+    & .content {
+      padding: 0;
+      margin: 0;
+    }
 
-  #tooltip-container .content {
-    padding: 0;
-    margin: 0;
-  }
+    & .content p:last-child {
+      margin-bottom: 0;
+    }
 
-  #tooltip-container .content p:last-child {
-    margin-bottom: 0;
-  }
-
-  /* These elements, .outertip and .innertip, make the little speech-balloon
+    /* These elements, .outertip and .innertip, make the little speech-balloon
      styled tip appear along the top of the tooltip. */
-  #tooltip-container .outertip {
-    border: 0 solid transparent;
-    border-bottom-color: #000;
-    content: ' ';
-    height: 0;
-    position: absolute;
-    left: -5px;
-    top: -20px;
-    width: 0;
-  }
+    & .outertip {
+      border: 0 solid transparent;
+      border-bottom-color: #000;
+      content: ' ';
+      height: 0;
+      position: absolute;
+      left: -5px;
+      top: -20px;
+      width: 0;
+    }
 
-  #tooltip-container .innertip {
-    border: 7px solid transparent;
-    border-bottom-color: #e4e2e0;
-    content: ' ';
-    height: 0;
-    position: absolute;
-    left: 8px;
-    top: -14px;
-    width: 0;
+    & .innertip {
+      border: 7px solid transparent;
+      border-bottom-color: #e4e2e0;
+      content: ' ';
+      height: 0;
+      position: absolute;
+      left: 8px;
+      top: -14px;
+      width: 0;
+    }
   }
 
   .tooltip-target {


### PR DESCRIPTION
I noticed some CSS in the before you claim app that could be cleaned up:

- `#claiming-social-security` was nested inside `#claiming-social-security`
- Nested classes under IDs
- Removes unreferenced `benefit-selection`
- Removes `hero_image` inside media query (app's page doesn't have a hero)
- Removes `#age-selector-response .next-steps li.next-step-two`. `next-step-two` is not in HTML.
- Fix small screen responsive styling.


## Changes

- Retirement: Clean up CSS and remove unused selectors


## How to test this PR

1. http://localhost:8000/consumer-tools/retirement/before-you-claim/ should be unchanged from production, EXCEPT at mobile, where it should have spacing between form elements:

Before:
<img width="787" alt="Screenshot 2024-01-30 at 10 06 46 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/fc18ab40-b4b8-4b6d-905a-7cca3bd025f3">

After:
<img width="784" alt="Screenshot 2024-01-30 at 10 06 37 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/328cee54-085d-48f5-939c-fb2b2f8ab253">


