### PR TITLE
Prepaid agreements: Add `id` for `for` attribute

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -22,7 +22,7 @@
                    for="issuer_name">
                 Issuer name
             </label>
-            <select id="issuer_name" name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" id="issuer_name" class="o-multiselect">
+            <select id="issuer_name" name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" class="o-multiselect">
                 {% for issuer in active_filters['issuer_name'] %}
                     <option
                         value="{{ issuer }}"

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -19,10 +19,10 @@
         <div class="m-form-field u-mb15">
             {% set selections = filters['issuer_name'] %}
             <label class="a-label a-label__heading"
-                   for="card_type">
+                   for="issuer_name">
                 Issuer name
             </label>
-            <select id="card_type" name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" id="issuer_name" class="o-multiselect">
+            <select id="issuer_name" name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" id="issuer_name" class="o-multiselect">
                 {% for issuer in active_filters['issuer_name'] %}
                     <option
                         value="{{ issuer }}"

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -22,7 +22,7 @@
                    for="card_type">
                 Issuer name
             </label>
-            <select name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" id="issuer_name" class="o-multiselect">
+            <select id="card_type" name="issuer_name" multiple="multiple" data-placeholder="Enter prepaid account issuer name" placeholder="Enter card issuer name" id="issuer_name" class="o-multiselect">
                 {% for issuer in active_filters['issuer_name'] %}
                     <option
                         value="{{ issuer }}"


### PR DESCRIPTION
The label has an attribute `for="card_type"`, but there is no associated ID. This PR fixes ID association.

## Changes

- Prepaid agreements: Fix `id` for `for` attribute by changing name to `issuer_name`.


## How to test this PR

1. Visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and see that interacting with "Issuer name" will interact with its associated multiselect.