### PR TITLE
Refactor translation_links macro signature

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
@@ -26,7 +26,7 @@
                 block__flush-top">
 
         {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render({'modifier_classes': 'block__flush-top'}) }}
+        {{ translation_links.render(modifier_classes='block__flush-top') }}
 
         <section class="ask-search block__sub block__flush-top">
             {{ ask_search.render( language=page.language, is_subsection=False ) }}

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -33,9 +33,8 @@
                 </p>
 
                 {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-                {{ translation_links.render({
-                    'language': 'en' if current_language == 'en' else 'es',
-                    'links': [
+                {{ translation_links.render(
+                    links=[
                     {
                         'href': '../',
                         'language': 'en',
@@ -45,7 +44,7 @@
                         'language': 'es',
                         'text': 'Spanish'
                     }]
-                }) }}
+                ) }}
                 <div class="o-well">
                     {% if current_language == 'en' %}
                     <p>The Social Security Administration offers

--- a/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
@@ -41,7 +41,7 @@
     <h1>{{ value.heading }}</h1>
 
     {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-    {{ translation_links.render(value) }}
+    {{ translation_links.render() }}
 {%- endif %}
 
 {% if value.intro.source %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -2,10 +2,6 @@
 
     Render a list of translation links, given:
 
-    language: The current page language code, e.g. "en".
-              We already should have {{ language }},
-              because it was passed by context.
-
     links: A list of translation links.
 
     modifier_classes: classes to add to the translation links container.

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -26,7 +26,7 @@
 
     ======================================================================== #}
 
-{% macro render(links=None, modifier_classes="") %}
+{% macro render(links=none, modifier_classes="") %}
     {% set links = links or (page and page.get_translation_links(request)) %}
 
     {%- if links and links | length > 1 %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -2,11 +2,13 @@
 
     Render a list of translation links, given:
 
-    value.language: The current page language code, e.g. "en".
+    language: The current page language code, e.g. "en".
+              We already should have {{ language }},
+              because it was passed by context.
 
-    value.links:    A list of translation links.
+    links: A list of translation links.
 
-    value.modifier_classes: classes to add to the translation links container.
+    modifier_classes: classes to add to the translation links container.
 
     Each translation link should have:
 
@@ -28,20 +30,15 @@
 
     ======================================================================== #}
 
-{% macro render(value={}) %}
+{% macro render(links=None, modifier_classes="") %}
+    {% set links = links or (page and page.get_translation_links(request)) %}
 
-    {%- if page is defined and not value.language or not value.links %}
-        {% set temp = value.update({
-            'language': ( language or page.language )| default( "en" ),
-            'links': page.get_translation_links( request ),
-        }) %}
-    {%- endif %}
-
-    {%- if value.links and value.links|length > 1 %}
-    <div class="block block__sub {{ value.modifier_classes }}">
+    {%- if links and links | length > 1 %}
+    <div class="block block__sub {{ modifier_classes }}">
         <ul dir="ltr" class="m-translation-links">
-            {%- for link in value.links %}
-                {%- set render_link = value.language and link.language != value.language %}
+            {%- for link in links %}
+                {# language is set by the context in the base template. #}
+                {%- set render_link = language and link.language != language %}
                 <li>
                 {%- if render_link %}
                     <a href="{{ link.href }}"

--- a/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
@@ -45,7 +45,7 @@
         <h1>{{ value.heading | safe }}</h1>
 
         {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render(value) }}
+        {{ translation_links.render() }}
     {%- endif %}
 
     {% if value.paragraph %}

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -28,9 +28,8 @@
     <h1>{{ _('Why financial well-being?') }}</h1>
 
     {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-    {{ translation_links.render({
-        'language': 'en' if current_language == 'en' else 'es',
-        'links': [
+    {{ translation_links.render(
+        links=[
         {
             'href': url('fwb_about_en'),
             'language': 'en',
@@ -40,7 +39,7 @@
             'language': 'es',
             'text': 'Spanish'
         }]
-    }) }}
+    ) }}
 
     <p class="lead-paragraph">
         {{ _('At the CFPB, we work to help consumers like you take control of your financial life to reach your own life goals,') }}

--- a/cfgov/wellbeing/jinja2/wellbeing/error.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/error.html
@@ -22,9 +22,8 @@
         <h1>{{ _('There was a problem with your submission') }}</h1>
 
         {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render({
-            'language': 'en' if current_language == 'en' else 'es',
-            'links': [
+        {{ translation_links.render(
+            links=[
             {
                 'href': url('fwb_error_en'),
                 'language': 'en',
@@ -34,7 +33,7 @@
                 'language': 'es',
                 'text': 'Spanish'
             }]
-        }) }}
+        ) }}
 
         <p class="lead-paragraph">
             {{ _('Please use your browser’s back button to return to the questionnaire and retake it to receive your score.') }}

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -62,9 +62,8 @@
         <h2>{{ _('Here’s how it works:') }}</h2>
 
         {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render({
-            'language': 'en' if current_language == 'en' else 'es',
-            'links': [
+        {{ translation_links.render(
+            links=[
             {
                 'href': url('fwb_home_en'),
                 'language': 'en',
@@ -74,7 +73,7 @@
                 'language': 'es',
                 'text': 'Spanish'
             }]
-        }) }}
+        ) }}
 
         <p>
             <b>{{ _('Answer the questions and get your score.') }}</b>


### PR DESCRIPTION
Translation_links `value` object was bleeding outside the macro with the call to `value.update(…)`. This PR refactors the macro signature to pass in explicit arguments.

## Changes

- Refactor translation links template to pass in specific arguments.
- Get `language` from the page context only.


## How to test this PR

1. http://localhost:8000/ask-cfpb/
http://localhost:8000/ask-cfpb/what-should-i-know-before-i-shop-for-auto-loan-at-a-bank-credit-union-dealership-or-other-lender-en-755/
http://localhost:8000/language/ru/
http://localhost:8000/consumer-tools/financial-well-being/
http://localhost:8000/consumer-tools/financial-well-being/about/
http://localhost:8000/consumer-tools/financial-well-being/error/
http://localhost:8000/consumer-tools/retirement/before-you-claim/

text-introduction page (should not have language link)
http://localhost:8000/rules-policy/final-rules/

item-introduction page (should not have language link)
http://localhost:8000/consumer-tools/credit-reports-and-scores/consumer-reporting-companies/companies-list/amrent/
