### PR TITLE
Refactor tags to align with design system tags

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -120,10 +120,10 @@
     {% if filters | length %}
 
         <div class="filters_applied">
-            <div class="filters_tags">
-                <span class="filters_applied-label">
+            <span class="filters_applied-label">
                 Filters applied:
             </span>
+            <div class="filters_tags">
                 {% set filters_to_remove = [] %}
                 {% for filter in filters %}
                     {% if filter in valid_filters %}
@@ -138,13 +138,13 @@
                         {% endfor %}
                     {% endif %}
                 {% endfor %}
-
-                {% set clear_url = remove_url_parameter(request, filters) %}
-                <a class="a-btn a-btn__link a-btn__warning results_filters-clear u-mb10"
-                        data-js-hook="behavior_clear-all" href="{{ clear_url if clear_url else '.' }}">
-                    Clear all filters
-                </a>
             </div>
+
+            {% set clear_url = remove_url_parameter(request, filters) %}
+            <a class="a-btn a-btn__link a-btn__warning results_filters-clear u-mb10"
+                    data-js-hook="behavior_clear-all" href="{{ clear_url if clear_url else '.' }}">
+                Clear all filters
+            </a>
         </div>
     {% endif %}
 

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -14,7 +14,6 @@
 .filters_applied,
 .filters_tags {
   display: flex;
-  display: flex;
   gap: 15px;
   align-items: baseline;
   flex-wrap: wrap;

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.less
@@ -11,18 +11,22 @@
   }
 }
 
+.filters_applied,
+.filters_tags {
+  display: flex;
+  display: flex;
+  gap: 15px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
 .filters_applied {
   padding: 30px 15px;
   border-bottom: 1px solid @gray-40;
+
   &-label {
-    display: inline-block;
-    margin-right: 15px;
     font-weight: 600;
   }
-}
-
-.filters_tags {
-  display: inline-block;
 }
 
 .search_results {

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -36,12 +36,7 @@ function attachHandlers() {
  * @param {Event} event - Click event.
  */
 function clearFilter(event) {
-  // Continue only if the X icon was clicked and not the parent button
-  let target = event.target.tagName.toLowerCase();
-  if (target !== 'svg' && target !== 'path') {
-    return;
-  }
-  target = event.target.closest('.a-tag');
+  let target = event.currentTarget;
   const checkbox = document.querySelector(
     `#regulation-${target.getAttribute('data-value')}`,
   );
@@ -70,14 +65,10 @@ function removeTag(tag) {
  * @param {Event} event - Click event.
  */
 function clearFilters(event) {
-  let filterIcons = document.querySelectorAll('.filters_tags svg');
-  // IE doesn't support forEach w/ node lists so convert it to an array.
-  filterIcons = Array.prototype.slice.call(filterIcons);
-  filterIcons.forEach((filterIcon) => {
-    const target = filterIcon.closest('.a-tag');
+  let filterTags = document.querySelectorAll('.filters_tags .a-tag');
+  filterTags.forEach((filterTag) => {
     clearFilter({
-      target: filterIcon,
-      value: target,
+      currentTarget: filterTag,
     });
   });
   handleFilter(event);

--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -36,7 +36,7 @@ function attachHandlers() {
  * @param {Event} event - Click event.
  */
 function clearFilter(event) {
-  let target = event.currentTarget;
+  const target = event.currentTarget;
   const checkbox = document.querySelector(
     `#regulation-${target.getAttribute('data-value')}`,
   );
@@ -65,7 +65,7 @@ function removeTag(tag) {
  * @param {Event} event - Click event.
  */
 function clearFilters(event) {
-  let filterTags = document.querySelectorAll('.filters_tags .a-tag');
+  const filterTags = document.querySelectorAll('.filters_tags .a-tag');
   filterTags.forEach((filterTag) => {
     clearFilter({
       currentTarget: filterTag,

--- a/cfgov/unprocessed/css/atoms/tag.less
+++ b/cfgov/unprocessed/css/atoms/tag.less
@@ -4,13 +4,27 @@
    ========================================================================== */
 
 .a-tag {
-  cursor: default;
-  display: inline-block;
-  padding: 5px 10px;
-  border-radius: 5px;
-  margin: 5px 15px 10px 0;
-  background-color: @gray-20;
-  font-size: 14px;
+  border: 1px solid @teal;
+  padding: 4px 10px;
+  background-color: @teal-20;
+  margin-right: 4px;
+  border-radius: unit(3px / @base-font-size-px, rem);
+  font-weight: 500;
+  color: @black;
+
+  &:hover {
+    background-color: @teal-40;
+    cursor: pointer;
+  }
+
+  &:focus {
+    outline: 1px dotted @teal;
+    outline-offset: 1px;
+  }
+
+  &:active {
+    background-color: @teal;
+  }
 
   .cf-icon-svg {
     display: inline-block;
@@ -18,7 +32,8 @@
     cursor: pointer;
   }
 
-  a {
-    color: inherit;
+  a& {
+    // Colors for :link, :visited, :hover, :focus, :active.
+    .u-link__colors( @black, @black, @black, @black, @black );
   }
 }

--- a/cfgov/unprocessed/css/search.less
+++ b/cfgov/unprocessed/css/search.less
@@ -4,18 +4,22 @@
   }
 }
 
+.filters_applied,
+.filters_tags {
+  display: flex;
+  display: flex;
+  gap: 15px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
 .filters_applied {
   padding: 30px 15px;
   border-bottom: 1px solid @gray-40;
+
   &-label {
-    display: inline-block;
-    margin-right: 15px;
     font-weight: 600;
   }
-}
-
-.filters_tags {
-  display: inline-block;
 }
 
 .search_results {

--- a/cfgov/unprocessed/css/search.less
+++ b/cfgov/unprocessed/css/search.less
@@ -7,7 +7,6 @@
 .filters_applied,
 .filters_tags {
   display: flex;
-  display: flex;
   gap: 15px;
   align-items: baseline;
   flex-wrap: wrap;

--- a/cfgov/v1/jinja2/v1/includes/atoms/tag.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/tag.html
@@ -22,14 +22,19 @@
    ========================================================================== #}
 
 {% macro render( options ) %}
+  {%- set behavior = 'data-js-hook=behavior_' ~ options.behavior if options.behavior else '' -%}
+  {%- set value = 'data-value=' ~ options.value if options.value else '' -%}
+  {%- set href = 'href=' ~ options.href if options.href else '' -%}
 
-{%- set behavior = 'data-js-hook=behavior_' ~ options.behavior if options.behavior else '' -%}
-{%- set value = 'data-value=' ~ options.value if options.value else '' -%}
-{%- set href = 'href=' ~ options.href if options.href else '' -%}
-
-<div class="a-tag"
-     {{ value }}
-     {{ behavior }}>
-   {{ options.label }} {% if href %}<a {{href}}>{% endif %}{{ svg_icon('error') }}{% if href %}</a>{% endif %}
-</div>
+  {% if href %}
+    <a {{href}} class="a-tag" {{ value }} {{ behavior }}>
+  {% else %}
+    <button class="a-tag" {{ value }} {{ behavior }}>
+  {% endif %}
+      {{ options.label }} {{ svg_icon('error') }}
+  {% if href %}
+    </a>
+  {% else %}
+    </button>
+  {% endif %}
 {% endmacro %}

--- a/test/unit_tests/apps/regulations3k/js/search-spec.js
+++ b/test/unit_tests/apps/regulations3k/js/search-spec.js
@@ -80,7 +80,7 @@ describe('The Regs3K search page', () => {
     expect(numFilters).toEqual(0);
   });
 
-  it('should not clear a filter when its tag is clicked', () => {
+  it('should clear a filter when its tag is clicked', () => {
     const div = document.querySelector('div.a-tag');
 
     let numFilters = document.querySelectorAll('div.a-tag').length;
@@ -88,7 +88,7 @@ describe('The Regs3K search page', () => {
 
     simulateEvent('click', div);
     numFilters = document.querySelectorAll('div.a-tag').length;
-    expect(numFilters).toEqual(1);
+    expect(numFilters).toEqual(0);
   });
 
   it('should clear all filters when the `clear all` link is clicked', () => {


### PR DESCRIPTION
Analytics requested that these tags in TDP be clickable on the whole button, as they function on CCDB. These tags are shared between iRegs, Prepaid product agreements database, and TDP, so I took this opportunity to align them all with the tags/pills we have in the DS on https://cfpb.github.io/design-system/components/selects

## Changes

- Refactor tags/pills in iRegs, Prepaid product agreements database, and TDP to be clickable on the whole button and look like the tags in the DS.
 

## How to test this PR

1. Compare the tags/pills of these three apps to production and across different screensizes.

Prepaid
http://localhost:8000/data-research/prepaid-accounts/search-agreements/

TDP
http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/

iRegs
http://localhost:8000/rules-policy/regulations/search-regulations/results/


## Screenshots

Before:
<img width="865" alt="Screenshot 2024-01-31 at 2 57 25 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/1ffa9265-ad84-4a63-a129-f81af587cdc4">

After:
<img width="881" alt="Screenshot 2024-01-31 at 2 57 11 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/18ea0e3c-010e-48be-af9e-24c70289d58c">


Before:
<img width="772" alt="Screenshot 2024-01-31 at 2 57 59 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/788410a7-56b4-4aee-9a7d-dd8302b3beb6">

After:
<img width="776" alt="Screenshot 2024-01-31 at 2 57 32 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/14e9f930-68f5-4dc6-9077-771ab96f952a">


