### PR TITLE
Remove unused `content_main_modifiers` blocks

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
@@ -20,10 +20,6 @@
     {{ super() }} ask-cfpb-page ask-cfpb-page__answer
 {%- endblock %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
     <div class="block
                 block__flush-top

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer.html
@@ -7,10 +7,6 @@
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type == 'item_introduction' %}

--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
@@ -7,10 +7,6 @@
   <link rel="stylesheet" href="{{ static('css/on-demand/job_listing_page.css') }}">
 {%- endblock css %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
 
     {% set usajobs_links = page.usajobs_application_links.all() %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -22,10 +22,6 @@
     {{ self.desc() }}
 {%- endblock og_desc %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom prepaid-agreements prepaid-agreements-detail
-{%- endblock %}
-
 {% block content_main %}
 
 <div class="content prepaid-agreements prepaid-agreements-detail">

--- a/cfgov/v1/jinja2/v1/document-detail/index.html
+++ b/cfgov/v1/jinja2/v1/document-detail/index.html
@@ -3,10 +3,6 @@
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type == 'item_introduction' %}

--- a/cfgov/v1/jinja2/v1/enforcement-action/index.html
+++ b/cfgov/v1/jinja2/v1/enforcement-action/index.html
@@ -4,10 +4,6 @@
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type == 'item_introduction' %}

--- a/cfgov/v1/jinja2/v1/landing-page/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page/index.html
@@ -3,10 +3,6 @@
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_intro -%}
     {% for block in page.header -%}
         {% if 'hero' in block.block_type %}

--- a/cfgov/v1/jinja2/v1/learn-page/index.html
+++ b/cfgov/v1/jinja2/v1/learn-page/index.html
@@ -4,10 +4,6 @@
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
-{% block content_main_modifiers -%}
-    {{ super() }} content__flush-bottom
-{%- endblock %}
-
 {% block content_main %}
     {% for block in page.header -%}
         {% if block.block_type == 'item_introduction' %}


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/8079 migrated the layout-2-1 to a CSS grid, which doesn't need the `content_main_modifiers`. Therefore the child templates that extend this template don't need `content_main_modifiers` blocks.

## Removals

- Remove unused `content_main_modifiers` blocks
 
## How to test this PR

The layout-2-1.html template doesn't have the `block content_main_modifiers` block, so there should be no change in removing this, but if you want to double-check, these are example pages from the changed templates:

ask-cfpb/answer-page.html
http://localhost:8000/ask-cfpb/a-box-on-my-credit-card-bill-says-that-i-will-pay-off-the-balance-in-three-years-if-i-pay-a-certain-amount-what-does-that-mean-do-i-have-to-pay-that-much-if-i-pay-that-much-and-make-new-purchases-will-i-still-owe-nothing-after-three-years-en-36/

hdma-explorer.html
http://localhost:8000/data-research/hmda/historic-data/

job_listing_page.html
http://localhost:8000/about-us/careers/current-openings/paralegal-specialist24-cfpb-70-p24-cfpb-69-mp/

prepaid_agreements/detail.html
http://localhost:8000/data-research/prepaid-accounts/search-agreements/detail/100658/

document-detail/index.html
http://localhost:8000/administrative-adjudication-proceedings/administrative-adjudication-docket/accelerate-mortgage-llc/

enforcement-action/index.html
http://localhost:8000/enforcement/actions/1st-alliance-lending/

landing-page/index.html
http://localhost:8000/consumer-tools/

learn-page/index.html
http://localhost:8000/about-us/budget-strategy/financial-reports/cfo-q1-2012/
