### PR TITLE
Remove unused `content_sidebar_modifiers` blocks

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-page.html
@@ -101,10 +101,6 @@
     </div>
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped  %}
     {% if about_us %}
         <div class="block

--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-search-results.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-search-results.html
@@ -90,10 +90,6 @@
 
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {% if about_us %}
         <div class="block block__flush-top about-us-text">

--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
@@ -104,10 +104,6 @@
 
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {% if about_us %}
         <div class="block block__flush-top about-us-text">

--- a/cfgov/hmda/jinja2/hmda/hmda-explorer.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer.html
@@ -38,10 +38,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
@@ -142,10 +142,6 @@
 
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped %}
 
     {% if about_us %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -115,10 +115,6 @@
 
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {% if support_text %}
         <div class="block block__flush-top">

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -36,10 +36,6 @@
     {%- endfor %}
 {% endblock content_main %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ recent_notices }}
     {{ streamfield_sidefoot.render(page.sidefoot) }}

--- a/cfgov/unprocessed/css/main.less
+++ b/cfgov/unprocessed/css/main.less
@@ -97,7 +97,6 @@
 @import (less) 'organisms/resource-list.less';
 @import (less) 'organisms/secondary-nav.less';
 @import (less) 'organisms/sidebar-breakout.less';
-@import (less) 'organisms/sidebar-content.less';
 @import (less) 'organisms/video-player.less';
 
 /* Template pieces

--- a/cfgov/unprocessed/css/molecules/related-posts.less
+++ b/cfgov/unprocessed/css/molecules/related-posts.less
@@ -45,7 +45,7 @@
 .respond-to-min(@bp-med-min, {
   // If in the sidebar at desktop sizes, do not break into columns.
   // Related posts also appear in the pre-footer, so we exclude that here.
-  .o-sidebar-content .m-related-posts_list {
+  .u-layout-grid_sidebar .m-related-posts_list {
     grid-template-columns: initial;
   }
 });

--- a/cfgov/unprocessed/css/organisms/sidebar-content.less
+++ b/cfgov/unprocessed/css/organisms/sidebar-content.less
@@ -1,8 +1,0 @@
-.o-sidebar-content {
-  border-width: 0;
-
-  // Tablet only.
-  .respond-to-range(@bp-sm-min, @bp-sm-max, {
-    border-width: 0 unit(@grid_gutter-width / 2 / @base-font-size-px, em);
-  } );
-}

--- a/cfgov/v1/jinja2/v1/document-detail/index.html
+++ b/cfgov/v1/jinja2/v1/document-detail/index.html
@@ -25,10 +25,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/v1/jinja2/v1/enforcement-action/index.html
+++ b/cfgov/v1/jinja2/v1/enforcement-action/index.html
@@ -26,10 +26,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content enforcement-action-sidebar
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ related_metadata_enforcement_action.render() }}
     {{ streamfield_sidefoot.render(page.sidefoot) }}

--- a/cfgov/v1/jinja2/v1/landing-page/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page/index.html
@@ -26,10 +26,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/v1/jinja2/v1/learn-page/index.html
+++ b/cfgov/v1/jinja2/v1/learn-page/index.html
@@ -28,10 +28,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}

--- a/cfgov/v1/jinja2/v1/sublanding-page/index.html
+++ b/cfgov/v1/jinja2/v1/sublanding-page/index.html
@@ -52,10 +52,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% block content_sidebar_modifiers -%}
-    o-sidebar-content
-{%- endblock %}
-
 {% block content_sidebar scoped -%}
     {{ streamfield_sidefoot.render(page.sidefoot) }}
 {%- endblock %}


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/8079 migrated the layout-2-1 to a CSS grid, which doesn't need the `content_sidebar_modifiers`. Therefore the child templates that extend this template don't need `content_sidebar_modifiers` blocks.

Additionally, the related-posts did target the (now unused) sidebar class, so we need to update that to target the newer CSS grid sidebar container class. I don't love burying this class reference in the related-posts, but I couldn't immediately think of a better way.

## Removals

- Remove unused `content_sidebar_modifiers` blocks
- Remove unused `sidebar-content.less` file.

## Changes

- Target sidebar for related-posts to fix layout bug.

## How to test this PR

http://localhost:8000/enforcement/actions/enforcement-action-definitions/ should have related posts that extend the full width of the sidebar content area.

Other than that, the layout-2-1.html template doesn't have the `block content_sidebar_modifiers` block, so there should be no change in removing this, but if you want to double-check, these are example pages from the changed templates:

ask-cfpb/answer-page.html
http://localhost:8000/ask-cfpb/a-box-on-my-credit-card-bill-says-that-i-will-pay-off-the-balance-in-three-years-if-i-pay-a-certain-amount-what-does-that-mean-do-i-have-to-pay-that-much-if-i-pay-that-much-and-make-new-purchases-will-i-still-owe-nothing-after-three-years-en-36/

ask-cfpb/answer-search-results.html
http://localhost:8000/ask-cfpb/search/?q=mortage

ask-cfpb/landing-page.html
http://localhost:8000/ask-cfpb/

hdma-explorer.html
http://localhost:8000/data-research/hmda/historic-data/

job_listing_page.html 
http://localhost:8000/about-us/careers/current-openings/paralegal-specialist24-cfpb-70-p24-cfpb-69-mp/ (or a current job posting)

prepaid_agreements/detail.html
http://localhost:8000/data-research/prepaid-accounts/search-agreements/detail/100658/

regulations3k/landing-page.html
http://localhost:8000/rules-policy/regulations/

document-detail/index.html
http://localhost:8000/administrative-adjudication-proceedings/administrative-adjudication-docket/accelerate-mortgage-llc/

enforcement-action/index.html
http://localhost:8000/enforcement/actions/1st-alliance-lending/

landing-page/index.html
http://localhost:8000/consumer-tools/

learn-page/index.html
http://localhost:8000/about-us/budget-strategy/financial-reports/cfo-q1-2012/

sublanding-page/index.html
http://localhost:8000/about-us/careers/


## Screenshots

Before:
<img width="445" alt="Screenshot 2024-02-01 at 10 43 25 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f34fce98-86e7-45f2-9bc9-49e55327ea06">

After:
<img width="465" alt="Screenshot 2024-02-01 at 10 43 46 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f6299556-d14a-4fd8-88d2-0ca77e984c74">


