### PR TITLE
Move homepage styles to homepage app

### DIFF
--- a/cfgov/unprocessed/apps/homepage/css/main.less
+++ b/cfgov/unprocessed/apps/homepage/css/main.less
@@ -1,0 +1,21 @@
+.content_level--1 {
+  max-width: 1230px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content_level-1 {
+  max-width: 930px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content_level-2 {
+  max-width: 870px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.content_main__flush-inner {
+  padding-top: 0;
+}

--- a/cfgov/unprocessed/css/enhancements/layout.less
+++ b/cfgov/unprocessed/css/enhancements/layout.less
@@ -9,34 +9,6 @@
   });
 }
 
-.content_level--1 {
-  max-width: 1230px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.content_level-1 {
-  max-width: 930px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.content_level-2 {
-  max-width: 870px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.content_level-3 {
-  max-width: 600px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.content_main__flush-inner {
-  padding-top: 0;
-}
-
 .content__half-top-on-desk {
   // Desktop and above.
   .respond-to-min(@bp-med-min, {

--- a/cfgov/v1/jinja2/v1/home_page/home_page.html
+++ b/cfgov/v1/jinja2/v1/home_page/home_page.html
@@ -8,6 +8,11 @@
     {{ _('Consumer Financial Protection Bureau') }}
 {%- endblock %}
 
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="{{ static('apps/homepage/css/main.css') }}">
+{% endblock %}
+
 {% block content_main_modifiers -%}
 content_main__flush-inner
 {%- endblock %}

--- a/esbuild/styles.js
+++ b/esbuild/styles.js
@@ -14,6 +14,7 @@ const styledApps = [
   'financial-well-being',
   'find-a-housing-counselor',
   'form-explainer',
+  'homepage',
   'know-before-you-owe',
   'owning-a-home',
   'paying-for-college',


### PR DESCRIPTION
We have a homepage app that has images for the homepage. However, the CSS that is only used on the homepage is included in the global layout CSS delivered to all pages. This PR moves the homepage-specific classes to a new CSS file in the homepage app.

## Changes

- Move homepage styles to homepage app


## How to test this PR

1. Homepage should be unchanged.
