### PR TITLE
Build the artifact as part of the merge queue instead of on push to main

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -2,9 +2,7 @@ name: 'Build cf.gov artifact'
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This way, we know that a commit that lands in main will have a corresponding artifact