### PR TITLE
Bump setup-python to latest

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -64,7 +64,7 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.8
 
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.8
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           git fetch --no-tags --prune --depth=1 origin gh-pages
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.8
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: '20.x'
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
This internally uses node 20 now, suppressing the warning we were getting