### PR TITLE
Edit admin Cypress test to assert "Copy" exists on regulations test before clicking it

### DIFF
--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -111,7 +111,7 @@ export class AdminPage {
   }
 
   copyRegulation() {
-    this.getFirstTableRow().find('.children').click();
+    this.getFirstTableRow().find('.children a').click();
     this.getFirstTableRow().contains('Copy').should('be.visible');
     this.getFirstTableRow().contains('Copy').click();
     this.setRegulationEffectiveDate('3099-01-01');

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -112,7 +112,8 @@ export class AdminPage {
 
   copyRegulation() {
     this.getFirstTableRow().find('.children').click();
-    this.getFirstTableRow().contains('Copy').click({ force: true });
+    this.getFirstTableRow().contains('Copy').should('be.visible');
+    this.getFirstTableRow().contains('Copy').click();
     this.setRegulationEffectiveDate('3099-01-01');
     this.submitForm();
   }


### PR DESCRIPTION
## Changes

-  Edit admin Cypress test to assert "Copy" exists on regulations test before clicking it 
- Target link inside the `children` class


## How to test this PR

1. PR checks should pass
