### PR TITLE
Clear floats on full-width text blocks

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -1,5 +1,5 @@
 .o-full-width-text-group {
-  overflow: auto;
+  clear: both;
 
   /**
      * Fix for Wagtail's default img markup that includes height attribute


### PR DESCRIPTION
This came up as part of #8127: because we have an `overflow: auto` on `.o-full-width-text-group`, [margins don't collapse across the scroll container boundary](https://www.joshwcomeau.com/css/rules-of-margin-collapse/#blocked-by-a-scroll-container-7). In practice, this means that if you happen to put a block that has a top margin at the beginning of a full-width text group (or a block with a bottom margin at the end), the margin won't collapse with whatever precedes (or follows) the full-width text block. That can lead to some huge margins. As an example, look on Content at `/data-research/credit-card-data/terms-credit-card-plans-survey-new/terms-of-credit-card-plans-tccp-data-dictionary/`:

![double-margin](https://github.com/cfpb/consumerfinance.gov/assets/1862695/c1e3156b-79f4-4c59-a4f7-6008fffe12d9)

That 120 px margin between the text introduction and the first table is because the page is structured like:

```
div.block.block__flush-top (text introduction, 60 px bottom margin)
div.block.block__flush-top
    div.o-full-width-text-group (with overflow: auto)
        div.block (table, 60 px top margin)
```

Because the `overflow: auto` on `.o-full-width-text-group` creates a scroll container boundary, the 60 px bottom margin on the text introduction block and the 60 px top margin on the table block add instead of collapsing. That's not what we want there.

It looks like `overflow: auto` was introduced in #1237 way back in 2015 as a way to fix float issues with inset elements like pull quotes. After talking with @anselmbradford and @contolini, it seems like the best way to fix this is to change `overflow: auto` to `clear: both`. That will still take care of any float issues but without the side effect of non-collapsing margins.

Note that, with this change, some pages that have lots of floats in full-width text blocks will look a little different. Specifically, our compliance email signup page (`/compliance/compliance-resources/signup/`) will have smaller margins between each block. That page is such an edge case, though, that as long as it's usable, small visual changes are fine. Also, other pages will look slightly different because the non-collapsing margins have been subtly adding too much space between blocks for years (look at the margins on `/coronavirus/mortgage-and-housing-assistance/renter-protections/emergency-rental-assistance-for-renters/`, for example).

---

## Changes

- `overflow: auto` to `clear: both` on `.o-full-width-text-group`

## How to test this PR

1. Create a page with a text introduction in the header and a full-width text group with a table (or a well) immediately following. On `main`, note that the `.block` margins don't collapse and there's 120 px of space between the text intro and the table/well. On this branch, note that the margins do collapse to the intended 60 px.
2. Check out some other pages that use full-width text blocks, especially those with floating elements like pull quotes or calls to action. Make sure those pages still look OK, even if some margins have slightly changed. @contolini did an automated visual diffing of our top pages (awesome!) and didn't see anything break.

## Screenshots

Before  | After
---- | ----
![double-margin](https://github.com/cfpb/consumerfinance.gov/assets/1862695/c1e3156b-79f4-4c59-a4f7-6008fffe12d9) | ![single-margin](https://github.com/cfpb/consumerfinance.gov/assets/1862695/0f2192b7-092d-418f-a3b9-b60b5a5d7f95)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)