### PR TITLE
Set language default from page

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/translation-links.html
@@ -28,6 +28,7 @@
 
 {% macro render(links=none, modifier_classes="") %}
     {% set links = links or (page and page.get_translation_links(request)) %}
+    {% set language = (language or page.language) | default( 'en' ) %}
 
     {%- if links and links | length > 1 %}
     <div class="block block__sub {{ modifier_classes }}">


### PR DESCRIPTION
https://www.consumerfinance.gov/consumer-tools/prepaid-cards/understand-fees/ isn't showing language links because text introduction is not receiving `language`. This PR sets the language from the page, if `language` is not available.

## Changes

- Set language default from page


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/prepaid-cards/understand-fees/ and see that there's a language picker that works.
2. Visit http://localhost:8000/es/herramientas-del-consumidor/tarjetas-prepagadas/entienda-las-tarifas/ and see that there is a functional language picker.

## Screenshots

Before:
 
<img width="534" alt="Screenshot 2024-02-07 at 5 34 07 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/1adedab0-ff49-49e3-9a90-c74a5fe421c7">


After:

<img width="553" alt="Screenshot 2024-02-07 at 5 33 59 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2c97822a-6b64-4c79-ad6b-0d7eeb5cf9f1">

