### PR TITLE
Update pre-commit@3.5.0 from 2.18.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,11 @@
+exclude: .+\/migrations\/.+\.py
+default_language_version:
+  python: python3.8
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1
     hooks:
       - id: black
-        language_version: python3.8
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.2.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.1
+    rev: 24.1.1
     hooks:
       - id: black
         language_version: python3.8
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.2.1
     hooks:
       - id: ruff
   - repo: https://github.com/pycqa/isort
@@ -15,7 +15,7 @@ repos:
         name: isort (python)
         args: ['cfgov']
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.6
+    rev: 1.7.7
     hooks:
       - id: bandit
         args: ['-c', 'pyproject.toml', '--recursive']

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -2,5 +2,5 @@
 django-cprofile-middleware==1.0.5
 django-debug-toolbar==3.4.0
 django-sslserver==0.22
-pre-commit==2.18.1
+pre-commit==3.5.0
 tox==3.25.0


### PR DESCRIPTION
This is the latest version of pre-commit we can go to till we go beyond python 3.8, as pre-commit 3.6.0 drops python<3.9 support.

## Changes

- Update pre-commit@3.5.0 from 2.18.1
- Update pre-commit config to set default python version and exclude migrations from linting.

## How to test this PR

1. `./backend.sh`
2. `pre-commit run --all-files` should have no changes and pass.