### PR TITLE
FWB: fix incorrect event payload key

### DIFF
--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js
@@ -90,11 +90,11 @@ function handleRadio(input) {
  * @param {HTMLElement} el - A DOM element
  */
 function handleAnalytics(el) {
+  const event = el.getAttribute('data-gtm-category');
   const action = el.getAttribute('data-gtm-action');
   const label = el.getAttribute('data-gtm-label');
-  const category = el.getAttribute('data-gtm-category');
 
-  analyticsSendEvent({ action, label, category });
+  analyticsSendEvent({ event, action, label });
 }
 
 /**

--- a/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
+++ b/cfgov/unprocessed/apps/financial-well-being/js/fwb-results.js
@@ -42,14 +42,14 @@ function switchComparisons(category) {
  * @param {HTMLElement} el - A dom element
  */
 function handleAnalytics(el) {
+  const event = el.getAttribute('data-gtm-category');
   const action = el.getAttribute('data-gtm-action');
   const label = el.getAttribute('data-gtm-label');
-  const category = el.getAttribute('data-gtm-category');
 
   analyticsSendEvent({
+    event,
     action,
     label,
-    category,
   });
 }
 


### PR DESCRIPTION
In https://github.com/cfpb/consumerfinance.gov/pull/7336, there was a call to `getDataLayerOptions(…)`, which took an argument of `category`. Inside that function the `category` was then assigned to an `event` key in the event payload. Unfortunately, when `getDataLayerOptions(…)` was refactored away the `category` key was sent in the payload directly, instead of mapping it to `event` before sending. This PR fixes that.

## Changes

- FWB: fix incorrect event payload key (`category` --> `event`)


## How to test this PR

1. PR checks should pass and then analytics team needs to test