### PR TITLE
Iterating on the TCCP card list view

### DIFF
--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -33,7 +33,5 @@ class CheckboxFilter(filters.BooleanFilter):
         )
         super().__init__(*args, **kwargs)
 
-
-class YesNoFilter(CheckboxFilter):
     def filter(self, qs, value):
-        return super().filter(qs, "Yes") if value else qs
+        return super().filter(qs, True) if value else qs

--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -23,6 +23,10 @@ class CardOrderingFilter(filters.OrderingFilter):
         if value[0] == "low_fees":
             return qs.order_by("late_fees", "late_fee_dollars")
 
+        # Otherwise, if we're sorting by APR, we want to exclude any cards
+        # that don't specify an APR.
+        qs = qs.exclude(**{f"{value[0]}__isnull": True})
+
         return super().filter(qs, value)
 
 

--- a/cfgov/tccp/filterset.py
+++ b/cfgov/tccp/filterset.py
@@ -30,7 +30,6 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         "periodic_fee_type",
         method="filter_for_empty_list",
         label="No account fee",
-        exclude=True,
     )
     no_late_payment_fee = CheckboxFilter(
         "late_fees", label="No late payment fee"
@@ -40,7 +39,9 @@ class CardSurveyDataFilterSet(filters.FilterSet):
     )
     introductory_apr_offered = CheckboxFilter(label="Introductory APR offers")
     secured_card = CheckboxFilter(label="Secured card")
-    rewards = CheckboxFilter(label="Offers rewards")
+    rewards = CheckboxFilter(
+        label="Offers rewards", method="filter_for_nonempty_list"
+    )
     ordering = CardOrderingFilter(
         label="Sort by", null_label=None, empty_label=None, widget=Select
     )
@@ -99,3 +100,6 @@ class CardSurveyDataFilterSet(filters.FilterSet):
 
     def filter_for_empty_list(self, queryset, name, value):
         return queryset.filter(**{name: []}) if value else queryset
+
+    def filter_for_nonempty_list(self, queryset, name, value):
+        return queryset.exclude(**{name: []}) if value else queryset

--- a/cfgov/tccp/filterset.py
+++ b/cfgov/tccp/filterset.py
@@ -3,7 +3,7 @@ from django.db.models import F
 from django_filters import rest_framework as filters
 
 from .enums import CreditTierChoices, StateChoices
-from .filters import CardOrderingFilter, CheckboxFilter, YesNoFilter
+from .filters import CardOrderingFilter, CheckboxFilter
 from .models import CardSurveyData
 from .widgets import Select
 
@@ -22,22 +22,25 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         choices=StateChoices,
         method="filter_geo_availability",
         label="Availability",
-        null_label="Available everywhere in the US",
-        empty_label="Show me cards regardless of where they are available",
+        null_label="National",
+        empty_label="Select availability",
         widget=Select,
     )
-    no_balance_transfer_fees = YesNoFilter(
-        "balance_transfer_fees", label="No balance transfer fees", exclude=True
-    )
-    introductory_apr_offered = YesNoFilter(label="Introductory APR offers")
-    secured_card = YesNoFilter(label="Secured card")
-    no_periodic_fees = CheckboxFilter(
+    no_account_fee = CheckboxFilter(
         "periodic_fee_type",
         method="filter_for_empty_list",
-        label="No periodic fees",
+        label="No account fee",
         exclude=True,
     )
-    rewards = YesNoFilter(label="Offers rewards")
+    no_late_payment_fee = CheckboxFilter(
+        "late_fees", label="No late payment fee"
+    )
+    no_balance_transfer_fee = CheckboxFilter(
+        "balance_transfer_fees", label="No balance transfer fee", exclude=True
+    )
+    introductory_apr_offered = CheckboxFilter(label="Introductory APR offers")
+    secured_card = CheckboxFilter(label="Secured card")
+    rewards = CheckboxFilter(label="Offers rewards")
     ordering = CardOrderingFilter(
         label="Sort by", null_label=None, empty_label=None, widget=Select
     )

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -3,6 +3,7 @@
 {% from 'tccp/macros/data_published.html' import data_published %}
 {% from 'tccp/macros/filter_form.html' import filter_form with context %}
 {% import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context %}
+{% import 'v1/includes/molecules/notification.html' as notification %}
 {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
 
 {% block javascript scoped %}
@@ -21,7 +22,7 @@
 
 <div id="o-filterable-list-controls" class="o-filterable-list-controls">
     {% call() expandable({
-        "label": "Refine and sort cards",
+        "label": "Customize results",
         "is_bordered": true,
         "is_expanded": true,
         "is_midtone": true
@@ -31,18 +32,29 @@
 </div>
 
 
-<div class="block">
+
+<div class="block block__sub">
     <div class="o-filterable-list-results">
 
         {% if count -%}
-            <h3>{{ count }} cards</h3>
+        {{- notification.render(
+            'success',
+            true,
+            count ~ ' result' ~ count | pluralize()
+        ) -}}
         {%- else -%}
-            There are no results for your search.
+        {{- notification.render(
+            'warning',
+            true,
+            'There are no results for your search.'
+        ) -}}
         {%- endif %}
 
-        {% if first_report_date -%}
+        <p>
+            {% if first_report_date -%}
             {{ data_published(first_report_date) }}
-        {%- endif %}
+            {%- endif %}
+        </p>
 
         {%- set card_columns = [
             {'heading': 'Card'},

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -59,14 +59,20 @@
         {%- set card_columns = [
             {'heading': 'Card'},
             {'heading': 'Purchase APR'},
-            {'heading': 'Transfer APR'}
+            {'heading': 'Availability'},
+            {'heading': 'Account fee'},
+            {'heading': 'Secured'},
+            {'heading': 'Rewards'},
         ] %}
         {%- set card_rows = [] %}
         {%- for card in results %}
             {% do card_rows.append( [
                 ('<a href="' ~ card.url ~ '">' ~ card.product_name ~ '</a>') | safe,
-                card.purchase_apr,
-                card.transfer_apr
+                ('%.2f%%' | format(card.purchase_apr * 100)) if card.purchase_apr else 'None',
+                ('Regionally: ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
+                (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
+                card.secured_card,
+                (card.rewards | join(', ')) if card.rewards else 'None'
             ] ) %}
         {% endfor %}
         {%- with value = {

--- a/cfgov/tccp/jinja2/tccp/macros/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/macros/filter_form.html
@@ -2,42 +2,63 @@
 {%- import 'v1/includes/molecules/notification.html' as notification -%}
 
 {%- macro render_field(field, field_type) -%}
-<div class="o-form_group">
-    <div class="m-form-field m-form-field__{{ field_type }}">
-        {# Checkboxes render the label after the input. #}
-        {% if field_type == "checkbox" -%}
-            {{ field }}
-        {%- endif %}
+<div class="m-form-field m-form-field__{{ field_type }}">
+    {# Checkboxes render the label after the input. #}
+    {% if field_type == "checkbox" -%}
+        {{ field }}
+    {%- endif %}
 
-        <label class="a-label a-label__heading" for="{{ field.id_for_label }}">
-            {{ field.label }}
-        </label>
+    <label
+        class="a-label
+        {%- if field_type == "select" %} a-label__heading{% endif -%}"
+        for="{{ field.id_for_label }}">
+        {{ field.label }}
+    </label>
 
-        {# Checkboxes render the label after the input. #}
-        {% if field_type != "checkbox" -%}
-            {{ field }}
-        {%- endif %}
-    </div>
+    {# Checkboxes render the label after the input. #}
+    {% if field_type != "checkbox" -%}
+        {{ field }}
+    {%- endif %}
 </div>
 {%- endmacro -%}
 
 {%- macro render_form_fields(form) -%}
 <div class="content-l_col content-l_col-1">
-    {{ render_field(form.targeted_credit_tiers, "select") }}
+    <div class="o-form_group">
+        {{ render_field(form.targeted_credit_tiers, "select") }}
+    </div>
 
-    {{ render_field(form.geo_availability, "select") }}
+    <div class="o-form_group">
+        {{ render_field(form.geo_availability, "select") }}
+    </div>
 
-    {{ render_field(form.no_balance_transfer_fees, "checkbox") }}
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <legend class="a-legend">Fees</legend>
 
-    {{ render_field(form.introductory_apr_offered, "checkbox") }}
+            {{ render_field(form.no_account_fee, "checkbox") }}
 
-    {{ render_field(form.secured_card, "checkbox") }}
+            {{ render_field(form.no_late_payment_fee, "checkbox") }}
 
-    {{ render_field(form.no_periodic_fees, "checkbox") }}
+            {{ render_field(form.no_balance_transfer_fee, "checkbox")}}
+        </fieldset>
+    </div>
 
-    {{ render_field(form.rewards, "checkbox") }}
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <legend class="a-legend">Features</legend>
 
-    {{ render_field(form.ordering, "select") }}
+            {{ render_field(form.secured_card, "checkbox") }}
+
+            {{ render_field(form.introductory_apr_offered, "checkbox") }}
+
+            {{ render_field(form.rewards, "checkbox") }}
+        </fieldset>
+    </div>
+
+    <div class="o-form_group">
+        {{ render_field(form.ordering, "select") }}
+    </div>
 </div>
 {%- endmacro -%}
 

--- a/cfgov/tccp/situations.py
+++ b/cfgov/tccp/situations.py
@@ -31,7 +31,7 @@ SITUATIONS = [
         ],
         query={
             "ordering": "transfer_apr",
-            "no_balance_transfer_fees": True,
+            "no_balance_transfer_fee": True,
         },
     ),
     Situation(
@@ -58,7 +58,7 @@ SITUATIONS = [
         details=["No annual fee", "Low late payment fee"],
         query={
             "ordering": "low_fees",
-            "no_periodic_fees": True,
+            "no_account_fee": True,
         },
     ),
     Situation(

--- a/cfgov/tccp/tests/test_fields.py
+++ b/cfgov/tccp/tests/test_fields.py
@@ -2,12 +2,14 @@ from django.core import serializers
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.test import SimpleTestCase, TestCase
+from django.test.utils import isolate_apps
 
 from tccp.fields import JSONListField, YesNoBooleanField
 
 from .testapp.models import YEAR_IN_SCHOOL_CHOICES, YearsInSchool
 
 
+@isolate_apps()
 class JSONListFieldTests(SimpleTestCase):
     def check_construction(self, **kwargs):
         class TestModel(models.Model):

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -30,6 +30,7 @@ class CardSurveyDataFilterSetTests(TestCase):
                 availability_of_credit_card_plan="One State/Territory",
                 state=state,
                 targeted_credit_tiers=["Credit scores from 620 to 719"],
+                purchase_apr_good=0.99,
                 _quantity=3,
             )
 

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -49,6 +49,7 @@ class CardListViewTests(TestCase):
         baker.make(
             CardSurveyData,
             targeted_credit_tiers="Credit score of 720 or greater",
+            purchase_apr_great=0.99,
             _quantity=5,
         )
         baker.make(

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -62,15 +62,15 @@ class CardListViewTests(TestCase):
         request = RequestFactory().get(f"/{querystring}")
         return view(request)
 
-    def test_no_querystring_filters_by_all_credit_scores(self):
+    def test_no_querystring_filters_by_good_tier(self):
         response = self.make_request()
-        self.assertContains(response, "8 cards")
+        self.assertContains(response, "There are no results for your search.")
 
     def test_filter_by_no_credit_score(self):
         response = self.make_request(
             "?targeted_credit_tiers=Credit+score+of+720+or+greater"
         )
-        self.assertContains(response, "5 cards")
+        self.assertContains(response, "5 results")
 
     def test_invalid_json_query_renders_error(self):
         response = self.make_request("?format=json&targeted_credit_tiers=foo")


### PR DESCRIPTION
These commits fix a few minor bugs from #8153 and iterates on the card list view.

## How to test this PR

Visit http://localhost:8000/consumer-tools/credit-cards/tccp/cards/ to test locally.

Alternatively visit the same URL on our internal DEV4 server to see this branch deployed there.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)