### PR TITLE
Add card name and availability to details page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -49,8 +49,8 @@
     </dd>
     {% if card.requirements_for_opening %}
         <dt>Other requirements</dt>
-        {% for requirement in card.geographic_restrictions, card.professional_affiliation, card.other%}
-            {% if requirement is not none %}
+        {% for requirement in [card.geographic_restrictions, card.professional_affiliation, card.other] %}
+            {% if requirement %}
                 <dd>{{ requirement }}</dd>
             {% endif %}
         {% endfor %}
@@ -58,45 +58,27 @@
     <dt>Credit score</dt>
     <dd>
         This card is targeted to people with these credit scores:
+        {% set scores = [
+            "No credit score",
+            "619 or less",
+            "620 to 719",
+            "720 or greater"]
+        %}
         <table class="o-table">
             <thead>
                 <tr>
-                    <th>No credit score</th>
-                    <th>619 or less</th>
-                    <th>620–719</th>
-                    <th>720 or greater</th>
+                    {% for score in scores %}
+                    <th>{{ score }}</th>
+                    {% endfor %}
                 </tr>
             </thead>
             <tbody>
                 <tr>
+                    {% for score in scores %}
                     <td>
-                        {% if "No credit score" is in card.targeted_credit_tiers %}
-                            Yes
-                        {% else %}
-                            No
-                        {% endif %}
+                        {{ "Yes" if score in card.targeted_credit_tiers|string else "No" }}
                     </td>
-                    <td>
-                        {% if "Credit score 619 or less" is in card.targeted_credit_tiers %}
-                            Yes
-                        {% else %}
-                            No
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if "Credit scores from 620 to 719" is in card.targeted_credit_tiers %}
-                            Yes
-                        {% else %}
-                            No
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if "Credit score of 720 or greater" is in card.targeted_credit_tiers %}
-                            Yes
-                        {% else %}
-                            No
-                        {% endif %}
-                    </th>
+                    {% endfor %}
                 </tr>
             </tbody>
         </table>
@@ -105,11 +87,7 @@
         Secured card
     </dt>
     <dd>
-        {% if card.secured_card %}
-            Yes
-        {% else %}
-            No
-        {% endif %}
+        {{ "Yes" if card.secured_card else "No" }}
     </dd>
 </dl>
 <h2>Purchases</h2>

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -1,26 +1,118 @@
-{% extends "v1/layouts/layout-full.html" %}
+{% extends "v1/layouts/layout-2-1.html" %}
 
 {% from 'tccp/macros/data_published.html' import data_published %}
 
+{% block css%}
+    {{ super() }}
+    <style>
+        dt {
+            margin-top: 15px;
+        }
+        dt,
+        dd {
+            display: block;
+        }
+        dd {
+            margin-left: 0;
+        }
+        dd + dd {
+            margin-top: 15px;
+        }
+        dd::after {
+            content: none;
+        }
+        dd .o-table {
+            margin-top: 10px;
+        }
+    </style>
+{% endblock css%}
+
 {% block content_main %}
 
-<h1>{{ card.product_name }}</h1>
+<h1>{{ card.institution_name }} {{ card.product_name }}</h1>
 
 {{ data_published(card.report_date) }}
 
-<h2 class="h3">Availability</h2>
-
-<h3 class="h5">Location</h3>
-
-{% if not card.state_limitations %}
-Available to anyone in the United States
-{% else %}
-Available in {{ card.state_limitations | join(", ") }}
-{% endif %}
-
-<h3 class="h5">Credit scores</h3>
-
-Available to credit scores: {{ card.targeted_credit_tiers | join(", ") }}
+<h2>Availability</h2>
+<dl class="m-list">
+    <dt>Location</dt>
+    <dd>
+        {% if not card.state_limitations %}
+            Available to anyone in the United States
+        {% else %}
+            Available only to people who live in
+            {% if card.pertains_to_specific_counties %}
+                specific counties in
+            {% endif %}
+            {{ card.state_limitations | join(", ") }}
+        {% endif %}
+    </dd>
+    {% if card.requirements_for_opening %}
+        <dt>Other requirements</dt>
+        {% for requirement in card.geographic_restrictions, card.professional_affiliation, card.other%}
+            {% if requirement is not none %}
+                <dd>{{ requirement }}</dd>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+    <dt>Credit score</dt>
+    <dd>
+        This card is targeted to people with these credit scores:
+        <table class="o-table">
+            <thead>
+                <tr>
+                    <th>No credit score</th>
+                    <th>619 or less</th>
+                    <th>620–719</th>
+                    <th>720 or greater</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        {% if "No credit score" is in card.targeted_credit_tiers %}
+                            Yes
+                        {% else %}
+                            No
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if "Credit score 619 or less" is in card.targeted_credit_tiers %}
+                            Yes
+                        {% else %}
+                            No
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if "Credit scores from 620 to 719" is in card.targeted_credit_tiers %}
+                            Yes
+                        {% else %}
+                            No
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if "Credit score of 720 or greater" is in card.targeted_credit_tiers %}
+                            Yes
+                        {% else %}
+                            No
+                        {% endif %}
+                    </th>
+                </tr>
+            </tbody>
+        </table>
+    </dd>
+    <dt>
+        Secured card
+    </dt>
+    <dd>
+        {% if card.secured_card %}
+            Yes
+        {% else %}
+            No
+        {% endif %}
+    </dd>
+</dl>
+<h2>Purchases</h2>
 
 <h3 class="h5">Other fields that haven't been styled yet</h3>
 


### PR DESCRIPTION
Adds the card name and availability to the TCCP card details page. Since this is still more prototype than production, some notes:

- Since we're still iterating on both this page and the front end of the TCCP app, I'm just stuffing all the CSS in the head of the card details page for now. We'll refactor that to the right place once the front end architecture comes together more.
- Similarly, right now there's a ton of logic to handle all the possible combinations of card availability data in the Jinja template. We'll refactor that as we keep adding data and iterating on this page.

---

## Additions

- Card name details
- Card availability details

## How to test this PR

1. Pull up some card detail pages and make sure the heading, updated date, and availability section appear and match what's in the data. Some good example cards:
    - http://localhost:8000/consumer-tools/credit-cards/tccp/cards/100/ is a pretty simple, nationally available card
    - http://localhost:8000/consumer-tools/credit-cards/tccp/cards/16/ is only available in specific counties
    - http://localhost:8000/consumer-tools/credit-cards/tccp/cards/41/ is only available in a single state
    - http://localhost:8000/consumer-tools/credit-cards/tccp/cards/239/ has a bunch of other requirements for opening

## Screenshots

![card-details](https://github.com/cfpb/consumerfinance.gov/assets/1862695/54f41481-d608-499f-af13-da550b6a52ee)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets