### PR TITLE
Show all columns in TCCP cards table

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -77,7 +77,7 @@
                 ('Regionally; ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
                 (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
                 'Yes' if card.late_fees else 'No',
-                ('$' ~ card.late_fee_dollars) if card.late_fee_dollars else 'None',
+                '$' ~ (card.late_fee_dollars or '0'),
                 ('%.2f%%' | format(card.transfer_apr * 100)) if card.transfer_apr else 'None',
                 'Yes' if balance_transfer_fees else 'No',
                 'Yes' if card.secured_card else 'No',

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -61,17 +61,27 @@
             {'heading': 'Purchase APR'},
             {'heading': 'Availability'},
             {'heading': 'Account fee'},
-            {'heading': 'Secured'},
-            {'heading': 'Rewards'},
+            {'heading': 'Late payment fee'},
+            {'heading': 'First late fee'},
+            {'heading': 'Balance transfer APR'},
+            {'heading': 'Balance transfer fee'},
+            {'heading': 'Secured card'},
+            {'heading': 'Introductory APR offers'},
+            {'heading': 'Offers rewards'},
         ] %}
         {%- set card_rows = [] %}
         {%- for card in results %}
             {% do card_rows.append( [
                 ('<a href="' ~ card.url ~ '">' ~ card.product_name ~ '</a>') | safe,
                 ('%.2f%%' | format(card.purchase_apr * 100)) if card.purchase_apr else 'None',
-                ('Regionally: ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
+                ('Regionally; ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
                 (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
-                card.secured_card,
+                'Yes' if card.late_fees else 'No',
+                ('$' ~ card.late_fee_dollars) if card.late_fee_dollars else 'None',
+                ('%.2f%%' | format(card.transfer_apr * 100)) if card.transfer_apr else 'None',
+                'Yes' if balance_transfer_fees else 'No',
+                'Yes' if card.secured_card else 'No',
+                'Yes' if card.introductory_apr_offered else 'No',
                 (card.rewards | join(', ')) if card.rewards else 'None'
             ] ) %}
         {% endfor %}

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -14,6 +14,8 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
         fields = [
             "balance_transfer_fees",
             "introductory_apr_offered",
+            "late_fees",
+            "late_fee_dollars",
             "periodic_fee_type",
             "product_name",
             "purchase_apr",

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -87,11 +87,13 @@ class CardSurveyDataFilterSetTests(TestCase):
                 (True, 4),
                 (False, 1),
                 (True, 2),
+                (True, None),
+                (False, None),
             ]
         ]
 
         qs = CardSurveyData.objects.all()
         fs = CardSurveyDataFilterSet({"ordering": "low_fees"}, queryset=qs)
         self.assertQuerysetEqual(
-            fs.qs, [cards[2], cards[0], cards[3], cards[1]]
+            fs.qs, [cards[5], cards[2], cards[0], cards[3], cards[1]]
         )


### PR DESCRIPTION
This changes the TCCP cards table so that all filterable/sortable columns are shown.

To test, visit http://localhost:8000/consumer-tools/credit-cards/find-cards/cards/ (or check DEV4).

See internal DTUR#226 for background.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)