### PR TITLE
Remove two unused tox.ini environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,12 +78,10 @@ changedir=
 passenv=
     PGUSER PGPASSWORD PGDATABASE PGHOST PGPORT ES_HOST ES_PORT GITHUB_ACTIONS SKIP_DJANGO_MIGRATIONS TEST_RUNNER
 setenv=
-    GOVDELIVERY_ACCOUNT_CODE=fake_account_code
     DJANGO_ADMIN_USERNAME=admin
     DJANGO_ADMIN_PASSWORD=admin
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
-    WAGTAIL_SHARING_HOSTNAME=content.localhost
     DJANGO_SETTINGS_MODULE=cfgov.settings.test
 deps=
     -r{toxinidir}/requirements/libraries.txt


### PR DESCRIPTION
These two environment variables don't need to be explicitly passed to tox.

See #1098 for background.

## How to test this PR

All tests pass even without these variables set.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)