### PR TITLE
Fix ruff warnings due to ruff 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ exclude = [
     # standards
     "cfgov/cfgov/settings",
 ]
+
+[tool.ruff.lint]
 ignore = [
     # Assigned Lambdas are fine.
     "E731",


### PR DESCRIPTION
ruff version 0.2.0 deprecated certain settings and their use is currently generating these warnings when running `tox -e lint`:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
```

This commit fixes those warnings.

## How to test this PR

`tox -e lint` and look for warnings -- you won't see any!

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)