### PR TITLE
Add new hybrid responsive table pattern to TCCP app

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -47,6 +47,7 @@ module.exports = {
     'declaration-property-value-no-unknown': null,
     'function-no-unknown': [true, { ignoreFunctions: ['unit'] }],
     'media-feature-range-notation': ['prefix'],
+    'media-query-no-invalid': null,
     'no-descending-specificity': null,
     'number-max-precision': 10,
     'rule-empty-line-before': [

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -95,7 +95,7 @@
                 'columns': card_columns,
                 'rows': card_rows
             },
-            'options': ['stack_on_mobile_hybrid']
+            'options': ['stack_on_mobile']
         } %}
             {% include 'v1/includes/organisms/tables/base.html' %}
         {% endwith %}

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -11,6 +11,11 @@
 <script src="{{ static( 'js/routes/on-demand/filterable-list-controls.js' ) }}"></script>
 {% endblock %}
 
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">
+{% endblock %}
+
 {% block content_main %}
 
 <h1>Card search results</h1>
@@ -57,8 +62,8 @@
         </p>
 
         {%- set card_columns = [
-            {'heading': 'Card'},
-            {'heading': 'Purchase APR'},
+            {'heading': 'Card', 'preserve_column_on_mobile': true},
+            {'heading': 'Purchase APR', 'preserve_column_on_mobile': true, 'right_align': true},
             {'heading': 'Availability'},
             {'heading': 'Account fee'},
             {'heading': 'Late payment fee'},
@@ -90,7 +95,7 @@
                 'columns': card_columns,
                 'rows': card_rows
             },
-            'options': ['is_stacked', 'stack_on_mobile']
+            'options': ['stack_on_mobile_hybrid']
         } %}
             {% include 'v1/includes/organisms/tables/base.html' %}
         {% endwith %}

--- a/cfgov/unprocessed/apps/tccp/.yarnrc
+++ b/cfgov/unprocessed/apps/tccp/.yarnrc
@@ -1,0 +1,1 @@
+yarn-offline-mirror "./npm-packages-offline-cache"

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -13,6 +13,7 @@
     th,
     td {
       padding: unit((10px / @base-font-size-px), rem);
+      width: auto;
     }
 
     thead,

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -1,0 +1,65 @@
+@import (reference) '../../../css/main.less';
+
+.o-table__stack-on-small-hybrid {
+  // We don't want responsive table styles applied to the `print` media type
+  // so we're not using .respond-to-max(@bp-xs-max ) here.
+  @media only screen and (max-width: @bp-xs-max) {
+    --columns: 0;
+
+    display: grid;
+    grid-template-columns: repeat(var(--columns), auto);
+
+    tr,
+    th,
+    td {
+      padding: unit((12px / @base-font-size-px), em);
+    }
+
+    thead,
+    tbody,
+    tr {
+      display: contents;
+    }
+
+    th {
+      display: none;
+      &[data-column] {
+        display: block;
+        margin-bottom: 0.5rem;
+        border-bottom: 1px solid @table-border;
+      }
+    }
+
+    td:last-child {
+      &:not([data-column]) {
+        border-bottom: 1px solid @table-border;
+        margin-bottom: unit((10px / @base-font-size-px), em);
+        padding-bottom: unit((20px / @base-font-size-px), em);
+      }
+    }
+
+    td[data-label] {
+      &::before {
+        .heading-5();
+        display: block;
+        margin-top: 0;
+        margin-bottom: unit((5px / @base-font-size-px), em);
+        content: attr(data-label);
+        line-height: 1.83333333;
+      }
+      &:not([data-column]) {
+        grid-column: 1 / span var(--columns);
+      }
+      &[data-column]::before {
+        display: none;
+      }
+    }
+  }
+  // Override .o-table_cell__right-align on non-mobile
+  @media only screen and (min-width: @bp-sm-min) {
+    th,
+    td {
+      text-align: left;
+    }
+  }
+}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -12,7 +12,7 @@
     tr,
     th,
     td {
-      padding: unit((12px / @base-font-size-px), em);
+      padding: unit((10px / @base-font-size-px), rem);
     }
 
     thead,
@@ -25,7 +25,7 @@
       display: none;
       &[data-column] {
         display: block;
-        margin-bottom: 0.5rem;
+        margin-bottom: unit((8px / @base-font-size-px), rem);
         border-bottom: 1px solid @table-border;
       }
     }
@@ -33,8 +33,8 @@
     td:last-child {
       &:not([data-column]) {
         border-bottom: 1px solid @table-border;
-        margin-bottom: unit((10px / @base-font-size-px), em);
-        padding-bottom: unit((20px / @base-font-size-px), em);
+        margin-bottom: unit((10px / @base-font-size-px), rem);
+        padding-bottom: unit((20px / @base-font-size-px), rem);
       }
     }
 
@@ -43,7 +43,7 @@
         .heading-5();
         display: block;
         margin-top: 0;
-        margin-bottom: unit((5px / @base-font-size-px), em);
+        margin-bottom: unit((5px / @base-font-size-px), rem);
         content: attr(data-label);
         line-height: 1.83333333;
       }
@@ -55,8 +55,9 @@
       }
     }
   }
-  // Override .o-table_cell__right-align on non-mobile
+
   @media only screen and (min-width: @bp-sm-min) {
+    // Override .o-table_cell__right-align on non-mobile devices
     th,
     td {
       text-align: left;

--- a/cfgov/unprocessed/apps/tccp/package.json
+++ b/cfgov/unprocessed/apps/tccp/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cfpb-tccp",
+  "description": "CFPB's Terms of Credit Card Plans (TCCP) survey",
+  "author": {
+    "name": "Consumer Financial Protection Bureau",
+    "email": "tech@cfpb.gov",
+    "url": "https://cfpb.github.io/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cfpb/consumerfinance.gov.git"
+  },
+  "private": "true",
+  "license": "SEE LICENSE IN TERMS.md",
+  "type": "module"
+}

--- a/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
@@ -49,7 +49,6 @@
 {%- set is_full_width = 'is_full_width' in (value.options or []) -%}
 {%- set stack_on_mobile = 'stack_on_mobile' in (value.options or []) -%}
 
-
 {% if value.heading -%}
     {% include_block value.heading %}
 {%- endif %}

--- a/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
@@ -43,14 +43,12 @@
 
    stack_on_mobile:        Stack the table columns on mobile.
 
-   stack_on_mobile_hybrid: Stack *some* table columns on mobile. Experimental.
-
    ========================================================================== #}
 
 {%- set first_column_header = 'first_column_header' in (value.options or []) -%}
 {%- set is_full_width = 'is_full_width' in (value.options or []) -%}
 {%- set stack_on_mobile = 'stack_on_mobile' in (value.options or []) -%}
-{%- set stack_on_mobile_hybrid = 'stack_on_mobile_hybrid' in (value.options or []) -%}
+
 
 {% if value.heading -%}
     {% include_block value.heading %}
@@ -68,6 +66,8 @@
         {%- do columns_to_right_align.append(loop.index0) if col.right_align %}
     {% endfor %}
 {%- endif %}
+
+{%- set stack_on_mobile_hybrid = true if stack_on_mobile and columns_to_preserve_on_mobile -%}
 
 <table class="o-table
     {{- ' o-table__stack-on-small' if stack_on_mobile else '' -}}

--- a/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
@@ -13,8 +13,15 @@
 
                              {
                                  columns: [
-                                     {'heading': 'Column 1'},
-                                     {'heading': 'Column 2'},
+                                     {
+                                        'heading': 'Column 1',
+                                        'preserve_column_on_mobile': true   # Optional
+                                     },
+                                     {
+                                        'heading': 'Column 2',
+                                        'preserve_column_on_mobile': true,  # Optional
+                                        'right_align': true                 # Optional
+                                     },
                                      ...
                                  ],
                                  rows [
@@ -36,11 +43,14 @@
 
    stack_on_mobile:        Stack the table columns on mobile.
 
+   stack_on_mobile_hybrid: Stack *some* table columns on mobile. Experimental.
+
    ========================================================================== #}
 
 {%- set first_column_header = 'first_column_header' in (value.options or []) -%}
 {%- set is_full_width = 'is_full_width' in (value.options or []) -%}
 {%- set stack_on_mobile = 'stack_on_mobile' in (value.options or []) -%}
+{%- set stack_on_mobile_hybrid = 'stack_on_mobile_hybrid' in (value.options or []) -%}
 
 {% if value.heading -%}
     {% include_block value.heading %}
@@ -50,16 +60,30 @@
     <p class="u-mb30">{{ value.text_introduction }}</p>
 {%- endif %}
 
+{%- set columns_to_preserve_on_mobile = [] %}
+{%- set columns_to_right_align = [] %}
+{% if value.data.columns | selectattr('heading') | list -%}
+    {% for col in value.data.columns %}
+        {%- do columns_to_preserve_on_mobile.append(loop.index0) if col.preserve_column_on_mobile and col.heading %}
+        {%- do columns_to_right_align.append(loop.index0) if col.right_align %}
+    {% endfor %}
+{%- endif %}
+
 <table class="o-table
     {{- ' o-table__stack-on-small' if stack_on_mobile else '' -}}
+    {{- ' o-table__stack-on-small-hybrid' if stack_on_mobile_hybrid else '' -}}
     {{- ' u-w100pct' if is_full_width else '' -}}
-">
+" {{- 'style="--columns: ' | safe ~ columns_to_preserve_on_mobile | length ~ '"' | safe if stack_on_mobile_hybrid else '' -}} >
     {% if value.data.columns | selectattr('heading') | list -%}
     <thead>
         <tr>
             {% for col in value.data.columns %}
                 {% if col.heading -%}
-                    <th scope="col">{{ col.heading }}</th>
+                    <th scope="col"
+                        {{- ' data-column' if col.preserve_column_on_mobile else '' -}}
+                        {{- ' class="o-table_cell__right-align"' | safe if col.right_align else '' -}}>
+                        {{ col.heading }}
+                    </th>
                 {%- endif %}
             {% endfor %}
         </tr>
@@ -79,12 +103,18 @@
                     {%- endif -%}
 
                     {%- set col_heading = value.data.columns[loop.index0].heading -%}
-                    {%- if stack_on_mobile and col_heading -%}
+                    {%- if (stack_on_mobile or stack_on_mobile_hybrid) and col_heading -%}
                         {% set attrs = attrs ~
                             (' data-label="' | safe) ~
                             (col_heading | escape) ~
                             ('"' | safe)
                         %}
+                    {%- endif -%}
+                    {%- if stack_on_mobile_hybrid and col_heading and loop.index0 in columns_to_preserve_on_mobile -%}
+                        {% set attrs = attrs ~ ' data-column' %}
+                    {%- endif -%}
+                    {%- if loop.index0 in columns_to_right_align -%}
+                        {% set attrs = attrs ~ ' class="o-table_cell__right-align"' | safe %}
                     {%- endif -%}
 
                     <{{ tag }}{{ attrs }}>

--- a/cfgov/v1/template_debug/tables.py
+++ b/cfgov/v1/template_debug/tables.py
@@ -33,6 +33,36 @@ table_test_cases = {
     "Stack on mobile": {
         "options": ["stack_on_mobile"],
     },
+    # The hybrid stack on mobile CSS currently lives within the TCCP app.
+    # It will eventually be made more generally available.
+    "Hybrid stack on mobile": {
+        "options": ["stack_on_mobile"],
+        "data": {
+            "columns": [
+                {"heading": "Column 1", "preserve_column_on_mobile": True},
+                {"heading": "Column 2", "preserve_column_on_mobile": True},
+                {"heading": "Column 3"},
+                {"heading": "Column 4"},
+                {"heading": "Column 5"},
+            ],
+            "rows": [
+                ["0,0", "0,1", "0,2", "0,3", "0,4"],
+                ["1,0", "1,1", "1,2", "1,3", "1,4"],
+                ["2,0", "2,1", "2,2", "2,3", "2,4"],
+                ["3,0", "3,1", "3,2", "3,3", "3,4"],
+                ["4,0", "4,1", "4,2", "4,3", "4,4"],
+            ],
+        },
+    },
+    "Right-align specific table rows": {
+        "data": {
+            "columns": [
+                {"heading": "Left-aligned column"},
+                {"heading": "Right-aligned column", "right_align": True},
+            ],
+            "rows": table_defaults["data"]["rows"],
+        }
+    },
     "Stack on mobile, no column headings": {
         "options": ["stack_on_mobile"],
         "data": {

--- a/esbuild/styles.js
+++ b/esbuild/styles.js
@@ -24,6 +24,7 @@ const styledApps = [
   'rural-or-underserved-tool',
   'teachers-digital-platform',
   'filing-instruction-guide',
+  'tccp',
 ];
 
 const cssPaths = [


### PR DESCRIPTION
Adds a new hybrid responsive table pattern that stacks *some* columns on smaller screens, specified with a new [`preserve_column_on_mobile`](https://github.com/cfpb/consumerfinance.gov/compare/tccp/styles?expand=1#diff-f7439a4b28b7d7839c310d626549810c4a56ec588d77c6807f08a82125306826R65-R66) property in our base table template. I also added a `right_align` property to let us [right align table cells](https://cfpb.github.io/design-system/components/tables#right-aligned-table).

See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/232

## Additions

- New hybrid responsive table pattern.
- Optional `preserve_column_on_mobile` and `right_align` table column properties.
- New stylesheet and front-end "app" for TCCP.


## How to test this PR

1. `./frontend.sh`
1. Visit http://localhost:8000/consumer-tools/credit-cards/find-cards/cards/
1. Shrink your viewport.
1. The table columns should stack with exception of card name and apr.

## Screenshots

| desktop view | partially-stacked mobile view |
|--------|-------|
| <img width="1197" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/ce87dc4c-b829-4fcf-a5f6-b6af7c706a18"> | <img width="514" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/50921edc-af47-4559-8785-d537de982fb7"> |

## Notes and todos

- The hybrid table pattern will evolve and eventually get added to the DS. We'll then remove the CSS from this repo and import the new DS code.

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
