### PR TITLE
Ask CFPB: Remove `content-l` from search landing page that was throwing the left alignment off

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
@@ -21,9 +21,7 @@
 {% endblock %}
 
 {% block content_main %}
-    <div class="content-l
-                block
-                block__flush-top">
+    <div class="block block__flush-top">
 
         {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
         {{ translation_links.render(modifier_classes='block__flush-top') }}


### PR DESCRIPTION
## Changes

- Ask CFPB: Remove `content-l` from search landing page that was throwing the left alignment off


## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/ and resize the page and watch the alignment of search input text.


## Screenshots

Before:

<img width="555" alt="Screenshot 2024-02-29 at 11 04 09 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2f62ee66-fbe6-4e7d-a1ca-8f0e0f26b112">


After:

<img width="506" alt="Screenshot 2024-02-29 at 11 04 17 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d539bcee-56d8-441e-8e16-1bd82b1e8c7e">
