### PR TITLE
Add purchase APR to card details page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -1,12 +1,16 @@
 {% extends "v1/layouts/layout-2-1.html" %}
 
 {% from 'tccp/macros/data_published.html' import data_published %}
+{% from 'tccp/macros/fields.html' import apr, apr_range %}
 
 {% block css%}
     {{ super() }}
     <style>
         dt {
             margin-top: 15px;
+        }
+        dt:last-of-type {
+            margin-bottom: 0.5em;
         }
         dt,
         dd {
@@ -34,7 +38,7 @@
 {{ data_published(card.report_date) }}
 
 <h2>Availability</h2>
-<dl class="m-list">
+<dl>
     <dt>Location</dt>
     <dd>
         {% if not card.state_limitations %}
@@ -91,6 +95,62 @@
     </dd>
 </dl>
 <h2>Purchases</h2>
+{% if card.purchase_apr_offered %}
+<dl>
+    <dt>Purchase APR</dt>
+    {#
+        There are lots of possible variations for how purchase APR can be
+        structured, and we want readable content for all cases. So, for cards
+        that list:
+            - Min and max APRs but no median: "13.74% - 23.99%"
+            - Min, max, and median APRs: "15.90% - 21.00% (15.53% median APR)"
+            - Median APR but no min or max APR: "29.74% median APR"
+            - Min and max APRs are the same: "29.99%"
+            - APRs that vary by credit tier: a table showing each tier's APR
+            - No APRs: "The issuer did not submit APR information for this card"
+    #}
+    <dd>
+        {% if card.purchase_apr_min or card.purchase_apr_max or card.purchase_apr_median %}
+            {% set purchase_apr_range = apr_range(card.purchase_apr_min, card.purchase_apr_max) if card.purchase_apr_min and card.purchase_apr_max %}
+            {% set purchase_apr_median = apr(card.purchase_apr_median) if card.purchase_apr_median %}
+            {{ purchase_apr_range if purchase_apr_range }}
+            {{ '(' if purchase_apr_median and purchase_apr_range and purchase_apr_median != purchase_apr_range }}{{ purchase_apr_median + ' median APR' if purchase_apr_median and purchase_apr_median != purchase_apr_range }}{{ ')' if purchase_apr_median and purchase_apr_range and purchase_apr_median != purchase_apr_range }}
+            {{ 'with median APRs varying by credit score:' if card.purchase_apr_vary_by_credit_tier }}
+        {% endif %}
+        {% if card.purchase_apr_vary_by_credit_tier %}
+            <table class="o-table">
+                <thead>
+                    <tr>
+                        <th>619 or less</th>
+                        <th>620 to 719</th>
+                        <th>720 or greater</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            {{ apr(card.purchase_apr_poor) if card.purchase_apr_poor else "N/A" }}
+                        </td>
+                        <td>
+                            {{ apr(card.purchase_apr_good) if card.purchase_apr_good else "N/A" }}
+                        </td>
+                        <td>
+                            {{ apr(card.purchase_apr_great) if card.purchase_apr_great else "N/A" }}
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        {% endif %}
+        {% if not card.purchase_apr_min and not card.purchase_apr_median and
+              not card.purchase_apr_max and not card.purchase_apr_poor and
+              not card.purchase_apr_good and not card.purchase_apr_great %}
+            The issuer did not submit APR information for this card
+        {% endif %}
+    </dd>
+</dl>
+{% else %}
+<p>This card does not offer a purchase APR.</p>
+{% endif %}
 
 <h3 class="h5">Other fields that haven't been styled yet</h3>
 

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -129,13 +129,13 @@
                 <tbody>
                     <tr>
                         <td>
-                            {{ apr(card.purchase_apr_poor) if card.purchase_apr_poor else "N/A" }}
+                            {{ apr(card.purchase_apr_poor) }}
                         </td>
                         <td>
-                            {{ apr(card.purchase_apr_good) if card.purchase_apr_good else "N/A" }}
+                            {{ apr(card.purchase_apr_good) }}
                         </td>
                         <td>
-                            {{ apr(card.purchase_apr_great) if card.purchase_apr_great else "N/A" }}
+                            {{ apr(card.purchase_apr_great) }}
                         </td>
                     </tr>
                 </tbody>

--- a/cfgov/tccp/jinja2/tccp/macros/fields.html
+++ b/cfgov/tccp/jinja2/tccp/macros/fields.html
@@ -1,5 +1,5 @@
 {%- macro apr(value) -%}
-    {{ '%.2f%%' | format(value * 100) }}
+    {{ ('%.2f%%' | format(value * 100)) if value is not none else "N/A" }}
 {%- endmacro -%}
 
 {%- macro apr_range(min, max) -%}


### PR DESCRIPTION
Add purchase APR details to credit card details. See DTUR issue 231 for more. There are a bunch of content questions we need to work out in that issue, so let's focus on the code in this PR. Lots of TODOs noted below, too.

---

## Additions

- Purchase APR details to credit card details page

## How to test this PR

There are a ton of possible combinations you can check on localhost:

- [Min and max APR, no median, varies by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/advantis-credit-union-signature-cashback-rewards-credit-card/)
- [Min, max, and median APR, doesn't vary by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/cadence-bank-platinum/)
- [A single APR (i.e. min, max, and median APR are all the same), doesn't vary by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-gap-good-rewards-mastercard/)
- [No min or max APR, just a median, doesn't vary by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-quicksilver-secured-rewards/)
- [No min, max, or median APR, varies by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-platinum-secured/)
- [No APR info provided but `purchase_apr_offered` is still `True`](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-national-bank-of-omaha-citizens-community-bank-secured-visa-card/)

## Screenshots

This is just a screenshot for the first case above (min and max APR, no median, varies by credit tier):

![purchase-apr](https://github.com/cfpb/consumerfinance.gov/assets/1862695/ee41ec38-6d6b-413a-a657-5accd72e124e)

Other cases look similar.

## Notes and todos

- Still need to pull the inline CSS into the new front-end framework; I'll do that in a separate PR
- Still need to do some cleanup to match our HTML/Jinja formatting standards; I'll also do that in a separate PR to keep changes minimal here
- Even though I'm using the `apr` and `apr_range` macros, there's probably more we can start pulling out of this template and making reusable for other screens
- Probably a ton of refactoring we can do to the Jinja, so feel free to make suggestions

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets