### PR TITLE
TCCP: Feature flag logic to support beta testing

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -626,8 +626,9 @@ FLAGS = {
     "ROBOTS_TXT_SEARCH_GOV_ONLY": [("environment is", "beta")],
     # TCCP credit card finder
     "TCCP": [
-        ("environment is not", "beta", True),
-        ("environment is not", "production", True),
+        ("environment is", "dev4"),
+        ("environment is", "local"),
+        ("environment is", "test"),
     ],
 }
 

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -120,3 +120,7 @@ CSP_IMG_SRC += (_placeholder_domain,)
 # The middleware's profiling is only available if DEBUG=True
 MIDDLEWARE += ("django_cprofile_middleware.middleware.ProfilerMiddleware",)
 DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF = False
+
+# If DEPLOY_ENVIRONMENT hasn't been set by the environment in base.py,
+# default it to local.
+DEPLOY_ENVIRONMENT = DEPLOY_ENVIRONMENT or "local"


### PR DESCRIPTION
Currently the TCCP feature flag logic prohibits it from running in either beta or production. Soon we want to be able to test on beta.

This change modifies the feature flag logic such that TCCP is always available locally or on our internal DEV4 testing server. Deploying it in other environments will require manually enabling it via the Wagtail UI.

## How to test this PR

Running locally (`./runserver.sh`) TCCP should work properly.
Running locally as if you were in another environment (`DEPLOY_ENVIRONMENT=beta ./runserver.sh`) should result in a 404 for TCCP pages, unless you explicitly enable it by going to http://localhost:8000/admin/flags/TCCP/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)