### PR TITLE
Credit card agreement database: migrate to use standard layout 2-1 template

### DIFF
--- a/cfgov/agreements/jinja2/agreements/archive.html
+++ b/cfgov/agreements/jinja2/agreements/archive.html
@@ -4,64 +4,54 @@
     Credit card agreement database archive | Consumer Financial Protection Bureau
 {%- endblock %}
 
-{% block content %}
-<main class="content content__2-1 content__bleedbar">
-    <div class="content_wrapper">
-      {% set breadcrumb_items = [
-        ({'href':'/','title':'Home'}),
-        ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
-        ({'href':'/credit-cards/agreements/','title':'Credit card agreement database'}),
-      ] %}
+{% set breadcrumb_items = [
+  ({'href':'/','title':'Home'}),
+  ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
+  ({'href':'/credit-cards/agreements/','title':'Credit card agreement database'}),
+] %}
 
-      {%- import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context -%}
-      {{ breadcrumbs.render(breadcrumb_items) }}
-    </div>
-    <div class="content_wrapper">
-        <div class="content_main">
-            <div class="block block__flush-top">
-                <h1>Credit card agreement archive</h1>
-                {% if agreements | length == 0 %}
-                  We encountered an error fetching the credit card agreement archive. Please try again.
-                {% endif %}
-                <ul class="m-list m-list__links u-mt15 cc-links">
-                  {% for agreement in agreements %}
-                    {% set year = agreement[-11:-7] %}
-                    {% set quarter = agreement[-6:-4] %}
-                    {% set name = quarter + "-" + year %}
-                    <li class="m-list m-list__links">
-                      <a href="https://files.consumerfinance.gov/{{agreement}}">
-                        {% if loop.index == 1 %}
+{% block content_main %}
+    <div class="block block__flush-top">
+        <h1>Credit card agreement archive</h1>
+        {% if agreements | length == 0 %}
+            We encountered an error fetching the credit card agreement archive. Please try again.
+        {% endif %}
+        <ul class="m-list m-list__links u-mt15 cc-links">
+            {% for agreement in agreements %}
+                {% set year = agreement[-11:-7] %}
+                {% set quarter = agreement[-6:-4] %}
+                {% set name = quarter + "-" + year %}
+                <li class="m-list m-list__links">
+                    <a href="https://files.consumerfinance.gov/{{agreement}}">
+                    {% if loop.index == 1 %}
                         <span style="font-size: 22px; line-height:3">Download all most recent agreements ({{name}})</span>
-                        {% else %}
+                    {% else %}
                         Archived {{name}} agreements
-                        {% endif %}
-                      </a>
-                    {% if name in flexibilities %}
-                      <br/>
-                      <span style="font-size:14px">
-                        Agreements may include omissions due to the Bureau’s COVID-19
-                        <a href=" https://files.consumerfinance.gov/f/documents/cfpb_data-collection-statement_covid-19_2020-03.pdf">
-                          regulatory flexibility statement
-                        </a>
-                      </span>
                     {% endif %}
-                    {% if notes[name] %}
-                      <br/>
-                      <span style="font-size:14px">
+                    </a>
+                {% if name in flexibilities %}
+                    <br/>
+                    <span style="font-size:14px">
+                    Agreements may include omissions due to the Bureau’s COVID-19
+                    <a href=" https://files.consumerfinance.gov/f/documents/cfpb_data-collection-statement_covid-19_2020-03.pdf">
+                        regulatory flexibility statement
+                    </a>
+                    </span>
+                {% endif %}
+                {% if notes[name] %}
+                    <br/>
+                    <span style="font-size:14px">
                         {{notes[name]}}
-                      </span>
-                    {% endif %}
-                    </li>
-                  {% endfor %}
-                </ul>
-            </div>
-        </div>
-
-        <aside class="content_sidebar o-sidebar-content">
-            <div class="block block__flush-top">
-                {% include '_need_help.html' %}
-            </div>
-        </aside>
+                    </span>
+                {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
     </div>
-</main>
+{% endblock %}
+
+{% block content_sidebar scoped  %}
+    <div class="block block__flush-top">
+        {% include '_need_help.html' %}
+    </div>
 {% endblock %}

--- a/cfgov/agreements/jinja2/agreements/base_agreements.html
+++ b/cfgov/agreements/jinja2/agreements/base_agreements.html
@@ -1,4 +1,4 @@
-{% extends "v1/layouts/base.html" %}
+{% extends "v1/layouts/layout-2-1.html" %}
 
 {% block css %}
 {{ super() }}

--- a/cfgov/agreements/jinja2/agreements/index.html
+++ b/cfgov/agreements/jinja2/agreements/index.html
@@ -4,95 +4,83 @@
     Credit card agreement database | Consumer Financial Protection Bureau
 {%- endblock %}
 
-{% block content %}
-<main class="content content__2-1 content__bleedbar">
-    <div class="content_wrapper">
-      {% set breadcrumb_items = [
-        ({'href':'/','title':'Home'}),
-        ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
-      ] %}
+{% set breadcrumb_items = [
+  ({'href':'/','title':'Home'}),
+  ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
+] %}
 
-      {%- import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context -%}
-      {{ breadcrumbs.render(breadcrumb_items) }}
-    </div>
-    <div class="content_wrapper">
-        <div class="content_main">
-            <div class="block block__flush-top">
-                <h1>Credit card agreement database</h1>
+{% block content_main %}
+    <div class="block block__flush-top">
+        <h1>Credit card agreement database</h1>
 
-                <div class="lead-paragraph">
-                    <p>
-                        The CFPB maintains a database
-                        of credit card agreements from hundreds of card issuers.
-                        Using the tool below,
-                        you can search for an agreement by the name of the issuer.
-                    </p>
-                </div>
-            </div>
-
-            <div class="block">
-                <h2 id="issuer-select">
-                    Show agreements by card issuer
-                </h2>
-
-                {{ agreements_issuer_select() | safe }}
-
-                <a href="#find-issuer">
-                    Can't find an issuer?
-                </a>
-
-                <p class="u-mt15">
-                    This search method accesses all credit card agreements as of the CFPB’s most recent quarterly collection of
-                    credit card agreements. To access all agreements from the most recent or earlier periods, please click on the
-                    relevant agreement link below. (Please note that the Bureau did not collect agreements for 2015. The January
-                    2016 archive is a sample that was collected by Bureau staff from the publicly-available websites of the largest
-                    credit card issuers as of the first week of January 2016, and does not constitute a full set of agreements).
-                    Credit card issuers are generally required to post the credit card agreements that they offer to the public on
-                    their websites, with limited exceptions.
-                    If you are an issuer, email <a href="mailto:CardAgreements@consumerfinance.gov">CardAgreements@consumerfinance.gov</a>
-                    for agreement submission instructions.
-                </p>
-
-                <h3 class="block__sub"><a style="border-bottom-width:1px" href="./archive/">View the credit card agreement archive</a></h3>
-
-                <h3>Looking for your own credit card agreement?</h3>
-                <p>
-                    We have provided this database so you can search for agreements between
-                    credit card issuers and their customers. The agreements in this database
-                    have general terms and conditions, pricing, and fee information.
-                </p>
-                <p>
-                    If you are looking for information specific to your account,
-                    contact the bank or institution that issued your card.
-                    By law, the issuer must make your agreement available to you upon request.
-                    If you are having trouble getting your agreement, let us know by
-                    <a href="https://www.consumerfinance.gov/complaint/">submitting a complaint</a>.
-                </p>
-
-                <h3>College credit card agreements</h3>
-                <p>
-                    We have collected credit card issuer marketing agreements with
-                    universities or affiliated organizations. We are also required to
-                    report to Congress on the state of college credit card agreements.
-                </p>
-                <p>
-                    <a href="/credit-cards/college-agreements/">
-                        View college credit card agreements information
-                    </a>
-                </p>
-            </div>
-
-            {% include '_database_disclaimer.html' %}
-
+        <div class="lead-paragraph">
+            <p>
+                The CFPB maintains a database
+                of credit card agreements from hundreds of card issuers.
+                Using the tool below,
+                you can search for an agreement by the name of the issuer.
+            </p>
         </div>
-        <!-- /.content_main -->
-
-        <aside class="content_sidebar o-sidebar-content">
-            <div class="block block__flush-top">
-                {% include '_need_help.html' %}
-            </div>
-        </aside>
     </div>
-    <!-- /.content_wrapper -->
-</main>
+
+    <div class="block">
+        <h2 id="issuer-select">
+            Show agreements by card issuer
+        </h2>
+
+        {{ agreements_issuer_select() | safe }}
+
+        <a href="#find-issuer">
+            Can't find an issuer?
+        </a>
+
+        <p class="u-mt15">
+            This search method accesses all credit card agreements as of the CFPB’s most recent quarterly collection of
+            credit card agreements. To access all agreements from the most recent or earlier periods, please click on the
+            relevant agreement link below. (Please note that the Bureau did not collect agreements for 2015. The January
+            2016 archive is a sample that was collected by Bureau staff from the publicly-available websites of the largest
+            credit card issuers as of the first week of January 2016, and does not constitute a full set of agreements).
+            Credit card issuers are generally required to post the credit card agreements that they offer to the public on
+            their websites, with limited exceptions.
+            If you are an issuer, email <a href="mailto:CardAgreements@consumerfinance.gov">CardAgreements@consumerfinance.gov</a>
+            for agreement submission instructions.
+        </p>
+
+        <h3 class="block__sub"><a style="border-bottom-width:1px" href="./archive/">View the credit card agreement archive</a></h3>
+
+        <h3>Looking for your own credit card agreement?</h3>
+        <p>
+            We have provided this database so you can search for agreements between
+            credit card issuers and their customers. The agreements in this database
+            have general terms and conditions, pricing, and fee information.
+        </p>
+        <p>
+            If you are looking for information specific to your account,
+            contact the bank or institution that issued your card.
+            By law, the issuer must make your agreement available to you upon request.
+            If you are having trouble getting your agreement, let us know by
+            <a href="https://www.consumerfinance.gov/complaint/">submitting a complaint</a>.
+        </p>
+
+        <h3>College credit card agreements</h3>
+        <p>
+            We have collected credit card issuer marketing agreements with
+            universities or affiliated organizations. We are also required to
+            report to Congress on the state of college credit card agreements.
+        </p>
+        <p>
+            <a href="/credit-cards/college-agreements/">
+                View college credit card agreements information
+            </a>
+        </p>
+    </div>
+
+    {% include '_database_disclaimer.html' %}
+
+{% endblock %}
+
+{% block content_sidebar scoped  %}
+    <div class="block block__flush-top">
+        {% include '_need_help.html' %}
+    </div>
 {% endblock %}

--- a/cfgov/agreements/jinja2/agreements/search.html
+++ b/cfgov/agreements/jinja2/agreements/search.html
@@ -1,150 +1,139 @@
 {% extends "agreements/base_agreements.html" %}
 
+{% set breadcrumb_items = [
+    ({'href':'/','title':'Home'}),
+    ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
+    ({'href':'/credit-cards/agreements/','title':'Credit card agreement database'}),
+] %}
+
 {% block title -%}
     Credit card agreement database search result | Consumer Financial Protection Bureau
 {%- endblock %}
 
-{% block content %}
-
-<main class="content content__2-1 content__bleedbar">
-    <div class="content_wrapper">
-        {% set breadcrumb_items = [
-          ({'href':'/','title':'Home'}),
-          ({'href':'/data-research/credit-card-data/','title':'Credit cards'}),
-          ({'href':'/credit-cards/agreements/','title':'Credit card agreement database'}),
-        ] %}
-
-        {%- import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context -%}
-        {{ breadcrumbs.render(breadcrumb_items) }}
+{% block content_main %}
+    <div class="block block__flush-top">
+        <h1>Credit card agreement database</h1>
     </div>
-    <div class="content_wrapper">
-        <div class="content_main">
-            <div class="block block__flush-top">
-                <h1>Credit card agreement database</h1>
-            </div>
-            <div class="block">
-                <div id="ccagrsearch">
-                    <h2>Agreements by '{{ issuer.name }}'</h2>
-                    <table class="o-table o-table__striped o-table__stack-on-small u-w100pct">
-                        <thead>
-                            <tr>
-                                <th>Issuer</th>
-                                <th>Agreement description</th>
-                                <th class="u-w20pct">Download</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {% for result in page.object_list %}
+    <div class="block">
+        <div id="ccagrsearch">
+            <h2>Agreements by '{{ issuer.name }}'</h2>
+            <table class="o-table o-table__striped o-table__stack-on-small u-w100pct">
+                <thead>
+                    <tr>
+                        <th>Issuer</th>
+                        <th>Agreement description</th>
+                        <th class="u-w20pct">Download</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for result in page.object_list %}
 
-                            <tr>
-                                <td data-label="Issuer">
-                                    {{ result.issuer.name }}
-                                </td>
-                                <td data-label="Agreement description">
-                                    {{ result.description }}
-                                </td>
-                                <td class="u-w20pct" data-label="Download">
-                                    <a href="{{ result.uri }}">
-                                        PDF ({{ result.size | filesizeformat }})
-                                        {{ svg_icon('download') }}
-                                    </a>
-                                </td>
-                            </tr>
+                    <tr>
+                        <td data-label="Issuer">
+                            {{ result.issuer.name }}
+                        </td>
+                        <td data-label="Agreement description">
+                            {{ result.description }}
+                        </td>
+                        <td class="u-w20pct" data-label="Download">
+                            <a href="{{ result.uri }}">
+                                PDF ({{ result.size | filesizeformat }})
+                                {{ svg_icon('download') }}
+                            </a>
+                        </td>
+                    </tr>
 
-                            {% endfor %}
-                        </tbody>
-                    </table>
+                    {% endfor %}
+                </tbody>
+            </table>
 
-                    {% if page.has_next() or page.has_previous() %}
+            {% if page.has_next() or page.has_previous() %}
 
-                    <nav class="m-pagination"
-                         role="navigation"
-                         aria-label="Pagination">
+            <nav class="m-pagination"
+                    role="navigation"
+                    aria-label="Pagination">
 
-                        {% if page.has_previous() %}
-                        <a class="a-btn m-pagination_btn-prev"
-                           href="?page={{ page.previous_page_number() }}#ccagrsearch">
-                            <span class="a-btn_icon a-btn_icon__on-left">{{ svg_icon('left') }}</span>
-                            Previous
-                        </a>
-                        {% else %}
-                        <a class="a-btn m-pagination_btn-prev" disabled>
-                            <span class="a-btn_icon a-btn_icon__on-left">{{ svg_icon('left') }}</span>
-                            Previous
-                        </a>
-                        {% endif %}
+                {% if page.has_previous() %}
+                <a class="a-btn m-pagination_btn-prev"
+                    href="?page={{ page.previous_page_number() }}#ccagrsearch">
+                    <span class="a-btn_icon a-btn_icon__on-left">{{ svg_icon('left') }}</span>
+                    Previous
+                </a>
+                {% else %}
+                <a class="a-btn m-pagination_btn-prev" disabled>
+                    <span class="a-btn_icon a-btn_icon__on-left">{{ svg_icon('left') }}</span>
+                    Previous
+                </a>
+                {% endif %}
 
-                        {% if page.has_next() %}
-                        <a class="a-btn m-pagination_btn-next"
-                            href="?page={{ page.next_page_number() }}#ccagrsearch">
-                            Next
-                            <span class="a-btn_icon a-btn_icon__on-right">{{ svg_icon('right') }}</span>
-                        </a>
-                        {% else %}
-                        <a class="a-btn m-pagination_btn-next" disabled>
-                            Next
-                            <span class="a-btn_icon a-btn_icon__on-right">{{ svg_icon('right') }}</span>
-                        </a>
-                        {% endif %}
+                {% if page.has_next() %}
+                <a class="a-btn m-pagination_btn-next"
+                    href="?page={{ page.next_page_number() }}#ccagrsearch">
+                    Next
+                    <span class="a-btn_icon a-btn_icon__on-right">{{ svg_icon('right') }}</span>
+                </a>
+                {% else %}
+                <a class="a-btn m-pagination_btn-next" disabled>
+                    Next
+                    <span class="a-btn_icon a-btn_icon__on-right">{{ svg_icon('right') }}</span>
+                </a>
+                {% endif %}
 
-                        <form class="m-pagination_form"
-                              action="#ccagrsearch">
-                            <label class="m-pagination_label"
-                                   for="m-pagination_current-page">
-                                Page
-                                <span class="u-visually-hidden">
-                                    number {{ page.number }} out
-                                </span>
-                                <input class="m-pagination_current-page"
-                                        id="m-pagination_current-page"
-                                        name="page"
-                                        type="number"
-                                        min="1"
-                                        max="999"
-                                        pattern="[0-9]*"
-                                        inputmode="numeric"
-                                        value="{{ page.number }}">
-                                of {{ page.paginator.num_pages }}
-                            </label>
-                            <button class="a-btn
-                                           a-btn__link
-                                           m-pagination_btn-submit"
-                                    id="m-pagination_btn-submit"
-                                    type="submit">Go</button>
-                        </form>
-                    </nav>
+                <form class="m-pagination_form"
+                        action="#ccagrsearch">
+                    <label class="m-pagination_label"
+                            for="m-pagination_current-page">
+                        Page
+                        <span class="u-visually-hidden">
+                            number {{ page.number }} out
+                        </span>
+                        <input class="m-pagination_current-page"
+                                id="m-pagination_current-page"
+                                name="page"
+                                type="number"
+                                min="1"
+                                max="999"
+                                pattern="[0-9]*"
+                                inputmode="numeric"
+                                value="{{ page.number }}">
+                        of {{ page.paginator.num_pages }}
+                    </label>
+                    <button class="a-btn
+                                    a-btn__link
+                                    m-pagination_btn-submit"
+                            id="m-pagination_btn-submit"
+                            type="submit">Go</button>
+                </form>
+            </nav>
 
-                    {% endif %}
-                </div>
-            </div>
-            {% include '_database_disclaimer.html' %}
+            {% endif %}
         </div>
-        <!-- /.content_main -->
-
-        <aside class="content_sidebar o-sidebar-content">
-            <div class="block block__flush-top">
-                <div class="m-related-links">
-                    <header class="m-slug-header">
-                        <h2 id="issuer-select" class="m-slug-header_heading">
-                            Search again
-                        </h2>
-                    </header>
-                    <h3 class="h6">
-                        Show agreements by card issuer
-                    </h3>
-                    {{ agreements_issuer_select(issuer.slug) | safe }}
-                    <p>
-                        <a href="#find-issuer">
-                            Can't find an issuer?
-                        </a>
-                    </p>
-                </div>
-            </div>
-            <div class="block">
-                {% include '_need_help.html' %}
-            </div>
-        </aside>
     </div>
-    <!-- /.content_wrapper -->
-</main>
+
+    {% include '_database_disclaimer.html' %}
+
+{% endblock %}
+
+{% block content_sidebar scoped  %}
+    <div class="block block__flush-top">
+        <div class="m-related-links">
+            <header class="m-slug-header">
+                <h2 id="issuer-select" class="m-slug-header_heading">
+                    Search again
+                </h2>
+            </header>
+            <h3 class="h6">
+                Show agreements by card issuer
+            </h3>
+            {{ agreements_issuer_select(issuer.slug) | safe }}
+            <p>
+                <a href="#find-issuer">
+                    Can't find an issuer?
+                </a>
+            </p>
+        </div>
+    </div>
+    <div class="block">
+        {% include '_need_help.html' %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Changes

- Credit card agreement database: migrate to use standard layout 2-1 template


## How to test this PR

1. The three agreement templates are as follows. They should largely be unchanged, but you will see when you resize to mobile that the breadcrumbs are in our standard breadcrumb gray box:

Landing page
http://localhost:8000/credit-cards/agreements/

Archive 
http://localhost:8000/credit-cards/agreements/archive/

Individual entry (example)
http://localhost:8000/credit-cards/agreements/issuer/1st-summit-bank/


## Screenshots

Before:
<img width="593" alt="Screenshot 2024-03-01 at 2 19 40 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/c80a5532-6487-4d13-9b54-9f764a72c608">

After:
<img width="594" alt="Screenshot 2024-03-01 at 2 19 27 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/42036a7a-e467-49f7-b854-d0d378111bcf">
