### PR TITLE
Tidy up TCCP form styles

### DIFF
--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -6,16 +6,21 @@
     {{ title }} | Consumer Financial Protection Bureau
 {%- endblock title %}
 
+{% block css %}
+{{ super() }}
+<link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">
+{% endblock %}
+
 {% block content_main %}
 
 <div class="content_wrapper">
     <div class="block block__sub">
         <h1>{{ heading }}</h1>
-        <div class="lead-paragraph u-readable-width">
+        <p class="lead-paragraph">
             We know people use credit cards for many reasons.
             Our database of {{ num_cards or "" }}
             cards can help you find ones that are best for you.
-        </div>
+        </p>
     </div>
 
     <div class="block block__sub">
@@ -50,23 +55,14 @@
                 </fieldset>
             </div>
 
-            <button
-                type="submit"
-                class="a-btn a-btn__full-on-xs"
-                title="See cards for your situation"
-            >
-                See cards for your situation
-            </button>
+            <div class="m-btn-group">
+                <button class="a-btn a-btn__full-on-xs" title="See cards for your situation">See cards for your situation</button>
+                <div class="u-btn-helper">
+                    Or <a href="{{ url('tccp:cards') }}">see all cards</a> in our database
+                </div>
+            </div>
 
         </form>
-    </div>
-
-    <div class="block block__sub block__flush-top u-text-centered">
-        <p>
-            Or
-            <a href="{{ url('tccp:cards') }}">see all cards</a>
-            in our database
-        </p>
     </div>
 </div>
 

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -1,5 +1,28 @@
 @import (reference) '../../../css/main.less';
 
+.respond-to-min(@bp-sm-min, {
+  .o-form_group {
+    max-width: unit((380px / @base-font-size-px), em);
+  }
+});
+
+.m-btn-group {
+  .u-btn-helper {
+    width: 100%;
+    margin-top: unit((15px / @base-font-size-px), em);
+    text-align: center;
+    a {
+      border-bottom-width: 1px;
+    }
+    .respond-to-min(@bp-sm-min, {
+      display: inline-block;
+      width: auto;
+      margin-top: 0;
+      margin-left: unit((6px / @btn-font-size), em);
+    });
+  }
+}
+
 .o-table__stack-on-small-hybrid {
   // We don't want responsive table styles applied to the `print` media type
   // so we're not using .respond-to-max(@bp-xs-max ) here.


### PR DESCRIPTION
Assorted visual improvements for TCCP, mostly around the width of form elements.

## How to test this PR

1. `./frontend.sh`
2. Form fields should be narrower and the "See all cards" link should be next to the submit button instead of under it.


## Screenshots

| before | after |
|--------|-------|
| <img width="1246" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/d8a5f0fc-0f92-4cfd-b2a9-50124a2161ea"> | <img width="1246" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/55595877-6363-414c-bfa0-34c216b41ec6"> |


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
