### PR TITLE
Add directory table pattern to base table template

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -63,8 +63,8 @@
         </p>
 
         {%- set card_columns = [
-            {'heading': 'Card', 'preserve_column_on_mobile': true},
-            {'heading': 'Purchase APR', 'preserve_column_on_mobile': true, 'right_align': true},
+            {'heading': 'Card'},
+            {'heading': 'Purchase APR'},
             {'heading': 'Availability'},
             {'heading': 'Account fee'},
             {'heading': 'Balance transfer APR'},
@@ -90,7 +90,7 @@
                 'columns': card_columns,
                 'rows': card_rows
             },
-            'options': ['stack_on_mobile']
+            'options': ['directory_table']
         } %}
             {% include 'v1/includes/organisms/tables/base.html' %}
         {% endwith %}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -23,6 +23,31 @@
   }
 }
 
+// Overrides to the make the directory table pattern sticky
+// https://cfpb.github.io/design-system/components/tables#responsive-stacked-table-with-header-directory-table
+@media only screen and (max-width: @bp-xs-max) {
+  .o-table__entry-header-on-small {
+    border-top: 0;
+
+    & > tbody td:first-child {
+      position: sticky;
+      margin-top: -1px;
+      margin-bottom: 0;
+      top: 0;
+      border-top: 1px solid @table-border;
+    }
+
+    & > tbody > tr {
+      margin-bottom: 0;
+    }
+
+    td:last-child {
+      margin-bottom: 0;
+      padding-bottom: unit((30px / @base-font-size-px), em);
+    }
+  }
+}
+
 .o-table__stack-on-small-hybrid {
   // We don't want responsive table styles applied to the `print` media type
   // so we're not using .respond-to-max(@bp-xs-max ) here.

--- a/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/tables/base.html
@@ -43,11 +43,14 @@
 
    stack_on_mobile:        Stack the table columns on mobile.
 
+   directory_table:        Uses first column data to stack rows.
+
    ========================================================================== #}
 
 {%- set first_column_header = 'first_column_header' in (value.options or []) -%}
 {%- set is_full_width = 'is_full_width' in (value.options or []) -%}
-{%- set stack_on_mobile = 'stack_on_mobile' in (value.options or []) -%}
+{%- set stack_on_mobile = 'stack_on_mobile' in (value.options or []) or 'directory_table' in (value.options or []) -%}
+{%- set directory_table = 'directory_table' in (value.options or []) -%}
 
 {% if value.heading -%}
     {% include_block value.heading %}
@@ -71,6 +74,7 @@
 <table class="o-table
     {{- ' o-table__stack-on-small' if stack_on_mobile else '' -}}
     {{- ' o-table__stack-on-small-hybrid' if stack_on_mobile_hybrid else '' -}}
+    {{- ' o-table__entry-header-on-small' if directory_table else '' -}}
     {{- ' u-w100pct' if is_full_width else '' -}}
 " {{- 'style="--columns: ' | safe ~ columns_to_preserve_on_mobile | length ~ '"' | safe if stack_on_mobile_hybrid else '' -}} >
     {% if value.data.columns | selectattr('heading') | list -%}

--- a/cfgov/v1/template_debug/tables.py
+++ b/cfgov/v1/template_debug/tables.py
@@ -33,6 +33,9 @@ table_test_cases = {
     "Stack on mobile": {
         "options": ["stack_on_mobile"],
     },
+    "Stack on mobile, directory table": {
+        "options": ["directory_table"],
+    },
     # The hybrid stack on mobile CSS currently lives within the TCCP app.
     # It will eventually be made more generally available.
     "Hybrid stack on mobile": {


### PR DESCRIPTION
Adds our directory table pattern that's already in the DS to our cf.gov table organism template.

Also iterates on our card listing page by using a new directory table variant that sticks the top rows to the viewport when scrolling.

See https://cfpb.github.io/design-system/components/tables#responsive-stacked-table-with-header-directory-table
See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/232

## Changes

- Replaces the table pattern used on the TCCP all cards page

## How to test this PR

1. `./frontend.sh`
2. Visit the [all cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) on a small screen and scroll to see a sticky header.

## Screenshots

![scroll](https://github.com/cfpb/consumerfinance.gov/assets/1060248/7e372d67-18d2-48ad-bc54-f6c8586938cf)

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
