### PR TITLE
TCCP: Simplify filtering by balance transfers

### DIFF
--- a/cfgov/tccp/filterset.py
+++ b/cfgov/tccp/filterset.py
@@ -29,9 +29,6 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         method="filter_for_empty_list",
         label="No account fee",
     )
-    no_balance_transfer_fee = CheckboxFilter(
-        "balance_transfer_fees", label="No balance transfer fee", exclude=True
-    )
     rewards = CheckboxFilter(
         label="Offers rewards", method="filter_for_nonempty_list"
     )

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -68,7 +68,6 @@
             {'heading': 'Availability'},
             {'heading': 'Account fee'},
             {'heading': 'Balance transfer APR'},
-            {'heading': 'Balance transfer fee'},
             {'heading': 'Offers rewards'},
         ] %}
         {%- set card_rows = [] %}
@@ -78,10 +77,7 @@
                 apr(card.purchase_apr_for_tier),
                 ('Regionally; ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
                 (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
-                apr(card.transfer_apr_for_tier) if card.transfer_apr_for_tier is not none else (
-                    apr_range(card.transfer_apr_min, card.transfer_apr_max) if card.transfer_apr_min is not none else 'None'
-                ),
-                'Yes' if card.balance_transfer_fees else 'No',
+                apr(card.transfer_apr_for_tier) if card.transfer_apr_for_tier is not none else apr_range(card.transfer_apr_min, card.transfer_apr_max),
                 (card.rewards | join(', ')) if card.rewards else 'None'
             ] ) %}
         {% endfor %}

--- a/cfgov/tccp/jinja2/tccp/macros/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/macros/filter_form.html
@@ -38,8 +38,6 @@
 
             {{ render_field(form.no_account_fee, "checkbox") }}
 
-            {{ render_field(form.no_balance_transfer_fee, "checkbox") }}
-
             {{ render_field(form.rewards, "checkbox") }}
         </fieldset>
     </div>

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -12,14 +12,12 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = CardSurveyData
         fields = [
-            "balance_transfer_fees",
-            "introductory_apr_offered",
             "periodic_fee_type",
             "product_name",
             "purchase_apr_for_tier",
+            "rewards",
             "secured_card",
             "state_limitations",
-            "rewards",
             "transfer_apr_for_tier",
             "transfer_apr_min",
             "transfer_apr_max",

--- a/cfgov/tccp/situations.py
+++ b/cfgov/tccp/situations.py
@@ -5,8 +5,8 @@ from typing import List
 @dataclass
 class Situation:
     title: str
-    details_intro_have: bool
     details: List[str]
+    details_intro_have: bool = field(default_factory=bool)
     query: dict = field(default_factory=dict)
 
     def __str__(self):
@@ -24,14 +24,11 @@ SITUATIONS = [
     ),
     Situation(
         title="Transfer a balance",
-        details_intro_have=True,
         details=[
             "Low balance transfer interest rates",
-            "No balance transfer fee",
         ],
         query={
             "ordering": "transfer_apr",
-            "no_balance_transfer_fee": True,
         },
     ),
     Situation(
@@ -49,12 +46,10 @@ SITUATIONS = [
     ),
     Situation(
         title="Build credit",
-        details_intro_have=False,
         details=["Are targeted for your credit score range"],
     ),
     Situation(
         title="Earn rewards",
-        details_intro_have=False,
         details=[
             (
                 "Have rewards",


### PR DESCRIPTION
Instead of filtering by balance transfer fees, we want to filter by whether balance transfers are offered or not.

New logic for "transfer a balance" is:

Filter by:
- Credit score

Sort by:
- Balance Transfer APR by credit tier in ascending order (We show results based on chosen credit tier, use min and max apr as fallback if tier column is empty. This also filters out cards that don't offer a balance transfer APR.)
- Secondary ordering: Purchase APR by credit tier in ascending order

See internal DTUR#235#issuecomment-350326.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
