### PR TITLE
Retitle TCCP to "Explore credit cards..."

### DIFF
--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -41,7 +41,7 @@
 
             <p>
                 If you don’t know your credit score,
-                <a href="/ask-cfpb/how-do-i-get-a-free-copy-of-my-credit-reports-en-5/">find out for free</a>
+                <a href="/ask-cfpb/where-can-i-get-my-credit-scores-en-316/">find out for free</a>
                 or play around to find out how credit score affects rates.
             </p>
 

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -22,7 +22,7 @@ from .serializers import CardSurveyDataSerializer
 class LandingPageView(FlaggedTemplateView):
     flag_name = "TCCP"
     template_name = "tccp/landing_page.html"
-    heading = "Explore cards for your situation"
+    heading = "Explore credit cards for your situation"
     breadcrumb_items = [
         {
             "title": "Credit cards",


### PR DESCRIPTION
This commit retitles the TCCP app from

> Explore cards for your situation

to

> Explore credit cards for your situation

For now the URL remains /explore-cards/.

It also updates the landing page link about credit scores to https://www.consumerfinance.gov/ask-cfpb/where-can-i-get-my-credit-scores-en-316/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)