### PR TITLE
Fix ruff warning for ruff v0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.3.0
     hooks:
       - id: ruff
   - repo: https://github.com/pycqa/isort

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ deps=
     bandit[toml]
 commands=
     black cfgov --check
-    ruff cfgov
+    ruff check cfgov
     isort --check-only --diff cfgov
     bandit -c "pyproject.toml" -r cfgov
 


### PR DESCRIPTION
The ruff linter version 0.3.0 (released 5 days ago) deprecates the usage `ruff <path>` in favor of `ruff check <path>`, see release notes:

https://github.com/astral-sh/ruff/releases/tag/v0.3.0

This fixes the warning that currently appears if you run ruff with the latest version:

```
lint: commands[1]> ruff cfgov
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)