### PR TITLE
ROUT: Remove unused `container.margin-top-2` print rule

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/css/print.less
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/css/print.less
@@ -14,10 +14,6 @@
     display: none;
   }
 
-  .container.margin-top-2 {
-    margin-top: 0;
-  }
-
   h1,
   .super {
     font-size: 18px;


### PR DESCRIPTION
I can't find any references to the `margin-top-2` CSS class.

## Changes

- ROUT: Remove unused `container.margin-top-2` print rule


## How to test this PR

1. PR checks should pass.
