### PR TITLE
FWB: convert utility classes to blocks for notifications

### DIFF
--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -90,22 +90,24 @@
             {{ _('to other U.S. adults from our national survey.') }}
         </p>
 
-        <div class="m-notification
-                    m-notification__visible
-                    m-notification__warning">
-            {{ svg_icon('warning-round') }}
-            <div class="m-notification_content">
-                <p class="h4 m-notification_message">
-                    {{ _('We never collect or store the answers you provide.') }}
-                </p>
-                <ul class="m-list m-list__links">
-                    <li class="m-list_item">
-                        <a class="m-list_link"
-                        href="/privacy/website-privacy-policy/">
-                            {{ _('See how your privacy is protected.') }}
-                        </a>
-                    </li>
-                </ul>
+        <div class="block block__sub">
+            <div class="m-notification
+                        m-notification__visible
+                        m-notification__warning">
+                {{ svg_icon('warning-round') }}
+                <div class="m-notification_content">
+                    <p class="h4 m-notification_message">
+                        {{ _('We never collect or store the answers you provide.') }}
+                    </p>
+                    <ul class="m-list m-list__links">
+                        <li class="m-list_item">
+                            <a class="m-list_link"
+                            href="/privacy/website-privacy-policy/">
+                                {{ _('See how your privacy is protected.') }}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
             </div>
         </div>
 

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -54,7 +54,7 @@
             {{ _('You’ve taken a good step in understanding your financial picture.') }}
         </p>
     {% elif (current_language == 'en') %}
-        <div class="u-mb15">
+        <div class="block block__sub">
             {{ notification.render(
                 'warning',
                 true,
@@ -64,7 +64,7 @@
             ) }}
         </div>
     {% else %}
-        <div class="u-mb15">
+        <div class="block block__sub">
             {{ notification.render(
                 'warning',
                 true,


### PR DESCRIPTION
## Changes

- FWB: convert utility classes to blocks for notifications


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/financial-well-being/ and http://localhost:8000/consumer-tools/financial-well-being/results/ and see the gap between the notification and the content isn't so tight.


## Screenshots

Before:
<img width="843" alt="Screenshot 2024-03-08 at 11 16 15 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/a6fb7995-1e5e-43e0-83b2-1803519a95e8">

After:
<img width="829" alt="Screenshot 2024-03-08 at 11 15 58 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/4753f0a8-b678-49a1-92da-80d582e91014">


Before:

<img width="829" alt="Screenshot 2024-03-08 at 11 19 43 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/b7903aaf-edd3-432f-bb07-15b03b9fdacd">

After:

<img width="823" alt="Screenshot 2024-03-08 at 11 19 55 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2d1be040-e7d8-4152-b7ca-f13d9de8652e">
