### PR TITLE
Pin psycopg to 2.9.6

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,11 +24,6 @@ govdelivery==1.4.0
 Jinja2==3.1.3
 lxml==5.1.0
 opensearch-py==2.4.2
-# psycopg2 > 2.9.6 causes cf.gov to hang locally for people with on-network
-# Macs, so we'll pin to 2.9.6 for now.
-# See https://github.com/psycopg/psycopg2/issues/1645
-# and https://github.com/dbt-labs/dbt-core/issues/9303#issuecomment-1864934933
-# for the details.
 psycopg2-binary==2.9.6
 python-dateutil==2.9.0
 regdown==1.0.7

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,7 +24,12 @@ govdelivery==1.4.0
 Jinja2==3.1.3
 lxml==5.1.0
 opensearch-py==2.4.2
-psycopg2-binary==2.9.9
+# psycopg2 > 2.9.6 causes cf.gov to hang locally for people with on-network
+# Macs, so we'll pin to 2.9.6 for now.
+# See https://github.com/psycopg/psycopg2/issues/1645
+# and https://github.com/dbt-labs/dbt-core/issues/9303#issuecomment-1864934933
+# for the details.
+psycopg2-binary==2.9.6
 python-dateutil==2.9.0
 regdown==1.0.7
 requests-aws4auth==1.2.3


### PR DESCRIPTION
`psycopg2` > 2.9.6 causes cf.gov to hang locally for people with on-network Macs, so we'll pin to 2.9.6 for now. See https://github.com/psycopg/psycopg2/issues/1645 and https://github.com/dbt-labs/dbt-core/issues/9303#issuecomment-1864934933 for the details. Huge thanks to @chosak for the super-sleuthing and figuring this out.

---

## Changes

- Pin psycopg to 2.9.6

## How to test this PR

If you happen to be on an on-network Mac:

1. Build cf.gov with this PR, `./runserver.sh`, and note the server starts up as normal
2. `pip install psycopg2-binary==2.9.7`, `./runserver.sh`, and note the server hangs when starting up

If you're not on an on-network Mac, build cf.gov and make sure everything works as expected.

## Notes and todos

- It's not clear when, if, or by whom this bug will ever be fixed (sounds like it's a misconfiguration of GSSAPI), but if it ever is, we can unpin `psycopg` from 2.9.6

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets