### PR TITLE
FIG: Add conditional for inclusion of eyebrow block

### DIFF
--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
@@ -15,7 +15,9 @@
 
 {% block content_main %}
 
-    <div class="eyebrow">{{ page.eyebrow }}</div>
+    {% if page.eyebrow %}
+      <div class="eyebrow">{{ page.eyebrow }}</div>
+    {% endif %}
     <h1>{{ page.page_header }}</h1>
     <div class="lead-paragraph">{{ page.subheader }}</div>
     <div class="block block__border-top u-fig-print-link">


### PR DESCRIPTION
The FIG can have an eyebrow added via Wagtail. If it doesn't have an eyebrow added, however, it gets an empty `<div class="eyebrow"></div>`, which occupies space on the page. This PR wraps that block in a conditional, so that it is only added if it has a value.


## Changes

- FIG: Add conditional for inclusion of eyebrow block


## How to test this PR

1. Visit http://localhost:8000/data-research/small-business-lending/filing-instructions-guide/2024-guide/ and edit the page in Wagtail and see that an eyebrow can be added.

## Screenshots

Before (has additional padding above h1 for the eyebrow's container):
<img width="1022" alt="Screenshot 2024-03-08 at 12 41 58 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ee03b148-ab89-4de3-b279-c84ab6830e97">

After:
<img width="1052" alt="Screenshot 2024-03-08 at 12 41 49 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2e03d4a6-9eec-48a7-89d2-861cd3f269bd">
