### PR TITLE
Find-a-housing-counselor: Migrate to layout-full template

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -1,4 +1,4 @@
-{% extends "v1/layouts/base.html" %}
+{% extends "v1/layouts/layout-full.html" %}
 {% import "v1/includes/molecules/social-media.html" as social_media with context %}
 
 {% block title %}
@@ -11,342 +11,334 @@
       href="{{ static('apps/find-a-housing-counselor/css/main.css') }}">
 {% endblock %}
 
-{% block content %}
-    <main class="content" id="main" lang="en">
-        <div class="content_wrapper">
-            <div class="content_main">
-                <section>
+{% block content_main %}
+    <section class="block block__flush-top">
+        <div class="u-print-only">
+            <!-- Show different content on print -->
+            <img src="{{ static( 'img/logo_237x50@2x.png' ) }}"
+                    width="237"
+                    height="50"
+                    alt="Consumer Financial Protection Bureau logo">
 
-                    <div class="u-print-only">
-                        <!-- Show different content on print -->
-                        <img src="{{ static( 'img/logo_237x50@2x.png' ) }}"
-                             width="237"
-                             height="50"
-                             alt="Consumer Financial Protection Bureau logo">
+            <h1>Housing counselors near you</h1>
+            <p>
+                The counseling agencies on this list are approved
+                by the U.S. Department of Housing and Urban
+                Development (HUD), and they can offer independent
+                advice about whether a particular set of mortgage
+                loan terms is a good fit based on your objectives
+                and circumstances, often at little or no cost to
+                you. This list shows you several approved agencies
+                in your area. You can find other approved counseling
+                agencies at the Consumer Financial
+                Protection Bureau’s (CFPB) website:
+                consumerfinance.gov/mortgagehelp or
+                by calling 1-855-411-CFPB (2372).
+                You can also access a list of nationwide
+                HUD-approved counseling agencies at:
+                https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home
+            </p>
+        </div><!-- end .hud_hca_api_print-header -->
 
-                        <h1>Housing counselors near you</h1>
-                        <p>
-                            The counseling agencies on this list are approved
-                            by the U.S. Department of Housing and Urban
-                            Development (HUD), and they can offer independent
-                            advice about whether a particular set of mortgage
-                            loan terms is a good fit based on your objectives
-                            and circumstances, often at little or no cost to
-                            you. This list shows you several approved agencies
-                            in your area. You can find other approved counseling
-                            agencies at the Consumer Financial
-                            Protection Bureau’s (CFPB) website:
-                            consumerfinance.gov/mortgagehelp or
-                            by calling 1-855-411-CFPB (2372).
-                            You can also access a list of nationwide
-                            HUD-approved counseling agencies at:
-                            https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home
-                        </p>
-                    </div><!-- end .hud_hca_api_print-header -->
-
-                    <div class="block
-                                block__flush-top
-                                u-screen-only
-                                o-sidebar-breakout">
-                        <div class="content-l">
-                            <div class="o-sidebar-breakout_col
-                                        content-l_col
-                                        content-l_col-2-3">
-                                <h1>Find a housing counselor</h1>
-                                <p>
-                                    Housing counselors throughout the country can
-                                    provide advice on buying a home, renting,
-                                    defaults, forbearances, foreclosures, and
-                                    credit issues. This list will show you
-                                    several approved agencies in your area.
-                                    The counseling agencies on this list are
-                                    approved by the U.S. Department of Housing
-                                    and Urban Development (HUD) and they can
-                                    offer independent advice, often at little or
-                                    no cost to you. There is also a
-                                    <a class="a-link a-link__icon"
-                                       href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
-                                        <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span></a>.
-                                </p>
-                                <p>
-                                    Using the search box below, you can find one
-                                    near you. <strong>Not every housing
-                                    counselor offers all services, so please
-                                    look at the list of services offered by
-                                    each agency.</strong>
-                                </p>
-                            </div>
-                            <aside class="o-sidebar-breakout_col
-                                          content-l_col
-                                          content-l_col-1-3">
-                                <header class="m-slug-header">
-                                    <h2 class="m-slug-header_heading">
-                                        Coronavirus affecting your mortgage or housing?
-                                    </h2>
-                                </header>
-                                <div class="o-sidebar-breakout_text-container">
-                                    <div class="o-sidebar-breakout_text-body">
-                                        <p>
-                                            We have resources from multiple federal agencies to help homeowners and renters understand options for relief and protection in light of the coronavirus emergency.
-                                        </p>
-                                        <p>
-                                            <a href="/coronavirus/mortgage-and-housing-assistance/">
-                                                See mortgage and housing assistance resources
-                                            </a>
-                                        </p>
-                                    </div>
-                                </div>
-                            </aside>
+        <div class="block
+                    block__flush-top
+                    u-screen-only
+                    o-sidebar-breakout">
+            <div class="content-l">
+                <div class="o-sidebar-breakout_col
+                            content-l_col
+                            content-l_col-2-3">
+                    <h1>Find a housing counselor</h1>
+                    <p>
+                        Housing counselors throughout the country can
+                        provide advice on buying a home, renting,
+                        defaults, forbearances, foreclosures, and
+                        credit issues. This list will show you
+                        several approved agencies in your area.
+                        The counseling agencies on this list are
+                        approved by the U.S. Department of Housing
+                        and Urban Development (HUD) and they can
+                        offer independent advice, often at little or
+                        no cost to you. There is also a
+                        <a class="a-link a-link__icon"
+                            href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
+                            <span class="a-link_text">list of nationwide HUD-approved counseling agencies</span></a>.
+                    </p>
+                    <p>
+                        Using the search box below, you can find one
+                        near you. <strong>Not every housing
+                        counselor offers all services, so please
+                        look at the list of services offered by
+                        each agency.</strong>
+                    </p>
+                </div>
+                <aside class="o-sidebar-breakout_col
+                                content-l_col
+                                content-l_col-1-3">
+                    <header class="m-slug-header">
+                        <h2 class="m-slug-header_heading">
+                            Coronavirus affecting your mortgage or housing?
+                        </h2>
+                    </header>
+                    <div class="o-sidebar-breakout_text-container">
+                        <div class="o-sidebar-breakout_text-body">
+                            <p>
+                                We have resources from multiple federal agencies to help homeowners and renters understand options for relief and protection in light of the coronavirus emergency.
+                            </p>
+                            <p>
+                                <a href="/coronavirus/mortgage-and-housing-assistance/">
+                                    See mortgage and housing assistance resources
+                                </a>
+                            </p>
                         </div>
                     </div>
+                </aside>
+            </div>
+        </div>
 
-                    <div class="block block__border u-screen-only">
-                        {#
-                            Set the `no-js` class on page load,
-                            which is reverted if and when the map is
-                            loaded via JavaScript.
-                        #}
-                        <section id="hud_search_container"
-                                 class="no-js
-                                        hud-search-container">
-                            <div class="hud-search-container_text">
-                                <form class="o-form" action="#hud_search_container">
-                                    <div class="m-form-field-with-button">
+        <div class="block block__border u-screen-only">
+            {#
+                Set the `no-js` class on page load,
+                which is reverted if and when the map is
+                loaded via JavaScript.
+            #}
+            <section id="hud_search_container"
+                        class="no-js
+                            hud-search-container">
+                <div class="hud-search-container_text">
+                    <form class="o-form" action="#hud_search_container">
+                        <div class="m-form-field-with-button">
 
-                                        <div class="m-form-field">
-                                            <label class="a-label a-label__heading" for="hud_hca_api_query">
-                                                Search by ZIP code:
-                                            </label>
+                            <div class="m-form-field">
+                                <label class="a-label a-label__heading" for="hud_hca_api_query">
+                                    Search by ZIP code:
+                                </label>
 
-                                            {% if zipcode and error_message %}
-                                            <div class="u-mb15">
-                                                <div class="m-notification
-                                                            m-notification__error
-                                                            m-notification__visible">
-                                                    {{ svg_icon('warning-round') }}
-                                                    <div class="m-notification_content" role="alert">
-                                                        <div class="h4 m-notification_message">
-                                                            {{ error_message }}
-                                                        </div>
-                                                        <div class="m-notification_explanation">
-                                                            {{ error_help }}
-                                                        </div>
-                                                    </div>
-                                                </div>
+                                {% if zipcode and error_message %}
+                                <div class="u-mb15">
+                                    <div class="m-notification
+                                                m-notification__error
+                                                m-notification__visible">
+                                        {{ svg_icon('warning-round') }}
+                                        <div class="m-notification_content" role="alert">
+                                            <div class="h4 m-notification_message">
+                                                {{ error_message }}
                                             </div>
-                                            {% endif %}
-
-                                            <input id="hud_hca_api_query"
-                                                   type="text"
-                                                   name="zipcode"
-                                                   class="a-text-input a-text-input__full"
-                                                   value="{% if zipcode %}{{ zipcode }}{% endif %}"
-                                                   placeholder="Please enter a five-digit ZIP code">
-                                        </div>
-
-                                        <button class="a-btn a-btn__full-on-xs"
-                                                type="submit"
-                                                data-cy="btn-fahc-submit">
-                                            Find a counselor
-                                        </button>
-                                        <div class="m-form-field-with-button_info">
-                                            <p>
-                                                This tool is powered by
-                                                <a class="a-link a-link__icon"
-                                                    href="https://data.hud.gov/housing_counseling.html">
-                                                    <span class="a-link_text">HUD's</span>
-                                                    {{ svg_icon('external-link') }}</a>
-                                                official list of housing counselors.
-                                            </p>
-                                            <p>
-                                                If you notice errors in the housing counselor data,
-                                                contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
-                                            </p>
+                                            <div class="m-notification_explanation">
+                                                {{ error_help }}
+                                            </div>
                                         </div>
                                     </div>
-                                </form>
-
-                                {% if zipcode and zipcode_valid %}
-                                <div class="skip-nav">
-                                    <a class="skip-nav_link
-                                              skip-nav_link__flush-left"
-                                       href="#hud_results-list_container">
-                                       Skip to results
-                                    </a>
                                 </div>
                                 {% endif %}
 
+                                <input id="hud_hca_api_query"
+                                        type="text"
+                                        name="zipcode"
+                                        class="a-text-input a-text-input__full"
+                                        value="{% if zipcode %}{{ zipcode }}{% endif %}"
+                                        placeholder="Please enter a five-digit ZIP code">
                             </div>
-                            {% if zipcode and zipcode_valid %}
-                              <div class="hud-search-container_map">
-                                  <!-- Mapbox map is ignored during voiceover navigation
-                                       as set by aria-hidden. -->
-                                  <div id="hud_hca_api_map_container"
-                                       aria-hidden="true">
-                                      <div id="hud_hca_api_map_canvas"></div>
-                                  </div><!-- end .hud_hca_api_map -->
-                              </div>
-                            {% endif %}
-                        </section>
 
-                    </div>
-                    {% if zipcode and zipcode_valid %}
-                    <div class="block" id="hud_results-list_container">
-                        <div class="results-header">
-                            <ul class="m-list
-                                       m-list__horizontal
-                                       hud_hca_api_results_actions">
-                                <li class="m-list_item">
-                                    <a class="a-link
-                                              a-link__icon"
-                                       id="hud_print-page-link"
-                                       href="#">
-                                        <span class="a-link_text">Print list</span>
-                                        {{ svg_icon('print') }}
-                                    </a>
-                                </li>
-                                <li class="m-list_item">
+                            <button class="a-btn a-btn__full-on-xs"
+                                    type="submit"
+                                    data-cy="btn-fahc-submit">
+                                Find a counselor
+                            </button>
+                            <div class="m-form-field-with-button_info">
+                                <p>
+                                    This tool is powered by
                                     <a class="a-link a-link__icon"
-                                       id="generate-pdf-link"
-                                       href="{{ pdf_url }}"
-                                       target="_blank"
-                                       rel="noopener noreferrer">
-                                        <span class="a-link_text">Save list as <abbr title="Portable Document Format">PDF</abbr></span>
-                                        {{ svg_icon('download') }}
-                                    </a>
-                                </li>
-                            </ul>
-
-                            <h2 class="h4">
-                                Displaying the
-                                {{ api_json.counseling_agencies | length }}
-                                locations closest to ZIP code
-                                {{ zipcode | escape }}
-                            </h2>
+                                        href="https://data.hud.gov/housing_counseling.html">
+                                        <span class="a-link_text">HUD's</span>
+                                        {{ svg_icon('external-link') }}</a>
+                                    official list of housing counselors.
+                                </p>
+                                <p>
+                                    If you notice errors in the housing counselor data,
+                                    contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+                                </p>
+                            </div>
                         </div>
+                    </form>
 
-                        <table class="o-table
-                                      o-table__stack-on-small
-                                      u-w100pct">
-                            <thead>
-                                <tr>
-                                    <th>Agency</th>
-                                    <th>Services</th>
-                                    <th>Distance</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for counselor in api_json.counseling_agencies %}
-                                <tr id="hud-result-{{ loop.index }}">
-                                    <td data-label="Agency">
-                                        <ol start="{{ loop.index }}">
-                                            <li>
-                                                <div class="u-mb15"
-                                                     itemscope
-                                                     itemtype="https://schema.org/PostalAddress">
-
-                                                    {% if counselor.weburl %}
-                                                    <a class="a-link a-link__icon"
-                                                       href="{{ counselor.weburl }}">
-                                                        <span class="a-link_text"><b itemprop="name">{{ counselor.nme }}</b></span>
-                                                        {{ svg_icon('external-link') }}
-                                                    </a>
-                                                    {% else %}
-                                                    <b itemprop="name">{{ counselor.nme }}</b>
-                                                    {% endif %}
-
-                                                    <br>
-
-                                                    <span itemprop="streetAddress">{{ counselor.adr1 }}</span>
-                                                    {% if counselor.adr2 and counselor.adr2 != ' '  %}
-                                                    <br>
-                                                    <span itemprop="streetAddress">{{ counselor.adr2 }}</span>
-                                                    {% endif %}
-                                                    <br>
-                                                    <span itemprop="addressLocality">{{ counselor.city }}</span>,
-                                                    <span itemprop="addressRegion">{{ counselor.statecd }}</span>
-                                                    <span itemprop="postalCode">{{ counselor.zipcd }}</span>
-
-                                                </div>
-
-                                                <dl>
-                                                    {% if counselor.weburl %}
-                                                    <dt>Website:</dt>
-                                                    <dd>
-                                                    <a class="a-link a-link__icon"
-                                                       href="{{ counselor.weburl }}"
-                                                       itemprop="url">
-                                                        <span class="a-link_text">{{ counselor.weburl }}</span>
-                                                        {{ svg_icon('external-link') }}
-                                                    </a>
-                                                    </dd>
-                                                    {% endif %}
-
-                                                    {% if counselor.phone1 %}
-                                                    <dt>Phone:</dt>
-                                                    <dd>
-                                                        <a href="tel:+1-{{ counselor.phone1 }}"
-                                                           itemprop="telephone">
-                                                            {{ counselor.phone1 }}
-                                                        </a>
-                                                    </dd>
-                                                    {% endif %}
-
-                                                    {% if counselor.email %}
-                                                    <dt>Email Address:</dt>
-                                                    <dd>
-                                                        <a href="mailto:{{ counselor.email }}"
-                                                           itemprop="email">
-                                                            {{ counselor.email }}
-                                                        </a>
-                                                    </dd>
-                                                    {% endif %}
-
-                                                    {% if counselor.languages %}
-                                                    <dt>Languages:</dt>
-                                                    <dd itemprop="knowsLanguage">
-                                                        {{ counselor.languages | join( ', ' ) }}
-                                                    </dd>
-                                                    {% endif %}
-                                                </dl>
-                                            </li>
-                                        </ol>
-                                    </td>
-                                    <td data-label="Services">
-                                        <ul>
-                                            {% for service in counselor.services %}
-                                            <li>{{ service }}</li>
-                                            {% endfor %}
-                                        </ul>
-                                    </td>
-                                    <td data-label="Distance">
-                                        {{ counselor.distance | round( 1 ) }} miles
-                                    </td>
-                                </tr>
-                                {% endfor %}
-
-                            </tbody>
-                        </table>
+                    {% if zipcode and zipcode_valid %}
+                    <div class="skip-nav">
+                        <a class="skip-nav_link
+                                    skip-nav_link__flush-left"
+                            href="#hud_results-list_container">
+                            Skip to results
+                        </a>
                     </div>
-
                     {% endif %}
 
-                    <div class="block
-                                block__flush-bottom
-                                u-screen-only">
-                        {{ social_media.render( {
-                        "twitter_text": "Use the @CFPB’s interactive tool to find a housing counselor.",
-                        "email_title": "Find a housing counselor tool from CFPB",
-                        "email_text": "The CFPB's tool helps you find a housing counselor:",
-                        "email_signature": "-- From the CFPB",
-                        "linkedin_title": "Find a housing counselor tool from @CFPB",
-                        "linkedin_text": "Use the @CFPB’s interactive tool to find a housing counselor."
-                        } ) }}
+                </div>
+                {% if zipcode and zipcode_valid %}
+                    <div class="hud-search-container_map">
+                        <!-- Mapbox map is ignored during voiceover navigation
+                            as set by aria-hidden. -->
+                        <div id="hud_hca_api_map_container"
+                            aria-hidden="true">
+                            <div id="hud_hca_api_map_canvas"></div>
+                        </div><!-- end .hud_hca_api_map -->
                     </div>
-                </section>
-            </div>
+                {% endif %}
+            </section>
         </div>
-    </main>
+
+        {% if zipcode and zipcode_valid %}
+        <div class="block" id="hud_results-list_container">
+            <div class="results-header">
+                <ul class="m-list
+                            m-list__horizontal
+                            hud_hca_api_results_actions">
+                    <li class="m-list_item">
+                        <a class="a-link
+                                    a-link__icon"
+                            id="hud_print-page-link"
+                            href="#">
+                            <span class="a-link_text">Print list</span>
+                            {{ svg_icon('print') }}
+                        </a>
+                    </li>
+                    <li class="m-list_item">
+                        <a class="a-link a-link__icon"
+                            id="generate-pdf-link"
+                            href="{{ pdf_url }}"
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            <span class="a-link_text">Save list as <abbr title="Portable Document Format">PDF</abbr></span>
+                            {{ svg_icon('download') }}
+                        </a>
+                    </li>
+                </ul>
+
+                <h2 class="h4">
+                    Displaying the
+                    {{ api_json.counseling_agencies | length }}
+                    locations closest to ZIP code
+                    {{ zipcode | escape }}
+                </h2>
+            </div>
+
+            <table class="o-table
+                            o-table__stack-on-small
+                            u-w100pct">
+                <thead>
+                    <tr>
+                        <th>Agency</th>
+                        <th>Services</th>
+                        <th>Distance</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for counselor in api_json.counseling_agencies %}
+                    <tr id="hud-result-{{ loop.index }}">
+                        <td data-label="Agency">
+                            <ol start="{{ loop.index }}">
+                                <li>
+                                    <div class="u-mb15"
+                                            itemscope
+                                            itemtype="https://schema.org/PostalAddress">
+
+                                        {% if counselor.weburl %}
+                                        <a class="a-link a-link__icon"
+                                            href="{{ counselor.weburl }}">
+                                            <span class="a-link_text"><b itemprop="name">{{ counselor.nme }}</b></span>
+                                            {{ svg_icon('external-link') }}
+                                        </a>
+                                        {% else %}
+                                        <b itemprop="name">{{ counselor.nme }}</b>
+                                        {% endif %}
+
+                                        <br>
+
+                                        <span itemprop="streetAddress">{{ counselor.adr1 }}</span>
+                                        {% if counselor.adr2 and counselor.adr2 != ' '  %}
+                                        <br>
+                                        <span itemprop="streetAddress">{{ counselor.adr2 }}</span>
+                                        {% endif %}
+                                        <br>
+                                        <span itemprop="addressLocality">{{ counselor.city }}</span>,
+                                        <span itemprop="addressRegion">{{ counselor.statecd }}</span>
+                                        <span itemprop="postalCode">{{ counselor.zipcd }}</span>
+
+                                    </div>
+
+                                    <dl>
+                                        {% if counselor.weburl %}
+                                        <dt>Website:</dt>
+                                        <dd>
+                                        <a class="a-link a-link__icon"
+                                            href="{{ counselor.weburl }}"
+                                            itemprop="url">
+                                            <span class="a-link_text">{{ counselor.weburl }}</span>
+                                            {{ svg_icon('external-link') }}
+                                        </a>
+                                        </dd>
+                                        {% endif %}
+
+                                        {% if counselor.phone1 %}
+                                        <dt>Phone:</dt>
+                                        <dd>
+                                            <a href="tel:+1-{{ counselor.phone1 }}"
+                                                itemprop="telephone">
+                                                {{ counselor.phone1 }}
+                                            </a>
+                                        </dd>
+                                        {% endif %}
+
+                                        {% if counselor.email %}
+                                        <dt>Email Address:</dt>
+                                        <dd>
+                                            <a href="mailto:{{ counselor.email }}"
+                                                itemprop="email">
+                                                {{ counselor.email }}
+                                            </a>
+                                        </dd>
+                                        {% endif %}
+
+                                        {% if counselor.languages %}
+                                        <dt>Languages:</dt>
+                                        <dd itemprop="knowsLanguage">
+                                            {{ counselor.languages | join( ', ' ) }}
+                                        </dd>
+                                        {% endif %}
+                                    </dl>
+                                </li>
+                            </ol>
+                        </td>
+                        <td data-label="Services">
+                            <ul>
+                                {% for service in counselor.services %}
+                                <li>{{ service }}</li>
+                                {% endfor %}
+                            </ul>
+                        </td>
+                        <td data-label="Distance">
+                            {{ counselor.distance | round( 1 ) }} miles
+                        </td>
+                    </tr>
+                    {% endfor %}
+
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+    <div class="block
+                u-screen-only">
+        {{ social_media.render( {
+        "twitter_text": "Use the @CFPB’s interactive tool to find a housing counselor.",
+        "email_title": "Find a housing counselor tool from CFPB",
+        "email_text": "The CFPB's tool helps you find a housing counselor:",
+        "email_signature": "-- From the CFPB",
+        "linkedin_title": "Find a housing counselor tool from @CFPB",
+        "linkedin_text": "Use the @CFPB’s interactive tool to find a housing counselor."
+        } ) }}
+    </div>
+</section>
+
 {% endblock %}
 
 {% block javascript %}

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud_print.css
@@ -64,13 +64,6 @@
     padding: 0;
   }
 
-  /* Prevent blank sheet at the end of the page. */
-  main,
-  .content_main {
-    margin-bottom: 0;
-    padding-bottom: 0;
-  }
-
   /* Item result row. */
   tr {
     display: grid !important;


### PR DESCRIPTION
## Changes

- Find-a-housing-counselor: Migrate to layout-full template


## How to test this PR

1. http://localhost:8000/find-a-housing-counselor/ should be basically unchanged. The one difference should be slightly more space after the social media icons at the bottom of the page.
