### PR TITLE
Retirement: tooltip script tweaks

### DIFF
--- a/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/tooltips-view.js
@@ -31,8 +31,7 @@ function toolTipper(elem) {
   const content = document.querySelector(contentSel).innerHTML;
   const innerTip = $ttc.find('.innertip');
   const outerTip = $ttc.find('.outertip');
-  const pageSel = '#main .content_wrapper';
-  const pagePadding = parseInt($(pageSel).css('padding-left'), 10);
+  const pagePadding = 10;
   let newLeft;
   let elemCenter;
   let elemRightOffset;
@@ -99,7 +98,6 @@ function toolTipper(elem) {
   window.addEventListener('resize', function () {
     if ($('#tooltip-container').is(':visible')) {
       $('#tooltip-container').hide();
-      toolTipper($('[data-tooltip-current-target]'));
     }
   });
 }


### PR DESCRIPTION
There's an existing bug where if you open a tooltip and resize the screen an error will be throw in the dev console. This PR removes the offending code. 

The existing JS also tries to determine the page's padding set in the CSS and match that as the tooltip margin from the edge of the screen. It seems like this could just be hardcoded to a reasonable amount, since the tooltip is floating.

## Changes

- Remove `[data-tooltip-current-target]` reference on resize, which doesn't reference an element.
- Hardcode padding to 10px.


## How to test this PR

1. If you visit http://localhost:8000/consumer-tools/retirement/before-you-claim/ and open a tooltip near the left or right corner of the screen, it shouldn't be able to clip the tooltip. 

2. If you open the tooltip and then resize the screen, the tooltip should disappear and there should be no error in the dev console.
