### PR TITLE
TCCP: Show institution name in list view

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -7,6 +7,10 @@
 {% import 'v1/includes/molecules/notification.html' as notification %}
 {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
 
+{% block title -%}
+    {{ title }} | {{ super() }}
+{%- endblock title %}
+
 {% block javascript scoped %}
 {{ super() }}
 <script src="{{ static( 'js/routes/on-demand/filterable-list-controls.js' ) }}"></script>
@@ -19,7 +23,7 @@
 
 {% block content_main %}
 
-<h1>Card search results</h1>
+<h1>{{ heading }}</h1>
 
 <p>
     Filter and sort the {{ total_count or "" }} cards in our database
@@ -62,6 +66,11 @@
             {%- endif %}
         </p>
 
+        {%- macro card_name_cell(card) -%}
+            <div class="a-card-institution-name">{{ card.institution_name }}</div>
+            <a href="{{ card.url }}">{{ card.product_name }}</a>
+        {%- endmacro -%}
+
         {%- set card_columns = [
             {'heading': 'Credit card'},
             {'heading': 'Purchase APR'},
@@ -73,7 +82,7 @@
         {%- set card_rows = [] %}
         {%- for card in results %}
             {% do card_rows.append( [
-                ('<a href="' ~ card.url ~ '">' ~ card.product_name ~ '</a>') | safe,
+                card_name_cell(card) | safe,
                 apr(card.purchase_apr_for_tier),
                 ('Regionally; ' ~ card.state_limitations | join(', ')) if card.state_limitations else 'Nationally',
                 (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -67,8 +67,10 @@
         </p>
 
         {%- macro card_name_cell(card) -%}
-            <div class="a-card-institution-name">{{ card.institution_name }}</div>
-            <a href="{{ card.url }}">{{ card.product_name }}</a>
+            <a href="{{ card.url }}">
+                <div class="a-card-institution-name">{{ card.institution_name }}</div>
+                <div>{{ card.product_name }}</div>
+            </a>
         {%- endmacro -%}
 
         {%- set card_columns = [

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -12,6 +12,7 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = CardSurveyData
         fields = [
+            "institution_name",
             "periodic_fee_type",
             "product_name",
             "purchase_apr_for_tier",

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -63,6 +63,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = CardSurveyDataFilterSet
     template_name = "tccp/cards.html"
+    heading = "Customize for your situation"
     breadcrumb_items = LandingPageView.breadcrumb_items + [
         {
             "title": LandingPageView.heading,
@@ -117,6 +118,8 @@ class CardListView(FlaggedViewMixin, ListAPIView):
 
             response.data.update(
                 {
+                    "title": title(self.heading),
+                    "heading": self.heading,
                     "breadcrumb_items": self.breadcrumb_items,
                     "form": filterset.form,
                     "total_count": statistics["count"],

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -114,6 +114,12 @@
   }
 }
 
+.a-card-institution-name {
+  .heading-5( @text-shadow: @gray );
+  color: @gray;
+  margin-bottom: 0;
+}
+
 .m-list__card-details {
   dt {
     margin-top: 15px;


### PR DESCRIPTION
This change modifies the TCCP list view so that institution names are listed above product names.

The list view page heading has also been updated to "Customize for your situation".

## How to test this PR

Run `./frontend.sh` to rebuild your frontend assets. Then visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ locally.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)