### PR TITLE
Add balance transfer and cash advance to card details

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -400,7 +400,7 @@
             </dd>
         </dl>
     {% else %}
-        This card does not offer balance transfers.
+        <p>This card does not offer balance transfers.</p>
     {% endif %}
     <h2>Cash advances</h2>
     {% if card.cash_advance_apr_offered %}
@@ -516,7 +516,7 @@
             {% endif %}
         </dl>
     {% else %}
-        This card does not offer cash advances.
+        <p>This card does not offer cash advances.</p>
     {% endif %}
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -3,6 +3,10 @@
 {% from 'tccp/macros/data_published.html' import data_published %}
 {% from 'tccp/macros/fields.html' import apr, apr_range %}
 
+{% block title -%}
+    {{ card.institution_name }} {{ card.product_name }}
+    | Consumer Financial Protection Bureau
+{%- endblock title %}
 
 {% block css %}
     {{ super() }}

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -287,6 +287,121 @@
             {% endif %}
         </dd>
     </dl>
+    <h2>Balance transfers</h2>
+    {% if card.balance_transfer_offered %}
+        <dl class="m-list m-list__card-details">
+            <dt>Balance transfer APR</dt>
+            {# Transfer APRs are displayed the same way as purchase APRs #}
+            <dd>
+                {% if card.transfer_apr_min is not none
+                    or card.transfer_apr_max is not none
+                    or card.transfer_apr_median is not none
+                %}
+                    {% set transfer_apr_range =
+                        apr_range(card.transfer_apr_min, card.transfer_apr_max) if
+                        card.transfer_apr_min is not none
+                        and card.transfer_apr_max is not none
+                    %}
+                    {% set transfer_apr_median = apr(card.transfer_apr_median) if
+                        card.transfer_apr_median is not none
+                    %}
+                    {{ transfer_apr_range if transfer_apr_range }}
+                    {{ '(' if transfer_apr_median
+                        and transfer_apr_range
+                        and transfer_apr_median != transfer_apr_range
+                    }}
+                    {{- transfer_apr_median ~ ' median balance transfer APR' if
+                        transfer_apr_median
+                        and transfer_apr_median != transfer_apr_range
+                    }}
+                    {{- ')' if transfer_apr_median
+                        and transfer_apr_range
+                        and transfer_apr_median != transfer_apr_range
+                    }}
+                    {{ 'with median balance transfer APRs varying by credit score:' if
+                        card.balance_transfer_apr_vary_by_credit_tier
+                    }}
+                {% endif %}
+                {% if card.balance_transfer_apr_vary_by_credit_tier %}
+                    <table class="o-table">
+                        <thead>
+                            <tr>
+                                <th>619 or less</th>
+                                <th>620 to 719</th>
+                                <th>720 or greater</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    {{ apr(card.transfer_apr_poor) }}
+                                </td>
+                                <td>
+                                    {{ apr(card.transfer_apr_good) }}
+                                </td>
+                                <td>
+                                    {{ apr(card.transfer_apr_great) }}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                {% endif %}
+                {{ 'The issuer did not submit balance transfer APR information for this card'
+                    if card.transfer_apr_min is none
+                    and card.transfer_apr_median is none
+                    and card.transfer_apr_max is none
+                    and card.transfer_apr_poor is none
+                    and card.transfer_apr_good is none
+                    and card.transfer_apr_great is none
+                }}
+            </dd>
+            <dt>Balance transfer fee</dt>
+            <dd>
+                {# Similar to how foreign transaction fees display #}
+                {% if card.balance_transfer_fees %}
+                    {{ '$' ~ card.balance_transfer_fee_dollars if
+                        card.balance_transfer_fee_dollars is not none
+                    }}
+                    {{ ' or ' if card.balance_transfer_fee_dollars is not none
+                        and card.balance_transfer_fee_percentage is not none
+                    }}
+                    {{ apr(card.balance_transfer_fee_percentage) if
+                        card.balance_transfer_fee_percentage is not none
+                    }}
+                    {% if card.minimum_balance_transfer_fee_amount is not none %}
+                    {% set balance_transfer_fee_minimum =
+                        card.minimum_balance_transfer_fee_amount | float
+                    %}
+                    {{ '($' ~ '%.2f' | format(balance_transfer_fee_minimum) ~
+                        ' minimum)' if card.minimum_balance_transfer_fee_amount
+                        is not none
+                    }}
+                    {% endif %}
+                    {% if card.balance_transfer_fee_calculation %}
+                    {{ '(' if card.balance_transfer_fee_dollars is not none
+                        or card.balance_transfer_fee_percentage is not none
+                    -}}
+                    {{- card.balance_transfer_fee_calculation -}}
+                    {{- ')' if card.balance_transfer_fee_dollars is not none
+                        or card.balance_transfer_fee_percentage is not none
+                    -}}
+                    {% endif %}
+                {% else %}
+                    None
+                {% endif %}
+            </dd>
+            <dt>Median length promotional period</dt>
+            <dd>
+                {{ '%g' | format(card.median_length_of_balance_transfer_apr) }} months
+            </dd>
+            <dt>Grace period</dt>
+            <dd>
+                {{ 'Yes' if card.balance_transfer_grace_period else 'No' }}
+            </dd>
+        </dl>
+    {% else %}
+        This card does not offer balance transfers.
+    {% endif %}
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}
     <h3 class="h5">All fields</h3>

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -402,6 +402,122 @@
     {% else %}
         This card does not offer balance transfers.
     {% endif %}
+    <h2>Cash advances</h2>
+    {% if card.cash_advance_apr_offered %}
+        <dl class="m-list m-list__card-details">
+            <dt>Cash advance APR</dt>
+            {# Cash advance APRs are displayed the same way as purchase APRs #}
+            <dd>
+                {% if card.advance_apr_min is not none
+                    or card.advance_apr_max is not none
+                    or card.advance_apr_median is not none
+                %}
+                    {% set advance_apr_range =
+                        apr_range(card.advance_apr_min, card.advance_apr_max) if
+                        card.advance_apr_min is not none
+                        and card.advance_apr_max is not none
+                    %}
+                    {% set advance_apr_median = apr(card.advance_apr_median) if
+                        card.advance_apr_median is not none
+                    %}
+                    {{ advance_apr_range if advance_apr_range }}
+                    {{ '(' if advance_apr_median
+                        and advance_apr_range
+                        and advance_apr_median != advance_apr_range
+                    }}
+                    {{- advance_apr_median ~ ' median cash advance APR' if
+                        advance_apr_median
+                        and advance_apr_median != advance_apr_range
+                    }}
+                    {{- ')' if advance_apr_median
+                        and advance_apr_range
+                        and advance_apr_median != advance_apr_range
+                    }}
+                    {{ 'with median cash advance APRs varying by credit score:' if
+                        card.cash_advance_apr_vary_by_credit_tier
+                    }}
+                {% endif %}
+                {% if card.cash_advance_apr_vary_by_credit_tier %}
+                    <table class="o-table">
+                        <thead>
+                            <tr>
+                                <th>619 or less</th>
+                                <th>620 to 719</th>
+                                <th>720 or greater</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    {{ apr(card.advance_apr_poor) }}
+                                </td>
+                                <td>
+                                    {{ apr(card.advance_apr_good) }}
+                                </td>
+                                <td>
+                                    {{ apr(card.advance_apr_great) }}
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                {% endif %}
+                {{ 'The issuer did not submit cash advance APR information for this card'
+                    if card.advance_apr_min is none
+                    and card.advance_apr_median is none
+                    and card.advance_apr_max is none
+                    and card.advance_apr_poor is none
+                    and card.advance_apr_good is none
+                    and card.advance_apr_great is none
+                }}
+            </dd>
+            <dt>Cash advance fee</dt>
+            <dd>
+                {# Similar to how foreign transaction fees display #}
+                {% if card.cash_advance_fees %}
+                    {{ '$' ~ card.cash_advance_fee_dollars if
+                        card.cash_advance_fee_dollars is not none
+                    }}
+                    {{ ' or ' if card.cash_advance_fee_dollars is not none
+                        and card.cash_advance_fee_percentage is not none
+                    }}
+                    {{ apr(card.cash_advance_fee_percentage) if
+                        card.cash_advance_fee_percentage is not none
+                    }}
+                    {% if card.minimum_cash_advance_fee_amount is not none %}
+                    {% set cash_advance_fee_minimum =
+                        card.minimum_cash_advance_fee_amount | float
+                    %}
+                    {{ '($' ~ '%.2f' | format(cash_advance_fee_minimum) ~
+                        ' minimum)' if card.minimum_cash_advance_fee_amount
+                        is not none
+                    }}
+                    {% endif %}
+                    {% if card.cash_advance_fee_calculation %}
+                    {{ '(' if card.cash_advance_fee_dollars is not none
+                        or card.cash_advance_fee_percentage is not none
+                    -}}
+                    {{- card.cash_advance_fee_calculation -}}
+                    {{- ')' if card.cash_advance_fee_dollars is not none
+                        or card.cash_advance_fee_percentage is not none
+                    -}}
+                    {% endif %}
+                {% else %}
+                    None
+                {% endif %}
+            </dd>
+            {% if card.cash_advance_fees %}
+                <dt>Cash advance fee frequency</dt>
+                <dd>
+                {{ 'The fee is charged for each cash advance transaction' if
+                    card.cash_advance_fee_for_each_transaction else
+                    'The fee is charged once per billing cycle'
+                }}
+                </dd>
+            {% endif %}
+        </dl>
+    {% else %}
+        This card does not offer cash advances.
+    {% endif %}
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}
     <h3 class="h5">All fields</h3>


### PR DESCRIPTION
Add balance transfer and cash advance data to TCCP credit card detail pages. Also add a `<title>` element.

---

## Additions

- Balance transfer data
- Cash advance data
- `<title>`

## How to test this PR

As with #8198, there are a bunch of variations of the data you can check.

### Balance transfer

#### Balance transfer APR

- [Single APR](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-security-bank-first-security-bank-visa-cash-back-card/)
- [Min-max (median)](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/golden-1-credit-union-the-member-cash-rewards/)
- [Min-max + median by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/los-angeles-police-federal-credit-union-visa-classic/)
- [No transfer offered](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/navy-federal-credit-union-platinum/)
- [Only provided a transfer APR max](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-venture-x-rewards/)
- [Median APR is below minimum](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/los-angeles-police-federal-credit-union-visa-platinum/)
- [Min and max are 0% but medians aren’t](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/baxter-credit-union-travel-rewards-visa-signature/)

#### Balance transfer fee

- [Percentage](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/community-choice-credit-union-priority-plus/)
- [Percentage with dollar minimum](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/american-express-national-bank-blue-cash-preferred-card/)
- [Calculation](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/farm-bureau-bank-fsb-farm-bureau-member-rewards-mastercard-platinum/)
- [Percentage + minimum + calculation example](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ally-bank-ally-unlimited-cash-back-mastercard_3/)
- [Dollar amount + percentage + minimum + calculation example](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-barnes-noble-mastercard/)

#### Median length of transfer period

- [Integer](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-quicksilver-rewards-for-good-credit/)
- [Decimal example](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/bmo-harris-bank-national-association-cash-back-credit-card/)
- [1 trillion months expressed as an exponential!!!](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/synovus-bank-consumer-classic/)
- ["999"](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/pinnacle-bank-consumer-platinum-rewards/)

#### Grace period

- [Yes](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-quicksilver-rewards-for-good-credit/)
- [No](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/jpmorgan-chase-bank-national-association-disney-premier-visa-card/)

### Cash advance

#### Cash advance APR

- [Single APR](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/jpmorgan-chase-bank-national-association-disney-premier-visa-card/)
- [Min–max (median)](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-quicksilver-rewards-for-good-credit/)
- [Min–max + medians by credit tier](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/boeing-employees-credit-union-becu-tradition-credit-card-secured/)
- [Not offered](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/citibank-na-wayfair-private-label/).

#### Cash advance fee

- [Percentage example](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/bank-of-america-national-association-bank-of-america-customized-cash-rewards/)
- [Percentage + minimum](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/jpmorgan-chase-bank-national-association-disney-premier-visa-card/)
- [Dollar amount or percentage](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-national-bank-of-omaha-citizens-community-bank-secured-visa-card/)
- [Dollar amount or percentage + minimum](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/celtic-bank-corporation-indigo-product-612/)
- [Calculation](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/bank-of-tampa-the-minaret-visa-black-relationship-banking/)
- [All fields](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-barnes-noble-mastercard/)
- [No fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/boeing-employees-credit-union-becu-tradition-credit-card-secured/)

#### Cash advance fee frequency

- [Per transaction](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/bank-of-america-national-association-bank-of-america-customized-cash-rewards/)
- [Not per transaction](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-mastercard-black-card/).

## Screenshots

A typical card:

![typical-card](https://github.com/cfpb/consumerfinance.gov/assets/1862695/6ad40817-9fa6-40bb-9cd8-99fef932b90d)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)