### PR TITLE
Add slugs to individual expandables

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable-group.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable-group.html
@@ -30,8 +30,10 @@
 
    ========================================================================== #}
 
+
 {% if value.heading %}
-<div id="{{ value.heading | slugify_unique }}">
+{% set group_slug = value.heading | slugify_unique %}
+<div id="{{ group_slug }}">
     <h3>{{ value.heading }}</h3>
 {% else %}
 <div>
@@ -46,7 +48,10 @@
         {# Should be a stack of Expandable instances. #}
         {% if value.expandables %}
             {% for expandable in value.expandables %}
-              {% do expandable.update({'is_faq': value.is_faq}) %}
+              {% do expandable.update({
+                  'is_faq': value.is_faq,
+                  'group_index_slug': group_slug + '-' + loop.index | string if group_slug else None
+               })%}
                 {{ expandable }}
             {% endfor %}
         {% endif %}

--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -27,6 +27,8 @@
    value.is_faq:          Whether the Expandable should be output with FAQ
                           schema attributes.
 
+   value.group_index_slug: Optional slug inherited from an Expandable Group.
+
    ========================================================================== #}
 
 {% macro expandable(value) %}
@@ -36,6 +38,7 @@
             {{ 'o-expandable__background' if value.is_midtone else '' }}
             {{ 'o-expandable__border' if value.is_bordered else '' }}
             {{ 'o-expandable__onload-open' if value.is_expanded else '' }}"
+     id="{{ value.group_index_slug if value.group_index_slug else value.label | slugify_unique }}"
      {{ 'itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question"'
         if value.is_faq else '' }} >
     <button class="o-expandable_header" type="button">


### PR DESCRIPTION
This change adds a unique slug to each `Expandable` based on either its `label`, if it is not part of an `ExpandableGroup` or if that `ExpandableGroup` does not have a `heading`, or on its index within the `ExpandableGroup` if the group does have a heading.

For example:

- A bare `Expandable` would have its `label` slugified.
- An `Expandable` that is part of an `ExpandableGroup` that *does not have* a `heading` will also have its `label` slugified.
- An `Expandable` that is part of an `ExpandableGroup` that *does have* a `heading` will have a slug that reflects its index within the group.

   If the heading of the group is "Coverage: Mortgages", the group will have the slug `coverage-mortgages` and the first `Expandable` in the group will have the slug `coverage-mortgages-1`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)