### PR TITLE
Add data link to mortgage chart template

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
@@ -173,6 +173,6 @@
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
-    {% if value.note %}<strong>Note:</strong> {{ value.note }}<br>{% endif %}
+    {% if value.note %}<strong>Note:</strong> {{ value.note }} <a href="/data-research/mortgage-performance-trends/about-the-data/">Learn more about the data</a>.<br>{% endif %}
     </p>
 </div>

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
@@ -212,6 +212,6 @@
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
-    {% if value.note %}<strong>Note:</strong> {{ value.note }}<br>{% endif %}
+    {% if value.note %}<strong>Note:</strong> {{ value.note }} <a href="/data-research/mortgage-performance-trends/about-the-data/">Learn more about the data</a>.<br>{% endif %}
     </p>
 </div>


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR adds a hyperlink to the Mortgage Chart Block HTML templates to standardize the addition of a "Learn more about the data" link at the end of the "Note" section.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## How to test this PR

1. localhost
2. Navigate to e.g. `/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/` and review the "Note" fields on both figures. Note that there should now be _two_ "Learn more about the data" links, as the first one is hard-coded in the Wagtail field

## Notes and todos

- Once this is live, we will remediate the pages that use this block to remove the hard-coded Wagtail version of the link.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
