### PR TITLE
Add anchors to related links and how-to headings

### DIFF
--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -68,7 +68,8 @@ class SchemaBlocksTestCase(TestCase):
             "<div itemscope"
             '     itemtype="https://schema.org/HowTo"'
             '     class="schema-block schema-block__how-to">'
-            '<h2 itemprop="name" class="schema-block_title">test title</h2>'  # noqa
+            '<h2 itemprop="name" class="schema-block_title" id="test-title">'
+            "test title</h2>"  # noqa
             '<div itemprop="description" class="schema-block_description">'
             "test description"
             "</div>"

--- a/cfgov/v1/jinja2/v1/includes/blocks/schema/how-to.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/schema/how-to.html
@@ -46,6 +46,7 @@
      class="schema-block schema-block__how-to">
     {%- if value.title %}
         <{{ value.title_tag }} itemprop="name"
+                               id="{{ value.title | slugify_unique }}"
                                class="schema-block_title
                                {% if not value.show_title %}
                                u-visually-hidden

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-content.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-content.html
@@ -32,7 +32,7 @@
 <div class="m-related-links">
     {% if value.heading %}
         <header class="m-slug-header">
-            <h2 class="m-slug-header_heading">
+            <h2 class="m-slug-header_heading" id="{{ value.heading | slugify_unique }}">
                 {{ value.heading }}
             </h2>
         </header>


### PR DESCRIPTION
This small change adds id slugs as anchors to our How-To schema block headings and our related links headings.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)