### PR TITLE
Restore a lost closing `</a>`

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/related-content.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-content.html
@@ -52,6 +52,7 @@
                   {% if link.is_link_boldface %}<strong>{% endif %}
                   {{ link.text }}
                   {% if link.is_link_boldface %}</strong>{% endif %}
+                </a>
             </li>
         {% endfor %}
         </ul>


### PR DESCRIPTION
This quick change restores a closing `</a>` that went missing in #8191 [here](https://github.com/cfpb/consumerfinance.gov/pull/8191/files#diff-bc71fb370e65a3a44b33b57e4f2327711d4b6b8e5ce670fa9f905218e5c1e7dfL49-R54).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
