### PR TITLE
TCCP: Add ability to filter cards by reward type

### DIFF
--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -2,6 +2,8 @@ from django import forms
 
 from django_filters import rest_framework as filters
 
+from .widgets import CheckboxSelectMultiple
+
 
 class CardOrderingFilter(filters.OrderingFilter):
     def __init__(self, *args, **kwargs):
@@ -47,3 +49,12 @@ class CheckboxFilter(filters.BooleanFilter):
 
     def filter(self, qs, value):
         return super().filter(qs, True) if value else qs
+
+
+class MultipleCheckboxFilter(filters.MultipleChoiceFilter):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault(
+            "widget",
+            CheckboxSelectMultiple(),
+        )
+        super().__init__(*args, **kwargs)

--- a/cfgov/tccp/jinja2/tccp/macros/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/macros/filter_form.html
@@ -39,8 +39,14 @@
             {{ render_field(form.small_institution, "checkbox") }}
 
             {{ render_field(form.no_account_fee, "checkbox") }}
+        </fieldset>
+    </div>
 
-            {{ render_field(form.rewards, "checkbox") }}
+    <div class="o-form_group">
+        <fieldset class="o-form_fieldset">
+            <legend class="a-legend">Rewards</legend>
+
+            {{ form.rewards }}
         </fieldset>
     </div>
 

--- a/cfgov/tccp/situations.py
+++ b/cfgov/tccp/situations.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import List
 
+from tccp import enums
+
 
 @dataclass
 class Situation:
@@ -18,18 +20,14 @@ SITUATIONS = [
         title="Pay less interest",
         details_intro_have=True,
         details=["Low interest rates"],
-        query={
-            "ordering": "purchase_apr",
-        },
+        query=[("ordering", "purchase_apr")],
     ),
     Situation(
         title="Transfer a balance",
         details=[
             "Low balance transfer interest rates",
         ],
-        query={
-            "ordering": "transfer_apr",
-        },
+        query=[("ordering", "transfer_apr")],
     ),
     Situation(
         title="Make a big purchase",
@@ -42,7 +40,7 @@ SITUATIONS = [
         title="Avoid annual fees",
         details_intro_have=True,
         details=["No annual fee"],
-        query={"no_account_fee": True},
+        query=[("no_account_fee", True)],
     ),
     Situation(
         title="Build credit",
@@ -56,7 +54,7 @@ SITUATIONS = [
                 "(like cash back, travel points, or other rewards)",
             )
         ],
-        query={"rewards": True},
+        query=[("rewards", reward) for reward in dict(enums.RewardsChoices)],
     ),
 ]
 

--- a/cfgov/tccp/templates/tccp/widgets/checkbox_option.html
+++ b/cfgov/tccp/templates/tccp/widgets/checkbox_option.html
@@ -1,0 +1,4 @@
+<div class="m-form-field m-form-field__checkbox">
+    {% include "django/forms/widgets/input.html" %}
+    <label class="a-label" for="{{ widget.attrs.id }}">{{ widget.label }}</label>
+</div>

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -39,3 +39,46 @@ class CardSurveyDataFilterSetTests(TestCase):
 
         fs = CardSurveyDataFilterSet({"geo_availability": "PA"}, queryset=qs)
         self.assertEqual(fs.qs.count(), 3)
+
+    def test_filter_by_no_account_fee(self):
+        baker.make(
+            CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
+            purchase_apr_good=0.99,
+            periodic_fee_type=["Annual"],
+        )
+
+        qs = CardSurveyData.objects.all()
+        self.assertEqual(qs.count(), 1)
+
+        fs = CardSurveyDataFilterSet({"no_account_fee": False}, queryset=qs)
+        self.assertEqual(fs.qs.count(), 1)
+
+        fs = CardSurveyDataFilterSet({"no_account_fee": True}, queryset=qs)
+        self.assertEqual(fs.qs.count(), 0)
+
+    def test_filter_by_rewards(self):
+        baker.make(
+            CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
+            purchase_apr_good=0.99,
+            rewards=["Cashback rewards"],
+        )
+
+        qs = CardSurveyData.objects.all()
+        self.assertEqual(qs.count(), 1)
+
+        fs = CardSurveyDataFilterSet(
+            {"rewards": ["Cashback rewards"]}, queryset=qs
+        )
+        self.assertEqual(fs.qs.count(), 1)
+
+        fs = CardSurveyDataFilterSet(
+            {"rewards": ["Other rewards"]}, queryset=qs
+        )
+        self.assertEqual(fs.qs.count(), 0)
+
+        fs = CardSurveyDataFilterSet(
+            {"rewards": ["Cashback rewards", "Other rewards"]}, queryset=qs
+        )
+        self.assertEqual(fs.qs.count(), 1)

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -50,7 +50,11 @@ class LandingPageView(FlaggedTemplateView):
             reverse("tccp:cards")
             + "?"
             + urlencode(
-                dict(targeted_credit_tiers=credit_tier, **situation.query)
+                [
+                    ("targeted_credit_tiers", credit_tier),
+                    *situation.query,
+                ],
+                doseq=True,
             )
         )
 

--- a/cfgov/tccp/widgets.py
+++ b/cfgov/tccp/widgets.py
@@ -14,5 +14,14 @@ class LandingPageRadioSelect(RadioSelect):
     option_template_name = "tccp/widgets/landing_page_radio_option.html"
 
 
+class CheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    option_template_name = "tccp/widgets/checkbox_option.html"
+
+    def __init__(self, attrs=None, **kwargs):
+        attrs = attrs or {}
+        attrs.setdefault("class", "a-checkbox")
+        super().__init__(attrs=attrs, **kwargs)
+
+
 class Select(forms.Select):
     template_name = "tccp/widgets/select.html"


### PR DESCRIPTION
This commit expands the current "Offers rewards" checkbox into three separate checkboxes allowing users to filter by cards offering different reward types: cashback, travel, and other.

These checkboxes work like an OR: if none are selected, no filter is applied. If one or more are selected, cards with any of the options are shown.

## How to test this PR

To test, run a local server and visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/. Select the "Earn rewards" option. Then experiment with the rewards checkboxes.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)