### PR TITLE
Add nonbreaking space to expandable icon

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -44,7 +44,7 @@
     <button class="o-expandable_header" type="button">
         <span class="{{ 'h2' if value.is_larger_heading else 'h4'}} o-expandable_label"
               {{'itemprop="name"' if value.is_faq else ''}}>
-            {% if value.icon %} {{ svg_icon( value.icon ) }} {% endif %} 
+            {% if value.icon %} {{ svg_icon( value.icon ) }}&nbsp; {% endif %} 
             {{ value.label }}
         </span>
         <span class="o-expandable_cues">


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR adds a single non-breaking space character after any icon added to an expandable, for more consistent spacing between elements.

---


## How to test this PR

1. localhost
2. review production vs localhost on any expandable label using icons, e.g. `/learnmore`


## Screenshots

| Before | After |
| - | - |
| ![Screenshot 2024-03-12 at 1 06 06 PM](https://github.com/cfpb/consumerfinance.gov/assets/29648039/dbc3c062-944c-4002-bce0-cc9979dd90ab) | ![Screenshot 2024-03-12 at 1 06 19 PM](https://github.com/cfpb/consumerfinance.gov/assets/29648039/0a00e903-b402-4fed-891c-fe5e8d443996) |

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance