### PR TITLE
Add "first published" and "schema" info to Ask report

### DIFF
--- a/cfgov/v1/templates/v1/ask_report.html
+++ b/cfgov/v1/templates/v1/ask_report.html
@@ -33,6 +33,9 @@
                         Live
                     </th>
                     <th>
+                        First published
+                    </th>
+                    <th>
                         Last edited
                     </th>
                     <th>
@@ -46,6 +49,9 @@
                     </th>
                     <th>
                         Related questions
+                    </th>
+                    <th>
+                        Schema
                     </th>
                     <th>
                         Language
@@ -83,6 +89,9 @@
                             {{ page.live }}
                         </td>
                         <td>
+                            {{ page.first_published_at }}
+                        </td>
+                        <td>
                             {{ page.last_edited }}
                         </td>
                         <td>
@@ -105,6 +114,9 @@
                                 {{ question.id }}
                                 <br>
                             {% endfor %}
+                        </td>
+                        <td>
+                            {{ page.schema }}
                         </td>
                         <td>
                             {{ page.language }}

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -307,11 +307,13 @@ class AskReportView(ReportView):
         "search_description",
         "url",
         "live",
+        "first_published_at",
         "last_edited",
         "portal_topic.all",
         "primary_portal_topic",
         "portal_category.all",
         "related_questions.all",
+        "schema",
         "language",
     ]
     export_headings = {
@@ -324,11 +326,13 @@ class AskReportView(ReportView):
         "search_description": "Meta description",
         "url": "URL",
         "live": "Live",
+        "first_published_at": "First published",
         "last_edited": "Last edited",
         "portal_topic.all": "Portal topics",
         "primary_portal_topic": "Primary portal topic",
         "portal_category.all": "Portal categories",
         "related_questions.all": "Related questions",
+        "schema": "Schema used",
         "language": "Language",
     }
 
@@ -357,6 +361,27 @@ class AskReportView(ReportView):
                 answer = ""
         return strip_html(answer)
 
+    def determine_schema(answer_content):
+        has_faq_schema = list(
+            filter(
+                lambda item: item["type"] == "faq_schema",
+                answer_content.raw_data,
+            )
+        )
+        has_how_to_schema = list(
+            filter(
+                lambda item: item["type"] == "how_to_schema",
+                answer_content.raw_data,
+            )
+        )
+
+        if has_faq_schema:
+            return "FAQ"
+        elif has_how_to_schema:
+            return "How To"
+        else:
+            return "None"
+
     custom_field_preprocess = {
         "answer_base": {"csv": partial(process_related_item, key="id")},
         "short_answer": {"csv": strip_html},
@@ -370,6 +395,7 @@ class AskReportView(ReportView):
         "related_questions.all": {
             "csv": partial(join_values_with_pipe, key="id")
         },
+        "schema": {"csv": determine_schema},
     }
 
     template_name = "v1/ask_report.html"


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR adds two fields to the Ask CFPB report `/admin/reports/ask-cfpb/`: The date the page was first published and information about whether the page uses Google schema (and which schema if so).

I need some assistance with the `determine_schema` function added to `reports.py` -- it's definitely not working, but I'm having trouble determining why.


## How to test this PR

1. `localhost/admin/reports/ask-cfpb/`


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance