### PR TITLE
Remove unnecessary redirect in YFPTG

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/college-costs/dispatchers/get-api-values.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/college-costs/dispatchers/get-api-values.js
@@ -65,7 +65,8 @@ function getSchoolData(iped) {
   const url =
     '/paying-for-college2/understanding-your-financial-aid-offer' +
     '/api/school/' +
-    iped;
+    iped +
+    '/';
 
   return getApi(url);
 }


### PR DESCRIPTION
The "Your financial path to graduation tool" tries to load school data from the API using a URL like this:

/paying-for-college2/understanding-your-financial-aid-offer/api/school/1234

Note the lack of trailing URL. These API URLs are always served with a trailing URL, so the URL should be

/paying-for-college2/understanding-your-financial-aid-offer/api/school/1234/

As it happens, Django will currently respond with a 301 redirect to the right URL, but this is an unnecessary delay and page load. Removing this unnecessary redirect will speed up our functional tests for this page, not to mention the end user experience.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)