### PR TITLE
Cap the width of TCCP's card availability column

### DIFF
--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -23,6 +23,14 @@
   }
 }
 
+// Some cards list a lot of available locations and disrupt the table layout.
+// Cap the width of the availability cell on non-mobile screens to prevent this.
+@media only screen and (min-width: @bp-sm-min) {
+  td[data-label='Availability'] {
+    max-width: unit((350px / @base-font-size-px), em);
+  }
+}
+
 // Overrides to the make the directory table pattern sticky
 // https://cfpb.github.io/design-system/components/tables#responsive-stacked-table-with-header-directory-table
 @media only screen and (max-width: @bp-xs-max) {


### PR DESCRIPTION
On non-mobile layouts, cards with a lot of states cause the table to poorly render.

## How to test this PR

1. `./frontend.sh`
1. Visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ and the table should look better.

## Screenshots

| before | after |
|--------|-------|
| <img width="1203" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/cf18baa7-7d82-4064-9458-b040d348dd37"> | <img width="1203" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/7aaf880f-ca29-4d26-8a1a-6dfab5145df4"> |
