### PR TITLE
Fix radio button label rendering by making it safe

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/atoms/radio-button.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/radio-button.html
@@ -43,7 +43,7 @@
            {{ 'disabled' if value.disabled else ''}}>
     <label class="a-label"
            for="{{ id }}">
-        {{ value.label }}
+        {{ value.label | safe}}
     </label>
 </{{ el }}>
 


### PR DESCRIPTION
This change fixes a bug introduced in #8169, which disabled converting unsafe HTML into safe HTML across a large swatch of components. We have some calls to the `radio.render` macro which include HTML in their `label`. This change enables that behavior explicitly by marking the label as safe.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
