### PR TITLE
Add htmx loading indicators to TCCP results

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -22,6 +22,10 @@
 <link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">
 {% endblock %}
 
+{% block content_main_modifiers -%}
+    {{ super() }} htmx-container
+{%- endblock %}
+
 {% block content_main %}
 
 <h1>{{ heading }}</h1>
@@ -45,7 +49,7 @@
 
 
 <div class="block block__sub">
-    <div class="o-filterable-list-results">
+    <div class="o-filterable-list-results htmx-results">
 
         {% if count -%}
         {{- notification.render(

--- a/cfgov/tccp/jinja2/tccp/macros/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/macros/filter_form.html
@@ -58,7 +58,7 @@
 
 {%- macro filter_form(form) -%}
 
-<form action="." method="get" hx-boost="true" hx-trigger="change delay:1s" hx-swap="show:none">
+<form action="." method="get" hx-boost="true" hx-trigger="change" hx-swap="show:none" hx-indicator=".htmx-container" >
     <div class="content-l">
 
         {{ render_form_fields(form) }}
@@ -66,6 +66,9 @@
         <div class="content-l_col content-l_col-1 m-btn-group">
             <button type="submit" class="a-btn" title="Apply filters">
                 Apply filters
+                <span class="a-btn_icon a-btn_icon__on-right htmx-spinner">
+                    {{ svg_icon('updating') }}
+                </span>
             </button>
             <a class="a-btn a-btn__link a-btn__warning" href="{{ request.path }}">
                 Clear filters

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -23,6 +23,21 @@
   }
 }
 
+// htmx loading indicators https://htmx.org/attributes/hx-indicator/
+.htmx-spinner {
+  display: none;
+}
+
+// Show the spinner and dim the results when a request is in flight
+.htmx-request {
+  .htmx-spinner {
+    display: inline;
+  }
+  .htmx-results {
+    opacity: 0.5;
+  }
+}
+
 // Some cards list a lot of available locations and disrupt the table layout.
 // Cap the width of the availability cell on non-mobile screens to prevent this.
 @media only screen and (min-width: @bp-sm-min) {


### PR DESCRIPTION
Adds a spinner to the submit button and dims the results pane when the user changes a filter and a request is in flight. See https://htmx.org/attributes/hx-indicator/

## How to test this PR

1. `./frontend.sh`
2. Visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ and change a filter.
3. A spinner will appear in the submit button and the results will dim while the request is being made.

## Screenshots

![spinner](https://github.com/cfpb/consumerfinance.gov/assets/1060248/5af6ba64-beb0-4197-b83f-a663b78a0684)


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
