### PR TITLE
Mark homepage strong heading as safe

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -1,5 +1,5 @@
 {%- set hero = {
-    "heading": "<strong>On your side</strong> through life’s financial moments.",
+    "heading": "<strong>On your side</strong> through life’s financial moments." | safe,
     "body": "We’re the Consumer Financial Protection Bureau, a U.S. government agency dedicated to making sure you are treated fairly by banks, lenders and other financial institutions.",
     "image": {
         "url": static( "apps/homepage/img/hero.jpg" ),


### PR DESCRIPTION
This small fix marks the hardcoded homepage heading string as safe.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
