### PR TITLE
Add fee details to TCCP card details

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -552,6 +552,42 @@
                 }}
             </dd>
         {% endif %}
+        <dt>Late fee</dt>
+        <dd>
+            {% if card.late_fees %}
+                {{ '$' ~ card.late_fee_dollars ~ ' for the first late payment' if
+                    card.late_fee_dollars
+                }}
+                {{ 'and' if card.late_fee_dollars
+                    and card.late_fee_six_month_billing_cycle
+                }}
+                {{ '$' ~ card.late_fee_six_month_billing_cycle ~
+                    ' for a late payment within six billing cycles of another
+                    late payment' if card.late_fee_six_month_billing_cycle
+                }}
+                {# A handful of cards specify neither a first nor repeat late
+                    fee and put all late fee info in the late_fee_policy_details
+                    field. For cards like that, we'll show the details here and
+                    not show the "Late fee policy details" item.
+                #}
+                {{ card.late_fee_policy_details if card.late_fee_types ==
+                    ['3. If you charge late fees that are not fixed dollar amounts, please explain your late fee policy here.']
+                }}
+            {% else %}
+                None
+            {% endif %}
+        </dd>
+        {# See the comment above: we won't show this if we're already showing
+            late fee details in the "Late fee" item, i.e. if the card has *only*
+            policy details chosen in late_fee_types
+        #}
+        {% if card.late_fee_policy_details
+            and card.late_fee_types !=
+            ['3. If you charge late fees that are not fixed dollar amounts, please explain your late fee policy here.']
+        %}
+            <dt>Late fee policy details</dt>
+            <dd>{{ card.late_fee_policy_details }}</dd>
+        {% endif %}
     </dl>
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -522,6 +522,37 @@
     {% else %}
         <p>This card does not offer cash advances.</p>
     {% endif %}
+    <h2>Fees</h2>
+    <dl class="m-list m-list__card-details">
+        {% if not card.periodic_fee_type %}
+            <dt>Annual fee</dt>
+            <dd>None</dd>
+        {% endif %}
+        {% if card.annual_fee %}
+            <dt>Annual fee</dt>
+            <dd>{{ '$' ~ card.annual_fee }}</dd>
+        {% endif %}
+        {% if card.monthly_fee %}
+            <dt>Monthly fee</dt>
+            <dd>{{ '$' ~ card.monthly_fee }}</dd>
+        {% endif %}
+        {% if card.weekly_fee %}
+            <dt>Weekly fee</dt>
+            <dd>{{ '$' ~ card.weekly_fee }}</dd>
+        {% endif %}
+        {% if card.other_periodic_fee_amount %}
+            <dt>{{ card.other_periodic_fee_name }}</dt>
+            <dd>{{ '$' ~ card.other_periodic_fee_amount ~ ', ' ~ card.other_periodic_fee_frequency | lower }}</dd>
+        {% endif %}
+        {% if card.fee_varies %}
+            <dt>Fee varies?</dt>
+            <dd>
+                {{ '$' ~ card.periodic_min ~ '–'  ~ card.periodic_max ~
+                    ' (' ~ card.fee_explanation | lower ~ ')'
+                }}
+            </dd>
+        {% endif %}
+    </dl>
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}
     <h3 class="h5">All fields</h3>

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -588,6 +588,56 @@
             <dt>Late fee policy details</dt>
             <dd>{{ card.late_fee_policy_details }}</dd>
         {% endif %}
+        <dt>Over-limit fee</dt>
+        <dd>
+            {% if card.over_limit_fees %}
+                {{ '$' ~ card.over_limit_fee_dollars if
+                    card.over_limit_fee_dollars
+                }}
+                {# A handful of cards specify only over-limit fee details and
+                    not a fixed dollar amount. For cards like that, we'll show
+                    the details here and not show the "Over-limit fee details."
+                #}
+                {{ card.overlimit_fee_detail if card.over_limit_fee_types ==
+                    ['2. If you charge overlimit fees that are not fixed dollar amounts, please explain what overlimit fees you charge here:']
+                }}
+            {% else %}
+                None
+            {% endif %}
+        </dd>
+        {# See the comment above: we won't show this if we're already showing
+            over-limit fee details in the "Over-limit fee" item, i.e. if the
+            card has *only* details chosen in over_limit_fee_types.
+        #}
+        {% if card.overlimit_fee_detail
+            and card.over_limit_fee_types !=
+            ['2. If you charge overlimit fees that are not fixed dollar amounts, please explain what overlimit fees you charge here:']
+        %}
+            <dt>Over-limit fee details</dt>
+            <dd>{{ card.overlimit_fee_detail }}</dd>
+        {% endif %}
+        {% if card.other_fees %}
+            {% for fee_name in [card.other_fee_name, card.other_fee_name_2,
+                card.other_fee_name_3, card.other_fee_name_4,
+                card.other_fee_name_5
+            ] %}
+                {% if fee_name %}
+                    <dt>{{ fee_name }}</dt>
+                    <dd>
+                        {% if loop.first %}
+                            {{ '$' ~ '%.2f' | format(card.other_fee_amount | float) ~ ' (' ~
+                                card.other_fee_explanation | lower ~ ')'
+                            }}
+                        {% else %}
+                            {{ '$' ~ '%.2f' | format(card['other_fee_amount_' ~ loop.index] | float) ~ ' (' ~
+                                card['other_fee_explanation_' ~ loop.index] | lower ~
+                                ')'
+                            }}
+                        {% endif %}
+                    </dd>
+                {% endif %}
+            {% endfor %}
+        {% endif %}
     </dl>
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}


### PR DESCRIPTION
Add periodic fee, late fee, over-limit fee, and other fees to the TCCP card details page.

---

## Additions

- Periodic fee
- Late fee
- Over-limit fee
- Other fees

## How to test this PR

As usual, there are a billion different fee combinations you can look at.

### Periodic fee

- [Annual fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-venture-rewards/)
- [Monthly fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/credit-one-bank-national-association-everyday-card/)
- [Annual + monthly fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/bank-of-missouri-the-fortiva-mastercard-aspire-mastercard/)
- [Other fee (that happens to be named “annual fee”)](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-national-bank-of-omaha-premio-plus-mastercard/)
- [Annual + other fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-mastercard-black-card/)
- [No periodic fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/city-national-bank-visa-signatureflex-rewards/)
- [Annual fee that varies](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/1st-financial-bank-usa-1st-financial-bank-usa-credit-card/)
- [Monthly fee that varies](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-premier-bank-first-premier-bank-mastercard-idt_7075/)
- [Monthly fee that varies but annual fee is fixed](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-premier-bank-first-premier-bankcard-mastercard_9144/)

### Late fee

- [First and repeat](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/hsbc-bank-usa-national-association-hsbc-premier-world-mastercard-credit-card/)
- [Just first](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/arkansas-federal-credit-union-platinum-classic/)
- [Just fee details](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/avidia-bank-platinum/)
- [Repeat + details](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-rei-co-op-mastercard/)
- [First + repeat + details](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ally-bank-ally-unlimited-cash-back-mastercard-for-educators/)
- [No late fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/citibank-na-citi-simplicity-card/)

### Over-limit fee

- [Single amount](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/community-financial-credit-union-consumer-world-mastercard/)
- [Details](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/meritrust-federal-credit-union-member-select-visa/)
- [Amount + details](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/university-bank-visa-credit-card/)
- [No fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/navy-federal-credit-union-more-rewards/)

### Other fees

- [One other fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/meritrust-federal-credit-union-member-select-visa/)
- [Many other fees](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/community-financial-credit-union-consumer-world-mastercard/)
- [No other fees](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/prosperity-bank-visa-traditional-rewards/)

## Screenshots

Here's a typical fee section for a card with lots of fees:

![fees](https://github.com/cfpb/consumerfinance.gov/assets/1862695/48a39bd2-73b6-462d-992a-f2b8bf8bce31)

## Notes and todos

- I tried to call this out in the comments as much as possible, but the data structure for the fees in the TCCP data is a little wonky in some places.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets