### PR TITLE
Add htmx linear progress bar to TCCP results

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -28,6 +28,10 @@
 
 {% block content_main %}
 
+<div class="htmx-progress">
+    <div class="htmx-progress-bar"></div>
+</div>
+
 <h1>{{ heading }}</h1>
 
 <p>

--- a/cfgov/tccp/jinja2/tccp/macros/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/macros/filter_form.html
@@ -66,9 +66,6 @@
         <div class="content-l_col content-l_col-1 m-btn-group">
             <button type="submit" class="a-btn" title="Apply filters">
                 Apply filters
-                <span class="a-btn_icon a-btn_icon__on-right htmx-spinner">
-                    {{ svg_icon('updating') }}
-                </span>
             </button>
             <a class="a-btn a-btn__link a-btn__warning" href="{{ request.path }}">
                 Clear filters

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -23,21 +23,6 @@
   }
 }
 
-// htmx loading indicators https://htmx.org/attributes/hx-indicator/
-.htmx-spinner {
-  display: none;
-}
-
-// Show the spinner and dim the results when a request is in flight
-.htmx-request {
-  .htmx-spinner {
-    display: inline;
-  }
-  .htmx-results {
-    opacity: 0.5;
-  }
-}
-
 // Some cards list a lot of available locations and disrupt the table layout.
 // Cap the width of the availability cell on non-mobile screens to prevent this.
 @media only screen and (min-width: @bp-sm-min) {
@@ -199,5 +184,86 @@
   }
   dd .o-table {
     margin-top: 10px;
+  }
+}
+
+// htmx animated progress bar
+// See https://htmx.org/attributes/hx-indicator/
+.htmx-progress {
+  display: none;
+
+  .htmx-request & {
+    display: inline;
+  }
+
+  position: fixed;
+  top: 0;
+  z-index: 1000;
+  height: unit((5px / @base-font-size-px), rem);
+  width: 100%;
+
+  .htmx-progress-bar {
+    background-color: @green;
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      background-color: inherit;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      will-change: left, right;
+      animation: indeterminate 2.5s cubic-bezier(0.65, 0.815, 0.735, 0.395)
+        infinite;
+    }
+    &::after {
+      animation-name: indeterminate-short;
+    }
+  }
+}
+
+// Dim search results while inflight
+.htmx-request .htmx-results {
+  opacity: 0.5;
+}
+
+// Hide form submit button for htmx users
+html.js form[hx-boost] {
+  .o-form_group:last-child {
+    margin-bottom: 0;
+  }
+
+  .m-btn-group {
+    display: none;
+  }
+}
+
+@keyframes indeterminate {
+  0% {
+    left: -35%;
+    right: 100%;
+  }
+  40% {
+    left: 100%;
+    right: -90%;
+  }
+  100% {
+    left: 100%;
+    right: -90%;
+  }
+}
+
+@keyframes indeterminate-short {
+  0% {
+    left: -200%;
+    right: 100%;
+  }
+  40% {
+    left: 107%;
+    right: -8%;
+  }
+  100% {
+    left: 107%;
+    right: -8%;
   }
 }


### PR DESCRIPTION
Here's another approach to showing loading state that we can test. Adds a progress bar at the top of the viewport so that users are aware when a request is inflight.

See https://htmx.org/examples/progress-bar/
See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/253

## Additions

- Sticky progress bar at the top of the viewport.

## Removals

- The TCCP filter submit button when a user has JS enabled.
- The spinner icon that was in the button.

## How to test this PR

1. `./frontend.sh`
2. Go to the [card pages](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) and change some filters.


## Screenshots

| mobile | desktop |
|--------|-------|
| ![linear-spinner-mobile](https://github.com/cfpb/consumerfinance.gov/assets/1060248/72b99881-203a-4331-9f6e-62957d2cf308) | ![linear-spinner](https://github.com/cfpb/consumerfinance.gov/assets/1060248/80ad780a-f81f-4bc1-b009-5857d2526129) |

## Notes and todos

- We're not using it currently but I'd like to explore the [loading-states](https://htmx.org/extensions/loading-states/) extension to further improve our loading animations.

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Safari on iOS
- [x] Chrome on Android

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
