### PR TITLE
Fix mortgage performance HTML entities

### DIFF
--- a/cfgov/data_research/jinja2/data_research/mortgage-performance-downloads.html
+++ b/cfgov/data_research/jinja2/data_research/mortgage-performance-downloads.html
@@ -16,7 +16,7 @@
 <div class="o-full-width-text-group">
     <div class="m-full-width-text">
         <h2>The most recent data</h2>
-        <p>We recommend using the most recent data, which include the full time series and all revisions. These data cover {{ from_month_formatted }}&ndash;{{ thru_month_formatted }}. In this update we use Connecticut’s new FIPS codes that changed in 2022 to nine county-equivalent boundaries.</p>
+        <p>We recommend using the most recent data, which include the full time series and all revisions. These data cover {{ from_month_formatted }}{{ '&ndash;' | safe }}{{ thru_month_formatted }}. In this update we use Connecticut’s new FIPS codes that changed in 2022 to nine county-equivalent boundaries.</p>
     </div>
 </div>
 
@@ -98,7 +98,7 @@
 {% set archive_90 = download_files[date]['percent_90'] %}
 <div class="o-full-width-text-group">
     <div class="m-full-width-text">
-        <h4> Download archival data {{ from_month_formatted }}&ndash;{{ download_files[date]['thru_month'] }}</h4>
+      <h4> Download archival data {{ from_month_formatted }}{{ '&ndash;' | safe }}{{ download_files[date]['thru_month'] }}</h4>
     </div>
 </div>
 <div class="block block__flush-top">

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -3,6 +3,7 @@ import logging
 from django.db import models
 
 from dateutil import parser
+from markupsafe import Markup
 
 from v1.models import BrowsePage
 
@@ -347,8 +348,8 @@ class MortgagePerformancePage(BrowsePage):
         thru_date = parser.parse(meta["sampling_dates"][-1])
         from_date = parser.parse(meta["sampling_dates"][0])
         meta["thru_month"] = thru_date.strftime("%Y-%m")
-        meta["thru_month_formatted"] = thru_date.strftime("%B&nbsp;%Y")
-        meta["from_month_formatted"] = from_date.strftime("%B&nbsp;%Y")
+        meta["thru_month_formatted"] = Markup(thru_date.strftime("%B&nbsp;%Y"))
+        meta["from_month_formatted"] = Markup(from_date.strftime("%B&nbsp;%Y"))
         meta["pub_date_formatted"] = meta.get("download_files")[
             meta["thru_month"]
         ]["pub_date"]

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
@@ -20,7 +20,7 @@
 {% set metro_meta = csv_meta['MetroArea'] %}
 {% set state_meta = csv_meta['State'] %}
 {% set data_vis_color = 'blue' if time_frame == '30-89' else 'navy' %}
-{% if time_frame == '30-89' %} {% set time_frame_styled = '30&ndash;89'%} {% else %} {% set time_frame_styled = time_frame %}{% endif %}
+{% if time_frame == '30-89' %} {% set time_frame_styled = '30&ndash;89' | safe %} {% else %} {% set time_frame_styled = time_frame %}{% endif %}
 
 <div class="o-full-width-text-group" id="mp-line-chart-container" data-chart-time-span="{{ time_frame }}" data-chart-start-date="{{ sampling_dates|first }}" data-chart-end-date="{{ sampling_dates|last }}">
     <div class="m-full-width-text">

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
@@ -15,7 +15,7 @@
 {% set metro_meta = csv_meta['MetroArea'] %}
 {% set state_meta = csv_meta['State'] %}
 {% set data_vis_color = 'blue' if time_frame == '30-89' else 'navy' %}
-{% if time_frame == '30-89' %} {% set time_frame_styled = '30&ndash;89'%} {% else %} {% set time_frame_styled = time_frame %}{% endif %}
+{% if time_frame == '30-89' %} {% set time_frame_styled = '30&ndash;89' | safe %} {% else %} {% set time_frame_styled = time_frame %}{% endif %}
 
 <div class="o-full-width-text-group" id="mp-map-container" data-chart-time-span="{{ time_frame }}" data-chart-color="{{ data_vis_color }}" data-chart-start-date="{{ sampling_dates|first }}" data-chart-end-date="{{ sampling_dates|last }}">
     <div class="m-full-width-text">


### PR DESCRIPTION
Mortgage performance charts and maps use non-breaking space entities and endash entities for formatting in month/years. This fixes the rendering of those entities after #8169 by marking them as safe.

Before:
<img width="603" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/10562538/9aafae81-9244-4869-a346-1fc3f5b1768b">
<img width="608" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/10562538/4c04950d-d3ff-4c8f-9a62-ce7f790dfdb1">

After:
<img width="518" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/10562538/dd72f77c-0d1a-4cd2-9cef-4494bead1d94">
<img width="526" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/10562538/850a1041-9570-4afd-8705-c520830a3468">


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)