### PR TITLE
TCCP: Multiple situation logic cleanup

### DIFF
--- a/cfgov/tccp/tests/test_situations.py
+++ b/cfgov/tccp/tests/test_situations.py
@@ -16,31 +16,28 @@ class SituationTests(SimpleTestCase):
         with self.assertRaises(KeyError):
             get_situation_by_title("invalid")
 
-    def test_get_unique_params(self):
+    def test_get_nonconflicting_params(self):
         self.assertEqual(
-            Situation.get_unique_params(
-                [{"a": 1, "b": 2}, {"c": [3, 4]}, {"a": 5, "b": 2}]
+            Situation.get_nonconflicting_params(
+                [
+                    Situation("one", {"a": 1, "b": 2}),
+                    Situation("two", {"c": [3, 4]}),
+                    Situation("three", {"a": 5, "b": 2}),
+                ]
             ),
             {"b": 2, "c": [3, 4]},
         )
 
-    def test_get_unique_params_multiple_duplicates(self):
+    def test_get_get_nonconflicting_params_multiple_duplicates(self):
         self.assertEqual(
-            Situation.get_unique_params([{"a": 1}, {"a": 2}, {"a": 1}]),
-            {},
-        )
-
-    def test_get_querystring(self):
-        self.assertEqual(
-            Situation.get_querystring({"a": 1, "b": [2, 3]}), "a=1&b=2&b=3"
-        )
-
-    def test_get_combined_query(self):
-        self.assertEqual(
-            Situation.get_combined_query(
-                [Situation("foo", {"a": 1}), Situation("bar", {"b": 2})]
+            Situation.get_nonconflicting_params(
+                [
+                    Situation("one", {"a": 1}),
+                    Situation("two", {"a": 2}),
+                    Situation("three", {"a": 1}),
+                ]
             ),
-            "a=1&b=2",
+            {},
         )
 
 

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -27,7 +27,8 @@ class LandingPageViewTests(TestCase):
             "?location=NY"
             + "&credit_tier="
             + quote_plus(tier)
-            + "&situations=Pay+less+interest"
+            + "&situations=Avoid+fees"
+            + "&situations=Earn+rewards"
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
@@ -36,8 +37,12 @@ class LandingPageViewTests(TestCase):
             + "?credit_tier="
             + quote_plus(tier)
             + "&location=NY"
-            + "&situations=Pay+less+interest"
-            + "&ordering=purchase_apr",
+            + "&situations=Avoid+fees"
+            + "&situations=Earn+rewards"
+            + "&no_account_fee=True"
+            + "&rewards=Cashback+rewards"
+            + "&rewards=Travel-related+rewards"
+            + "&rewards=Other+rewards",
         )
 
     def test_invalid_query_still_renders_page(self):

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -1,3 +1,4 @@
+from operator import attrgetter
 from urllib.parse import urlencode
 
 from django.shortcuts import redirect, reverse
@@ -50,17 +51,14 @@ class LandingPageView(FlaggedTemplateView):
             reverse("tccp:cards")
             + "?"
             + urlencode(
-                [
-                    ("credit_tier", credit_tier),
-                    ("location", location),
-                    *(
-                        ("situations", situation.title)
-                        for situation in situations
-                    ),
-                ]
+                {
+                    "credit_tier": credit_tier,
+                    "location": location,
+                    "situations": list(map(attrgetter("title"), situations)),
+                    **Situation.get_nonconflicting_params(situations),
+                },
+                doseq=True,
             )
-            + "&"
-            + Situation.get_combined_query(situations)
         )
 
 


### PR DESCRIPTION
This commit improves the logic for handling multiple TCCP situations. The logic is identical with previous, but uses less (and hopefully simpler) Python code to do the same thing.

## How to test this PR

Run a local server, visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/, and confirm that multiple situation selection continues to work as previously from #8236.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)