### PR TITLE
Remove unused css

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -363,15 +363,6 @@
     }
   }
 
-  // TODO: This class appears unused. Verify and remove, if so.
-  .arm-info-comparison {
-    position: absolute;
-    display: block;
-    width: 200%;
-    padding: 1em 0;
-    font-size: 0.75em;
-  }
-
   /*
         "Next steps"
         --------------------------- */

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -363,6 +363,7 @@
     }
   }
 
+  // TODO: This class appears unused. Verify and remove, if so.
   .arm-info-comparison {
     position: absolute;
     display: block;

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-text.less
@@ -19,21 +19,6 @@
   overflow: hidden;
 }
 
-.regdown-form_extend {
-  font-size: 0;
-  position: relative;
-
-  span {
-    border-top: 1px solid @black;
-    content: '';
-    display: block;
-    left: 100%;
-    position: absolute;
-    top: 1.2em;
-    width: 1000px;
-  }
-}
-
 .regulation-meta {
   margin-bottom: unit(25px / @base-font-size-px, rem);
 

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
@@ -180,19 +180,6 @@
     });
   }
 
-  .results__full {
-    margin-right: 0;
-    width: 100%;
-
-    // Desktop and above.
-    .respond-to-min(@bp-med-min, {
-      .results_list,
-      .results_footer {
-        padding-left: 0;
-      }
-    });
-  }
-
   .layout-row > * {
     display: inline-block;
   }


### PR DESCRIPTION
`regdown-form_extend` was used in the `regdown.py` file, which no longer exists.

## Removals

- TDP: `results__full` class.
- iRegs: `regdown-form_extend` class.
- BAH: `arm-info-comparison` class.

## How to test this PR

1. PR checks should pass. TDP and iRegs should be unchanged.
