### PR TITLE
Docs: Fix broken build due to PyYAML version

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -7,5 +7,5 @@ mkdocs-bootstrap==1.1.1
 mkdocs-bootswatch==1.1
 mkdocs-rtd-dropdown==1.0.2
 pymdown-extensions==10.1
-PyYAML==6.0.livereload1
+PyYAML==6.0.1
 tornado==6.3.3


### PR DESCRIPTION
The version of PyYAML specified in the docs requirements file is invalid, and as such our docs builds have been failing. This fixes it.

## How to test this PR

```
pip install -r requirements/docs.txt
mkdocs serve
```

## Notes and todos

@willbarton I'm not sure what happened here. Your PR #8188 last updated this file and the checks all passed on your PR. Could the `6.0.livereload1` version of PyYAML have been published and then unpublished at some point? I can't seem to find any reference to this release at all.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)