### PR TITLE
TCCP: Add "partial" page fragment results view

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -114,6 +114,7 @@ INSTALLED_APPS = (
     "wagtail_draftail_anchors",
     "tccp",
     "django_filters",
+    "django_htmx"
 )
 
 MIDDLEWARE = (
@@ -122,6 +123,7 @@ MIDDLEWARE = (
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "core.middleware.PathBasedCsrfViewMiddleware",
+    "django_htmx.middleware.HtmxMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "core.middleware.ParseLinksMiddleware",

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -114,7 +114,7 @@ INSTALLED_APPS = (
     "wagtail_draftail_anchors",
     "tccp",
     "django_filters",
-    "django_htmx"
+    "django_htmx",
 )
 
 MIDDLEWARE = (

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -1,10 +1,6 @@
 {% extends "v1/layouts/layout-full.html" %}
 
-{% from 'tccp/includes/data_published.html' import data_published %}
-{% from 'tccp/includes/fields.html' import apr, apr_range %}
 {% from 'tccp/includes/filter_form.html' import filter_form with context %}
-{% import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context %}
-{% import 'v1/includes/molecules/notification.html' as notification %}
 {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
 
 {% block title -%}
@@ -67,96 +63,12 @@
     {% endcall %}
 </div>
 
-{%- set purchase_apr_adjectives = ["less", "average", "more"] %}
-
 <div class="block block__sub">
     <div class="o-filterable-list-results htmx-results">
+        {% include "tccp/includes/card_list.html" %}
+    </div>
+</div>
 
-        {% if count -%}
-        {{- notification.render(
-            'success',
-            true,
-            count ~ ' result' ~ count | pluralize()
-        ) -}}
-        {%- else -%}
-        {{- notification.render(
-            'warning',
-            true,
-            'There are no results for your search.'
-        ) -}}
-        {%- endif %}
-
-        <div class="block__sub">
-            <div class="a-label__heading">Key</div>
-
-            {% for adjective in purchase_apr_adjectives %}
-                <p class="u-mb0">
-                    <span class="a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
-                        {%- for i in range(loop.index) -%}
-                            {{ svg_icon("dollar-round") }}
-                        {%- endfor -%}
-
-                        Pay {{ adjective ~ (" than average" if adjective != "average") }} interest
-                    </span>
-                </p>
-            {% endfor %}
-        </div>
-
-        <p>
-            {% if stats_all.first_report_date -%}
-            {{ data_published(stats_all.first_report_date) }}
-            {%- endif %}
-        </p>
-
-        {%- macro card_name_cell(card) -%}
-            <a href="{{ card.url }}">
-                <div class="a-card-institution-name">{{ card.institution_name }}</div>
-                <div>{{ card.product_name }}</div>
-            </a>
-        {%- endmacro -%}
-
-        {%- macro purchase_apr_cell(card) -%}
-            {%- set adjective = purchase_apr_adjectives[
-                card.purchase_apr_for_tier_rating
-            ] -%}
-
-            {{- apr(card.purchase_apr_for_tier) -}}
-
-            <span class="a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
-                {%- for i in range(card.purchase_apr_for_tier_rating + 1) %}
-                    {{ svg_icon("dollar-round") }}
-                {% endfor -%}
-
-                <strong>Pay {{ adjective }} interest</strong>
-            </span>
-        {%- endmacro -%}
-
-        {%- set card_columns = [
-            {'heading': 'Credit card'},
-            {'heading': 'Purchase APR'},
-            {'heading': 'Account fee'},
-            {'heading': 'Balance transfer APR'},
-            {'heading': 'Offers rewards'},
-        ] %}
-        {%- set card_rows = [] %}
-        {%- for card in results %}
-            {% do card_rows.append( [
-                card_name_cell(card) | safe,
-                purchase_apr_cell(card) | safe,
-                (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
-                apr(card.transfer_apr_for_tier) if card.transfer_apr_for_tier is not none else apr_range(card.transfer_apr_min, card.transfer_apr_max),
-                (card.rewards | join(', ')) if card.rewards else 'None'
-            ] ) %}
-        {% endfor %}
-        {%- with value = {
-            'data': {
-                'columns': card_columns,
-                'rows': card_rows
-            },
-            'options': ['directory_table']
-        } %}
-            {% include 'v1/includes/organisms/tables/base.html' %}
-        {% endwith %}
     </div>
 </div>
 

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -1,0 +1,91 @@
+{% from 'tccp/includes/data_published.html' import data_published %}
+{% from 'tccp/includes/fields.html' import apr, apr_range %}
+{% import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context %}
+{% import 'v1/includes/molecules/notification.html' as notification %}
+
+{% if count -%}
+{{- notification.render(
+    'success',
+    true,
+    count ~ ' result' ~ count | pluralize()
+) -}}
+{%- else -%}
+{{- notification.render(
+    'warning',
+    true,
+    'There are no results for your search.'
+) -}}
+{%- endif %}
+
+{%- set purchase_apr_adjectives = ["less", "average", "more"] %}
+
+<div class="block__sub">
+    <div class="a-label__heading">Key</div>
+    {% for adjective in purchase_apr_adjectives %}
+        <p class="u-mb0">
+            <span class="a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
+                {%- for i in range(loop.index) -%}
+                    {{ svg_icon("dollar-round") }}
+                {%- endfor -%}
+
+                Pay {{ adjective ~ (" than average" if adjective != "average") }} interest
+            </span>
+        </p>
+    {% endfor %}
+</div>
+
+<p>
+    {% if stats_all.first_report_date -%}
+    {{ data_published(stats_all.first_report_date) }}
+    {%- endif %}
+</p>
+
+{%- macro card_name_cell(card) -%}
+    <a href="{{ card.url }}">
+        <div class="a-card-institution-name">{{ card.institution_name }}</div>
+        <div>{{ card.product_name }}</div>
+    </a>
+{%- endmacro -%}
+
+{%- macro purchase_apr_cell(card) -%}
+    {%- set adjective = purchase_apr_adjectives[
+        card.purchase_apr_for_tier_rating
+    ] -%}
+
+    {{- apr(card.purchase_apr_for_tier) -}}
+
+    <span class="a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
+        {%- for i in range(card.purchase_apr_for_tier_rating + 1) %}
+            {{ svg_icon("dollar-round") }}
+        {% endfor -%}
+
+        <strong>Pay {{ adjective }} interest</strong>
+    </span>
+{%- endmacro -%}
+
+{%- set card_columns = [
+    {'heading': 'Credit card'},
+    {'heading': 'Purchase APR'},
+    {'heading': 'Account fee'},
+    {'heading': 'Balance transfer APR'},
+    {'heading': 'Offers rewards'},
+] %}
+{%- set card_rows = [] %}
+{%- for card in results %}
+    {% do card_rows.append( [
+        card_name_cell(card) | safe,
+        purchase_apr_cell(card) | safe,
+        (card.periodic_fee_type | join(', ')) if card.periodic_fee_type else 'None',
+        apr(card.transfer_apr_for_tier) if card.transfer_apr_for_tier is not none else apr_range(card.transfer_apr_min, card.transfer_apr_max),
+        (card.rewards | join(', ')) if card.rewards else 'None'
+    ] ) %}
+{% endfor %}
+{%- with value = {
+    'data': {
+        'columns': card_columns,
+        'rows': card_rows
+    },
+    'options': ['directory_table']
+} %}
+    {% include 'v1/includes/organisms/tables/base.html' %}
+{% endwith %}

--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -61,7 +61,14 @@
 
 {%- macro filter_form(form) -%}
 
-<form action="." method="get" hx-boost="true" hx-trigger="change" hx-swap="show:none" hx-indicator=".htmx-container" >
+<form action="."
+    method="get"
+    hx-boost="true"
+    hx-trigger="change"
+    hx-swap="show:none"
+    hx-indicator=".htmx-container"
+    hx-target=".htmx-results"
+    hx-replace-url="true">
     <div class="content-l">
 
         {{ render_form_fields(form) }}

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -70,6 +70,14 @@ class CardListViewTests(TestCase):
 
     def test_no_querystring_filters_by_good_tier(self):
         response = self.make_request()
+        self.assertContains(response, "Consumer Financial Protection Bureau")
+        self.assertContains(response, "There are no results for your search.")
+
+    def test_partial_includes_only_results(self):
+        response = self.make_request("?partial=1")
+        self.assertNotContains(
+            response, "Consumer Financial Protection Bureau"
+        )
         self.assertContains(response, "There are no results for your search.")
 
     def test_filter_by_no_credit_score(self):

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -81,7 +81,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
         return self.model.objects.all()
 
     def get_template_names(self):
-        if "partial" in self.request.GET:
+        if self.request.htmx:
             return ["tccp/includes/card_list.html"]
         else:
             return ["tccp/cards.html"]

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -69,7 +69,6 @@ class CardListView(FlaggedViewMixin, ListAPIView):
     serializer_class = CardSurveyDataSerializer
     filter_backends = [CardSurveyDataFilterBackend]
     filterset_class = CardSurveyDataFilterSet
-    template_name = "tccp/cards.html"
     heading = "Customize for your situation"
     breadcrumb_items = LandingPageView.breadcrumb_items + [
         {
@@ -80,6 +79,12 @@ class CardListView(FlaggedViewMixin, ListAPIView):
 
     def get_queryset(self):
         return self.model.objects.all()
+
+    def get_template_names(self):
+        if "partial" in self.request.GET:
+            return ["tccp/includes/card_list.html"]
+        else:
+            return ["tccp/cards.html"]
 
     def list(self, request, *args, **kwargs):
         render_format = request.accepted_renderer.format

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -12,6 +12,7 @@ django-extensions==3.2.3
 django-flags==5.0.13
 django-formtools==2.5.1
 django-health-check==3.18.1
+django-htmx==1.17.3
 django-localflavor==4.0
 django-mptt==0.14.0
 django-storages==1.14.2


### PR DESCRIPTION
This commit adds the ability to request a "partial" rendering of the TCCP list view, including only the results portion. This is intended to support better AJAX-based updates of the page.

## How to test this PR

To test, run a local server. Visit
http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ and then try visiting
http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?partial=1

## Notes and todos

TODO: @contolini we still need to modify the form to append `?partial` to the URL when being requested via AJAX. It'd be nice if there were a way to use [`hx-boost`](https://htmx.org/attributes/hx-boost/) with an alternate URL, but I'm not sure that's possible. Should we use JS to somehow alter that param on page load?

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)