### PR TITLE
TCCP: Add contact info to TCCP card details

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -690,6 +690,37 @@
             </dd>
         {% endif %}
     </dl>
+    <h2>Contact information</h2>
+    <dl class="m-list m-list__card-details">
+        {% if card.website_for_consumer %}
+            <dt>Website</dt>
+            <dd class="a-card-url">
+                {# Some issuers submitted more than one URL for a card. In all
+                    of those instances, the URLs are separated with a space, so
+                    we'll only turn the submitted URL into a link if it doesn't
+                    have a space in it for now. TODO: maybe split multiple URLs
+                    up.
+                #}
+                {% if ' ' is not in card.website_for_consumer %}
+                    {# TODO: Do we need to run this through link middelware? #}
+                    <a href="{{ card.website_for_consumer }}">
+                        {{ card.website_for_consumer }}
+                    </a>
+                {% else %}
+                    {{ card.website_for_consumer }}
+                {% endif %}
+            </dd>
+        {% endif %}
+        {% if card.telephone_number_for_consumers %}
+            <dt>Phone</dt>
+            <dd>
+                {# TODO: Do we want this marked up as a phone link? #}
+                <a href="tel:{{ card.telephone_number_for_consumers }}">
+                    {{ card.telephone_number_for_consumers }}
+                </a>
+            </dd>
+        {% endif %}
+    </dl>
 
     {% if flag_enabled("TCCP_DEBUG_DETAILS") %}
     <h3 class="h5">All fields</h3>

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -216,6 +216,9 @@
   dd .o-table {
     margin-top: 10px;
   }
+  .a-card-url {
+    overflow-wrap: break-word;
+  }
 }
 
 // htmx animated progress bar


### PR DESCRIPTION
Add website and phone number to TCCP card details page.

---

## Additions

- Card contact info to card detail page
- Style to wrap very long card URLs

## How to test this PR

Browse to any card's details and scroll to the last section. Every card will have a website, a phone number, or both. You might want to look at some outliers, like [cards whose issuers submitted multiple URLs](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/synchrony-financial-verizon-visa-card/) or [cards with very long URLs](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/wells-fargo-bank-national-association-wells-fargo-active-cash-card/).

## Screenshots

![contact-info](https://github.com/cfpb/consumerfinance.gov/assets/1862695/aee57799-a5bb-4ebd-997c-976fd623e009)

## Notes and todos

- I noted a couple of TODOs in the code.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets