### PR TITLE
Hide surplus TCCP card results behind a "show more" button

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -64,12 +64,12 @@
 </div>
 
 <div class="block block__sub">
-    <div class="o-filterable-list-results htmx-results">
+    <div class="o-filterable-list-results o-filterable-list-results__partial htmx-results">
         {% include "tccp/includes/card_list.html" %}
     </div>
-</div>
-
-    </div>
+    <button data-js-hook="behavior_show-more" class="a-btn a-btn__link a-btn__warning a-btn__full-on-xs u-mt20 u-js-only">
+        Show more results with higher interest rates
+    </button>
 </div>
 
 {% endblock content_main %}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -34,11 +34,9 @@
     {% endfor %}
 </div>
 
-<p>
-    {% if stats_all.first_report_date -%}
-    {{ data_published(stats_all.first_report_date) }}
-    {%- endif %}
-</p>
+{% if stats_all.first_report_date -%}
+{{ data_published(stats_all.first_report_date) }}
+{%- endif %}
 
 {%- macro card_name_cell(card) -%}
     <a href="{{ card.url }}">

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -72,6 +72,21 @@
   }
 }
 
+// "Show more results" functionality for JS users
+// Only show the first 10 results
+html.js .o-filterable-list-results__partial {
+  table {
+    tr:nth-child(10) {
+      border-bottom: 1px solid @table-border;
+      margin-bottom: unit((10px / @base-font-size-px), em);
+    }
+
+    tr:nth-child(n + 11) {
+      display: none;
+    }
+  }
+}
+
 // Some cards list a lot of available locations and disrupt the table layout.
 // Cap the width of the availability cell on non-mobile screens to prevent this.
 @media only screen and (min-width: @bp-sm-min) {

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -1,2 +1,29 @@
 // See https://htmx.org/
 import 'htmx.org';
+
+import { attach } from '@cfpb/cfpb-atomic-component';
+
+/**
+ * Initialize some things.
+ */
+function init() {
+  attach('show-more', 'click', handleShowMore);
+}
+
+/**
+ * Handle clicking of the results page "show more" link
+ * @param {Event} event - Click event.
+ */
+function handleShowMore(event) {
+  if (event instanceof Event) {
+    event.preventDefault();
+  }
+  const results = document.querySelector('.o-filterable-list-results');
+  results.classList.remove('o-filterable-list-results__partial');
+
+  event.target.classList.add('u-hidden');
+}
+
+window.addEventListener('load', () => {
+  init();
+});


### PR DESCRIPTION
Adds a "show more" button that hides table rows > 10.

See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/244

## How to test this PR

1. `./frontend.sh`
2. Go to the [cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/), scroll down and click the red link.

## Screenshots

![show-more-cards](https://github.com/cfpb/consumerfinance.gov/assets/1060248/ee22c4ce-5a41-4e5f-8b9e-65090dba16e3)

## Checklist

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
