### PR TITLE
TCCP: Clean up card details

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -632,9 +632,6 @@ FLAGS = {
         ("environment is", "local"),
         ("environment is", "test"),
     ],
-    "TCCP_DEBUG_DETAILS": [
-        ("environment is", "local"),
-    ],
 }
 
 REGULATIONS_REFERENCE_MAPPING = [

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -16,7 +16,8 @@
 {% block content_main %}
 <div class="block block__flush-top">
 
-    <h1>{{ card.institution_name }} {{ card.product_name }}</h1>
+    <div class="eyebrow">{{ card.institution_name }}</div>
+    <h1>{{ card.product_name }}</h1>
 
     {{ data_published(card.report_date) }}
 
@@ -717,7 +718,7 @@
     <dl class="m-list m-list__card-details">
         {% if card.website_for_consumer %}
             <dt>Website</dt>
-            <dd class="a-card-url">
+            <dd>
                 {# Some issuers submitted more than one URL for a card. In all
                     of those instances, the URLs are separated with a space, so
                     we'll only turn the submitted URL into a link if it doesn't
@@ -740,27 +741,6 @@
             </dd>
         {% endif %}
     </dl>
-
-    {% if flag_enabled("TCCP_DEBUG_DETAILS") %}
-    <h3 class="h5">All fields</h3>
-
-    <table class="o-table o-table__striped">
-        <thead>
-            <tr>
-                <th>Field</th>
-                <th>Value</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for field in card._meta.fields %}
-            <tr>
-                <td>{{ field.name }}</td>
-                <td>{{ card.__getattribute__(field.name) }}</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    {% endif %}
 </div>
 
 {% endblock content_main %}

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -21,7 +21,7 @@
 
     {{ data_published(card.report_date) }}
 
-    <h2>Availability</h2>
+    <h2>Application requirements</h2>
     <dl class="m-list m-list__card-details">
         <dt>Location</dt>
         <dd>
@@ -77,7 +77,7 @@
             </table>
         </dd>
         <dt>
-            Secured card
+            Down payment required?
         </dt>
         <dd>
             {{ "Yes" if card.secured_card else "No" }}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -234,9 +234,6 @@
   dd .o-table {
     margin-top: 10px;
   }
-  .a-card-url {
-    overflow-wrap: break-word;
-  }
 }
 
 // htmx animated progress bar


### PR DESCRIPTION
Cleans up a few things on the card details page ahead of usability testing.

---

## Removals

- `TCCP_DEBUG_DETAILS` feature flag
- Table of all card fields
- `a-card-url` class and style; #8252 makes an app-specific style redundant

## Changes

- Institution name is now an eyebrow instead of part of the main heading
- "Availability" section is now "Application requirements"
- "Secured card" is now "Down payment required?"

## How to test this PR

1. `./frontend.sh`
2. From http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/, check a few cards to make sure:
    - The institution name is in an eyebrow above the `h1`
    - "Availability" section is now "Application requirements"
    - "Secured card" is now "Down payment required?"
    - The table with all the card fields in it is gone
    - [Long URLs](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/wells-fargo-bank-national-association-wells-fargo-active-cash-card/) still wrap

## Screenshots

![cleanup](https://github.com/cfpb/consumerfinance.gov/assets/1862695/f820c84d-20cc-4678-a2b7-a9fe5e8de0c8)

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)