### PR TITLE
TCCP: Make card rating key more semantic

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -23,7 +23,7 @@
     <div class="a-label__heading">Key</div>
     <dl>
         {% for adjective in purchase_apr_adjectives %}
-        <div class="u-mb0 a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}"">
+        <div class="u-mb0 a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
             <dt>
                 {%- for i in range(loop.index) -%}
                     {{ svg_icon("dollar-round") }}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -21,17 +21,20 @@
 
 <div class="block__sub">
     <div class="a-label__heading">Key</div>
-    {% for adjective in purchase_apr_adjectives %}
-        <p class="u-mb0">
-            <span class="a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}">
+    <dl>
+        {% for adjective in purchase_apr_adjectives %}
+        <div class="u-mb0 a-card-purchase-apr-rating a-card-purchase-apr-rating__{{ adjective }}"">
+            <dt>
                 {%- for i in range(loop.index) -%}
                     {{ svg_icon("dollar-round") }}
                 {%- endfor -%}
-
+            </dt>
+            <dd>
                 Pay {{ adjective ~ (" than average" if adjective != "average") }} interest
-            </span>
-        </p>
-    {% endfor %}
+            </dd>
+        </div>
+        {% endfor %}
+    </dl>
 </div>
 
 <p>


### PR DESCRIPTION
This commit changes the HTML for the TCCP results view page so that the card rating key is more semantic.

Instead of using a list of `spans`, use a `dl`.

## Screenshots

Key continues to look like this:

<img width="392" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/cbc9cc66-7564-4b3b-910a-3bd9a693c2b5">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)