### PR TITLE
Remove querystring from generated canonical links

### DIFF
--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -240,7 +240,6 @@ class ActivitySetUpTests(TestCase):
             f"{self.search_page.url}?topic=1&topic=2&topic=3"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn("topic=1", response.content.decode("utf8"))
 
     def test_taxonomy_model_str(self):
         taxonomy_instance = ActivityBuildingBlock.objects.first()

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -65,7 +65,7 @@ itemscope="" itemtype="https://schema.org/FAQPage"
     <base target="_blank">
     {% endif %}
 
-    <link rel="canonical" href="{{ request.build_absolute_uri().split('?')[0] | lower }}">
+    <link rel="canonical" href={{ ("https://" ~ request.get_host() ~ request.path) | lower }}>
 
     {# Open Graph properties #}
 

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -65,7 +65,7 @@ itemscope="" itemtype="https://schema.org/FAQPage"
     <base target="_blank">
     {% endif %}
 
-    <link rel="canonical" href="{{ request.build_absolute_uri() | lower }}">
+    <link rel="canonical" href="{{ request.build_absolute_uri().split('?')[0] | lower }}">
 
     {# Open Graph properties #}
 

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -65,14 +65,16 @@ itemscope="" itemtype="https://schema.org/FAQPage"
     <base target="_blank">
     {% endif %}
 
-    <link rel="canonical" href={{ ("https://" ~ request.get_host() ~ request.path) | lower }}>
+    {% set canonical = request.build_absolute_uri(request.path) | lower %}
+
+    <link rel="canonical" href="{{ canonical }}">
 
     {# Open Graph properties #}
 
     {# Required Open Graph properties #}
     <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
-    <meta property="og:url" content="{{ request.build_absolute_uri() | lower }}">
+    <meta property="og:url" content="{{ canonical }}">
 
     {% block og_image %}
         {% if page and page.meta_image %}


### PR DESCRIPTION
This PR changes how canonical links are generated in `base.html`, specifically it strips the querystring. Across all the pages I audited (perhaps non-exhaustive) the querystring is simply used as a filter or as a way to track specific selections. The whole point of canonical links is to collate these views of the same page into one... canonical link... that google can then reference and give more link equity to, instead of diffusing it across N pages (where N is the number of pages in a filterable list or w/e).

## Testing:
- Pull
- Load various pages
  - On pages without querystrings, the canonical link should be unchanged
  - On pages WITH querystrings, eg, [this one](http://localhost:8000/about-us/blog/?title=&topics=access-to-credit&from_date=&to_date=), the canonical link should have the querystring stripped out.