### PR TITLE
TCCP: Exclude non-targeted cards

### DIFF
--- a/cfgov/tccp/models.py
+++ b/cfgov/tccp/models.py
@@ -77,6 +77,10 @@ class CardSurveyDataQuerySet(models.QuerySet):
         # We exclude cards that don't have a purchase APR for this tier.
         qs = qs.exclude(purchase_apr_for_tier__isnull=True)
 
+        # We also exclude those cards that aren't "specifically targeted" for
+        # this tier.
+        qs = qs.filter(targeted_credit_tiers__contains=credit_tier)
+
         # Finally, we want to annotate each card with a rating based on how
         # its purchase APR compares with other cards within the same tier.
         #

--- a/cfgov/tccp/tests/test_filters.py
+++ b/cfgov/tccp/tests/test_filters.py
@@ -11,6 +11,7 @@ class CardOrderingFilterTests(TestCase):
         for apr in [2.9, 0.9, 99.9, 0]:
             baker.make(
                 CardSurveyData,
+                targeted_credit_tiers=["Credit score 619 or less"],
                 purchase_apr_poor=apr,
             )
 
@@ -31,6 +32,7 @@ class CardOrderingFilterTests(TestCase):
         ]:
             baker.make(
                 CardSurveyData,
+                targeted_credit_tiers=["Credit score 619 or less"],
                 purchase_apr_poor=purchase_apr,
                 transfer_apr_poor=transfer_apr,
             )
@@ -45,7 +47,11 @@ class CardOrderingFilterTests(TestCase):
 
     def test_ordering_by_product_name(self):
         for product_name in ["e", "a", "b", "d", "c"]:
-            baker.make(CardSurveyData, product_name=product_name)
+            baker.make(
+                CardSurveyData,
+                targeted_credit_tiers=["Credit scores from 620 to 719"],
+                product_name=product_name,
+            )
 
         qs = CardSurveyData.objects.all()
         self.assertQuerysetEqual(

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -24,7 +24,12 @@ class CardSurveyDataFilterSetTests(TestCase):
         self.assertEqual(CardSurveyDataFilterSet(data).data, data)
 
     def test_filter_by_situations_noop(self):
-        baker.make(CardSurveyData, purchase_apr_good=0.99, _quantity=10)
+        baker.make(
+            CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
+            purchase_apr_good=0.99,
+            _quantity=10,
+        )
 
         qs = CardSurveyData.objects.all()
         self.assertEqual(qs.count(), 10)
@@ -40,6 +45,7 @@ class CardSurveyDataFilterSetTests(TestCase):
                 CardSurveyData,
                 availability_of_credit_card_plan="One State/Territory",
                 state=state,
+                targeted_credit_tiers=["Credit scores from 620 to 719"],
                 purchase_apr_good=0.99,
                 _quantity=3,
             )
@@ -53,6 +59,7 @@ class CardSurveyDataFilterSetTests(TestCase):
     def test_filter_by_no_account_fee(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
             purchase_apr_good=0.99,
             periodic_fee_type=["Annual"],
         )
@@ -69,6 +76,7 @@ class CardSurveyDataFilterSetTests(TestCase):
     def test_filter_by_rewards(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
             purchase_apr_good=0.99,
             rewards=["Cashback rewards"],
         )

--- a/cfgov/tccp/tests/test_models.py
+++ b/cfgov/tccp/tests/test_models.py
@@ -30,6 +30,7 @@ class CardSurveyDataQuerySetTests(TestCase):
     def test_for_credit_tier(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score 619 or less"],
             purchase_apr_poor=9.99,
             transfer_apr_poor=8.88,
             transfer_apr_min=7.77,
@@ -46,6 +47,7 @@ class CardSurveyDataQuerySetTests(TestCase):
 
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score of 720 or greater"],
             purchase_apr_great=9.99,
             transfer_apr_great=None,
             transfer_apr_min=7.77,
@@ -86,6 +88,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_poor=3,
             purchase_apr_good=2,
             purchase_apr_great=1,
@@ -94,6 +101,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_poor=9,
             purchase_apr_good=6,
             purchase_apr_great=3,
@@ -102,6 +114,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_great=0,
         )
 

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -58,6 +58,7 @@ class CardListViewTests(TestCase):
     def setUpTestData(cls):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score of 720 or greater"],
             purchase_apr_great=0.99,
             _quantity=5,
         )


### PR DESCRIPTION
Some credit cards offer a purchase APR for a specific credit tier but are not marked as being "specifically targeted" to that credit tier, recorded in the TCCP survey under the "Targeted credit tiers" column.

Previously TCCP filter results would include these cards, so if a user marked their credit tier as 620-719, they might see cards that, while they offer a purchase APR for this range, are not marked as being "specifically targeted" to this range.

This change removes those cards from the results.

## How to test this PR

The easiest way to do this is to do a search and see what doesn't show up in the results. Run a local server and visit [this link](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?credit_tier=Credit+scores+from+620+to+719&location=DC&situations=Pay+less+interest&ordering=product_name). That link shows cards for the "good" tier in DC, ordered by card name.  You'll see that [this card](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/tucson-federal-credit-union-visa-platinum-preferred-credit-card/) doesn't show up, even though it is available in that location and has a purchase APR for the good tier.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)