### PR TITLE
TCCP: Add breadcrumbs to card detail page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -8,6 +8,11 @@
     | Consumer Financial Protection Bureau
 {%- endblock title %}
 
+{% block javascript scoped %}
+    {{ super() }}
+    <script src="{{ static( 'apps/tccp/js/index.js' ) }}"></script>
+{% endblock %}
+
 {% block css %}
     {{ super() }}
     <link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -7,7 +7,7 @@ from django.test import RequestFactory, TestCase
 from django_htmx.middleware import HtmxMiddleware
 
 from tccp.models import CardSurveyData
-from tccp.views import CardListView, LandingPageView
+from tccp.views import CardDetailView, CardListView, LandingPageView
 
 from .baker import baker
 
@@ -105,3 +105,23 @@ class CardListViewTests(TestCase):
     def test_invalid_html_query_renders_empty_page(self):
         response = self.make_request("?credit_tier=foo")
         self.assertContains(response, "There are no results for your search.")
+
+
+class CardDetailViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        baker.make(
+            CardSurveyData,
+            slug="test-card",
+            product_name="Test Card",
+        )
+
+    def make_request(self, slug):
+        view = CardDetailView.as_view()
+        request = RequestFactory().get("/")
+        return view(request, **{"slug": slug})
+
+    def test_get(self):
+        response = self.make_request("test-card")
+        self.assertContains(response, "Test Card")
+        self.assertContains(response, "m-breadcrumb")

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -139,3 +139,14 @@ class CardDetailView(FlaggedViewMixin, DetailView):
     model = CardSurveyData
     context_object_name = "card"
     template_name = "tccp/card.html"
+    breadcrumb_items = CardListView.breadcrumb_items + [
+        {
+            "title": CardListView.heading,
+            "href": reverse_lazy("tccp:cards"),
+        }
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["breadcrumb_items"] = self.breadcrumb_items
+        return context

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -1,11 +1,15 @@
 import { attach } from '@cfpb/cfpb-atomic-component';
 
+import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
+
 /**
  * Initialize some things.
  */
 function init() {
   // Attach "show more" click handler
   attach('show-more', 'click', handleShowMore);
+  // Make the breadcrumb on the details page go back to a filtered list
+  updateBreadcrumb();
 }
 
 /**
@@ -20,6 +24,19 @@ function handleShowMore(event) {
   results.classList.remove('o-filterable-list-results__partial');
 
   event.target.classList.add('u-hidden');
+}
+
+/**
+ * Update the breadcrumb on the card details page to point back to the filtered
+ * list of cards the user came from. We have to do this client-side to prevent
+ * Akamai from caching the page with a breadcrumb to a filtered list.
+ */
+function updateBreadcrumb() {
+  const breadcrumb = document.querySelector('.m-breadcrumbs_crumb:last-child');
+  if (breadcrumb.innerText === 'Customize for your situation') {
+    breadcrumb.href =
+      webStorageProxy.getItem('tccp-filter-path') || breadcrumb.href;
+  }
 }
 
 window.addEventListener('load', () => {

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -47,3 +47,32 @@ describe('Explore credit cards results page', () => {
     cy.get('h2').contains('Application requirements').should('exist');
   });
 });
+
+// Disabling this test until we add card test data
+describe('Explore credit card details page', () => {
+  xit('should have a breadcrumb to the filtered list the user came from', () => {
+    exploreCards.openLandingPage();
+
+    exploreCards.selectCreditTier('Greater than 720');
+    exploreCards.selectLocation('FL');
+    exploreCards.selectSituation('Earn rewards');
+    exploreCards.clickSubmitButton();
+
+    cy.get('td[data-label="Credit card"] a').first().click();
+
+    cy.get('.m-breadcrumbs_crumb:last-child')
+      .should('have.attr', 'href')
+      .and('contain', 'credit_tier=Credit+score+of+720+or+greater')
+      .and('contain', 'location=FL')
+      .and('contain', 'situations=Earn+rewards');
+  });
+  xit('should have a breadcrumb to full list if the user never filtered', () => {
+    exploreCards.openResultsPage();
+
+    cy.get('td[data-label="Credit card"] a').first().click();
+
+    cy.get('.m-breadcrumbs_crumb:last-child')
+      .should('have.attr', 'href')
+      .and('eq', '/consumer-tools/credit-cards/explore-cards/cards/');
+  });
+});


### PR DESCRIPTION
Adds breadcrumbs to the card details page and progressively enhances them with JavaScript so the breadcrumb that points back to the card list will take you to the specific filtered list you came from.

We have to update that breadcrumb client-side because there's a chance Akamai may cache a version of the page with a breadcrumb to a specific filtered list if we do it on the backend, see #7108 for details. I'm comfortable making this enhancement here even though we chose to remove it in other places. A primary goal of the TCCP tool is to help users compare different cards that meet their needs, so we're actually **hoping** they'll go from a filtered list to card details back to the filtered list and so on to look at a number of different cards. Most people will use the back button for that, but for those who don't, we want to make sure they can always get back to the filtered list they came from.

@chosak and @contolini, a couple of specific questions I had with this one:

1. Now that our TCCP JS is running on two pages and not just the card list page, should we scope what happens in `init()` so each page only runs the relevant stuff? The `previousPage.pathname.includes(cardListPagePath)` condition in `updateBreadcrumb()` should prevent the breadcrumb update from happening on the card list page, but is that better done elsewhere?
2. Does the `previousPage.hostname === window.location.hostname` condition assuage our concerns about only updating the breadcrumb if you're coming from a cf.gov page?
3. Do we need unit tests for this JS now that it's gotten a little more complex?

And more generally, any other approaches to this that would make more sense?

---

## Additions

- Breadcrumbs to the card details page

## How to test this PR

1. Fire up http://localhost:8000/consumer-tools/credit-cards/explore-cards/ and choose some situations
2. From the card list page, choose a card to view; also note that the breadcrumbs on the card list page aren't affected
3. Confirm the breadcrumb on the card details page goes back to the filtered view you came from
4. Back on the card list page, change a filter and note that the URL doesn't change (yet, see the todo below)
5. From that newly filtered list, choose another card to view
6. Note the breadcrumb on that card details page still points to the original filtered list (again, see the todo below)
7. Finally, copy and paste a card details URL into a new tab, and note that the breadcrumb points back to the unfiltered card list (since there's no referrer)

## Screenshots

![breadcrumbs](https://github.com/cfpb/consumerfinance.gov/assets/1862695/1f988638-f22e-4cb7-baac-cd7a178b9605)

## Notes and todos

- I noted this in a TODO in the code, but right now we're not doing a `replaceState` when you change the filters on the card list page, so technically this breadcrumb isn't fully working yet. It will always take you back to the filtered list you first landed on from the landing page, even if you then change the filters on the list page. @contolini is working on a fix to enable `replaceState` to work with Akamai caching. When that's done we'll check the breadcrumbs to make sure they're working as  expected (and remove the TODO note).

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets