### PR TITLE
Add TCCP htmx extensions to handle cache busting and filter tracking

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -11,6 +11,7 @@
 {{ super() }}
 <script src="{{ static( 'js/routes/on-demand/filterable-list-controls.js' ) }}"></script>
 <script src="{{ static( 'apps/tccp/js/index.js' ) }}"></script>
+<script src="{{ static( 'apps/tccp/js/htmx.js' ) }}"></script>
 {% endblock %}
 
 {% block css %}

--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -68,7 +68,7 @@
     hx-swap="show:none"
     hx-indicator=".htmx-container"
     hx-target=".htmx-results"
-    hx-push-url="false">
+    hx-replace-url="true">
     <div class="content-l">
 
         {{ render_form_fields(form) }}

--- a/cfgov/unprocessed/apps/tccp/js/htmx.js
+++ b/cfgov/unprocessed/apps/tccp/js/htmx.js
@@ -54,6 +54,14 @@ webStorageProxy.setItem(
   window.location.pathname + window.location.search,
 );
 
+// Disable htmx localStorage cache. We've found CFPB pages are
+// large enough that htmx hits the localStorage limit pretty
+// quickly and throws harmless-but-annoying `historyCacheError`
+// console errors.
+// See https://htmx.org/attributes/hx-history/
+// See https://htmx.org/events/#htmx:historyCacheError
+document.body.setAttribute('hx-history', 'false');
+
 // Add htmx extensions to the dom and initialize them
 document.body.setAttribute('hx-ext', 'htmx-url-param, store-tccp-filter-path');
 htmx.process(document.body);

--- a/cfgov/unprocessed/apps/tccp/js/htmx.js
+++ b/cfgov/unprocessed/apps/tccp/js/htmx.js
@@ -35,7 +35,7 @@ htmx.defineExtension('htmx-url-param', {
 });
 
 /**
- * htmx extension that stores the page's pathname in web
+ * htmx extension that stores the page's path in web
  * storage whenever it's updated
  * See https://htmx.org/extensions/
  * See https://htmx.org/events/#htmx:replacedInHistory
@@ -47,6 +47,12 @@ htmx.defineExtension('store-tccp-filter-path', {
     }
   },
 });
+
+// Store the path on page load before htmx has started up
+webStorageProxy.setItem(
+  'tccp-filter-path',
+  window.location.pathname + window.location.search,
+);
 
 // Add htmx extensions to the dom and initialize them
 document.body.setAttribute('hx-ext', 'htmx-url-param, store-tccp-filter-path');

--- a/cfgov/unprocessed/apps/tccp/js/htmx.js
+++ b/cfgov/unprocessed/apps/tccp/js/htmx.js
@@ -1,0 +1,53 @@
+import htmx from 'htmx.org';
+
+import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
+
+/**
+ * htmx extension that adds an `htmx=true` query parameter
+ * to URLs immediately before htmx makes a request and then
+ * removes it before pushing it to the browser's history.
+ * This allows endpoints fetched by htmx via AJAX to have
+ * a URL that is different from their host page's URL,
+ * reducing CDN caching mistaken identity bugs.
+ *
+ * There are other ways to handle htmx cache busting,
+ * including a `getCacheBusterParam` config option and
+ * using a `Vary: HX-Request` HTTP header, but we've
+ * found them to be unreliable with our infrastructure.
+ *
+ * See https://htmx.org/docs/#caching
+ * See https://htmx.org/extensions/
+ * See https://htmx.org/events/#htmx:configRequest
+ * See https://htmx.org/events/#htmx:beforeHistoryUpdate
+ */
+htmx.defineExtension('htmx-url-param', {
+  onEvent: function (name, event) {
+    if (name === 'htmx:configRequest') {
+      event.detail.parameters.htmx = 'true';
+    }
+    if (name === 'htmx:beforeHistoryUpdate') {
+      event.detail.history.path = event.detail.history.path.replace(
+        /&?htmx=true/,
+        '',
+      );
+    }
+  },
+});
+
+/**
+ * htmx extension that stores the page's pathname in web
+ * storage whenever it's updated
+ * See https://htmx.org/extensions/
+ * See https://htmx.org/events/#htmx:replacedInHistory
+ */
+htmx.defineExtension('store-tccp-filter-path', {
+  onEvent: function (name, event) {
+    if (name === 'htmx:replacedInHistory') {
+      webStorageProxy.setItem('tccp-filter-path', event.detail.path);
+    }
+  },
+});
+
+// Add htmx extensions to the dom and initialize them
+document.body.setAttribute('hx-ext', 'htmx-url-param, store-tccp-filter-path');
+htmx.process(document.body);

--- a/cfgov/unprocessed/apps/tccp/js/htmx.js
+++ b/cfgov/unprocessed/apps/tccp/js/htmx.js
@@ -26,8 +26,8 @@ htmx.defineExtension('htmx-url-param', {
       event.detail.parameters.htmx = 'true';
     }
     if (name === 'htmx:beforeHistoryUpdate') {
-      event.detail.history.path = event.detail.history.path.replace(
-        /&?htmx=true/,
+      event.detail.history.path = event.detail.history.path.replaceAll(
+        /(&htmx=|(?<=\?)htmx=)true/g,
         '',
       );
     }

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -1,13 +1,14 @@
-import htmx from 'htmx.org';
 import { attach } from '@cfpb/cfpb-atomic-component';
 
-// See https://htmx.org/docs/#caching
-htmx.config.getCacheBusterParam = true;
+import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
 
 /**
  * Initialize some things.
  */
 function init() {
+  // Store the card filter query params to web storage for our breadcrumbs
+  webStorageProxy.setItem('tccp-filter-path', window.location.pathname);
+  // Attach "show more" click handler
   attach('show-more', 'click', handleShowMore);
 }
 

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -1,13 +1,9 @@
 import { attach } from '@cfpb/cfpb-atomic-component';
 
-import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
-
 /**
  * Initialize some things.
  */
 function init() {
-  // Store the card filter query params to web storage for our breadcrumbs
-  webStorageProxy.setItem('tccp-filter-path', window.location.pathname);
   // Attach "show more" click handler
   attach('show-more', 'click', handleShowMore);
 }

--- a/esbuild/scripts.js
+++ b/esbuild/scripts.js
@@ -43,6 +43,7 @@ const jsPaths = [
   `${apps}/teachers-digital-platform/js/index.js`,
   `${apps}/filing-instruction-guide/js/fig-init.js`,
   `${apps}/tccp/js/index.js`,
+  `${apps}/tccp/js/htmx.js`,
 ];
 
 /**

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards-helpers.cy.js
@@ -1,0 +1,63 @@
+export class ExploreCreditCards {
+  openLandingPage() {
+    cy.visit('/consumer-tools/credit-cards/explore-cards/');
+  }
+
+  openResultsPage(filterParams) {
+    const url =
+      '/consumer-tools/credit-cards/explore-cards/cards?' +
+      new URLSearchParams(filterParams).toString();
+    cy.visit(url);
+  }
+
+  selectCreditTier(tier) {
+    cy.get('select[name=credit_tier]').select(tier);
+  }
+
+  selectLocation(location) {
+    cy.get('select[name=location]').select(location);
+  }
+
+  selectSituation(situation) {
+    cy.get('input[name=situations]').check(situation, { force: true });
+  }
+
+  clickSubmitButton() {
+    cy.get('button').contains('See cards for your situation').click();
+  }
+
+  openFilterExpandable() {
+    cy.get('.o-filterable-list-controls button.o-expandable_header').click();
+  }
+
+  clickShowMoreButton() {
+    cy.get('button')
+      .contains('Show more results with higher interest rates')
+      .click();
+  }
+
+  getNumberResults() {
+    return new Promise((resolve) => {
+      return cy
+        .get('.htmx-container')
+        .not('.htmx-request')
+        .get('.o-filterable-list-results .m-notification')
+        .then((el) => resolve(Number(el.text().replace(/[^0-9]/g, ''))));
+    });
+  }
+
+  getNumberVisibleResults() {
+    return new Promise((resolve) => {
+      return cy
+        .get('.htmx-container')
+        .not('.htmx-request')
+        .get('.o-filterable-list-results table tr')
+        .filter(':visible')
+        .then((el) => resolve(el.length));
+    });
+  }
+
+  selectCheckboxFilter(name, value) {
+    cy.get(`input[name=${name}]`).check(value, { force: true });
+  }
+}

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -1,0 +1,48 @@
+import { ExploreCreditCards } from './explore-cards-helpers.cy.js';
+
+const exploreCards = new ExploreCreditCards();
+
+describe('Explore credit cards landing page', () => {
+  it('should show results tailored to the selected situation', () => {
+    exploreCards.openLandingPage();
+
+    exploreCards.selectLocation('FL');
+    exploreCards.selectSituation('Earn rewards');
+    exploreCards.clickSubmitButton();
+
+    exploreCards.openFilterExpandable();
+
+    cy.get('#id_rewards input').should('be.checked');
+  });
+});
+
+describe('Explore credit cards results page', () => {
+  it('should update results when user changes filters', () => {
+    exploreCards.openResultsPage();
+
+    exploreCards.getNumberResults().then((oldNumResults) => {
+      exploreCards.selectCheckboxFilter('rewards', 'Cashback rewards');
+      exploreCards.getNumberResults().then((newNumResults) => {
+        expect(newNumResults).to.be.lt(oldNumResults);
+      });
+    });
+  });
+  it('should show additional results when "Show more" button is clicked', () => {
+    exploreCards.openResultsPage();
+
+    exploreCards.getNumberVisibleResults().then((oldNumResults) => {
+      exploreCards.clickShowMoreButton();
+      exploreCards.getNumberVisibleResults().then((newNumResults) => {
+        expect(oldNumResults).to.be.lt(newNumResults);
+      });
+    });
+  });
+  it('should link to card detail pages', () => {
+    exploreCards.openResultsPage();
+
+    cy.get('td[data-label="Credit card"] a').first().click();
+
+    cy.get('h1').contains('Customize for your situation').should('not.exist');
+    cy.get('h2').contains('Application requirements').should('exist');
+  });
+});

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -37,7 +37,8 @@ describe('Explore credit cards results page', () => {
       });
     });
   });
-  it('should link to card detail pages', () => {
+  // Disabling this test until we add card test data
+  xit('should link to card detail pages', () => {
     exploreCards.openResultsPage();
 
     cy.get('td[data-label="Credit card"] a').first().click();


### PR DESCRIPTION
Adds two htmx extensions: One that adds an `htmx` query param to URLs immediately before htmx makes a request and then removes it before pushing it to the browser's history. This allows endpoints fetched via AJAX to have a URL that is different from their host page's URL, (hopefully) solving our Akamai issues. The second extension stores the filter page's
pathname to web storage so that our breadcrumbs can later retrieve it.

I also added a few cypress tests to detect future regressions.

## How to test this PR

1. `./frontend.sh`
1. Visit the [cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) and open the dev tools network tab. Notice that when you change filters, the AJAX requests have `htmx=true` query params but the page's URL does not.
1. Type `sessionStorage.getItem('tccp-filter-path')` into the browser console and you'll see the most recent page's pathname with query parameters (to be used for breadcrumbs).
1. `yarn cypress run --spec test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js`


## Screenshots


## Notes and todos

- You might sometimes see `htmx:historyCacheError` errors in your console. This happens when htmx's [caching logic](https://github.com/bigskysoftware/htmx/blob/c43d48163f578d2e6f719116da650ca351e323b2/src/htmx.js#L2297-L2303) exceeds the browser's local storage limit. We don't have any control over this error and it's unrelated to this PR.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
