### PR TITLE
Remove unused v1.jinja2tags.get_model

### DIFF
--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -1,5 +1,3 @@
-from django.utils.module_loading import import_string
-
 from jinja2 import pass_context
 from jinja2.ext import Extension
 

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -12,11 +12,6 @@ from v1.util import ref
 from v1.util.util import get_unique_id
 
 
-def get_model(model_name):
-    model_class = import_string(model_name)
-    return model_class
-
-
 def image_alt_value(image):
     """Given an ImageBasic block or a CFGOVImage rendition as `image`,
     return the appropriate alt text.
@@ -121,7 +116,6 @@ class V1Extension(Extension):
                 "category_label": ref.category_label,
                 "choices_for_page_type": ref.choices_for_page_type,
                 "get_category_icon": ref.get_category_icon,
-                "get_model": get_model,
                 "get_unique_id": get_unique_id,
                 "image_alt_value": image_alt_value,
                 "is_blog": ref.is_blog,


### PR DESCRIPTION
#8113 removed the ResourceList template but left behind the `get_model` Jinja tag that [had been created for it](https://github.com/cfpb/consumerfinance.gov/commit/6c2ac2b499a82970eb7d6ff3ee8e640fedbf237b#diff-02618be188a8919b4ad1e0c4c7d1487c2e46ad25bf09ccae90b477741cf91236). This tag isn't used elsewhere in the codebase and can be removed.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)