### PR TITLE
Global search: fix misalignment in non-english search text

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-search.less
+++ b/cfgov/unprocessed/css/molecules/global-search.less
@@ -129,18 +129,6 @@
 
   });
 
-  // Tablet and above.
-  .respond-to-min(@bp-sm-min, {
-
-    // Override for the .m-btn-inside-input class from the design system.
-    // This is needed because we do not have an icon inside the input
-    // at the desktop size (there is an icon at the mobile size).
-    .m-btn-inside-input .a-text-input {
-      padding-right: unit(14px / @base-font-size-px, em);
-    }
-
-  });
-
   // Desktop and above
   .respond-to-min(@bp-med-min, {
 
@@ -154,16 +142,15 @@
     overflow: hidden;
 
     &_trigger {
+      float: right;
+
       // Match height of input with button.
       padding: 8px 0;
+      line-height: unit(19px / @base-font-size-px);
 
       &[aria-expanded="true"] {
         .u-invisible();
       }
-    }
-
-    &_trigger {
-      float: right;
     }
 
     &_content {
@@ -191,16 +178,6 @@
         display: flex;
         width: initial;
         flex: 0 1 75%;
-
-        // Characters in some languages, like Chinese, have a larger x-height,
-        // which will make the button taller than the input. Fix that by making
-        // the input elements flex and stretch to fit the full height of the
-        // container (i.e. match the button height)
-        .m-btn-inside-input {
-          display: flex;
-          align-items: stretch;
-          flex-basis: 100%;
-        }
       }
 
       .o-form__input-w-btn_btn-container {
@@ -213,6 +190,11 @@
           border-top-left-radius: 0;
           border-bottom-left-radius: 0;
           white-space: nowrap;
+
+          // Characters in some languages, like Chinese, have a larger x-height,
+          // which will make the button taller than the input. Fix that by
+          // setting the line height on the button.
+          line-height: unit(19px / @base-font-size-px);
         }
       }
     }


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/8043 removed the `m-btn-inside-input` class from the global search markup, which was used to adjust the button size in non-english search buttons. This PR removes that class from the global search CSS and uses `line-height` instead of flexbox to align the non-english search buttons with their inputs.

## Changes

- Remove unused `m-btn-inside-input` CSS from global search.
- Set `line-height` on the search trigger and button to accommodate x-height differences in non-english typefaces.


## How to test this PR

1. Visit http://localhost:8000/language/zh/ and click through the language links at the top of the page and check that the button and input are aligned correctly across screen sizes.


## Screenshots

Before:
<img width="412" alt="Screenshot 2024-03-22 at 6 37 19 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/a6eae819-718d-40f7-8898-e92087360a92">

After:
<img width="472" alt="Screenshot 2024-03-22 at 6 36 57 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d6416c8a-9ef5-4680-9d1d-64f348ddd1c8">
