### PR TITLE
TCCP: Landing page tweaks

### DIFF
--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -45,7 +45,7 @@
 
 <div class="content_wrapper">
     <div class="block block__sub block__flush-top">
-        <h2 class="h3">
+        <h2>
             How is this comparison tool different than others you may have used?
         </h2>
         <p>

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -26,12 +26,6 @@ class LandingPageView(FlaggedTemplateView):
     flag_name = "TCCP"
     template_name = "tccp/landing_page.html"
     heading = "Explore credit cards for your situation"
-    breadcrumb_items = [
-        {
-            "title": "Credit cards",
-            "href": "/consumer-tools/credit-cards/",
-        }
-    ]
 
     def get(self, request):
         form = LandingPageForm(request.GET)
@@ -42,7 +36,6 @@ class LandingPageView(FlaggedTemplateView):
             {
                 "title": title(self.heading),
                 "heading": self.heading,
-                "breadcrumb_items": self.breadcrumb_items,
                 "form": LandingPageForm(),
                 "stats": CardSurveyData.objects.get_summary_statistics(),
                 "image_passthrough": image_passthrough,
@@ -73,11 +66,15 @@ class CardListView(FlaggedViewMixin, ListAPIView):
     filter_backends = [CardSurveyDataFilterBackend]
     filterset_class = CardSurveyDataFilterSet
     heading = "Customize for your situation"
-    breadcrumb_items = LandingPageView.breadcrumb_items + [
+    breadcrumb_items = [
+        {
+            "title": "Credit cards",
+            "href": "/consumer-tools/credit-cards/",
+        },
         {
             "title": LandingPageView.heading,
             "href": reverse_lazy("tccp:landing_page"),
-        }
+        },
     ]
 
     def get_queryset(self):


### PR DESCRIPTION
- Remove breadcrumbs on TCCP landing page
- Style subheading as h2, not h3

For context, visit internal DTUR#265.

## How to test this PR

To test, run a local server, visit:
http://localhost:8000/consumer-tools/credit-cards/explore-cards/

## Screenshots

<img width="1064" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/fd2866e6-cbcd-4367-bdb7-e9bb3a05292a">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)