### PR TITLE
Remove Wordpress-related redirect from Apache

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -541,7 +541,6 @@ RedirectMatch permanent (?i)^/about-us/advisory-groups/(.*) /rules-policy/adviso
 RedirectMatch permanent (?i)^/askcfpb/search/(.*) /ask-cfpb/search/$1
 RedirectMatch permanent (?i)^/how-to-prepare-your-finances-for-buying-a-home/(.*) /owning-a-home/prepare/
 Redirect /owning-a-home/help-us-improve/ /owning-a-home/feedback/
-RedirectMatch permanent (?i)^/wp-content/uploads/(.*) https://files.consumerfinance.gov/f/$1
 
 # Redirecting requests to the old, dead, api.consumerfinance.gov
 RewriteCond %{HTTP_HOST} api.consumerfinance.gov


### PR DESCRIPTION
This change removes a Wordpress-related redirect from our Apache configuration. Previously requests to `/wp-content/uploads/*` would be redirected to `files.consumerfinance.gov/f/*`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)