### PR TITLE
Inset email: Remove custom email signup CSS

### DIFF
--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -85,30 +85,5 @@
       padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
       float: right;
     });
-
-    .o-email-signup {
-      padding: unit(@grid_gutter-width / @base-font-size-px, em);
-      border: 1px solid @block__border-top;
-      margin-bottom: unit(@grid_gutter-width / @base-font-size-px, em);
-      background-color: @block__bg;
-
-      // Tablet only.
-      .respond-to-range(@bp-sm-min, @bp-sm-max, {
-        width: 100%;
-      });
-
-      .respond-to-max(320px, {
-        padding: unit( @grid_gutter-width / @base-font-size-px, em )
-        unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-      });
-    }
   }
-}
-
-// in .content__1-3 pages, inset should be 4 of 9 columns
-// except in the 600-650px range, where it becomes unusably narrow
-.content__1-3 .m-inset__email {
-  .respond-to-min(650px, {
-    width: percentage( 4 / 9 );
-  });
 }

--- a/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
@@ -36,8 +36,10 @@
                 {{ block | safe }}
             </div>
         {% elif block_type in ['email_signup'] %}
-            <div class="m-inset__email">
-                {% include_block block %}
+            <div class="block block__flush-top m-inset__email">
+                <div class="o-well">
+                    {% include_block block %}
+                </div>
             </div>
         {% elif block_type in ['table', 'well'] %}
             <div class="block">


### PR DESCRIPTION
Fixes an issue where inset email signups spilled off the page margin.

## Changes

- Remove custom email signup CSS and wrap email inset with a top-flushed `block` and `well`.


## How to test this PR

1. `yarn build` and visit any non-BAH page (they have their own issues) with an inset email signup, such as https://www.consumerfinance.gov/compliance/compliance-resources/signup/, and resize the page to see that the email signup is not clipped.


## Screenshots

Before:
<img width="354" alt="Screenshot 2024-03-29 at 3 57 19 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d919d481-610b-40be-b33b-4bce11bb8d6f">

After:
<img width="337" alt="Screenshot 2024-03-29 at 3 57 24 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/557076f6-bf81-4e0e-97f1-60cd0b8bb103">
