### PR TITLE
Move TCCP card sorting dropdown below filters' expandable

### DIFF
--- a/cfgov/tccp/filterset.py
+++ b/cfgov/tccp/filterset.py
@@ -10,7 +10,7 @@ from .enums import CreditTierChoices, RewardsChoices, StateChoices
 from .filters import CardOrderingFilter, CheckboxFilter, MultipleCheckboxFilter
 from .models import CardSurveyData
 from .situations import SituationChoices, get_situation_by_title
-from .widgets import Select
+from .widgets import OrderingSelect, Select
 
 
 class CardSurveyDataFilterSet(filters.FilterSet):
@@ -50,7 +50,10 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         method="filter_for_contains",
     )
     ordering = CardOrderingFilter(
-        label="Sort by", null_label=None, empty_label=None, widget=Select
+        label="Sort by",
+        null_label=None,
+        empty_label=None,
+        widget=OrderingSelect,
     )
 
     class Meta:

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -64,6 +64,8 @@
     {% endcall %}
 </div>
 
+<div class="block block__sub u-js-only" id="tccp-ordering-container"></div>
+
 <div class="block block__sub">
     <div class="o-filterable-list-results o-filterable-list-results__partial htmx-results">
         {% include "tccp/includes/card_list.html" %}

--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -50,7 +50,7 @@
         </fieldset>
     </div>
 
-    <div class="o-form_group">
+    <div class="o-form_group" id="tccp-ordering">
         {{ render_field(form.ordering, "select") }}
     </div>
 
@@ -63,8 +63,9 @@
 
 <form action="."
     method="get"
+    id="tccp-filters"
     hx-boost="true"
-    hx-trigger="change"
+    hx-trigger="change from:.htmx-container"
     hx-swap="show:none"
     hx-indicator=".htmx-container"
     hx-target=".htmx-results"

--- a/cfgov/tccp/tests/test_widgets.py
+++ b/cfgov/tccp/tests/test_widgets.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from tccp.widgets import RadioSelect
+from tccp.widgets import RadioSelect, Select
 
 
 class RadioSelectTests(SimpleTestCase):
@@ -18,3 +18,8 @@ class RadioSelectTests(SimpleTestCase):
             RadioSelect(attrs={"class": "a-something-else"}).attrs,
             {"class": "a-something-else"},
         )
+
+
+class SelectTests(SimpleTestCase):
+    def test_init_without_attrs_sets_class(self):
+        self.assertEqual(Select().attrs, {"form": "tccp-filters"})

--- a/cfgov/tccp/tests/test_widgets.py
+++ b/cfgov/tccp/tests/test_widgets.py
@@ -1,6 +1,6 @@
 from django.test import SimpleTestCase
 
-from tccp.widgets import RadioSelect, Select
+from tccp.widgets import OrderingSelect, RadioSelect
 
 
 class RadioSelectTests(SimpleTestCase):
@@ -20,6 +20,6 @@ class RadioSelectTests(SimpleTestCase):
         )
 
 
-class SelectTests(SimpleTestCase):
+class OrderingSelectTests(SimpleTestCase):
     def test_init_without_attrs_sets_class(self):
-        self.assertEqual(Select().attrs, {"form": "tccp-filters"})
+        self.assertEqual(OrderingSelect().attrs, {"form": "tccp-filters"})

--- a/cfgov/tccp/widgets.py
+++ b/cfgov/tccp/widgets.py
@@ -26,6 +26,9 @@ class SituationSelectMultiple(CheckboxSelectMultiple):
 class Select(forms.Select):
     template_name = "tccp/widgets/select.html"
 
+
+class OrderingSelect(Select):
+
     def __init__(self, attrs=None, **kwargs):
         attrs = attrs or {}
         attrs.setdefault("form", "tccp-filters")

--- a/cfgov/tccp/widgets.py
+++ b/cfgov/tccp/widgets.py
@@ -25,3 +25,8 @@ class SituationSelectMultiple(CheckboxSelectMultiple):
 
 class Select(forms.Select):
     template_name = "tccp/widgets/select.html"
+
+    def __init__(self, attrs=None, **kwargs):
+        attrs = attrs or {}
+        attrs.setdefault("form", "tccp-filters")
+        super().__init__(attrs=attrs, **kwargs)

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -10,6 +10,8 @@ function init() {
   attach('show-more', 'click', handleShowMore);
   // Make the breadcrumb on the details page go back to a filtered list
   updateBreadcrumb();
+  // Move the card ordering dropdown below the expandable
+  moveOrderingDropdown();
 }
 
 /**
@@ -39,6 +41,16 @@ function updateBreadcrumb() {
   }
 }
 
-window.addEventListener('load', () => {
+/**
+ * Moves the card ordering dropdown outside the filters' expandable to
+ * improve its visibility. Doing this via JS instead of at the template
+ * level preserves the HTML form for no-JS users.
+ */
+function moveOrderingDropdown() {
+  const orderingDropdown = document.querySelector('#tccp-ordering');
+  document.querySelector('#tccp-ordering-container').append(orderingDropdown);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
   init();
 });

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -48,7 +48,9 @@ function updateBreadcrumb() {
  */
 function moveOrderingDropdown() {
   const orderingDropdown = document.querySelector('#tccp-ordering');
-  document.querySelector('#tccp-ordering-container').append(orderingDropdown);
+  if (orderingDropdown) {
+    document.querySelector('#tccp-ordering-container').append(orderingDropdown);
+  }
 }
 
 window.addEventListener('DOMContentLoaded', () => {

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -45,6 +45,11 @@ describe('Explore credit cards results page', () => {
     cy.get('h1').contains('Customize for your situation').should('not.exist');
     cy.get('h2').contains('Application requirements').should('exist');
   });
+  it('should have the ordering option outside the filters expandable', () => {
+    exploreCards.openResultsPage();
+
+    cy.get('form#tccp-filters select#tccp-ordering').should('not.exist');
+  });
 });
 
 describe('Explore credit card details page', () => {


### PR DESCRIPTION
To increase the sorting dropdown's visibility, move it outside the expandable. To accommodate no-JS users, it's moved via JS instead of at the template level.

The `load` event listener was replaced with `DOMContentLoaded` because our JS only needs to wait for the DOM to load and not all images, stylesheets, etc.

See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/241

@chosak `form="tccp-filters"` gets added to all `select` elements but it technically only *needs* to be on the sorting select element. It's harmless but lmk if you'd prefer I create a separate widget for the sorting element.

## How to test this PR

1. Visit the [cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) and you'll see the sort dropdown is below the expandable when JS is enabled.
1. `tox -e unittest -- tccp`
1. `yarn cypress open --spec test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js`


## Screenshots

| before | after |
|--------|-------|
| <img width="1200" alt="Screenshot 2024-04-01 at 2 50 45 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/b0a6a927-1578-4f51-9150-78442467b18d"> | <img width="1200" alt="Screenshot 2024-04-01 at 2 50 03 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/a548f084-172a-4d65-bd38-d161c3e65e7d"> |

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
