### PR TITLE
Only apply flush-top if email signup is first

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
@@ -36,7 +36,7 @@
                 {{ block | safe }}
             </div>
         {% elif block_type in ['email_signup'] %}
-            <div class="block block__flush-top m-inset__email">
+            <div class="block{{ " block__flush-top" if loop.first}} m-inset__email">
                 <div class="o-well">
                     {% include_block block %}
                 </div>


### PR DESCRIPTION
Closes https://github.local/CFGOV/platform/issues/4560

Only applies flush-top to the email signup molecule if it is first in a full-width-text block, otherwise allows the natural block padding to shine through.

Before:
<img width="651" alt="Screenshot 2024-04-02 at 9 45 22 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/34b9db71-b323-469a-bb75-06291fed8751">

After:
<img width="647" alt="Screenshot 2024-04-02 at 9 45 34 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/99100d57-6fcc-45b0-8b61-c21422305476">

http://localhost:8000/consumer-tools/educator-tools/adult-financial-education/join-cfpb-finex-network/ should appear unchanged.