### PR TITLE
TCCP: Changes to card filtering and purchase APR logic

### DIFF
--- a/cfgov/tccp/filter_backend.py
+++ b/cfgov/tccp/filter_backend.py
@@ -4,19 +4,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 class CardSurveyDataFilterBackend(DjangoFilterBackend):
     """Custom filter backend for card filtering.
 
-    This backend passes summary statistics to the filterset.
-
-    It also keeps a reference to its most recent filterset.
+    This backend keeps a reference to its most recent filterset.
     """
-
-    def __init__(self, summary_stats, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.summary_stats = summary_stats
-
-    def get_filterset_kwargs(self, *args, **kwargs):
-        kwargs = super().get_filterset_kwargs(*args, **kwargs)
-        kwargs["summary_stats"] = self.summary_stats
-        return kwargs
 
     def get_filterset(self, *args, **kwargs):
         self._used_filterset = super().get_filterset(*args, **kwargs)

--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -25,16 +25,19 @@ class CardOrderingFilter(filters.OrderingFilter):
         if value[0] == "purchase_apr":
             # If we're sorting by purchase APR, we sort by the tier-specific
             # purchase APR that we previously annotated.
-            ordering = ["purchase_apr_for_tier"]
+            ordering = ["purchase_apr_for_tier_max"]
         elif value[0] == "transfer_apr":
             # If we're sorting by transfer APR, we want to exclude cards that
             # don't have either a tier-specific APR or a {minimum, maximum}
             # range, which we previously coalesced into the
             # transfer_apr_for_ordering field.
-            qs = qs.exclude(transfer_apr_for_ordering__isnull=True)
+            qs = qs.exclude(transfer_apr_for_tier_max__isnull=True)
 
             # We then order by that column first and purchase APR second.
-            ordering = ["transfer_apr_for_ordering", "purchase_apr_for_tier"]
+            ordering = [
+                "transfer_apr_for_tier_max",
+                "purchase_apr_for_tier_max",
+            ]
 
         # We always specify product name as the fallback ordering.
         return super().filter(qs, ordering + ["product_name"])

--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -30,7 +30,7 @@ class CardOrderingFilter(filters.OrderingFilter):
             # If we're sorting by transfer APR, we want to exclude cards that
             # don't have either a tier-specific APR or a {minimum, maximum}
             # range, which we previously coalesced into the
-            # transfer_apr_for_ordering field.
+            # transfer_apr_for_tier_max field.
             qs = qs.exclude(transfer_apr_for_tier_max__isnull=True)
 
             # We then order by that column first and purchase APR second.

--- a/cfgov/tccp/filterset.py
+++ b/cfgov/tccp/filterset.py
@@ -60,9 +60,7 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         model = CardSurveyData
         fields = []
 
-    def __init__(self, data=None, summary_stats=None, *args, **kwargs):
-        self.summary_stats = summary_stats
-
+    def __init__(self, data=None, *args, **kwargs):
         # Set field defaults to their initial values, if not set.
         #
         # https://django-filter.readthedocs.io/en/stable/guide/tips.html#using-initial-values-as-defaults
@@ -80,7 +78,7 @@ class CardSurveyDataFilterSet(filters.FilterSet):
         super().__init__(data, *args, **kwargs)
 
     def filter_credit_tier(self, queryset, name, value):
-        return queryset.for_credit_tier(value, self.summary_stats)
+        return queryset.for_credit_tier(value)
 
     def filter_location(self, queryset, name, value):
         return queryset.available_in(value)

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -66,7 +66,7 @@
 
 <div class="o-card-group">
     <div class="o-card-group_cards">
-        {%- for card in results %}
+        {%- for card in cards %}
         {%- set show_more = loop.index > 10 -%}
         <article class="m-card m-card--tabular{% if show_more %} u-show-more{% endif %}">
             <a href="{{ card.url }}">
@@ -79,7 +79,10 @@
                     <div class="m-data-spec m-data-spec--apr">
                         <dt><strong>Purchase APR</strong></dt>
                         <dd>
-                            <strong>{{ apr(card.purchase_apr_for_tier) }}</strong>
+                            <strong>{{ apr_range(
+                                card.purchase_apr_for_tier_min,
+                                card.purchase_apr_for_tier_max
+                            ) }}</strong>
                         </dd>
                     </div>
                     <div class="m-data-spec m-data-spec--fee">
@@ -91,7 +94,10 @@
                     <div class="m-data-spec m-data-spec--transfer">
                         <dt>Balance transfer APR</dt>
                         <dd>
-                            {{ apr(card.transfer_apr_for_tier) if card.transfer_apr_for_tier is not none else apr_range(card.transfer_apr_min, card.transfer_apr_max) }}
+                            {{- apr_range(
+                                card.transfer_apr_for_tier_min,
+                                card.transfer_apr_for_tier_max
+                            ) -}}
                         </dd>
                     </div>
                     <div class="m-data-spec m-data-spec--rewards">

--- a/cfgov/tccp/models.py
+++ b/cfgov/tccp/models.py
@@ -77,6 +77,10 @@ class CardSurveyDataQuerySet(models.QuerySet):
         # We exclude cards that don't have a purchase APR for this tier.
         qs = qs.exclude(purchase_apr_for_tier__isnull=True)
 
+        # We also exclude those cards that aren't "specifically targeted" for
+        # this tier.
+        qs = qs.filter(targeted_credit_tiers__contains=credit_tier)
+
         # Finally, we want to annotate each card with a rating based on how
         # its purchase APR compares with other cards within the same tier.
         #

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -5,6 +5,10 @@ from .models import CardSurveyData
 
 
 class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
+    purchase_apr_good_rating = serializers.IntegerField()
+    purchase_apr_great_rating = serializers.IntegerField()
+    purchase_apr_poor_rating = serializers.IntegerField()
+
     class Meta:
         model = CardSurveyData
         fields = "__all__"
@@ -30,9 +34,11 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
 
 class CardSurveyDataListSerializer(CardSurveyDataSerializer):
     annual_fee_estimated = serializers.FloatField()
-    purchase_apr_for_tier = serializers.FloatField()
+    purchase_apr_for_tier_max = serializers.FloatField()
+    purchase_apr_for_tier_min = serializers.FloatField()
     purchase_apr_for_tier_rating = serializers.IntegerField()
-    transfer_apr_for_tier = serializers.FloatField()
+    transfer_apr_for_tier_max = serializers.FloatField()
+    transfer_apr_for_tier_min = serializers.FloatField()
 
     class Meta(CardSurveyDataSerializer.Meta):
         fields = [
@@ -40,13 +46,13 @@ class CardSurveyDataListSerializer(CardSurveyDataSerializer):
             "institution_name",
             "periodic_fee_type",
             "product_name",
-            "purchase_apr_for_tier",
+            "purchase_apr_for_tier_max",
+            "purchase_apr_for_tier_min",
             "purchase_apr_for_tier_rating",
             "requirements_for_opening",
             "rewards",
             "top_25_institution",
-            "transfer_apr_for_tier",
-            "transfer_apr_min",
-            "transfer_apr_max",
+            "transfer_apr_for_tier_max",
+            "transfer_apr_for_tier_min",
             "url",
         ]

--- a/cfgov/tccp/tests/test_filters.py
+++ b/cfgov/tccp/tests/test_filters.py
@@ -11,6 +11,7 @@ class CardOrderingFilterTests(TestCase):
         for apr in [2.9, 0.9, 99.9, 0]:
             baker.make(
                 CardSurveyData,
+                targeted_credit_tiers=["Credit score 619 or less"],
                 purchase_apr_poor=apr,
             )
 
@@ -31,6 +32,7 @@ class CardOrderingFilterTests(TestCase):
         ]:
             baker.make(
                 CardSurveyData,
+                targeted_credit_tiers=["Credit score 619 or less"],
                 purchase_apr_poor=purchase_apr,
                 transfer_apr_poor=transfer_apr,
             )
@@ -45,7 +47,11 @@ class CardOrderingFilterTests(TestCase):
 
     def test_ordering_by_product_name(self):
         for product_name in ["e", "a", "b", "d", "c"]:
-            baker.make(CardSurveyData, product_name=product_name)
+            baker.make(
+                CardSurveyData,
+                targeted_credit_tiers=["Credit scores from 620 to 719"],
+                product_name=product_name,
+            )
 
         qs = CardSurveyData.objects.all()
         self.assertQuerysetEqual(

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -7,6 +7,9 @@ from .baker import baker
 
 
 class CardSurveyDataFilterSetTests(TestCase):
+    def get_queryset(self):
+        return CardSurveyData.objects.with_ratings()
+
     def test_filter_defaults_used_if_not_provided(self):
         self.assertEqual(
             CardSurveyDataFilterSet().data,
@@ -31,7 +34,7 @@ class CardSurveyDataFilterSetTests(TestCase):
             _quantity=10,
         )
 
-        qs = CardSurveyData.objects.all()
+        qs = self.get_queryset()
         self.assertEqual(qs.count(), 10)
 
         fs = CardSurveyDataFilterSet(
@@ -50,7 +53,7 @@ class CardSurveyDataFilterSetTests(TestCase):
                 _quantity=3,
             )
 
-        qs = CardSurveyData.objects.all()
+        qs = self.get_queryset()
         self.assertEqual(qs.count(), 9)
 
         fs = CardSurveyDataFilterSet({"location": "PA"}, queryset=qs)
@@ -64,7 +67,7 @@ class CardSurveyDataFilterSetTests(TestCase):
             periodic_fee_type=["Annual"],
         )
 
-        qs = CardSurveyData.objects.all()
+        qs = self.get_queryset()
         self.assertEqual(qs.count(), 1)
 
         fs = CardSurveyDataFilterSet({"no_account_fee": False}, queryset=qs)
@@ -81,7 +84,7 @@ class CardSurveyDataFilterSetTests(TestCase):
             rewards=["Cashback rewards"],
         )
 
-        qs = CardSurveyData.objects.all()
+        qs = self.get_queryset()
         self.assertEqual(qs.count(), 1)
 
         fs = CardSurveyDataFilterSet(

--- a/cfgov/tccp/tests/test_filterset.py
+++ b/cfgov/tccp/tests/test_filterset.py
@@ -24,7 +24,12 @@ class CardSurveyDataFilterSetTests(TestCase):
         self.assertEqual(CardSurveyDataFilterSet(data).data, data)
 
     def test_filter_by_situations_noop(self):
-        baker.make(CardSurveyData, purchase_apr_good=0.99, _quantity=10)
+        baker.make(
+            CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
+            purchase_apr_good=0.99,
+            _quantity=10,
+        )
 
         qs = CardSurveyData.objects.all()
         self.assertEqual(qs.count(), 10)
@@ -40,6 +45,7 @@ class CardSurveyDataFilterSetTests(TestCase):
                 CardSurveyData,
                 availability_of_credit_card_plan="One State/Territory",
                 state=state,
+                targeted_credit_tiers=["Credit scores from 620 to 719"],
                 purchase_apr_good=0.99,
                 _quantity=3,
             )
@@ -53,6 +59,7 @@ class CardSurveyDataFilterSetTests(TestCase):
     def test_filter_by_no_account_fee(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
             purchase_apr_good=0.99,
             periodic_fee_type=["Annual"],
         )
@@ -69,6 +76,7 @@ class CardSurveyDataFilterSetTests(TestCase):
     def test_filter_by_rewards(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit scores from 620 to 719"],
             purchase_apr_good=0.99,
             rewards=["Cashback rewards"],
         )

--- a/cfgov/tccp/tests/test_models.py
+++ b/cfgov/tccp/tests/test_models.py
@@ -7,6 +7,9 @@ from .baker import baker
 
 
 class CardSurveyDataQuerySetTests(TestCase):
+    def get_queryset(self):
+        return CardSurveyData.objects.with_ratings()
+
     def test_available_in(self):
         for availability, state, state_multiple in [
             ("National", None, None),
@@ -20,7 +23,7 @@ class CardSurveyDataQuerySetTests(TestCase):
                 state_multiple=state_multiple,
             )
 
-        qs = CardSurveyData.objects.all()
+        qs = self.get_queryset()
 
         self.assertEqual(qs.available_in(None).count(), 1)
         self.assertEqual(qs.available_in("NY").count(), 3)
@@ -54,32 +57,30 @@ class CardSurveyDataQuerySetTests(TestCase):
             transfer_apr_max=10.1,
         )
 
-        qs_poor = CardSurveyData.objects.for_credit_tier(
+        qs_poor = self.get_queryset().for_credit_tier(
             "Credit score 619 or less"
         )
         self.assertEqual(qs_poor.count(), 1)
         self.assertQuerysetEqual(
             qs_poor.values_list(
-                "purchase_apr_for_tier",
+                "purchase_apr_for_tier_max",
                 "purchase_apr_for_tier_rating",
-                "transfer_apr_for_tier",
-                "transfer_apr_for_ordering",
+                "transfer_apr_for_tier_max",
             ),
-            [(9.99, 2, 8.88, 8.88)],
+            [(9.99, 2, 8.88)],
         )
 
-        qs_great = CardSurveyData.objects.for_credit_tier(
+        qs_great = self.get_queryset().for_credit_tier(
             "Credit score of 720 or greater"
         )
         self.assertEqual(qs_great.count(), 1)
         self.assertQuerysetEqual(
             qs_great.values_list(
-                "purchase_apr_for_tier",
+                "purchase_apr_for_tier_max",
                 "purchase_apr_for_tier_rating",
-                "transfer_apr_for_tier",
-                "transfer_apr_for_ordering",
+                "transfer_apr_for_tier_max",
             ),
-            [(9.99, 2, None, 7.77)],
+            [(9.99, 2, 10.1)],
         )
 
     def test_get_summary_statistics(self):
@@ -128,18 +129,12 @@ class CardSurveyDataQuerySetTests(TestCase):
                 "count": 3,
                 "first_report_date": today,
                 "purchase_apr_poor_count": 2,
-                "purchase_apr_poor_min": 3,
-                "purchase_apr_poor_max": 9,
                 "purchase_apr_poor_pct25": 4.5,
                 "purchase_apr_poor_pct50": 6,
                 "purchase_apr_good_count": 2,
-                "purchase_apr_good_min": 2,
-                "purchase_apr_good_max": 6,
                 "purchase_apr_good_pct25": 3,
                 "purchase_apr_good_pct50": 4,
                 "purchase_apr_great_count": 3,
-                "purchase_apr_great_min": 0,
-                "purchase_apr_great_max": 3,
                 "purchase_apr_great_pct25": 0.5,
                 "purchase_apr_great_pct50": 1,
             },

--- a/cfgov/tccp/tests/test_models.py
+++ b/cfgov/tccp/tests/test_models.py
@@ -30,6 +30,7 @@ class CardSurveyDataQuerySetTests(TestCase):
     def test_for_credit_tier(self):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score 619 or less"],
             purchase_apr_poor=9.99,
             transfer_apr_poor=8.88,
             transfer_apr_min=7.77,
@@ -46,6 +47,7 @@ class CardSurveyDataQuerySetTests(TestCase):
 
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score of 720 or greater"],
             purchase_apr_great=9.99,
             transfer_apr_great=None,
             transfer_apr_min=7.77,
@@ -86,6 +88,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_poor=3,
             purchase_apr_good=2,
             purchase_apr_great=1,
@@ -94,6 +101,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_poor=9,
             purchase_apr_good=6,
             purchase_apr_great=3,
@@ -102,6 +114,11 @@ class CardSurveyDataQuerySetTests(TestCase):
         baker.make(
             CardSurveyData,
             report_date=today,
+            targeted_credit_tiers=[
+                "Credit score 619 or less",
+                "Credit scores from 620 to 719",
+                "Credit score of 720 or greater",
+            ],
             purchase_apr_great=0,
         )
 

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -59,6 +59,7 @@ class CardListViewTests(TestCase):
     def setUpTestData(cls):
         baker.make(
             CardSurveyData,
+            targeted_credit_tiers=["Credit score of 720 or greater"],
             purchase_apr_great=0.99,
             _quantity=5,
         )

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -135,7 +135,7 @@ class CardDetailViewTests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         card = json.loads(response.content)
-        self.assertEqual(card["product_name"], "Test Card")
+        self.assertEqual(card["card"]["product_name"], "Test Card")
 
     def test_get_invalid_uses_standard_404_handling(self):
         with self.assertRaises(Http404):


### PR DESCRIPTION
This PR makes some substantial changes to how the TCCP app filters, orders, and rates cards by purchase APR.

Some credit cards offer a purchase APR for a specific credit tier but are not marked as being "specifically targeted" to that credit tier, recorded in the TCCP survey under the "Targeted credit tiers" column. Previously TCCP filter results would include these cards, so if a user marked their credit tier as 620-719, they might see cards that, while they offer a purchase APR for this range, are not marked as being "specifically targeted" to this range. This PR removes those cards from the results.

This PR also modifies which cards are included in TCCP filtering results by expanding the purchase APR logic. Previously, we would only include cards that had a tier-specific purchase APR, for example the `purchase_apr_good` column in the TCCP dataset. With this change, we may also select a purchase APR from other columns in the dataset, for example the `purchase_apr_median` column. We may also use the `purchase_apr_min` and `purchase_apr_max` columns to define a range of APRs, if necessary. See the changes to cfgov/tccp/models.py for extensive documentation on the new logic.

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/270 for additional context and discussion.

## How to test this PR

To test, run a local server and explore card results under http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/. Results now contain (occasional) examples of cards with a range of credit scores. You may also want to visit the JSON version at http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?format=json to see the summary statistics being used.

If you click through to individual card detail pages, you'll notice that we are now using non-tier-specific purchase APRs to populate the list view. Additionally, the detail view now includes summary statistic logic to populate future display of card ratings there. Visit a detail page in JSON view to see the new columns and summary statistics, for example
http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-community-credit-union-visa-platinum/?format=json.

Alternatively, this branch is also deployed to our internal DEV4 server.

## Screenshots

Example of purchase APR range being used in the list view:

<img width="170" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/d48a83e7-d811-4c5d-b5a3-2475f59654dd">

## Notes and todos

There's quite a bit of complex backend logic here; @willbarton @wpears if you have availability your review would be also be welcomed. I've tried to overly document everything.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)