### PR TITLE
Ask CFPB: Featured cards tidying

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/feature-card.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/feature-card.html
@@ -16,8 +16,6 @@
    value.category.url:           A string for the URL of the category page.
 
    value.category.text:          A string for the title of the category.
-                               
-   value.category.aria_label:    (Optional) An aria-label for the category page link.
 
    value.icon:                   A string corresponding to an SVG icon.
 
@@ -40,44 +38,46 @@
 
 <article class="m-card">
     <h2 class="m-card_heading">
-        <a class="" href="{{ value.category.url }}">
-<span class="m-card_icon">{{ svg_icon( value.icon ) }}</span>
-<span>{{ value.category.text }}</span>
-</a>
-    </h2>
-     
-<ul class="m-list">
-{%- for link in value.links %}
-<li class="m-list_item">
-{%- if link.text is not none and link.text.find('@') > -1 -%}
-    {%- if not value.emails is defined -%}
-        {%- do value.update({'emails':[{'url':link.text}]}) -%}
-    {%- endif -%}
-    {% include 'contact-email.html' with context %}
-{%- else -%}
-    {%- set link_text = link.text if link.text
-        else 'Learn More' -%}
-
-    {%- set link -%}
-        <a class="a_link a-link__partially-styled"
-            href="{{ link.url }}"
-            {%- if link.aria_label -%}
-                aria-label="{{ link.aria_label }}"
-            {%- endif %}>
-            <span class="a-link__partially-styled_plain">{{ link_text }} </span>
-            <span class="a-link__partially-styled_underlined">{{ _('Read answer') }}</span>
+        <a href="{{ value.category.url }}">
+            <span class="m-card_icon">{{ svg_icon( value.icon ) }}</span>
+            <span>{{ value.category.text }}</span>
         </a>
-    {%- endset -%}
-    {{ link | safe }}
-{%- endif %}
-</li>
-{%- endfor %}
-</ul>
+    </h2>
 
-<div class="m-card_footer">
-    <a href="{{ value.category.url }}">
-        {{ value.footer_label }}
-    </a>
+    <ul class="m-list">
+        {%- for link in value.links %}
+        <li class="m-list_item">
+        {%- if link.text is not none and link.text.find('@') > -1 -%}
+            {%- if not value.emails is defined -%}
+                {%- do value.update({'emails':[{'url':link.text}]}) -%}
+            {%- endif -%}
+            {% include 'contact-email.html' with context %}
+        {%- else -%}
+            {%- set link_text = link.text if link.text else 'Learn More' -%}
+            {%- set link -%}
+                <a class="a_link a-link__partially-styled"
+                   href="{{ link.url }}"
+                   {%- if link.aria_label -%}
+                   aria-label="{{ link.aria_label }}"
+                   {%- endif %}>
+                    <span class="a-link__partially-styled_plain">
+                        {{ link_text }}
+                    </span>
+                    <span class="a-link__partially-styled_underlined">
+                        {{ _('Read answer') }}
+                    </span>
+                </a>
+            {%- endset -%}
+            {{ link | safe }}
+        {%- endif %}
+        </li>
+        {%- endfor %}
+    </ul>
+
+    <div class="m-card_footer">
+        <a href="{{ value.category.url }}">
+            {{ value.footer_label }}
+        </a>
     </div>
 
 </article>

--- a/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
@@ -23,27 +23,26 @@
         Browse questions by category
     </h2>
 
-<ul class="u-show-on-mobile category_list m-list m-list__links u-mb0">
-{% for card in value.feature_cards %}
-    <li class="m-list_item">
-        <a class="m-list_link a-link a-link__jump a-link__icon-after-text" href="{{ card.category.url }}">
-            <span class="a-link_text">{{ card.category.text }}</span>
-            {{ svg_icon( card.icon ) }}
-        </a>
-    </li>
-{% endfor %}
-</ul>
+    <ul class="u-show-on-mobile category_list m-list m-list__links u-mb0">
+    {% for card in value.feature_cards %}
+        <li class="m-list_item">
+            <a class="m-list_link a-link a-link__jump a-link__icon-after-text" href="{{ card.category.url }}">
+                <span class="a-link_text">{{ card.category.text }}</span>
+                {{ svg_icon( card.icon ) }}
+            </a>
+        </li>
+    {% endfor %}
+    </ul>
 
-<div class="u-hide-on-mobile question-categories u-mb30">
-<div class="o-card-group o-card-group__column-2">
-<div class="o-card-group_cards">
+    <div class="u-hide-on-mobile question-categories u-mb30">
+        <div class="o-card-group o-card-group__column-2">
+            <div class="o-card-group_cards">
 
-{% for card in value.feature_cards %}
-    {{- feature_card(card) }}
-{% endfor %}
+            {% for card in value.feature_cards %}
+                {{- feature_card(card) }}
+            {% endfor %}
 
-</div>
-</div>
-</div>
-
+            </div>
+        </div>
+    </div>
 </section>

--- a/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
@@ -18,7 +18,7 @@
 {%- from 'v1/includes/blocks/heading.html' import heading without context %}
 {%- from 'v1/includes/molecules/feature-card.html' import feature_card with context %}
 
-<section class="ask-categories">
+<section>
     <h2 class="u-show-on-mobile u-mt45">
         Browse questions by category
     </h2>


### PR DESCRIPTION
## Changes

- Indent featured cards markup.
- Remove unimplemented `value.category.aria_label` from code comment.
- Remove empty `class=""` from link.
- Remove unused `ask-categories` class.

## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/ and it should be visually unchanged. 


## Screenshots

## Notes and todos

- These featured cards should probably go inside the ask_cfpb app, as they are only used on the Ask landing pages, and the CSS associated with them (aside from the card classes) lives in Ask only.
- This seems like it just about could use the existing `card-group.html` template. We should probably consider either elevating the ask cards to the Design System, or changing the ask cards to the existing featured card from the Design System.
- We should probably find a way to make the cards `h3`s, like the other cards on the site. There is an `h2` "Browse questions by category" heading above the cards, but it only appears at mobile. Without CSS it's a sibling heading to the cards, which seems wrong. See this before and after structure for if the cards were `h3`s:

Before:
<img width="354" alt="Screenshot 2024-04-03 at 2 40 53 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/4306e83b-f649-412c-82ad-9cef22396075">

After:
<img width="343" alt="Screenshot 2024-04-03 at 2 41 11 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/660ebfda-3f5f-48a2-b7d5-7dc0babc91eb">

We probably need to keep the "Browse questions by category" h2 heading across screen sizes, but visually hide it on anything but mobile.