### PR TITLE
Ask CFPB: Remove `inset-row`, `video_player-row`, `content_sidebar`

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/ask-answer-content.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/ask-answer-content.html
@@ -15,7 +15,7 @@
 {% for block in value %}
     {% set after_tip = value[loop.index - 2].block_type == 'tip' if loop.index > 1 else False %}
     {% if not after_tip %}
-    <div class="row {{'inset-row' if block.block_type == 'tip' else block.block_type~'-row'}}"
+    <div class="row"
         {% if block.value.anchor_tag %}
         id="{{ block.value.anchor_tag }}"
         {% endif %}>

--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -27,7 +27,7 @@ class AskBlocksTestCase(TestCase):
         block = AskAnswerContent()
         value = block.to_python([self.tip_data])
         html = block.render(value)
-        expected_html = '<div class="inset-row row">{}</div>'.format(
+        expected_html = '<div class="row">{}</div>'.format(
             self.expected_tip_html
         )
         self.assertHTMLEqual(html, expected_html)
@@ -36,7 +36,7 @@ class AskBlocksTestCase(TestCase):
         block = AskAnswerContent()
         value = block.to_python([self.tip_data, self.text_data])
         html = block.render(value)
-        expected_html = '<div class="inset-row row">{}{}</div>'.format(
+        expected_html = '<div class="row">{}{}</div>'.format(
             self.expected_tip_html, self.expected_text_html
         )
         self.assertHTMLEqual(html, expected_html)
@@ -45,10 +45,10 @@ class AskBlocksTestCase(TestCase):
         block = AskAnswerContent()
         value = block.to_python([self.text_data])
         html = block.render(value)
-        expected_html = '<div class="text-row row">{}</div>'.format(
+        expected_html = '<div class="row">{}</div>'.format(
             self.expected_text_html
         )
-        self.assertNotIn('<div class="inset-row row">', html)
+        self.assertNotIn('<div class="row">', html)
         self.assertHTMLEqual(html, expected_html)
 
 

--- a/cfgov/unprocessed/css/on-demand/ask.less
+++ b/cfgov/unprocessed/css/on-demand/ask.less
@@ -128,16 +128,6 @@
     max-width: 41.875rem;
   }
 
-  .respond-to-min(@bp-lg-min, {
-    .content_sidebar {
-      padding-top: 0;
-    }
-  });
-
-  .o-expandable_cue-close {
-    display: none;
-  }
-
   .answer-text {
     h2,
     h3,
@@ -148,7 +138,6 @@
       margin-top: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
     }
 
-    .video_player-row + .row,
     .row + .row > .o-table:first-child,
     .row + .row > .o-video-player:first-child {
       margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
@@ -162,10 +151,11 @@
       margin-top: unit(@grid_gutter-width / @size-iii, em);
     }
 
-    .row + .row:not(.inset-row) h4 {
+    .row + .row h4 {
       margin-top: unit(@grid_gutter-width / @size-iv, em);
     }
 
+    // Large desktop size.
     .respond-to-min(@bp-lg-min, {
       .row + .row h2 {
         margin-top: unit( @grid_gutter-width * 1.5 / @size-ii, em );
@@ -173,16 +163,8 @@
     });
   }
 
+  // Mobile only.
   .respond-to-max(@bp-xs-max, {
-    .inset-row {
-      display: flex;
-      flex-direction: column-reverse;
-
-      .m-inset {
-        margin-top: unit( @grid_gutter-width / @base-font-size-px, em );
-      }
-    }
-
     .related-questions {
       margin: unit( @grid_gutter-width / @base-font-size-px, em ) 0;
     }


### PR DESCRIPTION
The expandable cue CSS I suspect predates the summary component.

## Removals

- Ask: Remove `inset-row`, `video_player-row`, `content_sidebar`
- Ask: Remove `o-expandable_cue-close` custom CSS.

## How to test this PR

1. Search the crawler for `video_player-row`, which will give you the video player pages, such as http://localhost:8000/ask-cfpb/i-cant-make-my-mortgage-payments-how-long-will-it-take-before-ill-face-foreclosure-en-1849/ and see that the video player has existing space above it.

2. Search the crawler for `inset-row`, which will give you a list of pages with an inset tip, such as http://localhost:8000/ask-cfpb/i-want-to-submit-a-complaint-about-an-international-money-transfer-what-should-i-do-en-1753/ and see that the tip doesn't reverse positions at mobile.
