### PR TITLE
Fix regs secondary nav for ds@0.43.0

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/regulations3k-secondary-nav.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations3k-secondary-nav.html
@@ -13,7 +13,7 @@
 {% macro render() %}
     {% set nav_items, has_children = get_secondary_nav_items(request, page) %}
     {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
-    <nav class="o-regs3k-navigation o-expandable__padded"
+    <nav class="o-regs3k-navigation"
          aria-label="Section navigation">
         <button class="o-regs3k-navigation_header o-expandable_header">
             <span class="o-expandable_label">

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -38,10 +38,10 @@
   .o-expandable_header {
     // Desktop and above.
     .respond-to-min(@bp-med-min, {
-      padding-left: 0;
+      padding: 0.9375em 0;
     });
+    gap: 0;
     border: 0;
-    padding-right: 0;
   }
 
   .o-expandable_content {
@@ -69,11 +69,9 @@
 
 // Regs3K secondary nav header
 .o-regs3k-navigation {
-  // TODO:
-  // This is an override for the non-conforming use of o-expandable__padded
-  // in the iRegs secondary nav. Remove this when that component is overhauled.
-  &.o-expandable__padded .o-expandable_label {
+  .o-expandable_label {
     padding: 0 !important;
+    font-size: 1.125em;
   }
 
   // Tablet and below.

--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.less
@@ -40,7 +40,6 @@
     .respond-to-min(@bp-med-min, {
       padding: 0.9375em 0;
     });
-    gap: 0;
     border: 0;
   }
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -42,9 +42,9 @@
      {{ 'itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question"'
         if value.is_faq else '' }} >
     <button class="o-expandable_header" type="button">
-        <span class="o-expandable_icon">
-            {% if value.icon %} {{ svg_icon( value.icon ) }} {% endif %}
-        </span>
+        {% if value.icon %}
+          <span>{{ svg_icon( value.icon ) }}</span>
+        {% endif %}
         <span class="o-expandable_label"
               {{'itemprop="name"' if value.is_faq else ''}}>
             {{ value.label }}


### PR DESCRIPTION
The change introduced in https://github.com/cfpb/consumerfinance.gov/commit/51f8662800884863004932829d7c375893d3cdf8, broke the regs3k secondary nav. This restores the previous appearance (but with better expandable button alignment ^_^)

Current:
<img width="1166" alt="Screenshot 2024-04-05 at 9 54 12 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/79584206-61b7-4901-9756-afd394dffbee">

With this PR:
<img width="1206" alt="Screenshot 2024-04-05 at 10 05 23 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/76b72dbc-f9b4-4785-9249-5c794140217b">

