### PR TITLE
TDP: Remove `@supports` checks for flexbox

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/molecules/search-hero.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/molecules/search-hero.less
@@ -7,9 +7,7 @@
 
   // Tablet and above.
   .respond-to-min(@bp-sm-min, {
-    @supports ( display: flex ) {
-      display: flex;
-    }
+    display: flex;
   });
 }
 
@@ -18,12 +16,7 @@
 
   // Desktop and above.
   .respond-to-min(@bp-med-min, {
-    float: left;
     width: 60%;
-
-    @supports ( display: flex ) {
-      float: none;
-    }
   });
 }
 
@@ -34,12 +27,7 @@
   // Desktop and above.
   .respond-to-min(@bp-med-min, {
     display: block;
-    float: right;
     width: 40%;
     padding-left: unit( 30px / @base-font-size-px, em );
-
-    @supports ( display: flex ) {
-      float: none;
-    }
   });
 }

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
@@ -224,28 +224,16 @@
 
     // Tablet and above.
     .respond-to-min(@bp-sm-min, {
-      @supports ( display: flex ) {
-        display: flex;
-      }
+      display: flex;
 
       > div:first-child {
-        float: left;
         margin-bottom: 0;
         padding-right: unit( 30px / @base-font-size-px, em );
         width: 66%;
-
-        @supports ( display: flex ) {
-          float: none;
-        }
       }
 
       > div:last-child {
-        float: right;
         width: 33%;
-
-        @supports ( display: flex ) {
-          float: none;
-        }
       }
     });
   }


### PR DESCRIPTION
Flexbox has wide browser support. This was maybe there for IE9?

## Removals

- TDP: Remove `@supports` checks for flexbox

## How to test this PR

1. On http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/ the hero and search results `activity_meta-wrapper` blocks should have a flexbox layout, as they do in production currently.