### PR TITLE
TCCP: Fix list of states on card detail page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -45,7 +45,8 @@
                 {{ 'specific counties in ' if card.pertains_to_specific_counties }}
                 {% for state in state_limitations %}
                     {{ state_lookup[state] -}}
-                    {{- ', ' if not loop.last and loop.length > 2 -}}
+                    {{- ',' if not loop.last and loop.length > 2 -}}
+                    {{- ' ' if not loop.last and loop.length > 1 -}}
                     {{- 'and ' if loop.index == loop.length - 1}}
                 {% endfor %}
             {% endif %}


### PR DESCRIPTION
Fixes issue when card had only two states.

Before: "Illinoisand Missouri"
After "Illinois and Missouri"

## How to test this PR

Visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-community-credit-union-visa-platinum/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)