### PR TITLE
Set canonical links to current reg/section in iregs

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -16,6 +16,14 @@
     {%- endif %} | Consumer Financial Protection Bureau
 {%- endblock title %}
 
+{%- block canonical -%}
+  {%- if section -%}
+    {% set canonical = canonical + section.label %}
+  {%- endif -%}
+  <link rel="canonical" href="{{ canonical }}">
+  <meta property="og:url" content="{{ canonical }}">
+{%- endblock -%}
+
 {% block desc -%}
     {#- 'section' pages are ones that show the actual text of the regulation -#}
     {% if section -%}

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -337,6 +337,7 @@ class RegulationPage(ShareableRoutablePageMixin, CFGOVPage):
             {
                 "regulation": self.regulation,
                 "current_version": self.get_effective_version(request),
+                "canonical": request.build_absolute_uri(self.url).lower(),
                 "breadcrumb_items": self.get_breadcrumbs(
                     request, *args, **kwargs
                 ),

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -65,16 +65,17 @@ itemscope="" itemtype="https://schema.org/FAQPage"
     <base target="_blank">
     {% endif %}
 
-    {% set canonical = request.build_absolute_uri(request.path) | lower %}
-
-    <link rel="canonical" href="{{ canonical }}">
+    {%- block canonical -%}
+      {% set canonical = request.build_absolute_uri(request.path) | lower %}
+      <link rel="canonical" href="{{ canonical }}">
+      <meta property="og:url" content="{{ canonical }}">
+    {%- endblock -%}
 
     {# Open Graph properties #}
 
     {# Required Open Graph properties #}
     <meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
     <meta property="og:type" content="{% block og_type %}website{% endblock %}">
-    <meta property="og:url" content="{{ canonical }}">
 
     {% block og_image %}
         {% if page and page.meta_image %}


### PR DESCRIPTION
Currently the canonical link in iregs, no matter the regulation version being viewed, is just set to the current URL. Analytics pointed out it would make more sense if the canonical link was set to the current regulation. This PR does that (and does so for the open graph url as well).