### PR TITLE
Strip whitespace for template block content checks

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
@@ -6,7 +6,7 @@
           id="main"
           {% if language == 'ar' %} dir="rtl" {% endif %}>
 
-        {% if self.content_intro() %}
+        {% if self.content_intro().strip() %}
             <div class="u-layout_content-intro">
                 {% block content_intro scoped -%}{%- endblock %}
             </div>

--- a/cfgov/v1/jinja2/v1/layouts/layout-full.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-full.html
@@ -10,7 +10,7 @@
           id="main"
           {% if language == 'ar' %} dir="rtl" {% endif %}>
 
-        {% if self.content_intro() %}
+        {% if self.content_intro().strip() %}
             <div class="u-layout_content-intro">
                 {% block content_intro scoped -%}{%- endblock %}
             </div>


### PR DESCRIPTION
Pages like https://www.consumerfinance.gov/compliance/compliance-resources/ have an empty content_intro block, but it does contain whitespace, so it is passing the check on whether the block is empty, which leads to an empty `<div class="u-layout_content-intro"></div>` block on the page. This PR aims to strip out the whitespace on the check, so it is only included if it actually has non-whitespace content.

## Changes

- Strip whitespace for template block content checks


## How to test this PR

1. http://localhost:8000/compliance/compliance-resources/  should not have an empty `<div class="u-layout_content-intro"></div>` block.
