### PR TITLE
TCCP: Fix import command of currency values

### DIFF
--- a/cfgov/tccp/fields.py
+++ b/cfgov/tccp/fields.py
@@ -1,4 +1,5 @@
 import re
+from decimal import Decimal
 
 from django.core import checks
 from django.core.exceptions import ValidationError
@@ -28,6 +29,10 @@ class CurrencyDecimalField(models.DecimalField):
     def to_python(self, value):
         if isinstance(value, str):
             value = value.lstrip("$")
+        elif isinstance(value, float):
+            value = Decimal(value).quantize(
+                Decimal("1." + "0" * self.decimal_places)
+            )
 
         return super().to_python(value)
 

--- a/cfgov/tccp/tests/test_fields.py
+++ b/cfgov/tccp/tests/test_fields.py
@@ -23,6 +23,15 @@ class CurrencyDecimalFieldTests(SimpleTestCase):
             field.clean(value, None), kwargs.get("expected", value)
         )
 
+    def test_clean_float(self):
+        self.check_clean(0.7, expected=Decimal("0.7"))
+
+    def test_clean_float_rounding(self):
+        self.check_clean(12.714, expected=Decimal("12.71"))
+
+    def test_clean_float_rounding_up(self):
+        self.check_clean(123.715, expected=Decimal("123.72"))
+
     def test_clean_decimal(self):
         self.check_clean(Decimal("100"))
 


### PR DESCRIPTION
Commit b4121bb1e0a3248afc2d63f887e02ea7997ca2a9 modified some of the TCCP dataset columns, changing them from strings to decimal values. This broke import of the last dataset. This change fixes that.

## How to test this PR

To test:

1. Download current dataset from https://files.consumerfinance.gov/f/documents/cfpb_tccp-data_2023-01-01_2023-06-30.xlsx
2. Run `cfgov/manage.py import_tccp cfpb_tccp-data_2023-01-01_2023-06-30.xlsx`. Confirm that the dataset loads with no errors.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)