### PR TITLE
TCCP: Move "Sort by" widget into the card results pane

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -63,8 +63,6 @@
     {% endcall %}
 </div>
 
-<div class="block block__sub u-js-only" id="tccp-ordering-container"></div>
-
 <div class="block block__sub">
     <div class="o-filterable-list-results o-filterable-list-results__partial htmx-results">
         {% include "tccp/includes/card_list.html" %}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -38,6 +38,8 @@
     </dl>
 </div>
 
+<div class="block block__sub u-js-only" id="tccp-ordering-container"></div>
+
 {% if stats_all.first_report_date -%}
 {{ data_published(stats_all.first_report_date) }}
 {%- endif %}

--- a/cfgov/unprocessed/apps/tccp/js/htmx.js
+++ b/cfgov/unprocessed/apps/tccp/js/htmx.js
@@ -1,5 +1,6 @@
 import htmx from 'htmx.org';
 
+import orderingDropdown from './ordering';
 import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
 
 /**
@@ -35,6 +36,33 @@ htmx.defineExtension('htmx-url-param', {
 });
 
 /**
+ * htmx extension that saves a snapshot of the TCCP ordering dropdown
+ * immediately before rendering new card results and injects it
+ * into the page immediately after rendering the results.
+ *
+ * We query the DOM every time because A) the container is blown away
+ * after every htmx request and B) we want a copy of the dropdown that
+ * includes the most recently selected value.
+ *
+ * See https://htmx.org/extensions/
+ * See https://htmx.org/events/#htmx:beforeSwap
+ * See https://htmx.org/events/#htmx:afterSwap
+ */
+htmx.defineExtension('move-tccp-ordering', {
+  onEvent: function (name, event) {
+    if (name === 'htmx:beforeSwap') {
+      orderingDropdown.el = document.querySelector('#tccp-ordering');
+    }
+    if (name === 'htmx:afterSwap') {
+      orderingDropdown.container = document.querySelector(
+        '#tccp-ordering-container',
+      );
+      orderingDropdown.move();
+    }
+  },
+});
+
+/**
  * htmx extension that stores the page's path in web
  * storage whenever it's updated
  * See https://htmx.org/extensions/
@@ -63,5 +91,8 @@ webStorageProxy.setItem(
 document.body.setAttribute('hx-history', 'false');
 
 // Add htmx extensions to the dom and initialize them
-document.body.setAttribute('hx-ext', 'htmx-url-param, store-tccp-filter-path');
+document.body.setAttribute(
+  'hx-ext',
+  'htmx-url-param, store-tccp-filter-path, move-tccp-ordering',
+);
 htmx.process(document.body);

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -1,5 +1,6 @@
 import { attach } from '@cfpb/cfpb-atomic-component';
 
+import orderingDropdown from './ordering';
 import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
 
 /**
@@ -11,7 +12,7 @@ function init() {
   // Make the breadcrumb on the details page go back to a filtered list
   updateBreadcrumb();
   // Move the card ordering dropdown below the expandable
-  moveOrderingDropdown();
+  orderingDropdown.move();
 }
 
 /**
@@ -38,18 +39,6 @@ function updateBreadcrumb() {
   if (breadcrumb.innerText === 'Customize for your situation') {
     breadcrumb.href =
       webStorageProxy.getItem('tccp-filter-path') || breadcrumb.href;
-  }
-}
-
-/**
- * Moves the card ordering dropdown outside the filters' expandable to
- * improve its visibility. Doing this via JS instead of at the template
- * level preserves the HTML form for no-JS users.
- */
-function moveOrderingDropdown() {
-  const orderingDropdown = document.querySelector('#tccp-ordering');
-  if (orderingDropdown) {
-    document.querySelector('#tccp-ordering-container').append(orderingDropdown);
   }
 }
 

--- a/cfgov/unprocessed/apps/tccp/js/ordering.js
+++ b/cfgov/unprocessed/apps/tccp/js/ordering.js
@@ -1,0 +1,18 @@
+/**
+ * Keep track of the card ordering dropdown so that it can be moved
+ * outside the filters expandable to improve its visibility.
+ * Doing this via JS instead of at the template level preserves the
+ * HTML form for no-JS users. This is in its own file so that it can
+ * be shared between initial page load JS and dynamic HTMX requests.
+ */
+const orderingDropdown = {
+  container: document.querySelector('#tccp-ordering-container'),
+  el: document.querySelector('#tccp-ordering'),
+  move: () => {
+    if (orderingDropdown.el) {
+      orderingDropdown.container.append(orderingDropdown.el);
+    }
+  },
+};
+
+export default orderingDropdown;

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards-helpers.cy.js
@@ -22,6 +22,10 @@ export class ExploreCreditCards {
     cy.get('input[name=situations]').check(situation, { force: true });
   }
 
+  selectOrdering(ordering) {
+    cy.get('#tccp-ordering select').select(ordering);
+  }
+
   clickSubmitButton() {
     cy.get('button').contains('See cards for your situation').click();
   }
@@ -34,6 +38,10 @@ export class ExploreCreditCards {
     cy.get('button')
       .contains('Show more results with higher interest rates')
       .click();
+  }
+
+  getOrderingDropdownValue() {
+    return cy.get('#tccp-ordering select').find('option:selected');
   }
 
   getNumberResults() {

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -67,6 +67,11 @@ describe('Explore credit cards results page', () => {
     exploreCards.openResultsPage();
 
     cy.get('form#tccp-filters select#tccp-ordering').should('not.exist');
+    exploreCards
+      .getOrderingDropdownValue()
+      .should('have.text', 'Lowest purchase APR');
+    exploreCards.selectOrdering('Card name');
+    exploreCards.getOrderingDropdownValue().should('have.text', 'Card name');
   });
 });
 


### PR DESCRIPTION
Moves the "Sort by" dropdown immediately above the list of card results. This section of the page is swapped out by htmx so we have to re-inject the element after every htmx update.

See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/271

## How to test this PR

1. `./frontend.sh`
1. Visit the [cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) and you should see the sort by dropdown under the APR key.
1. `yarn cypress run --spec test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js`

## Screenshots

| before | after |
|--------|-------|
| <img width="468" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/6c0458c3-59f4-414e-8b99-c21f0ea46111"> | <img width="468" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/47cb201e-70c5-4ca6-a9b6-0ec813d4627c"> |

## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [x] Safari on iOS
- [x] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
