### PR TITLE
TCCP: Results redesign based on round 2 testing

### DIFF
--- a/cfgov/tccp/filters.py
+++ b/cfgov/tccp/filters.py
@@ -10,8 +10,8 @@ class CardOrderingFilter(filters.OrderingFilter):
         kwargs.update(
             {
                 "choices": [
-                    ("purchase_apr", "Lowest purchase APR"),
-                    ("transfer_apr", "Lowest balance transfer APR"),
+                    ("purchase_apr", "Purchase APR"),
+                    ("transfer_apr", "Balance transfer APR"),
                     ("product_name", "Card name"),
                 ],
                 "initial": "purchase_apr",

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -31,32 +31,11 @@
 
 <h1>{{ heading }}</h1>
 
-<div class="block block__sub">
-    {% if not situations %}
-        <p>
-            Filter and sort the {{ stats_all.count or "" }} cards in our database
-            to find cards that have the features that fit your situation.
-        </p>
-    {% else %}
-        <h2>You’re looking to...</h2>
-
-        {% for situation in situations %}
-            <div class="block block__sub">
-                <div class="o-well">
-                    <h3>{{ situation.title }}</h3>
-
-                    {{ situation.results_html }}
-                </div>
-            </div>
-        {% endfor %}
-    {% endif %}
-</div>
-
 <div id="o-filterable-list-controls" class="o-filterable-list-controls">
     {% call() expandable({
-        "label": "Customize results",
+        "label": "Customize card features",
         "is_bordered": true,
-        "is_expanded": not situations,
+        "is_expanded": not situations or not cards,
         "is_midtone": true
     }) %}
         {{ filter_form(form) }}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -4,6 +4,18 @@
 {% import 'v1/includes/molecules/breadcrumbs.html' as breadcrumbs with context %}
 {% import 'v1/includes/molecules/notification.html' as notification %}
 
+{% if situation_features -%}
+<div class="block block__sub">
+    <h2>Cards you’re looking for have these features:</h2>
+
+    <ul>
+        {% for feature in situation_features -%}
+        <li>{{ feature.results_html }}</li>
+        {%- endfor %}
+    </ul>
+</div>
+{%- endif %}
+
 {% if count -%}
 {{- notification.render(
     'success',
@@ -18,20 +30,22 @@
 ) -}}
 {%- endif %}
 
-{%- set purchase_apr_adjectives = ["less", "average", "more"] %}
-
 <div class="block__sub">
-    <div class="a-label__heading">Key</div>
+    <div class="a-label__heading">
+        Use our ratings to compare your results:
+    </div>
     <dl>
-        {% for adjective in purchase_apr_adjectives %}
-        <div class="u-mb0 a-credit-card-apr-rating a-credit-card-apr-rating--{{ adjective }}">
+        {% for label, label_count in purchase_apr_rating_counts.items() %}
+        <div class="u-mb0 a-credit-card-apr-rating a-credit-card-apr-rating--{{ label }}">
             <dt>
                 {%- for i in range(loop.index) -%}
                     {{ svg_icon("dollar-round") }}
                 {%- endfor -%}
             </dt>
             <dd>
-                Pay {{ adjective ~ (" than average" if adjective != "average") }} interest
+                Pay {{ label }} interest (
+                    {{- label_count ~ ' card' ~ label_count | pluralize() -}}
+                )
             </dd>
         </div>
         {% endfor %}
@@ -45,16 +59,14 @@
 {%- endif %}
 
 {%- macro card_rating(card) -%}
-    {%- set adjective = purchase_apr_adjectives[
-        card.purchase_apr_for_tier_rating
-    ] -%}
+    {%- set label = purchase_apr_rating_labels[card.purchase_apr_for_tier_rating] -%}
 
-    <span class="a-credit-card-apr-rating--{{ adjective }}">
+    <span class="a-credit-card-apr-rating--{{ label }}">
         {%- for i in range(card.purchase_apr_for_tier_rating + 1) %}
             {{ svg_icon("dollar-round") }}
         {% endfor -%}
 
-        Pay {{ adjective }} interest
+        Pay {{ label }} interest
     </span>
 {%- endmacro -%}
 

--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -55,7 +55,7 @@
                 <li class="m-list_item m-list_item__has-icon">
                     <a
                         href="/data-research/credit-card-data/terms-credit-card-plans-survey/"
-                    >Issuers required by law to submit data to us</a>
+                    >Credit card companies are required by law to submit data to us</a>
                 </li>
                 <li class="m-list_item m-list_item__has-icon">
                     No paid advertising

--- a/cfgov/tccp/jinja2/tccp/situations/results/avoid-fees.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/avoid-fees.html
@@ -1,9 +1,1 @@
-<p>
-    A yearly fee that may be charged for having a credit card. Some card issuers
-    assess the fee in monthly installments. Some cards do not have an annual fee.
-</p>
-<p>
-    <strong>Did you know:</strong>
-    It may be prudent for consumers to add up monthly fees for a year to better
-    compare with cards that charge fees on an annual basis.
-</p>
+No annual, monthly, or weekly account fees.

--- a/cfgov/tccp/jinja2/tccp/situations/results/build-credit.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/build-credit.html
@@ -1,7 +1,4 @@
-<p>
-   Credit building credit cards are typically available to people with little or no credit history and can be used to help establish one.
-</p>
-<p>
-    <strong>Did you know:</strong>
-    Use the card only for necessary purchases and pay your credit card balance in full every month.
-</p>
+Targeted for your credit score range.
+<a
+    href="https://www.youtube.com/watch?v=wFTOZollKdk"
+>Learn about ways to build credit and your credit score.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/earn-rewards.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/earn-rewards.html
@@ -1,9 +1,1 @@
-<p>
-    Credit card rewards programs are a common type of consumer incentive that
-    encourage applications for and continued use of a particular product.
-</p>
-<p>
-    <strong>Did you know:</strong>
-    When a consumer revolves a balance on their credit card, interest and fee
-    costs typically exceed the value of any rewards earned.
-</p>
+Offers rewards.

--- a/cfgov/tccp/jinja2/tccp/situations/results/make-a-big-purchase.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/make-a-big-purchase.html
@@ -1,10 +1,4 @@
-<p>
-    If you have carried balances in the past, or think you are likely to do so,
-    consider credit cards that have the lowest interest rates.
-</p>
-<p>
-    <strong>Did you know:</strong>
-    If a card has a promotional interest, you have to keep track of how you are
-    paying off that balance within the promotional period, or you could end up
-    owing more in interest than the original purchase amount.
-</p>
+Lower than average interest rates.
+<a
+    href="/about-us/newsroom/cfpb-warns-credit-card-companies-against-deceptively-marketing-promotional-offers/"
+>Learn about the risks of 0% offers.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
@@ -1,0 +1,4 @@
+Lower than average interest rates.
+<a>Learn how APRs affect your monthly bill</a>
+and
+<a>about the risks of 0% offers.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest.html
@@ -1,16 +1,4 @@
-<p>
-    Finding a card with a lower interest rate, called a purchase APR,
-    is the best way to lower your monthly payment.
-
-    <a
-        class="a-link a-link__jump"
-        style="margin-top: 0.375em"
-        href="/ask-cfpb/what-is-a-credit-card-interest-rate-what-does-apr-mean-en-44/">
-        <span class="a-link__text">Learn how APRs affect your monthly bill.</span>
-    </a>
-</p>
-<p>
-    <strong>Did you know:</strong>
-    Many regional and local banks offer cards with low interest rates
-    even to people who don’t live in the banks’ areas.
-</p>
+Lower than average interest rates.
+<a
+    href="/ask-cfpb/how-does-my-credit-card-company-calculate-the-amount-of-interest-i-owe-en-51/"
+>Learn how APRs affect your monthly bill.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/transfer-a-balance.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/transfer-a-balance.html
@@ -1,10 +1,3 @@
-<p>
-    Balance transfers are generally available to consumers with good and great
-    credit scores. They typically include a transfer fee, and the card is likely
-    to incur interest charges on new purchases.
-</p>
-<p>
-    <strong>Did you know:</strong>
-    It would be prudent for some consumers to use a separate card for new
-    purchases while they pay down the transferred balance.
-</p>
+Low balance transfer interest rates.
+Cards designed to transfer a balance are generally available to
+consumers with good or great credit scores.

--- a/cfgov/tccp/tests/test_situations.py
+++ b/cfgov/tccp/tests/test_situations.py
@@ -5,6 +5,7 @@ from django.test import SimpleTestCase
 from tccp.situations import (
     SITUATIONS,
     Situation,
+    SituationFeatures,
     SituationSpeedBumps,
     get_situation_by_title,
 )
@@ -51,6 +52,31 @@ class SituationContentTests(SimpleTestCase):
         for situation, content in product(SITUATIONS, ["select", "results"]):
             with self.subTest(title=situation.title, content=content):
                 self.assertTrue(getattr(situation, f"{content}_html"))
+
+
+class SituationFeatureTests(SimpleTestCase):
+    def test_no_combinations(self):
+        features = SituationFeatures(
+            [
+                Situation("Pay less interest"),
+                Situation("Foo"),
+            ]
+        )
+        self.assertSequenceEqual(
+            [s.title for s in features], ["Pay less interest", "Foo"]
+        )
+
+    def test_combination(self):
+        features = SituationFeatures(
+            [
+                Situation("Pay less interest"),
+                Situation("Make a big purchase"),
+            ]
+        )
+        self.assertSequenceEqual(
+            [s.title for s in features],
+            ["Pay less interest Make a big purchase"],
+        )
 
 
 class SituationSpeedBumpTests(SimpleTestCase):

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -159,6 +159,29 @@
     border-bottom: 1px dotted @link-underline;
     color: @link-text;
   }
+
+  .a-credit-card-apr-rating {
+    font-size: unit((16px / @base-font-size-px), rem);
+    font-weight: 600;
+
+    @media only screen and (min-width: @bp-sm-min) {
+      font-size: unit((18px / @base-font-size-px), rem);
+      font-weight: 500;
+    }
+  }
+}
+
+dl {
+  .a-credit-card-apr-rating {
+    display: grid;
+    grid-template-columns: unit(45px / @base-font-size-px, em) 1fr;
+    align-items: baseline;
+    gap: unit(8px / @base-font-size-px, em);
+
+    dt {
+      justify-self: right;
+    }
+  }
 }
 
 .m-data-specs {
@@ -273,13 +296,6 @@ html.js .o-filterable-list-results__partial {
 
 .a-credit-card-apr-rating {
   margin-bottom: unit((20px / @base-font-size-px), rem);
-  font-size: unit((16px / @base-font-size-px), rem);
-  font-weight: 600;
-
-  @media only screen and (min-width: @bp-sm-min) {
-    font-size: unit((18px / @base-font-size-px), rem);
-    font-weight: 500;
-  }
 
   &--less .cf-icon-svg {
     color: var(--green);

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -36,7 +36,7 @@ function handleShowMore(event) {
  */
 function updateBreadcrumb() {
   const breadcrumb = document.querySelector('.m-breadcrumbs_crumb:last-child');
-  if (breadcrumb.innerText === 'Customize for your situation') {
+  if (breadcrumb.innerText === 'Explore credit cards') {
     breadcrumb.href =
       webStorageProxy.getItem('tccp-filter-path') || breadcrumb.href;
   }

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -60,16 +60,14 @@ describe('Explore credit cards results page', () => {
 
     cy.get('.m-card--tabular > a').first().click();
 
-    cy.get('h1').contains('Customize for your situation').should('not.exist');
+    cy.get('h1').contains('Explore credit cards').should('not.exist');
     cy.get('h2').contains('Making purchases').should('exist');
   });
   it('should have the ordering option outside the filters expandable', () => {
     exploreCards.openResultsPage();
 
     cy.get('form#tccp-filters select#tccp-ordering').should('not.exist');
-    exploreCards
-      .getOrderingDropdownValue()
-      .should('have.text', 'Lowest purchase APR');
+    exploreCards.getOrderingDropdownValue().should('have.text', 'Purchase APR');
     exploreCards.selectOrdering('Card name');
     exploreCards.getOrderingDropdownValue().should('have.text', 'Card name');
   });


### PR DESCRIPTION
This PR modifies the TCCP results view in a few ways: it reorders the introductory content, migrates that content from wells to a bulleted list, and adds rating-specific result counts.

See internal Figma for latest comps, and internal DTUR#271 for context.

## How to test this PR

To test, first rebuild your local assets with `./frontend.sh`. Then run a local server and visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/. Experiment with selecting multiple scenarios to see how the results change. Also visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ without any scenarios to see how that looks.

## Screenshots

<img width="386" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/86a9b4cb-b408-4c13-83b0-a06bded5aeb2">

## Notes and todos

- ~~The "sort by" disappears when we make a new AJAX request; I need to rebase this against @contolini #8302 once that is merged, so marking this PR as draft for now.~~ Done.
- There's a bit of extra margin in the notification which appears to be a bug in the CFPB Design System, see https://github.com/cfpb/design-system/issues/1952.
- A couple of the links in the results content are placeholder still need to be filled in at some future date @caheberer.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)