### PR TITLE
TCCP: Add APR ratings to TCCP details page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -898,7 +898,7 @@
                     <thead>
                         <tr>
                             <th>Credit score</th>
-                            <th>Median balance transfer APR</th>
+                            <th>Median cash advance APR</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -215,9 +215,9 @@
                 {% endif %}
             </div>
             <p>
-                {{'Your APR will be based on your credit score. ' if card.purchase_apr_vary_by_credit_tier }}
+                {{ 'Your APR will be based on your credit score. ' if card.purchase_apr_vary_by_credit_tier }}
                 You’ll only know your exact APR if you are approved for the
-                card. Here are average APRs for different credit scores for this
+                card. Here are typical APRs for different credit scores for this
                 card:
             </p>
             <table class="o-table o-table--apr">

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -177,54 +177,24 @@
             card.purchase_apr_good_rating,
             card.purchase_apr_great_rating
         ] %}
-        {# Cards with a tier-specific median #}
-        {% if card.purchase_apr_vary_by_credit_tier %}
-            {% set purchase_aprs = [
-                card.purchase_apr_poor,
-                card.purchase_apr_good,
-                card.purchase_apr_great
-            ] %}
-        {# Cards with a single median and a range of APRs #}
-        {% elif card.purchase_apr_median is not none
-            and card.purchase_apr_min != card.purchase_apr_max
+        {% set purchase_aprs = [
+            (card.purchase_apr_poor_min, card.purchase_apr_poor_max),
+            (card.purchase_apr_good_min, card.purchase_apr_good_max),
+            (card.purchase_apr_great_min, card.purchase_apr_great_max),
+        ] %}
+        {% if card.purchase_apr_offered
+            and card.purchase_apr_poor_min is none
+            and card.purchase_apr_poor_max is none
+            and card.purchase_apr_good_min is none
+            and card.purchase_apr_good_max is none
+            and card.purchase_apr_great_min is none
+            and card.purchase_apr_great_max is none
         %}
-            {% set purchase_aprs = [
-                card.purchase_apr_median,
-                card.purchase_apr_median,
-                card.purchase_apr_median
-            ] %}
-        {# Cards with a single median only #}
-        {% elif card.purchase_apr_median is not none
-            and card.purchase_apr_min is none
-            and card.purchase_apr_max is none
-        %}
-            {% set purchase_aprs = [
-                card.purchase_apr_median,
-                card.purchase_apr_median,
-                card.purchase_apr_median
-            ] %}
-        {# Cards with a single APR #}
-        {% elif card.purchase_apr_min is not none
-            and card.purchase_apr_max is not none
-            and card.purchase_apr_min == card.purchase_apr_max
-        %}
-            {% set purchase_aprs = [
-                card.purchase_apr_median,
-                card.purchase_apr_median,
-                card.purchase_apr_median
-            ] %}
-        {# Cards that (erroneouly) list only a max APR #}
-        {% elif card.purchase_apr_max is not none %}
-            {% set purchase_aprs = [
-                card.purchase_apr_max,
-                card.purchase_apr_max,
-                card.purchase_apr_max
-            ] %}
-        {# Some cards erroneously provide no APR data, so we'll catch those #}
+            {% set purchase_apr_data_incomplete = true %}
         {% else %}
-            {% set purchase_aprs = 'no data' %}
+            {% set purchase_apr_data_incomplete = false %}
         {% endif %}
-        {% if card.purchase_apr_offered and purchase_aprs != 'no data' %}
+        {% if card.purchase_apr_offered and not purchase_apr_data_incomplete %}
             {# How top-line APR displays if the card has:
                 - Min and max APRs: "19.49% - 31.99% purchase APR"
                 - No min and max but a median: "29.74% median purchase APR"
@@ -266,7 +236,7 @@
                     {% for purchase_apr in purchase_aprs %}
                         <tr>
                             <td>{{ credit_tiers[loop.index][1] }}</td>
-                            <td>{{ apr(purchase_apr) }}</td>
+                            <td>{{ apr_range(purchase_apr[0], purchase_apr[1]) }}</td>
                             <td>
                                 {% if purchase_apr_ratings[loop.index0] is not none %}
                                     {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
@@ -301,8 +271,8 @@
                     more about fixed APRs.</a>
                 {% endif %}
             </p>
-        {% elif card.purchase_apr_offered and purchase_aprs == 'no data' %}
-            <p>The issuer did not provide APR information for this card.</p>
+        {% elif card.purchase_apr_offered and purchase_apr_data_incomplete %}
+            <p>The issuer did not submit information about purchase APR.</p>
         {% else %}
             <p>This card does not charge interest on purchases.</p>
         {% endif %}

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -164,12 +164,72 @@
             {{ svg_icon("cart-round") }}
             Making purchases
         </h2>
-        {# How top-line APR displays if the card has:
-            - Min and max APRs: "19.49% - 31.99% purchase APR"
-            - No min and max but a median: "29.74% median purchase APR"
-            - Single APR for everyone: "24.90% purchasae APR"
-        #}
-        {% if card.purchase_apr_offered %}
+        {# TODO: Unify ratings code with results list view #}
+        {# TODO: Maybe we can simplify a lot of this template if we have
+            something like purchase_apr_display that tells us what kind of APR
+            data is there: tier-specific median, single median, min-max,
+            single APR, or an outlier #}
+        {% set purchase_apr_rating_labels = [
+            'less', 'average', 'more'
+        ] %}
+        {% set purchase_apr_ratings = [
+            card.purchase_apr_poor_rating,
+            card.purchase_apr_good_rating,
+            card.purchase_apr_great_rating
+        ] %}
+        {# Cards with a tier-specific median #}
+        {% if card.purchase_apr_vary_by_credit_tier %}
+            {% set purchase_aprs = [
+                card.purchase_apr_poor,
+                card.purchase_apr_good,
+                card.purchase_apr_great
+            ] %}
+        {# Cards with a single median and a range of APRs #}
+        {% elif card.purchase_apr_median is not none
+            and card.purchase_apr_min != card.purchase_apr_max
+        %}
+            {% set purchase_aprs = [
+                card.purchase_apr_median,
+                card.purchase_apr_median,
+                card.purchase_apr_median
+            ] %}
+        {# Cards with a single median only #}
+        {% elif card.purchase_apr_median is not none
+            and card.purchase_apr_min is none
+            and card.purchase_apr_max is none
+        %}
+            {% set purchase_aprs = [
+                card.purchase_apr_median,
+                card.purchase_apr_median,
+                card.purchase_apr_median
+            ] %}
+        {# Cards with a single APR #}
+        {% elif card.purchase_apr_min is not none
+            and card.purchase_apr_max is not none
+            and card.purchase_apr_min == card.purchase_apr_max
+        %}
+            {% set purchase_aprs = [
+                card.purchase_apr_median,
+                card.purchase_apr_median,
+                card.purchase_apr_median
+            ] %}
+        {# Cards that (erroneouly) list only a max APR #}
+        {% elif card.purchase_apr_max is not none %}
+            {% set purchase_aprs = [
+                card.purchase_apr_max,
+                card.purchase_apr_max,
+                card.purchase_apr_max
+            ] %}
+        {# Some cards erroneously provide no APR data, so we'll catch those #}
+        {% else %}
+            {% set purchase_aprs = 'no data' %}
+        {% endif %}
+        {% if card.purchase_apr_offered and purchase_aprs != 'no data' %}
+            {# How top-line APR displays if the card has:
+                - Min and max APRs: "19.49% - 31.99% purchase APR"
+                - No min and max but a median: "29.74% median purchase APR"
+                - Single APR for everyone: "24.90% purchasae APR"
+            #}
             <div class="h2 u-mb0 u-mt15">
                 {% if card.purchase_apr_min is not none
                     and card.purchase_apr_max is not none
@@ -188,14 +248,11 @@
                     Median purchase APR
                 {% endif %}
             </div>
-        {% else %}
-            <p>This card does not charge interest on purchases.</p>
-        {% endif %}
-        {% if card.purchase_apr_vary_by_credit_tier %}
             <p>
-                Your APR will be based on your credit score. You’ll only know your
-                exact APR if you are approved for the card. Here are average APRs
-                for different credit scores for this card:
+                {{'Your APR will be based on your credit score. ' if card.purchase_apr_vary_by_credit_tier }}
+                You’ll only know your exact APR if you are approved for the
+                card. Here are average APRs for different credit scores for this
+                card:
             </p>
             <table class="o-table o-table--apr">
                 <thead>
@@ -206,47 +263,49 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for purchase_apr in [
-                        card.purchase_apr_poor,
-                        card.purchase_apr_good,
-                        card.purchase_apr_great
-                    ] %}
+                    {% for purchase_apr in purchase_aprs %}
                         <tr>
                             <td>{{ credit_tiers[loop.index][1] }}</td>
                             <td>{{ apr(purchase_apr) }}</td>
-                            {# TODO: Put in actual ratings #}
                             <td>
-                                <span class="a-credit-card-apr-rating--average">
-                                    {{ svg_icon("dollar-round") }}
-                                    {{ svg_icon("dollar-round") }}
-                                    Average for this range
-                                </span>
+                                {% if purchase_apr_ratings[loop.index0] is not none %}
+                                    {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
+                                    <span class="a-credit-card-apr-rating--{{ label }}">
+                                        {%- for i in range(purchase_apr_ratings[loop.index0] + 1) %}
+                                            {{ svg_icon("dollar-round") }}
+                                        {% endfor -%}
+
+                                        Pay {{ label }} interest
+                                    </span>
+                                {% elif purchase_aprs == 'no data' %}
+                                    N/A
+                                {% else %}
+                                    Not targeted for these credit scores
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}
                 </tbody>
             </table>
-        {% elif card.purchase_apr_median is not none
-            and card.purchase_apr_min != card.purchase_apr_max %}
             <p>
-                You’ll only know your exact APR if you are approved for the card.
-                The median APR for this card is {{ apr(card.purchase_apr_median) }}.
+                The purchase APR is
+                {% if 'V' in card.index %}
+                    variable, meaning it can go up or down based on an index. You can
+                    <a href="/ask-cfpb/what-is-the-difference-between-a-fixed-apr-and-a-variable-apr-en-45/">learn
+                    more about variable APRs in general</a> or expand this section to
+                    learn more about the index this APR is based on.
+                {% else %}
+                    fixed, meaning it will not go up or down with changes to an index
+                    but may still change. You can
+                    <a href="/ask-cfpb/what-is-the-difference-between-a-fixed-apr-and-a-variable-apr-en-45/">learn
+                    more about fixed APRs.</a>
+                {% endif %}
             </p>
+        {% elif card.purchase_apr_offered and purchase_aprs == 'no data' %}
+            <p>The issuer did not provide APR information for this card.</p>
+        {% else %}
+            <p>This card does not charge interest on purchases.</p>
         {% endif %}
-        <p>
-            The purchase APR is
-            {% if 'V' in card.index %}
-                variable, meaning it can go up or down based on an index. You can
-                <a href="/ask-cfpb/what-is-the-difference-between-a-fixed-apr-and-a-variable-apr-en-45/">learn
-                more about variable APRs in general</a> or expand this section to
-                learn more about the index this APR is based on.
-            {% else %}
-                fixed, meaning it will not go up or down with changes to an index
-                but may still change. You can
-                <a href="/ask-cfpb/what-is-the-difference-between-a-fixed-apr-and-a-variable-apr-en-45/">learn
-                more about fixed APRs.</a>
-            {% endif %}
-        </p>
         {% if card.introductory_apr_offered %}
             <div class="h3 u-mb0 u-mt30">
                 {% if card.intro_apr_min is not none

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -165,10 +165,6 @@
             Making purchases
         </h2>
         {# TODO: Unify ratings code with results list view #}
-        {# TODO: Maybe we can simplify a lot of this template if we have
-            something like purchase_apr_display that tells us what kind of APR
-            data is there: tier-specific median, single median, min-max,
-            single APR, or an outlier #}
         {% set purchase_apr_rating_labels = [
             'less', 'average', 'more'
         ] %}
@@ -247,8 +243,6 @@
 
                                         Pay {{ label }} interest
                                     </span>
-                                {% elif purchase_aprs == 'no data' %}
-                                    N/A
                                 {% else %}
                                     Not targeted for these credit scores
                                 {% endif %}

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -6,8 +6,14 @@ from .models import CardSurveyData
 
 class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
     purchase_apr_good_rating = serializers.IntegerField()
+    purchase_apr_good_min = serializers.FloatField()
+    purchase_apr_good_max = serializers.FloatField()
     purchase_apr_great_rating = serializers.IntegerField()
+    purchase_apr_great_min = serializers.FloatField()
+    purchase_apr_great_max = serializers.FloatField()
     purchase_apr_poor_rating = serializers.IntegerField()
+    purchase_apr_poor_min = serializers.FloatField()
+    purchase_apr_poor_max = serializers.FloatField()
 
     class Meta:
         model = CardSurveyData

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -5,15 +5,15 @@ from .models import CardSurveyData
 
 
 class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
-    purchase_apr_good_rating = serializers.IntegerField()
-    purchase_apr_good_min = serializers.FloatField()
     purchase_apr_good_max = serializers.FloatField()
-    purchase_apr_great_rating = serializers.IntegerField()
-    purchase_apr_great_min = serializers.FloatField()
+    purchase_apr_good_min = serializers.FloatField()
+    purchase_apr_good_rating = serializers.IntegerField()
     purchase_apr_great_max = serializers.FloatField()
-    purchase_apr_poor_rating = serializers.IntegerField()
-    purchase_apr_poor_min = serializers.FloatField()
+    purchase_apr_great_min = serializers.FloatField()
+    purchase_apr_great_rating = serializers.IntegerField()
     purchase_apr_poor_max = serializers.FloatField()
+    purchase_apr_poor_min = serializers.FloatField()
+    purchase_apr_poor_rating = serializers.IntegerField()
 
     class Meta:
         model = CardSurveyData


### PR DESCRIPTION
Adds APR ratings to the credit card details page. Also shows the APR-by-credit-tier table for all cards instead of just for those with tier-specific APRs as a way to show ratings for cards that have a single median or a single APR.

There's so much refactoring we can do here to get a lot of the messy logic out of the Jinja template and reuse pieces across the list and detail views. I figured I'd open this PR in case we want to get APR ratings in quickly for testing and refactor later. If we don't need to go to testing as soon, we can refactor this now, either in this PR or a new one.

---

## Additions

- Purchase APR ratings to card details

## Changes

- Purchase APR-by-credit-tier tables now show for all cards as a way to show the ratings for cards that have a single median or just one APR for everyone

## How to test this PR

I tried to account for all the variations of purchase APR data, so you can test cards that have (all links are localhost):

- [Tier-specific APRs](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/advantis-credit-union-signature-cashback-rewards-credit-card/)
- [Min-max and a single median](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/cadence-bank-platinum/)
- [One APR for everyone](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-gap-good-rewards-mastercard/)
- [Just a single median, no min and max](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-quicksilver-secured-rewards/)
- [Outlier: just a single tier median, no min and max](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/capital-one-national-association-platinum-secured/)
- [Outlier: issuer said purchase APR is available but then provided no APR data](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/first-national-bank-of-omaha-citizens-community-bank-secured-visa-card/)
- [Outlier: purchase APR is not available](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/td-bank-na-td-clear-1000/)

## Screenshots

![apr-ratings](https://github.com/cfpb/consumerfinance.gov/assets/1862695/d79e7d6c-c572-43ef-ab23-88f82243eb9a)

## Notes and todos

- I _think_ I captured all the possible variations of how APR data could come in with that giant `{% set purchase_aprs %}` conditional. Knowing what kind of APR data the card has would be useful to extract and reuse throughout the details page, so we should consider refactoring that into something like a `purchase_apr_display` property either on the backend or more globally in the Jinja template.
- We could probably extract some of the patterns that are now repeating on the details page, like the APR table, into includes.
- We should also extract what have become common patterns across the list and details view, like the APR rating element.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets