### PR TITLE
TCCP: Assorted visual and content improvements

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -42,6 +42,14 @@
     {% endcall %}
 </div>
 
+{% if not situations %}
+<div class="block block__sub">
+    <p>
+        <a href="/consumer-tools/credit-cards/explore-cards/">Choose what you're looking for in a card</a>
+    </p>
+</div>
+{% endif %}
+
 <div class="block block__sub">
     <div class="o-filterable-list-results o-filterable-list-results__partial htmx-results">
         {% include "tccp/includes/card_list.html" %}

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -45,7 +45,7 @@
 {% if not situations %}
 <div class="block block__sub">
     <p>
-        <a href="/consumer-tools/credit-cards/explore-cards/">Choose what you're looking for in a card</a>
+        <a href="{{ url('tccp:landing_page') }}">Choose what you're looking for in a card</a>
     </p>
 </div>
 {% endif %}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -6,13 +6,17 @@
 
 {% if situation_features -%}
 <div class="block block__sub">
-    <h2>Cards you’re looking for have these features:</h2>
+    <h2>Cards you're looking for have these features:</h2>
 
     <ul>
         {% for feature in situation_features -%}
         <li>{{ feature.results_html }}</li>
         {%- endfor %}
     </ul>
+
+    <p>
+        <a href="/consumer-tools/credit-cards/explore-cards/">Change what you're looking for in a card</a>
+    </p>
 </div>
 {%- endif %}
 
@@ -30,13 +34,13 @@
 ) -}}
 {%- endif %}
 
-<div class="block__sub">
-    <div class="a-label__heading">
+<div class="block block__sub o-apr-rating-group">
+    <p class="o-apr-rating-group--heading">
         Use our ratings to compare your results:
-    </div>
+    </p>
     <dl>
         {% for label, label_count in purchase_apr_rating_counts.items() %}
-        <div class="u-mb0 a-credit-card-apr-rating a-credit-card-apr-rating--{{ label }}">
+        <div class="m-apr-rating m-apr-rating--{{ label }}">
             <dt>
                 {%- for i in range(loop.index) -%}
                     {{ svg_icon("dollar-round") }}
@@ -61,13 +65,13 @@
 {%- macro card_rating(card) -%}
     {%- set label = purchase_apr_rating_labels[card.purchase_apr_for_tier_rating] -%}
 
-    <span class="a-credit-card-apr-rating--{{ label }}">
+    <div class="m-apr-rating m-apr-rating--{{ label }}">
         {%- for i in range(card.purchase_apr_for_tier_rating + 1) %}
             {{ svg_icon("dollar-round") }}
         {% endfor -%}
 
         Pay {{ label }} interest
-    </span>
+    </div>
 {%- endmacro -%}
 
 {%- macro card_rewards(card) -%}
@@ -88,7 +92,7 @@
                     <h3 class="m-card__heading">{{ card.institution_name }}</h3>
                     <p class="m-card__subtitle">{{ card.product_name }}</p>
                 </div>
-                <div class="a-credit-card-apr-rating">{{ card_rating(card) | safe }}</div>
+                {{ card_rating(card) | safe }}
                 <dl class="m-data-specs">
                     <div class="m-data-spec m-data-spec--apr">
                         <dt><strong>Purchase APR</strong></dt>
@@ -122,9 +126,9 @@
                     </div>
                     {%- if card.requirements_for_opening -%}
                     <div class="m-data-spec m-data-spec--requirements">
-                        <dt>Does this card have special requirements?</dt>
+                        <dt>Does this card have requirements?</dt>
                         <dd>
-                            See card details page for special requirements
+                            {{ svg_icon("flag-round") }} Eligibility requirements
                         </dd>
                     </div>
                     {%- endif -%}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -15,7 +15,7 @@
     </ul>
 
     <p>
-        <a href="/consumer-tools/credit-cards/explore-cards/">Change what you're looking for in a card</a>
+        <a href="{{ url('tccp:landing_page') }}">Change what you're looking for in a card</a>
     </p>
 </div>
 {%- endif %}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -94,6 +94,7 @@
 
 .o-well.o-well--speed-bump {
   padding: unit((20px / @base-font-size-px), rem);
+  background-color: var(--teal-10);
 }
 
 .m-card.m-card--tabular {
@@ -115,9 +116,9 @@
       color: @link-text-visited;
     }
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       padding-bottom: unit((20px / @base-font-size-px), rem);
-    }
+    });
   }
   &:hover {
     > a {
@@ -159,28 +160,46 @@
     border-bottom: 1px dotted @link-underline;
     color: @link-text;
   }
-
-  .a-credit-card-apr-rating {
-    font-size: unit((16px / @base-font-size-px), rem);
-    font-weight: 600;
-
-    @media only screen and (min-width: @bp-sm-min) {
-      font-size: unit((18px / @base-font-size-px), rem);
-      font-weight: 500;
-    }
-  }
 }
 
-dl {
-  .a-credit-card-apr-rating {
+.o-apr-rating-group {
+  &--heading {
+    .h3();
+  }
+
+  .m-apr-rating {
+    margin-bottom: unit((5px / @base-font-size-px), rem);
     display: grid;
     grid-template-columns: unit(45px / @base-font-size-px, em) 1fr;
     align-items: baseline;
-    gap: unit(8px / @base-font-size-px, em);
+    gap: unit(5px / @base-font-size-px, em);
+    font-weight: 500;
 
-    dt {
-      justify-self: right;
-    }
+    .respond-to-min(@bp-sm-min, {
+      margin-bottom: 0;
+    });
+  }
+
+  dt {
+    justify-self: right;
+  }
+}
+
+.m-apr-rating {
+  .h4();
+  margin-bottom: unit((20px / @base-font-size-px), rem);
+  font-weight: 600;
+
+  &--less .cf-icon-svg {
+    color: var(--green);
+  }
+
+  &--average .cf-icon-svg {
+    color: var(--gold);
+  }
+
+  &--more .cf-icon-svg {
+    color: var(--red);
   }
 }
 
@@ -194,10 +213,10 @@ dl {
   column-gap: 20px;
   row-gap: 15px;
 
-  @media only screen and (min-width: @bp-sm-min) {
+  .respond-to-min(@bp-sm-min, {
     grid-template-areas: 'apr fee transfer rewards requirements';
     grid-template-columns: 5fr 4fr 6fr 7fr 7fr;
-  }
+  });
 }
 
 .m-data-spec {
@@ -230,14 +249,13 @@ dl {
     padding-bottom: unit((15px / @base-font-size-px), rem);
     grid-area: requirements;
     align-self: start;
-    justify-self: end;
     dt {
       .u-visually-hidden;
     }
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       padding-bottom: 0;
-    }
+    });
   }
 
   dt,
@@ -249,13 +267,13 @@ dl {
       font-weight: 500;
     }
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       font-size: unit((16px / @base-font-size-px), rem);
       line-height: unit((22px / @base-font-size-px), rem);
       strong {
         font-size: unit((18px / @base-font-size-px), rem);
       }
-    }
+    });
   }
 
   dd {
@@ -269,13 +287,13 @@ dl {
       content: none;
     }
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       font-size: unit((22px / @base-font-size-px), rem);
       line-height: unit((26px / @base-font-size-px), rem);
       strong {
         font-size: unit((26px / @base-font-size-px), rem);
       }
-    }
+    });
   }
 }
 
@@ -294,31 +312,15 @@ html.js .o-filterable-list-results__partial {
   }
 }
 
-.a-credit-card-apr-rating {
-  margin-bottom: unit((20px / @base-font-size-px), rem);
-
-  &--less .cf-icon-svg {
-    color: var(--green);
-  }
-
-  &--average .cf-icon-svg {
-    color: var(--gold);
-  }
-
-  &--more .cf-icon-svg {
-    color: var(--red);
-  }
-}
-
 .m-credit-tier-chart {
   display: flex;
   align-items: stretch;
   font-size: unit((15px / @base-font-size-px), rem);
 
-  @media only screen and (min-width: @bp-sm-min) {
+  .respond-to-min(@bp-sm-min, {
     margin-left: unit((-18px / @base-font-size-px), rem);
     font-size: unit((16px / @base-font-size-px), rem);
-  }
+  });
 
   &__tier {
     display: flex;
@@ -327,11 +329,11 @@ html.js .o-filterable-list-results__partial {
       unit((15px / @base-font-size-px), rem);
     background-color: var(--teal-10);
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       display: block;
       padding: unit((5px / @base-font-size-px), rem)
         unit((20px / @base-font-size-px), rem);
-    }
+    });
   }
   &__tier:first-child {
     border-radius: 20px 0 0 20px;
@@ -350,9 +352,9 @@ html.js .o-filterable-list-results__partial {
     border-left: 1px solid var(--white);
   }
   &__tier--unselected &__icon {
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       display: none;
-    }
+    });
   }
 }
 
@@ -418,17 +420,17 @@ html.js .o-filterable-list-results__partial {
   display: flex;
   flex-direction: column;
 
-  @media only screen and (min-width: @bp-sm-min) {
+  .respond-to-min(@bp-sm-min, {
     flex-direction: row;
     gap: unit((30px / @base-font-size-px), rem);
-  }
+  });
 
   &__operator {
     margin-bottom: 0;
 
-    @media only screen and (min-width: @bp-sm-min) {
+    .respond-to-min(@bp-sm-min, {
       align-self: center;
-    }
+    });
   }
 }
 


### PR DESCRIPTION
Changes the size of some headings, adds a link back to the landing page, and changes the eligibility requirements text. Also speed bumps are teal now.

See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/291

## How to test this PR

1. `./frontend.sh`
1. Visit the [cards page](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/) and things should look a little different. You'll see a new `Choose what you're looking for in a card` that reads `Change what you're looking for in a card` if you selected a situation on the landing page.
1. `yarn cypress run --spec test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js`


## Screenshots

| before | after |
|--------|-------|
| <img width="433" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/1d5a5e0a-9136-46d6-ba33-14521406a0d7"> | <img width="433" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/86ce1072-46c1-4b9d-b027-bbb6f6e16ee5"> |

### Front-end testing

#### Browser testing

Visually tested in the following supported browsers:
- [x] Firefox
- [x] Chrome
- [x] Safari
- [x] Edge 18 (the last Edge prior to it switching to Chromium)
- [x] Safari on iOS
- [x] Chrome on Android

#### Accessibility

- [x] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [x] Screen reader friendly
- [x] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [x] Is useable without CSS
- [x] Is useable without JS
- [x] Does not introduce new lint warnings
- [x] Flexible from small to large screens
