### PR TITLE
Bugfix: re-add `o-expandable_icon` class

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -43,7 +43,7 @@
         if value.is_faq else '' }} >
     <button class="o-expandable_header" type="button">
         {% if value.icon %}
-          <span>{{ svg_icon( value.icon ) }}</span>
+          <span class="o-expandable_icon">{{ svg_icon( value.icon ) }}</span>
         {% endif %}
         <span class="o-expandable_label"
               {{'itemprop="name"' if value.is_faq else ''}}>


### PR DESCRIPTION
Whoops, https://github.com/cfpb/consumerfinance.gov/pull/8295 removed the `o-expandable_icon` class, which busts the styles for padded expandables that have icons.

## Changes

- Bugfix: re-add `o-expandable_icon` class


## How to test this PR

1. `yarn build` and visit http://localhost:8000/learnmore and compare to production


## Screenshots

Before:
<img width="802" alt="Screenshot 2024-04-11 at 5 41 24 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/46b06f4d-017b-498b-b369-82d0fde03e88">

After:
<img width="797" alt="Screenshot 2024-04-11 at 5 41 13 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/7dc36054-c7da-4cc4-a040-17f019842791">
