### PR TITLE
TCCP: Tweak a few card detail details

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -103,7 +103,7 @@
                 </ul>
             {% endif %}
             {% if card.professional_affiliation is not none or card.other is not none %}
-                <div class="h4 u-mt15">Other requirements for applying</div>
+                <div class="h4 u-mt15">Eligibility requirements</div>
                 <ul>
                     {% for requirement in [
                         card.professional_affiliation,
@@ -247,7 +247,7 @@
                             <td>
                                 {% if purchase_apr_ratings[loop.index0] is not none %}
                                     {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
-                                    <span class="a-credit-card-apr-rating--{{ label }}">
+                                    <span class="m-apr-rating--{{ label }}">
                                         {%- for i in range(purchase_apr_ratings[loop.index0] + 1) %}
                                             {{ svg_icon("dollar-round") }}
                                         {% endfor -%}


### PR DESCRIPTION
Couple of small tweaks to the TCCP card details page for testing. The APR ratings element is not correctly BEM'd yet; we're going to refactor that to use the same macro across the list and details views in a subsequent PR, so I just made it look right for testing for now.

---

## Changes

- Fixed APR rating colors
- "Other requirements for applying" heading is now "Eligibility requirements" to match how we refer to those in the results list


## How to test this PR

1. Make sure APR rating dollar signs are the right colors on the card details page
2. Make sure the heading before the list of other requirements is now "Eligibility requirements"

## Notes and todos

- As mentioned above, refactor the `card_rating` element to be a macro that can be shared by both the card list and details views

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets