### PR TITLE
Remove unused `URLOrRelativeURLBlock`

### DIFF
--- a/cfgov/v1/atomic_elements/atoms.py
+++ b/cfgov/v1/atomic_elements/atoms.py
@@ -4,34 +4,9 @@ from wagtail import blocks
 from wagtail.blocks.struct_block import StructBlockValidationError
 from wagtail.images.blocks import ImageChooserBlock
 
-from url_or_relative_url_field.forms import URLOrRelativeURLFormField
-
 
 def is_required(field_name):
     return [str(field_name) + " is required."]
-
-
-class URLOrRelativeURLBlock(blocks.FieldBlock):
-    def __init__(
-        self,
-        required=True,
-        help_text=None,
-        max_length=None,
-        min_length=None,
-        validators=(),
-        **kwargs,
-    ):
-        self.field = URLOrRelativeURLFormField(
-            required=required,
-            help_text=help_text,
-            max_length=max_length,
-            min_length=min_length,
-            validators=validators,
-        )
-        super().__init__(**kwargs)
-
-    class Meta:
-        icon = "site"
 
 
 class Hyperlink(blocks.StructBlock):

--- a/cfgov/v1/tests/atomic_elements/test_atoms.py
+++ b/cfgov/v1/tests/atomic_elements/test_atoms.py
@@ -1,33 +1,10 @@
-from django.core.exceptions import ValidationError
-from django.test import SimpleTestCase, TestCase
+from django.test import TestCase
 
 from wagtail.blocks.struct_block import StructBlockValidationError
 from wagtail.images.tests.utils import get_test_image_file
 
-from v1.atomic_elements.atoms import (
-    Hyperlink,
-    ImageBasic,
-    URLOrRelativeURLBlock,
-)
+from v1.atomic_elements.atoms import Hyperlink, ImageBasic
 from v1.models import CFGOVImage
-
-
-class URLOrRelativeURLBlockTests(SimpleTestCase):
-    def setUp(self):
-        self.block = URLOrRelativeURLBlock()
-
-    def check_clean(self, url):
-        self.assertEqual(self.block.clean(url), url)
-
-    def test_clean_absolute_url(self):
-        self.check_clean("https://www.consumerfinance.gov/foo/bar/")
-
-    def test_clean_relative_url(self):
-        self.check_clean("/foo/bar/")
-
-    def test_clean_invalid_url_raises_validation_error(self):
-        with self.assertRaises(ValidationError):
-            self.check_clean("url with spaces")
 
 
 def make_image(alt_text):

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -17,7 +17,6 @@ django-localflavor==4.0
 django-mptt==0.14.0
 django-storages==1.14.2
 django-treebeard==4.7.1
-django-url-or-relative-url-field==0.2.0
 djangosaml2==1.9.2
 edgegrid-python==1.3.1
 elasticsearch<7.11  # Keep pinned to the deployed ES version


### PR DESCRIPTION
`URLOrRelativeURLBlock` was added in https://github.com/cfpb/consumerfinance.gov/commit/f1e99cb734246fef46a4f8241a8e7a2995c4b32d and used in `HighlightCardBlock`, which was later removed in https://github.com/cfpb/consumerfinance.gov/commit/48ad711103a36da36a683086c32f8db3a74fa71f

## Removals

- Remove unused `URLOrRelativeURLBlock`, tests, and related `django-url-or-relative-url-field` dependency

## How to test this PR

1. PR checks should pass.
