### PR TITLE
Remove unused `AskSearch`

### DIFF
--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -26,34 +26,6 @@ from v1.atomic_elements.tables import (  # noqa: F401
 from v1.util import ref
 
 
-class AskSearch(blocks.StructBlock):
-    show_label = blocks.BooleanBlock(
-        default=True, required=False, help_text="Whether to show form label."
-    )
-
-    complaint_link = blocks.BooleanBlock(
-        default=False,
-        required=False,
-        label="Direct long searches to submit a complaint",
-        help_text=(
-            "Add a link to the complaint submission page to the end of "
-            "the error message for searches over the max length"
-        ),
-    )
-
-    placeholder = blocks.TextBlock(
-        required=False,
-        help_text="Text to show for the input placeholder text.",
-    )
-
-    class Meta:
-        icon = "search"
-        template = "v1/includes/organisms/ask-search.html"
-
-    class Media:
-        js = ["ask-autocomplete.js"]
-
-
 class Well(blocks.StructBlock):
     content = v1_blocks.UnescapedRichTextBlock(required=False, label="Well")
 


### PR DESCRIPTION
`AskSearch` was used in `WellWithAskSearch`, which was added in https://github.com/cfpb/consumerfinance.gov/pull/5230/ and removed in https://github.com/cfpb/consumerfinance.gov/commit/f2067960135362dc2ca560db0c4a814180c66b80

## Removals

- Remove `AskSearch`

## How to test this PR

1. PR checks should pass.
