### PR TITLE
TCCP: Move location of hidden fields to fix padding bug

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -24,6 +24,9 @@
 
 {%- macro render_form_fields(form) -%}
 <div class="content-l_col content-l_col-1">
+    {# This is a hidden field. #}
+    {{ form.situations }}
+
     <div class="o-form_group">
         {{ render_field(form.credit_tier, "select") }}
     </div>
@@ -53,9 +56,6 @@
     <div class="o-form_group" id="tccp-ordering">
         {{ render_field(form.ordering, "select") }}
     </div>
-
-    {# This is a hidden field. #}
-    {{ form.situations }}
 </div>
 {%- endmacro -%}
 


### PR DESCRIPTION
The hidden form fields conflict with a `last-child` CSS rule. Moving them to the start of the form fixes the issue. The order of all the form fields doesn't matter to the server.

## How to test this PR

1. Check the bottom of the expandable.
1. The Cypress GHA tests should pass.

## Screenshots

| before | after |
|--------|-------|
| <img width="1166" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/8381d7c7-e5d7-4419-8cdf-3838ff5597ed"> | <img width="1166" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/1060248/5c138cfb-102c-403a-a942-d9cf4a5ef021"> |






