### PR TITLE
TCCP: Adjust container padding

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -50,7 +50,7 @@
 </div>
 {% endif %}
 
-<div class="block block__sub">
+<div class="block block__flush-top">
     <div class="o-filterable-list-results o-filterable-list-results__partial htmx-results">
         {% include "tccp/includes/card_list.html" %}
     </div>

--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -42,7 +42,6 @@
 
 {% block content_main %}
 
-<div class="content_wrapper">
     <div class="block block__sub block__flush-top">
         <h2>
             How is this comparison tool different than others you may have used?
@@ -67,7 +66,7 @@
         </p>
     </div>
 
-    <div class="block block__sub">
+    <div class="block block__flush-top">
         <form action="." method="get">
 
             <div class="o-form_group">
@@ -121,7 +120,6 @@
 
         </form>
     </div>
-</div>
 
 {% endblock content_main %}
 


### PR DESCRIPTION
AFAIK the left-hand text should be aligned. This was getting indented by the extra `content_wrapper` container. Also, the last block should have greater space between the content and the footer.

## Changes

- Remove `content_wrapper` container.
- Change ending blocks to `block__flush-top` instead of `block__sub`


## How to test this PR

1. Visit TCCP landing page and see that left edge of the text aligns across the hero and the content area. Also, check the bottom of the content on the landing page and search results page and see that the gap between the content and the footer has been increased (see screenshots).


## Screenshots

Before:
<img width="708" alt="Screenshot 2024-04-12 at 12 36 07 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8038727a-d3b1-415d-9ad7-ff0334181c67">

After:
<img width="652" alt="Screenshot 2024-04-12 at 12 36 23 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/fbf08a13-1c32-4e38-b435-84a39342f2e0">

Before:
<img width="1267" alt="Screenshot 2024-04-12 at 12 35 44 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/b076e0c8-cdd3-4a65-8f70-9db72071d004">

After:
<img width="1264" alt="Screenshot 2024-04-12 at 12 35 32 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/99cabc7b-6d2c-4868-8c47-c564e51b1728">

