### PR TITLE
TCCP: Fix grace periods in card details

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -402,7 +402,7 @@
                     <dt>Grace period</dt>
                     <dd>
                         {{ card.grace_period ~ ' days until interest begins to accrue on
-                            purchases' if grace_period_offered else 'None, interest
+                            purchases' if card.grace_period_offered else 'None, interest
                             begins accruing on purchases immediately'
                         }}
                     </dd>


### PR DESCRIPTION
Fixes a bug that made all cards show that they had no grace periods.

---

## Changes

- Fix grace period logic

## How to test this PR

1. Check that a card that does have a grace period (like [this one](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/interra-credit-union-standard-mastercard/), although almost all of them do) lists it in the other details expandable in the making purchases section. It should say something like "25 days until interest begins to accrue on purchases"
2. Make sure that cards that don't offer a grace period, like [this one](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/credit-human-federal-credit-union-rate-preferred-mastercard/), still say "None, interest begins accruing on purchases immediately"

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)