### PR TITLE
Remove ask h4 custom margin

### DIFF
--- a/cfgov/unprocessed/css/on-demand/ask.less
+++ b/cfgov/unprocessed/css/on-demand/ask.less
@@ -151,10 +151,6 @@
       margin-top: unit(@grid_gutter-width / @size-iii, em);
     }
 
-    .row + .row h4 {
-      margin-top: unit(@grid_gutter-width / @size-iv, em);
-    }
-
     // Large desktop size.
     .respond-to-min(@bp-lg-min, {
       .row + .row h2 {


### PR DESCRIPTION
Ask pages shouldn't have an h4 outside of a tip. If they do, the page should be opened, saved and re-published.

## Changes

- Remove ask h4 custom margin


## How to test this PR

1. PR checks should pass. Pages like http://localhost:8000/ask-cfpb/can-a-debt-collector-take-my-social-security-or-va-benefits-en-1157/ shouldn't have a large gap before the h4 in the embedded tip.
