### PR TITLE
iRegs: Remove unneeded empty results classes

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -177,8 +177,8 @@
     </div>
 </div>
 {% else %}
-<div class="block block__flush-top search_results_empty">
-    <p class="results_initial__all">
+<div class="block block__flush-top">
+    <p>
         Search for a term above, then filter the results to find what you’re looking for.
     </p>
 </div>


### PR DESCRIPTION
These classes appear in the markup only and appear to be unused.

## Changes

- Remove unneeded empty results classes.


## How to test this PR

1. http://localhost:8000/rules-policy/regulations/search-regulations/results/?regs=1002&q= vs https://www.consumerfinance.gov/rules-policy/regulations/search-regulations/results/?regs=1002&q= should be unchanged.
