### PR TITLE
FIG: Remove dark tag modification

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/secondary-nav-fig.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/secondary-nav-fig.html
@@ -18,10 +18,9 @@
 
 {% macro render(version_status=none, effective_start_date=none, effective_end_date=none) %}
 <div class="o-fig_sidebar">
-    {% set tag_modification = 'dark' if version_status == 'Archived' else 'info'  %}
     <div class="u-hide-on-tablet">
         {% if version_status %}
-            <div class="a-tag a-tag__{{ tag_modification }} u-mb20">
+            <div class="a-tag u-mb20">
                 {{ version_status }}
             </div>
             <p>


### PR DESCRIPTION
I don't see any CSS attached to `a-tag__dark`

## Removals

- FIG: Remove dark tag `a-tag__dark` class

## How to test this PR

1. Visit https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide-archive-v2/ and see `a-tag__dark` can be removed with no effect.
