### PR TITLE
TCCP: Fix multiple checkbox rendering

### DIFF
--- a/cfgov/tccp/templates/tccp/widgets/checkbox_select.html
+++ b/cfgov/tccp/templates/tccp/widgets/checkbox_select.html
@@ -1,0 +1,5 @@
+{% with id=widget.attrs.id %}<div{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
+  <div><label>{{ group }}</label>{% endif %}{% for option in options %}
+    {% include option.template_name with widget=option %}{% endfor %}{% if group %}
+  </div>{% endif %}{% endfor %}
+</div>{% endwith %}

--- a/cfgov/tccp/templates/tccp/widgets/checkbox_select.html
+++ b/cfgov/tccp/templates/tccp/widgets/checkbox_select.html
@@ -1,3 +1,11 @@
+{% comment %}
+  This template overrides the default Django template from:
+
+  https://github.com/django/django/blob/4.2.11/django/forms/jinja2/django/forms/widgets/multiple_input.html
+
+  It removes a wrapping <div></div> around each option template which is
+  unnecessary since our checkbox widget is already contained within a div.
+{% endcomment %}
 {% with id=widget.attrs.id %}<div{% if id %} id="{{ id }}"{% endif %}{% if widget.attrs.class %} class="{{ widget.attrs.class }}"{% endif %}>{% for group, options, index in widget.optgroups %}{% if group %}
   <div><label>{{ group }}</label>{% endif %}{% for option in options %}
     {% include option.template_name with widget=option %}{% endfor %}{% if group %}

--- a/cfgov/tccp/widgets.py
+++ b/cfgov/tccp/widgets.py
@@ -11,6 +11,7 @@ class RadioSelect(forms.RadioSelect):
 
 
 class CheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    template_name = "tccp/widgets/checkbox_select.html"
     option_template_name = "tccp/widgets/checkbox_option.html"
 
     def __init__(self, attrs=None, **kwargs):


### PR DESCRIPTION
The cf.gov upgrade to Django 4.2 broke rendering of multiple checkboxes, removing the intended space between them. This was due to this Django commit:

https://github.com/django/django/commit/5942ab5eb165ee2e759174e297148a40dd855920

which added `<div></div>` wrappers around each select option. This broke our expected markup per our design system:

https://cfpb.github.io/design-system/components/fieldsets#sizes-1

## Screenshots

|Before|After|
|-|-|
|<img width="493" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/58752975-f024-4381-afe3-07b7d3a46d20">|<img width="497" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/cb912927-6515-43ca-9791-d313cb53f8d1">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)