### PR TITLE
TCCP: Tweak design of card details page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -243,24 +243,27 @@
                 </thead>
                 <tbody>
                     {% for purchase_apr in purchase_aprs %}
-                        <tr>
-                            <td>{{ credit_tiers[loop.index][1] }}</td>
-                            <td>{{ apr_range(purchase_apr[0], purchase_apr[1]) }}</td>
-                            <td>
-                                {% if purchase_apr_ratings[loop.index0] is not none %}
-                                    {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
-                                    <span class="m-apr-rating--{{ label }}">
-                                        {%- for i in range(purchase_apr_ratings[loop.index0] + 1) %}
-                                            {{ svg_icon("dollar-round") }}
-                                        {% endfor -%}
+                        {% if apr_range(purchase_apr[0], purchase_apr[1]) != 'N/A' %}
+                            <tr>
+                                <td>{{ credit_tiers[loop.index][1] }}</td>
+                                <td>{{ apr_range(purchase_apr[0], purchase_apr[1]) }}</td>
+                                <td>
+                                    {% if purchase_apr_ratings[loop.index0] is not none %}
+                                        {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
+                                        <span class="m-apr-rating--{{ label }}">
+                                            {%- for i in range(purchase_apr_ratings[loop.index0] + 1) %}
+                                                {{ svg_icon("dollar-round") }}
+                                            {% endfor -%}
 
-                                        Pay {{ label }} interest
-                                    </span>
-                                {% else %}
-                                    Not targeted for these credit scores
-                                {% endif %}
-                            </td>
-                        </tr>
+                                            Pay {{ label }} interest
+                                        </span>
+                                    {% else %}
+                                        Not targeted for these credit scores
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endif %}
+
                     {% endfor %}
                 </tbody>
             </table>
@@ -324,10 +327,12 @@
                         card.intro_apr_good,
                         card.intro_apr_great
                     ] %}
-                        <tr>
-                            <td>{{ credit_tiers[loop.index][1] }}</td>
-                            <td>{{ apr(intro_apr) }}</td>
-                        </tr>
+                        {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
+                            <tr>
+                                <td>{{ credit_tiers[loop.index][1] }}</td>
+                                <td>{{ apr(intro_apr) }}</td>
+                            </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>
@@ -810,10 +815,12 @@
                             card.transfer_apr_good,
                             card.transfer_apr_great
                         ] %}
-                            <tr>
-                                <td>{{ credit_tiers[loop.index][1] }}</td>
-                                <td>{{ apr(transfer_apr) }}</td>
-                            </tr>
+                            {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
+                                <tr>
+                                    <td>{{ credit_tiers[loop.index][1] }}</td>
+                                    <td>{{ apr(transfer_apr) }}</td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </tbody>
                 </table>
@@ -920,10 +927,12 @@
                             card.advance_apr_good,
                             card.advance_apr_great
                         ] %}
-                            <tr>
-                                <td>{{ credit_tiers[loop.index][1] }}</td>
-                                <td>{{ apr(advance_apr) }}</td>
-                            </tr>
+                            {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
+                                <tr>
+                                    <td>{{ credit_tiers[loop.index][1] }}</td>
+                                    <td>{{ apr(advance_apr) }}</td>
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -155,7 +155,7 @@
             </div>
         {% endif %}
     </div>
-    {{ data_published(card.report_date) }}
+    {{ data_published(card.report_date, verbose=true) }}
 
     {% if card.secured_card %}
         <div class="u-mt30 u-mb30">

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -171,7 +171,7 @@
     {% endif %}
 
     <div class="o-card-details-section">
-        <h2 class="h3 u-mb15">
+        <h2>
             {{ svg_icon("cart-round") }}
             Purchase interest rate and fees
         </h2>
@@ -207,7 +207,7 @@
                 - No min and max but a median: "29.74% median purchase APR"
                 - Single APR for everyone: "24.90% purchase APR"
             #}
-            <div class="h2 u-mb0 u-mt15">
+            <div class="h2 u-mb0">
                 {% if card.purchase_apr_min is not none
                     and card.purchase_apr_max is not none
                 %}
@@ -350,7 +350,7 @@
                 'label': 'Foreign transaction fee, grace period, and other details',
                 'is_bordered': true,
                 'is_expanded': false,
-                'is_midtone': false
+                'is_midtone': true
             }) %}
                 <dl class="m-list m-list__card-details">
                     <dt>Foreign transaction fee</dt>
@@ -438,7 +438,7 @@
     </div>
 
     <div class="o-card-details-section">
-        <h2 class="h3">
+        <h2>
             {{ svg_icon("credit-payment-round") }}
             Fees
         </h2>
@@ -558,7 +558,7 @@
                 'label': other_fees_label,
                 'is_bordered': true,
                 'is_expanded': false,
-                'is_midtone': false
+                'is_midtone': true
             }) %}
                 <dl class="m-list m-list__card-details">
                     <dt>Late fee</dt>
@@ -654,12 +654,12 @@
     </div>
 
     <div class="o-card-details-section">
-        <h2 class="h3">
+        <h2>
             {{ svg_icon("gift-round") }}
             Rewards and perks
         </h2>
         {% if card.rewards %}
-            <div class="h2 u-mb0 u-mt15">
+            <div class="h2 u-mb0">
                 {%- set rewards = [] -%}
                 {%- for reward in card.rewards -%}
                     {%- do rewards.append(rewards_lookup[reward]) -%}
@@ -680,7 +680,7 @@
                 'label': 'Card services and features',
                 'is_bordered': true,
                 'is_expanded': false,
-                'is_midtone': false
+                'is_midtone': true
             }) %}
                 <dl class="m-list m-list__card-details">
                     {% if card.services %}
@@ -717,7 +717,7 @@
     </div>
 
     <div class="o-card-details-section">
-        <h2 class="h3 u-mb15">
+        <h2>
             {{ svg_icon("money-transfer-round") }}
             Balance transfer interest rate and fees
         </h2>
@@ -734,7 +734,7 @@
         {% if card.balance_transfer_offered %}
             <div class="m-payment-calculation u-mb15">
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt15">
+                    <div class="h2 u-mb0">
                         {% if card.transfer_apr_min is not none
                             and card.transfer_apr_max is not none
                         %}
@@ -758,7 +758,7 @@
                 </div>
                 <div class="m-payment-calculation__operator h2">+</div>
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt15">
+                    <div class="h2 u-mb0">
                         {{ currency(card.balance_transfer_fee_dollars) if
                             card.balance_transfer_fee_dollars is not none
                         }}
@@ -836,14 +836,14 @@
     </div>
 
     <div class="o-card-details-section">
-        <h2 class="h3 u-mb15">
+        <h2>
             {{ svg_icon("quick-cash-round") }}
             Cash advance interest rate and fees
         </h2>
         {% if card.cash_advance_apr_offered %}
             <div class="m-payment-calculation u-mb15">
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt15">
+                    <div class="h2 u-mb0">
                         {% if card.advance_apr_min is not none
                             and card.advance_apr_max is not none
                         %}
@@ -868,7 +868,7 @@
                 </div>
                 <div class="m-payment-calculation__operator h2">+</div>
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt15">
+                    <div class="h2 u-mb0">
                         {{ currency(card.cash_advance_fee_dollars) if
                             card.cash_advance_fee_dollars is not none
                         }}

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -10,7 +10,7 @@
     ) }}
     ({{- 'credit card terms may have changed since then, check with the issuer
           for the most current terms or ' if verbose -}}
-    <a href="{{ url('tccp:about') }}">learn about the data</a>)
+    <a href="{{ url('tccp:about') }}">{{ 'l' if verbose else 'L' }}earn about the data</a>)
 </p>
 
 {%- endmacro %}

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -1,11 +1,16 @@
 {%- import 'v1/includes/macros/time.html' as time -%}
 
-{%- macro data_published(date) -%}
+{%- macro data_published(date, verbose=false) -%}
 
-<p style="font-size: 14px; color: #5a5d61">
-    Data published {{ time.render(
+<p class="u-small-text u-small-text--gray">
+    Data reported
+    {{' directly by the issuer ' if verbose }}
+    on {{ time.render(
         ensure_date(date), {"date": true}, text_format=true
     ) }}
+    ({{- 'credit card terms may have changed since then, check with the issuer
+          for the most current terms or ' if verbose -}}
+    <a href="{{ url('tccp:about') }}">learn about the data</a>)
 </p>
 
 {%- endmacro %}

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -2,7 +2,7 @@
 
 {%- macro data_published(date, verbose=false) -%}
 
-<p class="u-small-text u-small-text--gray">
+<p class="u-small-text u-small-text--subtle">
     Data reported
     {{' directly by the issuer ' if verbose }}
     on {{ time.render(

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -4,7 +4,7 @@
 
 <p class="u-small-text u-small-text--subtle">
     Data reported
-    {{' directly by the issuer ' if verbose }}
+    {{- ' directly by the issuer ' if verbose -}}
     on {{ time.render(
         ensure_date(date), {"date": true}, text_format=true
     ) }}

--- a/cfgov/tccp/jinja2/tccp/includes/fields.html
+++ b/cfgov/tccp/jinja2/tccp/includes/fields.html
@@ -1,5 +1,11 @@
 {%- macro apr(value) -%}
-    {{ ('%.2f%%' | format(value * 100)) if value is not none else "N/A" }}
+    {% if value is none -%}
+        N/A
+    {%- elif value == 0 -%}
+        0%
+    {%- else -%}
+        {{ ('%.2f%%' | format(value * 100)) }}
+    {%- endif %}
 {%- endmacro -%}
 
 {%- macro apr_range(min, max) -%}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -92,7 +92,7 @@
   }
 }
 
-.u-small-text--gray {
+.u-small-text--subtle {
   color: var(--gray);
 }
 

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -92,6 +92,10 @@
   }
 }
 
+.u-small-text--gray {
+  color: var(--gray);
+}
+
 .o-well.o-well--speed-bump {
   padding: unit((20px / @base-font-size-px), rem);
   background-color: var(--teal-10);

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -377,9 +377,18 @@ html.js .o-filterable-list-results__partial {
 
   &--introduction {
     padding-bottom: unit((30px / @base-font-size-px), rem);
-    margin-top: 0;
     margin-bottom: unit((10px / @base-font-size-px), rem);
     border-bottom: 1px solid var(--gray-40);
+
+    .respond-to-max(@bp-sm-min, {
+      margin-top: unit((30px / @base-font-size-px), rem);
+    });
+  }
+
+  h2 {
+    .respond-to-max(@bp-sm-min, {
+      font-weight: 600;
+    });
   }
 }
 
@@ -430,10 +439,9 @@ html.js .o-filterable-list-results__partial {
   });
 
   &__operator {
-    margin-bottom: 0;
-
     .respond-to-min(@bp-sm-min, {
       align-self: center;
+      margin-bottom: 0;
     });
   }
 }


### PR DESCRIPTION
Make some design tweaks to the card details page. See https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/272 for more details.

---

## Changes

- The "data published" info now comes in two flavors: a compact version for the list view and a more verbose version for the details view
- Section headings are now H2 on desktop and H3 + demi-bold on mobile
- Expandables are now gray
- All APR-by-credit-tier tables now only show rows for targeted credit tiers
- Any 0% APRs now show as "0%" instead of "0.00%"

## How to test this PR

Generally everything should look like the screenshots below. You may want to check some cards with tier-specific median APRs to make sure the APR tables are only showing rows for targeted credit tiers, like:

- [1](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/advantis-credit-union-signature-cashback-rewards-credit-card/)
- [2](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/credit-human-federal-credit-union-rate-preferred-mastercard/)
- [3](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/los-angeles-police-federal-credit-union-visa-classic/)
- [4](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/boeing-employees-credit-union-becu-tradition-credit-card-secured/)
- [5](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/wells-fargo-bank-national-association-wells-fargo-active-cash-card/)

## Screenshots

Mobile | Desktop
---- | ----
![mobile](https://github.com/cfpb/consumerfinance.gov/assets/1862695/29ebf421-067f-406e-9efc-2d103de15604) | ![desktop](https://github.com/cfpb/consumerfinance.gov/assets/1862695/462acaae-65ca-4124-976f-69ae270abc49)

## Notes and todos

- In a subsequent PR we're going to refactor the APR tables to be a reusable macro, so no need to stress too much if there's a better way to only render rows for targeted tiers—we'll improve that in the refactor

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets