### PR TITLE
Add translation links to the hero

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/hero.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/hero.html
@@ -45,7 +45,7 @@
                                     extra large (jumbo).
 
    ========================================================================== #}
-{% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+
 
 {# TODO: This is simple now, but in the future we'll hopefully be able to
    provide 1x and 2x values as well. We should update this to be an image
@@ -128,10 +128,3 @@
     {% endif %}
     </style>
 </section>
-
-{% set t_links = translation_links.render(modifier_classes='block__flush-bottom') %}
-{% if t_links and t_links | trim | length > 1 %}
-  <div class="u-layout-grid_wrapper">
-    {{ t_links }}
-  </div>
-{% endif %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/hero.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/hero.html
@@ -45,7 +45,7 @@
                                     extra large (jumbo).
 
    ========================================================================== #}
-
+{% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
 
 {# TODO: This is simple now, but in the future we'll hopefully be able to
    provide 1x and 2x values as well. We should update this to be an image
@@ -128,3 +128,10 @@
     {% endif %}
     </style>
 </section>
+
+{% set t_links = translation_links.render(None, 'block__flush-bottom') %}
+{% if t_links and t_links | trim | length > 1 %}
+  <div class="u-layout-grid_wrapper">
+    {{ t_links }}
+  </div>
+{% endif %}

--- a/cfgov/v1/jinja2/v1/includes/molecules/hero.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/hero.html
@@ -129,7 +129,7 @@
     </style>
 </section>
 
-{% set t_links = translation_links.render(None, 'block__flush-bottom') %}
+{% set t_links = translation_links.render(modifier_classes='block__flush-bottom') %}
 {% if t_links and t_links | trim | length > 1 %}
   <div class="u-layout-grid_wrapper">
     {{ t_links }}

--- a/cfgov/v1/jinja2/v1/landing-page/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page/index.html
@@ -12,11 +12,21 @@
 {% endblock %}
 
 {% block content_main %}
+    {% set has_hero = [] %}
     {% for block in page.header -%}
         {% if block.block_type != 'hero' %}
             {{ render_block.render(block, loop.index) }}
+         {% else %}
+           {% set _ = has_hero.append(1) %}
         {% endif %}
     {%- endfor %}
+    {% if has_hero %}
+      {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
+      {% set t_links = translation_links.render(modifier_classes='block__flush-top') %}
+      {% if t_links and t_links | trim | length > 1 %}
+        {{ t_links }}
+      {% endif %}
+    {% endif %}
     {% for block in page.content -%}
         {{ render_block.render(block, loop.index) }}
     {%- endfor %}

--- a/cfgov/v1/jinja2/v1/landing-page/index.html
+++ b/cfgov/v1/jinja2/v1/landing-page/index.html
@@ -12,17 +12,17 @@
 {% endblock %}
 
 {% block content_main %}
-    {% set has_hero = [] %}
+    {% set has_hero = namespace(found=false) %}
     {% for block in page.header -%}
-        {% if block.block_type != 'hero' %}
+        {% if block.block_type == 'hero' %}
+            {% set has_hero.found = true %}
+        {% else %}
             {{ render_block.render(block, loop.index) }}
-         {% else %}
-           {% set _ = has_hero.append(1) %}
         {% endif %}
     {%- endfor %}
-    {% if has_hero %}
+    {% if has_hero.found %}
       {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-      {% set t_links = translation_links.render(modifier_classes='block__flush-top') %}
+      {% set t_links = translation_links.render(modifier_classes='block--flush-top') %}
       {% if t_links and t_links | trim | length > 1 %}
         {{ t_links }}
       {% endif %}


### PR DESCRIPTION
Currently, pages with heroes don't get `translation-links` like pages with item introductions or text-introductions. This PR changes that, rendering these links if they exist (english versions of translated pages set in the wagtail config).

## Testing
- Get a recent dump
- Visit https://www.consumerfinance.gov/consumer-tools/ and notice no links
- Compare with http://localhost:8000/consumer-tools/ and notice the links
- Pages with heroes (or jumbo heroes) and no linked translations (like the homepage at http://localhost:8000) should not render any new markup