### PR TITLE
TCCP: Underline link on landing page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -83,11 +83,11 @@
 
                     {{ form.credit_tier }}
 
-                    <small class="a-label_helper a-label_helper__block">
+                    <p class="a-label_helper a-label_helper__block">
                         If you don’t know it,
                         <a href="/ask-cfpb/where-can-i-get-my-credit-scores-en-316/"
                             >find your credit score</a>.
-                    </small>
+                    </p>
                 </div>
             </div>
 


### PR DESCRIPTION
This commit adds a missing underline to the link on the landing page that says "find your credit score".

## How to test this PR

To test, visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/.

## Screenshots

|Before|After|
|-|-|
|<img width="380" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/a2454e27-c0f5-4c9a-b927-2c1b9aaf5af3">|<img width="381" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/e6983b6b-f4c4-4f8f-9ffd-e53285f7e205">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)