### PR TITLE
TCCP: Exclude cards with inconsistent APRs

### DIFF
--- a/cfgov/tccp/jinja2/tccp/about.html
+++ b/cfgov/tccp/jinja2/tccp/about.html
@@ -27,7 +27,7 @@
     </p>
 
     <p>
-        Because data is being provided directly by the company, there may be inconsistencies in formatting or differences in wording from card to card. It's also possible that an APR is no longer available or has changed since the time of publishing.
+        Because data is being provided directly by the company, there may be inconsistencies in formatting or differences in wording from card to card. It's also possible that an APR is no longer available or has changed since the time of publishing. Cards with inconsistent or invalid APR data may be excluded from the tool.
     </p>
 </div>
 

--- a/cfgov/tccp/management/commands/validate_tccp.py
+++ b/cfgov/tccp/management/commands/validate_tccp.py
@@ -33,7 +33,18 @@ class Command(BaseCommand):
         if not summary_stats["count"]:
             raise CommandError("No cards in dataset!")
 
-        cards = CardSurveyData.objects.with_ratings(
+        all_cards = CardSurveyData.objects.all()
+        self.stdout.write(f"{all_cards.count()} cards in database")
+
+        invalid_cards = all_cards.only_invalid_aprs()
+        self.stdout.write(f"{invalid_cards.count()} cards with invalid APRs")
+
+        for i, invalid_card in enumerate(invalid_cards):
+            self.stdout.write(f"{i+1}: {invalid_card.slug}")
+
+        self.stdout.write()
+
+        cards = CardSurveyData.objects.exclude_invalid_aprs().with_ratings(
             summary_stats=summary_stats
         )
 

--- a/cfgov/tccp/tests/test_models.py
+++ b/cfgov/tccp/tests/test_models.py
@@ -149,6 +149,29 @@ class CardSurveyDataQuerySetTests(TestCase):
             },
         )
 
+    def test_exclude_invalid_aprs(self):
+        baker.make(
+            CardSurveyData,
+            purchase_apr_great=0.5,
+            purchase_apr_good=0.25,
+        )
+        baker.make(
+            CardSurveyData,
+            purchase_apr_great=0.25,
+            purchase_apr_good=0.5,
+        )
+
+        qs = CardSurveyData.objects.all()
+        self.assertEqual(qs.count(), 2)
+
+        invalid_aprs = qs.only_invalid_aprs()
+        self.assertEqual(invalid_aprs.count(), 1)
+        self.assertEqual(invalid_aprs[0].purchase_apr_great, 0.5)
+
+        valid_aprs = qs.exclude_invalid_aprs()
+        self.assertEqual(valid_aprs.count(), 1)
+        self.assertEqual(valid_aprs[0].purchase_apr_great, 0.25)
+
 
 class CardSurveyDataTests(SimpleTestCase):
     def test_annual_fee_estimated(self):

--- a/cfgov/tccp/tests/test_validate.py
+++ b/cfgov/tccp/tests/test_validate.py
@@ -13,8 +13,6 @@ from .baker import baker
 
 
 class TestValidation(TestCase):
-    maxDiff = None
-
     def setUp(self):
         self.dir = os.getcwd()
         self.tempdir = tempfile.mkdtemp()
@@ -56,12 +54,24 @@ class TestValidation(TestCase):
                     },
                 )
 
+        # Also create an invalid card to be filtered out.
+        baker.make(
+            CardSurveyData,
+            slug="invalid-card",
+            purchase_apr_great=0.5,
+            purchase_apr_poor=0.25,
+        )
+
     def test_stats(self):
         self.make_test_data()
 
         self.assertEqual(
             self.call_validate(),
             """
+8 cards in database
+1 cards with invalid APRs
+1: invalid-card
+
 CREDIT SCORE 619 OR LESS
 ------------------------
 Count: 1

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -96,7 +96,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
     ]
 
     def get_queryset(self):
-        return self.model.objects.all()
+        return self.model.objects.exclude_invalid_aprs()
 
     def get_template_names(self):
         if self.request.htmx:
@@ -205,7 +205,9 @@ class CardDetailView(FlaggedViewMixin, RetrieveAPIView):
 
     @cached_property
     def summary_stats(self):
-        return self.model.objects.get_summary_statistics()
+        return (
+            self.model.objects.exclude_invalid_aprs().get_summary_statistics()
+        )
 
     def get_queryset(self):
         return self.model.objects.with_ratings(self.summary_stats)


### PR DESCRIPTION
This commit modifies the TCCP "Explore credit cards" tool to exclude cards from the search results if they fail certain validation checks:

1. {purchase, transfer}_apr_great > {purchase, transfer}_apr_good
2. {purchase, transfer}_apr_good > {purchase, transfer}_apr_poor
3. {purchase, transfer}_apr_great > {purchase, transfer}_apr_poor
4. {purchase, transfer}_median > {purchase, transfer}_max
5. {purchase, transfer}_min > {purchase, transfer}_max
6. {purchase, transfer}_min > {purchase, transfer}_median

These cards are still available at a detail page URL but will not appear in search results.

A sentence mentioning this has been added to the "About this tool" page available locally at
http://localhost:8000/consumer-tools/credit-cards/explore-cards/about/.

Additionally, the TCCP dataset validation tool (validate_tccp) now counts and lists the cards that fail these validation checks.

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/289 for additional context.

## How to test this PR

To test, you can run a local server and confirm that a card like [this](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/discover-bank-discover-it-secured-credit-card/) doesn't show up in search results; if you look at this card's [JSON view](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/discover-bank-discover-it-secured-credit-card/?format=json), you can see that it has invalid (0) `purchase_apr_min` and `purchase_apr_max`, and its `purchase_apr_median` is non-zero.

You can also run `cfgov/manage.py validate_tccp` to see the list of invalid cards.

## Screenshots

Last sentence added here is new:

<img width="676" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/76274fee-e02b-40bf-8faf-96b21354e310">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)