### PR TITLE
TCCP: Card details page template consolidation

### DIFF
--- a/cfgov/tccp/enums.py
+++ b/cfgov/tccp/enums.py
@@ -44,10 +44,24 @@ CreditTierChoices = [
 ]
 
 
+CreditTierConciseChoices = [
+    ("No credit score", "No score"),
+    ("Credit score 619 or less", "619 or less"),
+    ("Credit scores from 620 to 719", "620-719"),
+    ("Credit score of 720 or greater", "720+"),
+]
+
+
 CreditTierColumns = [
     ("Credit score 619 or less", "poor"),
     ("Credit scores from 620 to 719", "good"),
     ("Credit score of 720 or greater", "great"),
+]
+
+
+CreditTierConciseColumnChoices = [
+    (value, concise_label, dict(CreditTierColumns).get(value))
+    for value, concise_label in CreditTierConciseChoices
 ]
 
 
@@ -117,6 +131,13 @@ OverlimitFeeTypeChoices = make_choices(
 
 
 PeriodicFeeTypeChoices = make_choices("Annual", "Monthly", "Weekly", "Other")
+
+
+PurchaseAPRRatings = [
+    (0, "less"),
+    (1, "average"),
+    (2, "more"),
+]
 
 
 PurchaseTransactionFeeTypeChoices = make_choices(

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -1,5 +1,6 @@
 {% extends 'v1/layouts/layout-2-1.html' %}
 
+{% from 'tccp/includes/apr_table.html' import apr_table with context %}
 {% from 'tccp/includes/data_published.html' import data_published %}
 {% from 'tccp/includes/fields.html' import apr, apr_range, currency, lower_first_letter, oxfordize %}
 {% from 'tccp/includes/speed_bump.html' import speed_bump %}
@@ -26,31 +27,27 @@
 <div class="block block__flush-top">
 
     <div class="eyebrow">{{ card.institution_name }}</div>
+
     <h1>{{ card.product_name }}</h1>
-    {% set credit_tiers = [
-        ("No credit score", "No score"),
-        ("619 or less", "619 or less"),
-        ("620 to 719", "620-719"),
-        ("720 or greater", "720+")
-    ] %}
+
     <div class="o-card-details-section o-card-details-section--introduction">
         {# TODO: Need to make this more accessible for screen readers #}
         <div class="m-credit-tier-chart">
-            {% for tier in credit_tiers %}
-                {% if tier[0] in card.targeted_credit_tiers | string %}
+            {% for tier_value, tier_name, _ in credit_tier_lookup %}
+                {% if tier_value in card.targeted_credit_tiers %}
                     {% set targeted_tier = true %}
                 {% else %}
                     {% set targeted_tier = false %}
                 {% endif %}
                 <div class="m-credit-tier-chart__tier m-credit-tier-chart__tier{{ '--selected' if targeted_tier else '--unselected' }}">
                     <span class="m-credit-tier-chart__icon">
-                        {% if targeted_tier %}
-                            {{ svg_icon('approved-round') if targeted_tier }}
-                        {% else %}
+                        {%- if targeted_tier -%}
+                            {{ svg_icon('approved-round') }}
+                        {%- else -%}
                             &nbsp;
-                        {% endif %}
+                        {%- endif -%}
                     </span>
-                    <span class="m-credit-tier-chart__label">{{ tier[1] }}</span>
+                    <span class="m-credit-tier-chart__label">{{ tier_name }}</span>
                 </div>
             {% endfor %}
         </div>
@@ -175,33 +172,7 @@
             {{ svg_icon("cart-round") }}
             Purchase interest rate and fees
         </h2>
-        {# TODO: Unify ratings code with results list view #}
-        {% set purchase_apr_rating_labels = [
-            'less', 'average', 'more'
-        ] %}
-        {% set purchase_apr_ratings = [
-            card.purchase_apr_poor_rating,
-            card.purchase_apr_good_rating,
-            card.purchase_apr_great_rating
-        ] %}
-        {% set purchase_aprs = [
-            (card.purchase_apr_poor_min, card.purchase_apr_poor_max),
-            (card.purchase_apr_good_min, card.purchase_apr_good_max),
-            (card.purchase_apr_great_min, card.purchase_apr_great_max),
-        ] %}
-        {% if card.purchase_apr_offered
-            and card.purchase_apr_poor_min is none
-            and card.purchase_apr_poor_max is none
-            and card.purchase_apr_good_min is none
-            and card.purchase_apr_good_max is none
-            and card.purchase_apr_great_min is none
-            and card.purchase_apr_great_max is none
-        %}
-            {% set purchase_apr_data_incomplete = true %}
-        {% else %}
-            {% set purchase_apr_data_incomplete = false %}
-        {% endif %}
-        {% if card.purchase_apr_offered and not purchase_apr_data_incomplete %}
+        {% if card.purchase_apr_offered and not card.purchase_apr_data_incomplete %}
             {# How top-line APR displays if the card has:
                 - Min and max APRs: "19.49% - 31.99% purchase APR"
                 - No min and max but a median: "29.74% median purchase APR"
@@ -233,40 +204,9 @@
                 }}
                 Here are typical APRs for different credit scores for this card:
             </p>
-            <table class="o-table o-table--apr">
-                <thead>
-                    <tr>
-                        <th>Credit score</th>
-                        <th>Median purchase APR</th>
-                        <th>Comparison to other cards</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for purchase_apr in purchase_aprs %}
-                        {% if apr_range(purchase_apr[0], purchase_apr[1]) != 'N/A' %}
-                            <tr>
-                                <td>{{ credit_tiers[loop.index][1] }}</td>
-                                <td>{{ apr_range(purchase_apr[0], purchase_apr[1]) }}</td>
-                                <td>
-                                    {% if purchase_apr_ratings[loop.index0] is not none %}
-                                        {% set label = purchase_apr_rating_labels[purchase_apr_ratings[loop.index0]] %}
-                                        <span class="m-apr-rating--{{ label }}">
-                                            {%- for i in range(purchase_apr_ratings[loop.index0] + 1) %}
-                                                {{ svg_icon("dollar-round") }}
-                                            {% endfor -%}
 
-                                            Pay {{ label }} interest
-                                        </span>
-                                    {% else %}
-                                        Not targeted for these credit scores
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endif %}
+            {{ apr_table(card, "purchase", show_comparison=true) }}
 
-                    {% endfor %}
-                </tbody>
-            </table>
             <p>
                 The purchase APR is
                 {% if 'V' in card.index %}
@@ -281,7 +221,7 @@
                 and about
                 <a href="/ask-cfpb/what-is-the-difference-between-a-fixed-apr-and-a-variable-apr-en-45/">fixed versus variable APRs</a>.
             </p>
-        {% elif card.purchase_apr_offered and purchase_apr_data_incomplete %}
+        {% elif card.purchase_apr_offered and card.purchase_apr_data_incomplete %}
             <p>The issuer did not submit information about purchase APR.</p>
         {% else %}
             <p>This card does not charge interest on purchases.</p>
@@ -309,33 +249,13 @@
                 {% endif %}
             </div>
             {% if card.introductory_apr_vary_by_credit_tier %}
-            <p>
-                Your introductory APR will vary based on your credit score.
-                Here are typical introductory APRs for different credit scores
-                for this card:
-            </p>
-            <table class="o-table o-table--apr">
-                <thead>
-                    <tr>
-                        <th>Credit score</th>
-                        <th>Median intro APR</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for intro_apr in [
-                        card.intro_apr_poor,
-                        card.intro_apr_good,
-                        card.intro_apr_great
-                    ] %}
-                        {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
-                            <tr>
-                                <td>{{ credit_tiers[loop.index][1] }}</td>
-                                <td>{{ apr(intro_apr) }}</td>
-                            </tr>
-                        {% endif %}
-                    {% endfor %}
-                </tbody>
-            </table>
+                <p>
+                    Your introductory APR will vary based on your credit score.
+                    Here are typical introductory APRs for different credit scores
+                    for this card:
+                </p>
+
+                {{ apr_table(card, "intro") }}
             {% elif card.intro_apr_median is not none
                 and card.intro_apr_min != card.intro_apr_max %}
                 <p>
@@ -802,28 +722,8 @@
                     score. Here are typical balance transfer APRs for different
                     credit scores for this card:
                 </p>
-                <table class="o-table o-table--apr">
-                    <thead>
-                        <tr>
-                            <th>Credit score</th>
-                            <th>Median balance transfer APR</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for transfer_apr in [
-                            card.transfer_apr_poor,
-                            card.transfer_apr_good,
-                            card.transfer_apr_great
-                        ] %}
-                            {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
-                                <tr>
-                                    <td>{{ credit_tiers[loop.index][1] }}</td>
-                                    <td>{{ apr(transfer_apr) }}</td>
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                    </tbody>
-                </table>
+
+                {{ apr_table(card, "transfer", apr_label="balance transfer") }}
             {% elif card.transfer_apr_median is not none
                 and card.transfer_apr_min != card.transfer_apr_max %}
                 <p>
@@ -914,28 +814,8 @@
                     Here are typical cash advance APRs for different credit
                     scores for this card:
                 </p>
-                <table class="o-table o-table--apr">
-                    <thead>
-                        <tr>
-                            <th>Credit score</th>
-                            <th>Median cash advance APR</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for advance_apr in [
-                            card.advance_apr_poor,
-                            card.advance_apr_good,
-                            card.advance_apr_great
-                        ] %}
-                            {% if credit_tiers[loop.index][0] in card.targeted_credit_tiers | string %}
-                                <tr>
-                                    <td>{{ credit_tiers[loop.index][1] }}</td>
-                                    <td>{{ apr(advance_apr) }}</td>
-                                </tr>
-                            {% endif %}
-                        {% endfor %}
-                    </tbody>
-                </table>
+
+                {{ apr_table(card, "advance", apr_label="cash advance") }}
             {% elif card.advance_apr_median is not none
                 and card.advance_apr_min != card.advance_apr_max %}
                 <p>

--- a/cfgov/tccp/jinja2/tccp/includes/apr_table.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_table.html
@@ -45,8 +45,6 @@
 
                                 Pay {{ label }} interest
                             </span>
-                        {% else %}
-                            Not targeted for these credit scores
                         {% endif %}
                     </td>
                     {% endif %}

--- a/cfgov/tccp/jinja2/tccp/includes/apr_table.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_table.html
@@ -1,0 +1,58 @@
+{% from 'tccp/includes/fields.html' import apr, apr_range %}
+
+{% macro apr_table(
+    card,
+    apr_column_prefix,
+    apr_label=none,
+    show_comparison=false
+) %}
+<table class="o-table o-table--apr">
+    <thead>
+        <tr>
+            <th>Credit score</th>
+            <th>Median {{ apr_label or apr_column_prefix }} APR</th>
+            {% if show_comparison %}<th>Comparison to other cards</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for tier_value, tier_label, tier_column_suffix in credit_tier_lookup %}
+            {% if not tier_column_suffix %}{% continue %}{% endif -%}
+
+            {% set tier_column = apr_column_prefix ~ "_apr_" ~ tier_column_suffix -%}
+            {% set tier_apr_value = card[tier_column] -%}
+            {% set tier_apr_min = card[tier_column ~ "_min"] -%}
+            {% set tier_apr_max = card[tier_column ~ "_max"] -%}
+            {% set tier_apr_rating = card[tier_column ~ "_rating"] -%}
+
+            {%- set tier_apr_str = (
+                apr_range(tier_apr_min, tier_apr_max)
+                if (tier_apr_min is defined and tier_apr_max is defined)
+                else apr(tier_apr_value)
+            ) -%}
+
+            {% if tier_value in card.targeted_credit_tiers and tier_apr_str != 'N/A' %}
+                <tr>
+                    <td>{{ tier_label }}</td>
+                    <td>{{ tier_apr_str }}</td>
+                    {% if show_comparison %}
+                    <td>
+                        {% if tier_apr_rating is not none %}
+                            {% set label = apr_rating_lookup[tier_apr_rating] %}
+                            <span class="m-apr-rating--{{ label }}">
+                                {%- for i in range(tier_apr_rating + 1) %}
+                                    {{ svg_icon("dollar-round") }}
+                                {% endfor -%}
+
+                                Pay {{ label }} interest
+                            </span>
+                        {% else %}
+                            Not targeted for these credit scores
+                        {% endif %}
+                    </td>
+                    {% endif %}
+                </tr>
+            {% endif %}
+        {% endfor %}
+    </tbody>
+</table>
+{% endmacro %}

--- a/cfgov/tccp/models.py
+++ b/cfgov/tccp/models.py
@@ -1,6 +1,6 @@
 import re
 from functools import partial
-from itertools import product
+from itertools import chain, product
 
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
@@ -724,3 +724,17 @@ class CardSurveyData(models.Model):
             fee += 52 * self.weekly_fee
 
         return fee
+
+    @property
+    def purchase_apr_data_incomplete(self):
+        return self.purchase_apr_offered and not any(
+            chain(
+                *[
+                    [
+                        getattr(self, f"purchase_apr_{tier_column}_min"),
+                        getattr(self, f"purchase_apr_{tier_column}_max"),
+                    ]
+                    for _, tier_column in enums.CreditTierColumns
+                ]
+            )
+        )

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -14,6 +14,7 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
     purchase_apr_poor_max = serializers.FloatField()
     purchase_apr_poor_min = serializers.FloatField()
     purchase_apr_poor_rating = serializers.IntegerField()
+    purchase_apr_data_incomplete = serializers.BooleanField()
 
     class Meta:
         model = CardSurveyData

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -12,7 +12,7 @@ from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
 from rest_framework.response import Response
 
-from .enums import RewardsChoices, StateChoices
+from . import enums
 from .filter_backend import CardSurveyDataFilterBackend
 from .filterset import CardSurveyDataFilterSet
 from .forms import LandingPageForm
@@ -163,7 +163,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
                     "speed_bumps": SituationSpeedBumps(situations),
                     "purchase_apr_rating_labels": purchase_apr_rating_labels,
                     "purchase_apr_rating_counts": purchase_apr_rating_counts,
-                    "rewards_lookup": dict(RewardsChoices),
+                    "rewards_lookup": dict(enums.RewardsChoices),
                 }
             )
 
@@ -178,14 +178,14 @@ class CardListView(FlaggedViewMixin, ListAPIView):
         # database query but the size of the data is small enough that we
         # can just as easily do it in Python.
         return {
-            rating: len(
+            rating_label: len(
                 [
                     card
                     for card in cards
-                    if card["purchase_apr_for_tier_rating"] == i
+                    if card["purchase_apr_for_tier_rating"] == rating_score
                 ]
             )
-            for i, rating in enumerate(["less", "average", "more"])
+            for rating_score, rating_label in enums.PurchaseAPRRatings
         }
 
 
@@ -228,8 +228,10 @@ class CardDetailView(FlaggedViewMixin, RetrieveAPIView):
             response.data.update(
                 {
                     "breadcrumb_items": self.breadcrumb_items,
-                    "state_lookup": dict(StateChoices),
-                    "rewards_lookup": dict(RewardsChoices),
+                    "credit_tier_lookup": enums.CreditTierConciseColumnChoices,
+                    "apr_rating_lookup": dict(enums.PurchaseAPRRatings),
+                    "state_lookup": dict(enums.StateChoices),
+                    "rewards_lookup": dict(enums.RewardsChoices),
                 }
             )
 


### PR DESCRIPTION
This commit consolidates some of the Jinja logic in the TCCP card details page. It creates a new `apr_table` macro to remove some of the duplication in the current details page. It also avoids the need to hardcode the various credit tiers in the template, instead reusing the values from the backend.

There is more cleanup and consolidation to be done on this page, and this is just a first iteration.

## How to test this PR

To test, run a local server and visit cards under http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/.

Past PRs iterating on this page are a good place to see example URLs to test:

https://github.com/cfpb/consumerfinance.gov/pulls?q=is%3Apr+author%3Aniqjohnson+is%3Aclosed

@niqjohnson this could definitely use your Level 5 JinjaStar eyes on it. I've tried to go through a number of cards but there may be some edge cases I missed.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)