### PR TITLE
Max out current_page at `num_pages`

### DIFF
--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -207,7 +207,10 @@ class ActivityIndexPage(CFGOVPage):
         results_per_page = 10
         paginator = Paginator(payload["results"], results_per_page)
         current_page = self.search_form.cleaned_data["page"]
+        if current_page > paginator.num_pages:
+            current_page = paginator.num_pages
         paginated_page = paginator.page(current_page)
+
         context_update = {
             "facets": all_facets,
             "activities": paginated_page,


### PR DESCRIPTION
Currently, when bingbot is hitting pages WITH facets that are globally valid (1 - 14) but are invalid for that result set. This results in `EmptyPage` errors.

To swallow these, this simply sets the current page to the `num_pages` before attempted to pull an out of bounds page from the paginator.

## Testing
http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/?page=5&grade_level=4&grade_level=5 should render page 4 of the results instead of throw an `EmptyPage` error