### PR TITLE
Remove unneeded breadcrumbs CSS

### DIFF
--- a/cfgov/unprocessed/css/breadcrumbs.less
+++ b/cfgov/unprocessed/css/breadcrumbs.less
@@ -11,13 +11,6 @@
   padding-bottom: unit(15px / @base-font-size-px, rem);
   min-height: 33px;
 
-  &__crumbs {
-    display: block;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
   // Desktop and above.
   .respond-to-min(@bp-med-min, {
     padding-top: unit(30px / @base-font-size-px, rem);
@@ -33,13 +26,3 @@
     display: none;
   }
 });
-
-// TODO: When all full-width templates use layout-full.html this can be removed.
-.content__wrapper .m-breadcrumbs {
-  margin-left: unit(15px / @base-font-size-px, rem);
-
-  // Tablet only.
-  .respond-to-range(@bp-sm-min, @bp-sm-max, {
-    margin-left: unit(30px / @base-font-size-px, rem);
-  });
-}


### PR DESCRIPTION
## Removals

- Remove unneeded `m-breadcrumbs__crumbs` CSS.
- Remove unneeded `.content__wrapper .m-breadcrumbs` rule.

## How to test this PR

1. The only place a breadcrumb appears inside `content__wrapper` is on http://localhost:8000/owning-a-home/explore-rates/. After running `yarn build`, see that the breadcrumb is unaffected across screen sizes on that page.

## Note

We have a `m-breadcrumbs__crumb` class that has no styles attached to it. However, the breadcrumb can either be a `a` or `span` element, and this class is referenced in JS in TCCP and in cypress tests, so I decided to leave it so that the crumb can be referenced independent of the underlying HTML element in use.