### PR TITLE
Ask CFPB: Remove `answer-module` CSS

### DIFF
--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from wagtail.models import Page, Site
 
 from ask_cfpb.models import Answer, AnswerLandingPage, AnswerPage
-from ask_cfpb.wagtail_hooks import create_answer_id, editor_css
+from ask_cfpb.wagtail_hooks import create_answer_id
 
 
 class TestAskHooks(TestCase):
@@ -29,9 +29,6 @@ class TestAskHooks(TestCase):
         self.site_root.add_child(instance=self.english_landing_page)
         self.english_landing_page.save()
         self.english_landing_page.save_revision(user=self.user).publish()
-
-    def test_js_functions(self):
-        self.assertIn("css/question-tips.css", editor_css())
 
     def test_create_answer_id_english(self):
         """Test that English page creation generates an Ask ID and pages."""

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -1,19 +1,7 @@
-from django.conf import settings
-from django.utils.html import format_html
-
 from wagtail import hooks
 from wagtail.models import Page
 
 from ask_cfpb.models import Answer, AnswerPage
-
-
-@hooks.register("insert_global_admin_css")
-def editor_css():
-    return format_html(
-        '<link rel="stylesheet" href="'
-        + settings.STATIC_URL
-        + 'css/question-tips.css">\n'
-    )
 
 
 @hooks.register("after_create_page")

--- a/cfgov/unprocessed/css/on-demand/ask.less
+++ b/cfgov/unprocessed/css/on-demand/ask.less
@@ -198,40 +198,6 @@
     display: block;
     color: var(--gray-90);
   }
-
-  .answer-module {
-    border-top: 3px solid var(--green);
-    border-bottom: 1px solid @block--border-bottom;
-    padding: unit(@grid_gutter-width / 2 / @base-font-size-px, em) 0;
-    margin: unit(@grid_gutter-width / @base-font-size-px, em) 0;
-    color: var(--gray);
-
-    // Tablet and above.
-    .respond-to-min(@bp-sm-min, {
-      padding: unit(@grid_gutter-width / 2 / @base-font-size-px, em );
-    });
-
-    // Desktop and above.
-    .respond-to-min(@bp-med-min, {
-      width: 80%;
-    });
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h6 {
-      .heading-5();
-      margin-top: 0;
-      margin-bottom: unit(@grid_gutter-width / 3 / @base-font-size-px, em);
-    }
-
-    p:last-child,
-    ul:last-child,
-    ol:last-child {
-      margin-bottom: 0 !important;
-    }
-  }
 }
 
 /* Landing page */

--- a/cfgov/wagtailadmin_overrides/static/css/question-tips.css
+++ b/cfgov/wagtailadmin_overrides/static/css/question-tips.css
@@ -1,9 +1,0 @@
-/* CSS to style the Ask CFPB tip markup within the Wagtail rich text editor */
-
-.answer-module {
-  border-top: 3px solid #20aa3f;
-  border-bottom: 1px solid #b4b5b6;
-  padding: 0.9375em 0;
-  margin: 1.875em 0;
-  color: #5a5d61;
-}


### PR DESCRIPTION
`answer-module` has been removed and replaced with the inset tip on Ask pages. 

## Removals

- Remove `answer-module` CSS


## How to test this PR

1. PR checks should pass.