### PR TITLE
Bugfix: Update `u-layout_content-intro` to `u-layout-grid__content-intro`

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
@@ -7,7 +7,7 @@
           {% if language == 'ar' %} dir="rtl" {% endif %}>
 
         {% if self.content_intro().strip() %}
-            <div class="u-layout_content-intro">
+            <div class="u-layout-grid__content-intro">
                 {% block content_intro scoped -%}{%- endblock %}
             </div>
         {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/layout-full.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-full.html
@@ -11,7 +11,7 @@
           {% if language == 'ar' %} dir="rtl" {% endif %}>
 
         {% if self.content_intro().strip() %}
-            <div class="u-layout_content-intro">
+            <div class="u-layout-grid__content-intro">
                 {% block content_intro scoped -%}{%- endblock %}
             </div>
         {% endif %}


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/8164 set the class `u-layout_content-intro` in the markup, but it should have been a block of `u-layout-grid`, and with BEM updates should be `u-layout-grid__content-intro`

## Changes

- Update `u-layout_content-intro` to `u-layout-grid__content-intro`


## How to test this PR

1. Inspect https://www.consumerfinance.gov/ask-cfpb/ vs http://localhost:8000/ask-cfpb/ and see that this branch adds `max-width: 41.875rem;` to the paragraph in the hero.