### PR TITLE
PfC: Remove unused classes

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/13-school-results.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/13-school-results.html
@@ -74,7 +74,7 @@
                           'label': 'in the U.S.',
                           'value': 'cohortRankByHighestDegree',
                           'id': 'graduation-rate_us',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                     {{
@@ -83,7 +83,7 @@
                           'label': '<span>in <span data-school-item="stateName"></span></span>' | safe,
                           'value': 'cohortRankByState',
                           'id': 'graduation-rate_state',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                     {{
@@ -92,7 +92,7 @@
                           'label': '<span data-school-item="control"></span>',
                           'value': 'cohortRankByControl',
                           'id': 'graduation-rate_school-type',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                 </fieldset>
@@ -117,7 +117,7 @@
                           'label': 'in the U.S.',
                           'value': 'cohortRankByHighestDegree',
                           'id': 'transfer-to-graduation-rate_us',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                     {{
@@ -126,7 +126,7 @@
                           'label': '<span>in <span data-school-item="stateName"></span></span>' | safe,
                           'value': 'cohortRankByState',
                           'id': 'transfer-to-graduation-rate_state',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                 </fieldset>
@@ -160,7 +160,7 @@
                           'label': 'in the U.S.',
                           'value': 'cohortRankByHighestDegree',
                           'id': 'repayment-rate_us',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                     {{
@@ -169,7 +169,7 @@
                           'label': '<span>in <span data-school-item="stateName"></span></span>' | safe,
                           'value': 'cohortRankByState',
                           'id': 'repayment-rate_state',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                     {{
@@ -178,7 +178,7 @@
                           'label': '<span data-school-item="control"></span>',
                           'value': 'cohortRankByControl',
                           'id': 'repayment-rate_school-type',
-                          'class': 'm-form-field--lg-target btn__cohort'
+                          'class': 'm-form-field--lg-target'
                         })
                     }}
                 </fieldset>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -663,7 +663,7 @@
                         </div>
                     </div>
                     <div class="offer-part contributions
-                    column-well__wrapper--overflow-small">
+                                column-well__wrapper--overflow-small">
                         <div class="offer-part__intro">
                             <div class="offer-part__intro-wrapper">
                                 <div class="offer-part__intro-content">

--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.less
@@ -25,14 +25,6 @@
 }
 
 /* ==========================================================================
-   Expanded intros
-   ========================================================================== */
-
-.hero--intro {
-  background-color: transparent;
-}
-
-/* ==========================================================================
    Capital Framework Notification Styling
    from https://github.com/cfpb/consumerfinance.gov/blob/2c62c966880afba0d634df7062876abec3393661/cfgov/unprocessed/css/cf-notifications.less
    ========================================================================== */

--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/number-callout.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/number-callout.less
@@ -38,9 +38,4 @@
     padding-top: unit(10px / @base-font-size-px, em);
     margin-top: unit(30px / @base-font-size-px, em);
   }
-
-  &--divisor .number-callout__value > span {
-    border-bottom: 1px solid black;
-    padding-bottom: unit(5px / @base-font-size-px, em);
-  }
 }

--- a/cfgov/unprocessed/apps/paying-for-college/css/disclosures.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/disclosures.less
@@ -303,11 +303,6 @@
     margin-bottom: unit(5px / 18px, em);
   }
 
-  &__caption {
-    margin-bottom: 0;
-    font-size: @small-font-size-px;
-  }
-
   &__label-wrapper,
   .form-label__text-wrapper {
     // Tablet and above.
@@ -350,8 +345,7 @@
       text-align: right;
     }
 
-    &--percent,
-    &--time {
+    &--percent {
       width: unit(65px / @base-font-size-px, em);
       text-align: right;
     }
@@ -1480,18 +1474,18 @@
          .grid__column(8);
        });
   }
+}
 
-  &__answers,
-  &__controls {
-    margin-top: unit(20px / @base-font-size-px, em);
-    margin-bottom: unit(20px / @base-font-size-px, em);
+.continue__controls,
+.question__answers {
+  margin-top: unit(20px / @base-font-size-px, em);
+  margin-bottom: unit(20px / @base-font-size-px, em);
 
-    // Tablet and above.
-    .respond-to-min(@bp-sm-min, {
-         margin-top: unit(30px / @base-font-size-px, em);
-         margin-bottom: unit(30px / @base-font-size-px, em);
-       });
-  }
+  // Tablet and above.
+  .respond-to-min(@bp-sm-min, {
+    margin-top: unit(30px / @base-font-size-px, em);
+    margin-bottom: unit(30px / @base-font-size-px, em);
+  });
 }
 
 /* ==========================================================================
@@ -1812,15 +1806,6 @@
          display: block;
        });
   }
-}
-
-.change-list {
-  padding-left: 1em;
-
-  // Tablet and above.
-  .respond-to-min(@bp-sm-min, {
-       padding-left: 2em;
-     });
 }
 
 /* ==========================================================================

--- a/cfgov/unprocessed/apps/paying-for-college/css/print.css
+++ b/cfgov/unprocessed/apps/paying-for-college/css/print.css
@@ -41,14 +41,6 @@ body {
   margin-bottom: 6px;
 }
 
-.btn {
-  display: none;
-}
-
-.btn-close {
-  display: none;
-}
-
 .uc {
   text-transform: uppercase;
   font-weight: 500;


### PR DESCRIPTION
These classes appear to be unused.

## Removals

- PfC: Remove unused classes: `btn`, `btn-close`, `btn__cohort`, `hero--intro`, `change-list`, `number-callout--divisor`, `aid-form__caption`, `aid-form--time`, `question__controls`, `continue__answers`

## How to test this PR

1. PfC disclosure tool should be unchanged.

## Notes and todos

- There are other classes in the markup that are unused, such as `cost-of-attendance`, `private-loans-group`, `tuition-payment-plan`, but I've left them for now.
