### PR TITLE
Retirement: BEM fixes

### DIFF
--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -258,8 +258,7 @@
     }
   }
 
-  #age-selector-response,
-  #age-selector-response .thank-you {
+  #age-selector-response {
     display: none;
   }
 
@@ -303,7 +302,7 @@
     display: none;
   }
 
-  .step-two .lifestyle-btn__active {
+  .step-two .lifestyle-btn--active {
     background-color: var(--navy);
   }
 
@@ -362,16 +361,12 @@
     }
   }
 
-  .step-three .helpful-btn {
-    width: 4em;
-  }
-
   /* cf-notification */
   .m-notification {
     margin-bottom: 20px;
   }
 
-  .step-one .notification-input__warning {
+  .step-one .notification-input-warning {
     border-color: var(--gold);
   }
 

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -209,9 +209,9 @@ function initIndicator() {
 function highlightAgeFields(bool) {
   const $ageFields = $('#bd-day, #bd-month, #bd-year');
   if (bool) {
-    $ageFields.addClass('notification-input__warning');
+    $ageFields.addClass('notification-input-warning');
   } else {
-    $ageFields.removeClass('notification-input__warning');
+    $ageFields.removeClass('notification-input-warning');
   }
 }
 

--- a/cfgov/unprocessed/apps/retirement/js/views/questions-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/questions-view.js
@@ -11,8 +11,8 @@ function init() {
     const $container = $(this).closest('.question');
     const respTo = $(this).val();
 
-    $container.find('.lifestyle-btn').removeClass('lifestyle-btn__active');
-    $(this).addClass('lifestyle-btn__active');
+    $container.find('.lifestyle-btn').removeClass('lifestyle-btn--active');
+    $(this).addClass('lifestyle-btn--active');
 
     $container.find('.lifestyle-img').slideUp();
     $container


### PR DESCRIPTION
Additional cleanup followup to https://github.com/cfpb/consumerfinance.gov/pull/8274

## Removals

- Removes unused `thank-you` class.
- Remves unused `helpful-btn` class.


## Changes

-  Update `lifestyle-btn__active` to `lifestyle-btn--active` modifier.
- Update `notification-input__warning` to `notification-input-warning` block.


## How to test this PR

1. http://localhost:8000/consumer-tools/retirement/before-you-claim/ should show golden border around age inputs when date is incorrect (put in letters, for example).
 
