### PR TITLE
ROUT: Remove `super` class

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/css/print.less
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/css/print.less
@@ -14,8 +14,7 @@
     display: none;
   }
 
-  h1,
-  .super {
+  h1 {
     font-size: 18px;
     margin-top: 0;
   }


### PR DESCRIPTION
This class appears unused.

## Removals

- ROUT: Remove `super` class

## How to test this PR

1. PR checks should pass.
