### PR TITLE
Events page: BEM fixes + refactor to remove bespoke layout classes

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.less
+++ b/cfgov/unprocessed/css/on-demand/event.less
@@ -10,6 +10,8 @@
 /* Event template settings
    ========================================================================== */
 .t-event__details {
+  margin-bottom: unit(10px / @base-font-size-px, rem);
+
   // Tablet and above.
   .respond-to-min(@bp-sm-min, {
     .modification-date {
@@ -38,21 +40,6 @@
   });
 }
 
-/* Event-Post
-   ========================================================================== */
-
-.post--event {
-  > footer {
-    margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-  }
-
-  // Desktop and above.
-  .respond-to-min(@bp-med-min, {
-    padding-right: unit( @grid_gutter-width / @base-font-size-px, em );
-    margin-right: unit( @grid_gutter-width / @base-font-size-px, em );
-  });
-}
-
 /* Event-Media-Container
    ========================================================================== */
 
@@ -64,11 +51,8 @@
    ========================================================================== */
 
 .event-meta__description {
+  display: block;
   text-transform: none;
-
-  &--block {
-    display: block;
-  }
 }
 
 .event-meta__address {
@@ -176,56 +160,6 @@
   background: var(--green-20);
   color: var(--black);
   letter-spacing: 0;
-  padding: unit(1px / @base-font-size-px, em)
-    unit(10px / @base-font-size-px, em);
+  padding: unit(9px / @base-font-size-px, rem);
   text-align: center;
-}
-
-.post__heading {
-  .h2();
-  margin-bottom: unit(13px / @font-size, em);
-  // Tablet and above.
-  .respond-to-min(@bp-sm-min, {
-    .h1();
-  });
-}
-
-.post__dek {
-  .h4();
-  margin-bottom: unit(20px / @font-size, em);
-}
-
-.post__body {
-  .u-clearfix();
-  margin-top: unit(@grid_gutter-width / @base-font-size-px, em);
-
-  p ~ h1,
-  p ~ .h1 {
-    margin-top: unit(22px / @base-font-size-px, em);
-  }
-
-  p ~ h2,
-  p ~ .h2 {
-    margin-top: unit(31px / @base-font-size-px, em);
-  }
-
-  p ~ h3,
-  p ~ .h3 {
-    margin-top: unit(35px / @base-font-size-px, em);
-  }
-
-  p ~ h4,
-  p ~ .h4 {
-    margin-bottom: unit(7px / @base-font-size-px, em);
-  }
-
-  p ~ h5,
-  p ~ .h5 {
-    margin-bottom: unit(6px / @base-font-size-px, em);
-  }
-
-  p ~ h6,
-  p ~ .h6 {
-    margin-bottom: unit(5px / @base-font-size-px, em);
-  }
 }

--- a/cfgov/v1/jinja2/v1/events/_event-detail.html
+++ b/cfgov/v1/jinja2/v1/events/_event-detail.html
@@ -1,11 +1,11 @@
 {% import 'v1/includes/macros/time.html' as time %}
 
-<article class="post post--event">
+<article class="block block--flush-top">
     <header>
-        <h1 class="post__heading">
+        <h1 class="h1">
             {{ page.title | safe }}
         </h1>
-        <p class="post__dek">
+        <p class="h4">
             {{ page.body | safe }}
         </p>
         <div class="t-event__details">
@@ -29,7 +29,7 @@
         {% from 'events/_macros.html' import event_venue as event_venue with context %}
         {{ event_venue( page, event_state ) }}
     </header>
-    <div class="post__body">
+    <div class="block">
         {% if event_state == 'future' and page.live_stream_availability %}
         <aside class="event-status">
             <div class="event-status__body">
@@ -40,7 +40,7 @@
                       <strong>Available on live stream</strong>
                   </p>
                   <p class="event-meta">
-                      <span class="event-meta__description event-meta__description--block">
+                      <span class="event-meta__description">
                           Video link available:
                       </span>
                       {{ time.render(page.live_stream_date) }}

--- a/cfgov/v1/jinja2/v1/events/_event-detail.html
+++ b/cfgov/v1/jinja2/v1/events/_event-detail.html
@@ -1,14 +1,14 @@
 {% import 'v1/includes/macros/time.html' as time %}
 
-<article class="post post__event">
+<article class="post post--event">
     <header>
-        <h1 class="post_heading">
+        <h1 class="post__heading">
             {{ page.title | safe }}
         </h1>
-        <p class="post_dek">
+        <p class="post__dek">
             {{ page.body | safe }}
         </p>
-        <div class="t-event_details">
+        <div class="t-event__details">
             {% if page.latest_revision_created_at %}
             <div class="modification-date">
                 <span>Updated</span>
@@ -29,18 +29,18 @@
         {% from 'events/_macros.html' import event_venue as event_venue with context %}
         {{ event_venue( page, event_state ) }}
     </header>
-    <div class="post_body">
+    <div class="post__body">
         {% if event_state == 'future' and page.live_stream_availability %}
         <aside class="event-status">
-            <div class="event-status_body">
+            <div class="event-status__body">
                 <h1 class="u-visually-hidden">Event viewing details</h1>
-                <div class="event-status_livestream">
+                <div class="event-status__livestream">
                   <p>
                       {{ svg_icon('broadcast') }}
                       <strong>Available on live stream</strong>
                   </p>
                   <p class="event-meta">
-                      <span class="event-meta_description event-meta_description__block">
+                      <span class="event-meta__description event-meta__description--block">
                           Video link available:
                       </span>
                       {{ time.render(page.live_stream_date) }}
@@ -50,8 +50,8 @@
         </aside>
         {% elif ( event_state == 'present' and page.live_stream_availability ) %}
         <aside class="event-status">
-            <div class="event-status_body">
-                <div class="event-status_livestream">
+            <div class="event-status__body">
+                <div class="event-status__livestream">
                     <p>
                         {{ svg_icon('broadcast') }}
                         <strong>

--- a/cfgov/v1/jinja2/v1/events/_macros.html
+++ b/cfgov/v1/jinja2/v1/events/_macros.html
@@ -90,7 +90,7 @@
                 {% if ( event_state == 'present' ) %}
                 <button class="a-btn event-venue__live-btn">
                     {{ svg_icon('broadcast') }}
-                    <span class="event-venue__live-btn-text">Live</span>
+                    <span>Live</span>
                 </button>
                 {% endif %}
                 <h2 class="event-venue__heading">

--- a/cfgov/v1/jinja2/v1/events/_macros.html
+++ b/cfgov/v1/jinja2/v1/events/_macros.html
@@ -24,29 +24,29 @@
     {%- set suite  =  event.venue_suite  | default('', true) -%}
     {%- set name   =  event.venue_name   | default('', true) -%}
     {%- set zip    =  event.venue_zipcode | default('', true) -%}
-    <p class="event-meta_address h-adr">
+    <p class="event-meta__address h-adr">
         {%- macro _city() %}
-            <span class="event-meta_city p-locality">{{ city }}</span>
+            <span class="event-meta__city p-locality">{{ city }}</span>
         {% endmacro %}
 
         {%- macro _state() %}
-            <span class="event-meta_state p-state">{{ state }}</span>
+            <span class="event-meta__state p-state">{{ state }}</span>
         {% endmacro %}
 
         {%- macro _street() %}
-            <span class="event-meta_street p-street-address">{{ street }}</span>
+            <span class="event-meta__street p-street-address">{{ street }}</span>
         {% endmacro -%}
 
         {%- macro _suite() %}
-            <span class="event-meta_suite p-extended-address">{{ suite }}</span>
+            <span class="event-meta__suite p-extended-address">{{ suite }}</span>
         {% endmacro -%}
 
         {% macro _venue() %}
-            <span class="event-meta_venue p-extended-address">{{ name }}</span>
+            <span class="event-meta__venue p-extended-address">{{ name }}</span>
         {% endmacro %}
 
         {% macro _zip() %}
-            <span class="event-meta_zip p-postal-code">{{ zip }}</span>
+            <span class="event-meta__zip p-postal-code">{{ zip }}</span>
         {% endmacro %}
 
         {{
@@ -85,15 +85,15 @@
     {% set city_prefix_state = event.venue_city ~ state_prefix ~ event.venue_state %}
 
     <section class="event-venue">
-        <div class="event-venue_details">
-            <header class="event-venue_header">
+        <div class="event-venue__details">
+            <header class="event-venue__header">
                 {% if ( event_state == 'present' ) %}
-                <button class="a-btn event-venue_live-btn">
+                <button class="a-btn event-venue__live-btn">
                     {{ svg_icon('broadcast') }}
-                    <span class="event-venue_live-btn_text">Live</span>
+                    <span class="event-venue__live-btn-text">Live</span>
                 </button>
                 {% endif %}
-                <h2 class="event-venue_heading">
+                <h2 class="event-venue__heading">
                     {{ city_prefix_state }}
                 </h2>
             </header>
@@ -120,7 +120,7 @@
        or (event_state == 'past' and event.archive_video_id)
        or (event_state == 'present' and event.live_video_id) %}
         <footer>
-            <figure class="event-media_container">
+            <figure class="event-media__container">
                 {% if event_state == 'present' and event.live_video_id %}
                     {# DISPLAY LIVESTREAM #}
                     {% import 'v1/includes/organisms/video-player.html' as video_player with context %}
@@ -187,7 +187,7 @@
               block--border-top">
     <h2>Agenda</h2>
     <table class="o-table
-                  event-agenda_table
+                  event-agenda__table
                   o-table--stack-on-small
                   u-w100pct
                   block


### PR DESCRIPTION
Additional cleanup followup to https://github.com/cfpb/consumerfinance.gov/pull/8274 + refactoring to remove unnecessary classes.

## Changes

- Update BEM class names in the events templates.
- Remove `post` classes and replace with standard `block` classes. 
- Increase padding in modified date pill so it doesn't look so squashed vertically.
- Increase bottom margin on social media block, so it's not up against the description.
- Merge `event-meta__description--text` into `event-meta__description`.
- Remove unused `event-venue_live-btn_text` class.

## How to test this PR

1. Visit an event, such as http://localhost:8000/about-us/events/spring-2024-consumer-advisory-board-meeting/, and compare to production.


## Screenshots

Before:
<img width="852" alt="Screenshot 2024-04-30 at 9 23 06 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8a604587-86cc-4095-8312-3d1465470f90">

After:
<img width="853" alt="Screenshot 2024-04-30 at 9 23 00 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/aa802c93-ae60-489b-a7ac-fe54303304ce">
