### PR TITLE
Remove unused `datetime` elements

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/macros/time.html
+++ b/cfgov/v1/jinja2/v1/includes/macros/time.html
@@ -22,17 +22,17 @@
                 text_format=False) -%}
 <span class="datetime">
     {%- if show_value_for.date == true  -%}
-    <time class="datetime_date" datetime="{{ dt.format_datetime(datetime) }}">
+    <time datetime="{{ dt.format_datetime(datetime) }}">
         {{- dt.format_date(datetime, text_format) -}}
     </time>
     {%- endif -%}
 
     {%- if show_value_for.date == true and show_value_for.time == true %}
-    <span class="datetime_divider">@</span>
+    <span>@</span>
     {% endif %}
 
     {%- if show_value_for.time == true %}
-    <time class="datetime_time" datetime="{{ dt.format_datetime(datetime) }}">
+    <time datetime="{{ dt.format_datetime(datetime) }}">
         {% if show_value_for.timezone == true %}
         {{ dt.format_time(localtime(datetime), show_timezone=true) }}
         {% else %}

--- a/test/cypress/integration/components/filterable-lists/filterable-list-control-helpers.cy.js
+++ b/test/cypress/integration/components/filterable-lists/filterable-list-control-helpers.cy.js
@@ -16,7 +16,7 @@ export class FilterableListControl {
   }
 
   resultDate() {
-    return cy.get('.datetime_date:first');
+    return cy.get('.datetime time:first');
   }
 
   filterFromDate(date) {


### PR DESCRIPTION
There are no styles associated with these elements.

## Removals

- Remove unused `datetime` elements, `datetime_date`, `datetime_divider`, `datetime_time`

## How to test this PR

1. PR checks should pass.
