### PR TITLE
Remove `o-form__email-signup`

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
@@ -53,7 +53,7 @@
         </a>
     </div>
 {% else %}
-    <form class="o-form o-form__email-signup"
+    <form class="o-form"
           id="{{ 'o-form__email-signup_' ~ form_id }}"
           method="POST"
           action="/subscriptions/new/"

--- a/docs/functional-testing.md
+++ b/docs/functional-testing.md
@@ -41,7 +41,7 @@ export default class ConsumerTools {
   }
 
   signUp(email) {
-    cy.get('.o-form__email-signup').within(() => {
+    cy.get('.o-email-signup form').within(() => {
       cy.get('input:first').type(email);
       cy.get('button:first').click();
     });

--- a/test/cypress/integration/components/email-signup/email-signup-helpers.cy.js
+++ b/test/cypress/integration/components/email-signup/email-signup-helpers.cy.js
@@ -6,7 +6,7 @@ export class EmailSignup {
   }
 
   signUp(email) {
-    cy.get('.o-form__email-signup').within(() => {
+    cy.get('.o-email-signup form').within(() => {
       cy.get('input:first').type(email);
       cy.get('button:first').click();
     });

--- a/test/unit_tests/mocks/emailSignupSnippet.js
+++ b/test/unit_tests/mocks/emailSignupSnippet.js
@@ -8,7 +8,7 @@ export default `
     <p>
         Subscribe to our email newsletter. We will update you on new blogs.
     </p>
-    <form class="o-form o-form__email-signup"
+    <form class="o-form"
           id="o-form__email-signup_371b6fce64d1b6"
           method="POST"
           action="/subscriptions/new/"


### PR DESCRIPTION
This class appears to be unused, other than as a reference in the tests, which can have their query written another way.


## Removals

- Remove `o-form__email-signup`

## How to test this PR

1. PR checks should pass.
