### PR TITLE
Update link middleware to getBEM style

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -145,7 +145,7 @@ class LinkUtilsTests(SimpleTestCase):
             data_pretty_href = f'data-pretty-href="{expected_pretty_href}" '
 
         expected_html = (
-            '<a class="a-link a-link__icon" '
+            '<a class="a-link a-link--icon" '
             f"{data_pretty_href}"
             f'href="{url}">'
             '<span class="a-link__text">foo</span> '
@@ -205,7 +205,7 @@ class LinkUtilsTests(SimpleTestCase):
         path = "/about-us/blog/"
 
         expected_html = (
-            '<a class="a-link a-link__icon" '
+            '<a class="a-link a-link--icon" '
             f'href="{url}">'
             "<svg></svg>"
             '<span class="a-link__text">foo</span> '

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -252,7 +252,7 @@ class LinkUtilsTests(SimpleTestCase):
             '<a class="a-btn" '
             f'href="{url}">'
             "Click"
-            '<span class="a-btn_icon a-btn_icon__on-right">'
+            '<span class="a-btn__icon a-btn__icon--on-right">'
             f"{self.external_link_icon}"
             "</span>"
             "</a>"

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -148,7 +148,7 @@ class LinkUtilsTests(SimpleTestCase):
             '<a class="a-link a-link__icon" '
             f"{data_pretty_href}"
             f'href="{url}">'
-            '<span class="a-link_text">foo</span> '
+            '<span class="a-link__text">foo</span> '
             f"{self.external_link_icon}"
             "</a>"
         )
@@ -199,7 +199,7 @@ class LinkUtilsTests(SimpleTestCase):
         tag = (
             f'<a class="a-link" href="{url}">'
             "<svg></svg>"
-            '<span class="a-link_text">foo</span>'
+            '<span class="a-link__text">foo</span>'
             "</a>"
         )
         path = "/about-us/blog/"
@@ -208,7 +208,7 @@ class LinkUtilsTests(SimpleTestCase):
             '<a class="a-link a-link__icon" '
             f'href="{url}">'
             "<svg></svg>"
-            '<span class="a-link_text">foo</span> '
+            '<span class="a-link__text">foo</span> '
             f"{self.external_link_icon}"
             "</a>"
         )

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -171,7 +171,7 @@ def add_link_markup(tag, request_path):
     # the right side.
     if not spans and "a-btn" in class_attrs:
         span = soup.new_tag(
-            "span", **{"class": "a-btn_icon a-btn_icon__on-right"}
+            "span", **{"class": "a-btn__icon a-btn__icon--on-right"}
         )
         span.contents.append(icon_soup)
 

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -26,7 +26,7 @@ ASK_CFPB_LINKS = re.compile(
 
 LINK_ICON_CLASSES = ["a-link", "a-link__icon"]
 
-LINK_ICON_TEXT_CLASSES = ["a-link_text"]
+LINK_ICON_TEXT_CLASSES = ["a-link__text"]
 
 # Regular expression format string that will match any tag <tag_name> (that is
 # not self-closing) and group its contents.

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -24,7 +24,7 @@ ASK_CFPB_LINKS = re.compile(
     r"(https?:\/\/(www\.)?(cfpb|consumerfinance)\.gov)?\/ask\-cfpb\/([-\w]{1,244})-(en)-(?P<ask_id>\d{1,6})\/?$"  # noqa: E501
 )
 
-LINK_ICON_CLASSES = ["a-link", "a-link__icon"]
+LINK_ICON_CLASSES = ["a-link", "a-link--icon"]
 
 LINK_ICON_TEXT_CLASSES = ["a-link__text"]
 


### PR DESCRIPTION
Additional cleanup followup to https://github.com/cfpb/consumerfinance.gov/pull/8274 

The link with an icon middleware was adding the old-style BEM classes. This PR updates them to the new style.

## Changes

- Update `a-link_text` to `a-link__text`
- Update `a-link__icon` to `a-link--icon`
- Update `a-btn_icon a-btn_icon__on-right` to `a-btn__icon a-btn__icon--on-right`

## How to test this PR

1. PR checks should pass. A page such as http://localhost:8000/consumer-tools/retirement/before-you-claim/about/ should have links with an external link icon that do not have the underline under the icon.


## Screenshots

Before:
<img width="207" alt="Screenshot 2024-05-01 at 9 10 02 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/06e1ca1f-c775-40b3-935f-cefb19853982">

After:
<img width="240" alt="Screenshot 2024-05-01 at 9 09 51 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/4c025396-ae0b-4df6-b71b-01f190dd4c5d">

