### PR TITLE
Fix video player modifiers

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
@@ -45,14 +45,14 @@
     -%}
 
     <div class="o-video-player
-                o-video-player__youtube
+                o-video-player--youtube
                 {{- ' o-featured-content-module__visual' if is_fcm else '' }}"
          data-id="{{ video_id }}"
          data-src="{{ video_url }}"
          {{- ' data-custom-thumbnail' if thumbnail_url else '' }}>
         {{ caller() | safe if caller else '' }}
         <div class="o-video-player__video-container
-                    {{- ' o-video-player__video-container__flexible' if not is_fcm else '' }}
+                    {{- ' o-video-player__video-container--flexible' if not is_fcm else '' }}
                     u-show-on-video-playing">
             <div class="o-video-player__video-actions-container">
                 <div class="o-video-player__video-actions">


### PR DESCRIPTION
Additional cleanup followup to https://github.com/cfpb/consumerfinance.gov/pull/8274

Video player `o-video-player__video-container__flexible` should be `o-video-player__video-container--flexible` and was messing up the player dimensions.

## Changes

- Fix video player modifiers (`o-video-player__video-container--flexible` and `o-video-player--youtube`)


## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/do-buy-now-pay-later-bnpl-loans-have-fees-en-2118/ and play the video. It should be full sized.


## Screenshots

Before:
<img width="914" alt="Screenshot 2024-05-01 at 10 51 01 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/cbe3c1ad-9fa4-4266-a44f-09d6eb324afb">

After:
<img width="804" alt="Screenshot 2024-05-01 at 10 58 10 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d5b4b818-5466-4706-b356-8e13100fc6ef">

