### PR TITLE
Ask: Migrate `question_summary` to `question__summary` and `question_title` to `question__title`

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-search-results.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/answer-search-results.html
@@ -39,8 +39,8 @@
 
                 <div>
                 {% for question in results %}
-                    <article class="question_summary">
-                        <p class="question_title"><a href="{{ question[0] }}">{{ question[1] | safe }}</a></p>
+                    <article class="question__summary">
+                        <p class="question__title"><a href="{{ question[0] }}">{{ question[1] | safe }}</a></p>
                         <p>{{ question[2] }}</p>
                     </article>
                 {% endfor %}


### PR DESCRIPTION
Additional cleanup followup to https://github.com/cfpb/consumerfinance.gov/pull/8274

## Changes

- Ask: Migrate `question_summary` to `question__summary` and `question_title` to `question__title`


## How to test this PR

1. Ask search results should look more formatted than prod http://localhost:8000/ask-cfpb/search/?q=mortgage
 
