### PR TITLE
iRegs: fix typo in class list

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -171,7 +171,7 @@
                 </div>
             </form>
         </aside>
-        <div id="regs3k-results" class="content__main content--flush-all-on-smallentm">
+        <div id="regs3k-results" class="content__main content--flush-all-on-small content--flush-bottom">
             {% include 'search-regulations-results.html' %}
         </div>
     </div>


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/commit/9d49f38de5c2e44d5d6f1477c3999300b1a5c5bc#diff-bd7e59eefd89b569316bc5cc82be98df274e751750f5bfbce965a6fb29feeaf7R174 made a typo on the class list in iRegs search. 

## Changes

- iRegs: fix typo in class list


## How to test this PR

1. PR checks should pass. http://localhost:8000/rules-policy/regulations/search-regulations/results/?q=mortgage should have a flush margin on the bottom of the content area.
