### PR TITLE
Trim whitespace in link in text introduction

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/text-introduction.html
@@ -61,9 +61,9 @@
                 <a class="m-list__link"
                    href="{{ link.url }}"
                    {% if link.aria_label %}aria-label="{{ link.aria_label }}"{% endif %}>
-                   {% if link.is_link_boldface %}<strong>{% endif %}
-                   {{ link.text }}
-                   {% if link.is_link_boldface %}</strong>{% endif %}
+                   {%- if link.is_link_boldface -%}<strong>{%- endif -%}
+                   {{- link.text -}}
+                   {%- if link.is_link_boldface -%}</strong>{%- endif -%}
                 </a>
             </li>
         {% if loop.last %}</ul>{% endif %}


### PR DESCRIPTION

## Changes

- Trim whitespace in link in text introduction


## How to test this PR

1. Check the "Download the user guide" link on http://localhost:8000/consumer-tools/educator-tools/financial-well-being-resources/measure-and-score/


## Screenshots

Before:

<img width="287" alt="Screenshot 2024-05-01 at 12 50 46 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2c707baf-fcdb-41ad-afdc-a5107fad9766">


After:

<img width="265" alt="Screenshot 2024-05-01 at 12 50 23 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/feb5df6e-045a-4aa0-9ae9-ea5390f6033c">


