### PR TITLE
Fix video thumbnails

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
@@ -120,7 +120,7 @@
                 static( 'img/cfpb_video_cover_card_954x200.png' )
             %}
             <img class="o-video-player__image
-                        {{- ' o-video-player__image__thumbnail' if thumbnail_url else '' }}
+                        {{- ' o-video-player__image--thumbnail' if thumbnail_url else '' }}
                         {{- ' o-featured-content-module__img' if is_fcm else '' }}"
                  alt=""
                  src="{{ image_url }}">


### PR DESCRIPTION
Missed this in https://github.com/cfpb/consumerfinance.gov/pull/8368

## Changes

- Fix video thumbnails `o-video-player__image--thumbnail` modifier
 

## How to test this PR

1. PR checks should pass. Pages like http://localhost:8000/complaint/ should have a video thumbnail.