### PR TITLE
TCCP: Remove unused `media-query-no-invalid` stylelint config and autofix linter issues

### DIFF
--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -25,7 +25,9 @@ rule-empty-line-before -
   Custom setting that differs from stylelint-config-standard.
 selector-id-pattern -
   Turned off.
-  TODO: Turn on this rule and work out regex for BEM syntax.
+  TODO: Turn on this rule and work out regex for consistent IDs.
+selector-class-pattern -
+  Set to getBEM.com style BEM pattern.
 less/color-no-invalid-hex
 less/no-duplicate-variables
   Both of the above settings are turned off till
@@ -44,7 +46,6 @@ module.exports = {
     'declaration-property-value-no-unknown': null,
     'function-no-unknown': [true, { ignoreFunctions: ['unit'] }],
     'media-feature-range-notation': ['prefix'],
-    'media-query-no-invalid': null,
     'no-descending-specificity': null,
     'number-max-precision': 10,
     'rule-empty-line-before': [

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -358,10 +358,10 @@ html.js .o-filterable-list-results--partial {
   cursor: pointer;
   background-image: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 0.7),
-    rgba(255, 255, 255, 0.97),
-    rgba(255, 255, 255, 1)
+    rgba(255, 255, 255, 0%),
+    rgba(255, 255, 255, 70%),
+    rgba(255, 255, 255, 97%),
+    rgba(255, 255, 255, 100%)
   );
 }
 


### PR DESCRIPTION
Remove unused stylelint rule added in https://github.com/cfpb/consumerfinance.gov/pull/8167

## Removals

- Remove unused stylelint rule `media-query-no-invalid`.
- Autofix linter issues with gradient.

## How to test this PR

1. `yarn build` and the gradient at the bottom of the TCCP results list should be unchanged.
