### PR TITLE
PfC: Remove unused border

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
+++ b/cfgov/unprocessed/apps/paying-for-college/css/college-costs/financial-item.less
@@ -5,8 +5,6 @@
     .financial-item__label,
     .financial-item__value {
       display: inline-block;
-      border-width: 0;
-      border: solid transparent;
       box-sizing: border-box;
       margin-right: -0.25em;
       vertical-align: top;


### PR DESCRIPTION
This style was setting the `border-width` to zero, but then on the next line has a `border` shorthand that sets a transparent border. This means the shorthand is actually overriding the border width and making a 1px transparent border, which indents the content 1px. It didn't appear an existing border was added that this was overriding, so it seems like the border is unnecessary.

## Removals

- PfC: Remove unused border on `financial-item__label` and `financial-item__value`


## How to test this PR

1. `yarn build` and http://localhost:8000/paying-for-college/your-financial-path-to-graduation/ should not have borders on the items after the first step.


## Screenshots

Before, indented 1px

<img width="661" alt="Screenshot 2024-05-02 at 9 28 22 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/50915c97-190e-4e7e-b358-b14a8fdde776">

After, left-aligned
<img width="626" alt="Screenshot 2024-05-02 at 9 28 30 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/e0700689-6c7f-424b-b9c5-3d42964dc9fe">

