### PR TITLE
TCCP: Render card contact info using Python

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -132,34 +132,9 @@
                 </ul>
             {% endif %}
         </div>
-        <div class="o-contact-info">
-            {% if card.website_for_consumer %}
-                {# Some issuers submitted more than one URL for a card, always
-                    separated by a space. To catch those, we'll make a list and
-                    render a link for each URL. #}
-                {% set urls = card.website_for_consumer.split() %}
-                {% for url in urls %}
-                    {# TODO: Make this into a custom filter instead of rpartition #}
-                    {% with value = {
-                        "url": url,
-                        "text": url.rpartition("//")[-1].partition("/")[0]
-                            | replace('www.', '')}
-                    %}
-                        {% include "v1/includes/molecules/contact-hyperlink.html" %}
-                    {% endwith %}
-                {% endfor %}
-            {% endif %}
-            {% if card.telephone_number_for_consumers %}
-                {# TODO: Make this into a custom filter instead of this terribleness #}
-                {% set phone_number = card.telephone_number_for_consumers | replace('-', '') | replace('(', '') | replace(')', '') | replace(' ', '') %}
-                {% if phone_number.startswith('1') %}
-                    {% set phone_number = phone_number[1:] %}
-                {% endif %}
-                {% with value = {"phones": [{"number": phone_number}]} %}
-                    {% include "v1/includes/molecules/contact-phone.html" %}
-                {% endwith %}
-            {% endif %}
-        </div>
+
+        {{ render_contact_info(card) }}
+
         {% if not card.top_25_institution %}
             <div class="u-mt30">
                 {# TODO: Maybe unify this content with the card list version? #}

--- a/cfgov/tccp/jinja2/tccp/includes/contact_info.html
+++ b/cfgov/tccp/jinja2/tccp/includes/contact_info.html
@@ -1,0 +1,13 @@
+{% if urls or phone_numbers -%}
+<div class="o-contact-info">
+    {% for value in urls %}
+        {%- include "v1/includes/molecules/contact-hyperlink.html" -%}
+    {% endfor %}
+
+    {% for phone_number in phone_numbers %}
+        {% with value = {"phones": [{"number": phone_number}]} %}
+            {%- include "v1/includes/molecules/contact-phone.html" -%}
+        {% endwith %}
+    {%- endfor %}
+</div>
+{%- endif %}

--- a/cfgov/tccp/jinja2tags.py
+++ b/cfgov/tccp/jinja2tags.py
@@ -1,0 +1,60 @@
+import re
+from urllib.parse import urlparse
+
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+
+# Contact website schemes must be either http or https.
+_valid_website_scheme = re.compile("https?")
+
+
+# Contact website hosts must have at least one . in them.
+_valid_website_netloc = re.compile(r".+\..+")
+
+
+def _format_contact_website(url):
+    parsed_url = urlparse(url)
+
+    if _valid_website_scheme.match(
+        parsed_url.scheme or ""
+    ) and _valid_website_netloc.match(parsed_url.netloc or ""):
+        return {
+            "url": url,
+            "text": f"{parsed_url.scheme}://{parsed_url.netloc}",
+        }
+    else:
+        return {
+            "text": url,
+        }
+
+
+def _format_contact_phone_number(phone_number):
+    phone_number = "".join(
+        c for c in phone_number if c.isalpha() or c.isdigit()
+    )
+    return phone_number[phone_number.startswith("1") :]
+
+
+def _format_contact_info(card):
+    def fmt_list(format_fn, value):
+        return list(map(format_fn, (value or "").split()))
+
+    return {
+        "urls": fmt_list(
+            _format_contact_website, card["website_for_consumer"]
+        ),
+        "phone_numbers": fmt_list(
+            _format_contact_phone_number,
+            card["telephone_number_for_consumers"],
+        ),
+    }
+
+
+def render_contact_info(card):
+    return mark_safe(
+        render_to_string(
+            "tccp/includes/contact_info.html",
+            _format_contact_info(card),
+        )
+    )

--- a/cfgov/tccp/jinja2tags.py
+++ b/cfgov/tccp/jinja2tags.py
@@ -6,11 +6,15 @@ from django.utils.safestring import mark_safe
 
 
 # Contact website schemes must be either http or https.
-_valid_website_scheme = re.compile("https?")
+_valid_website_scheme = re.compile(r"https?")
 
 
 # Contact website hosts must have at least one . in them.
 _valid_website_netloc = re.compile(r".+\..+")
+
+
+# We strip www. from the beginning of displayed URLs.
+_leading_www = re.compile(r"^www\.")
 
 
 def _format_contact_website(url):
@@ -19,10 +23,7 @@ def _format_contact_website(url):
     if _valid_website_scheme.match(
         parsed_url.scheme or ""
     ) and _valid_website_netloc.match(parsed_url.netloc or ""):
-        return {
-            "url": url,
-            "text": f"{parsed_url.scheme}://{parsed_url.netloc}",
-        }
+        return {"url": url, "text": _leading_www.sub("", parsed_url.netloc)}
     else:
         return {
             "text": url,

--- a/cfgov/tccp/tests/test_jinja2tags.py
+++ b/cfgov/tccp/tests/test_jinja2tags.py
@@ -1,0 +1,78 @@
+import re
+
+from django.test import SimpleTestCase
+
+from tccp.jinja2tags import (
+    _format_contact_phone_number,
+    _format_contact_website,
+    render_contact_info,
+)
+
+
+class FormatContactPhoneNumberTests(SimpleTestCase):
+    def test_phone_number_formatting(self):
+        for value, expected in [
+            ("FOOBAR", "FOOBAR"),
+            ("888-FOO-BAR", "888FOOBAR"),
+            ("18885551234", "8885551234"),
+            ("(800) 555-1234", "8005551234"),
+        ]:
+            with self.subTest(value=value, expected=expected):
+                self.assertEqual(_format_contact_phone_number(value), expected)
+
+
+class FormatContactWebsiteTests(SimpleTestCase):
+    def test_website_formatting(self):
+        for value, expected in [
+            (
+                "http://example.com",
+                {"text": "http://example.com", "url": "http://example.com"},
+            ),
+            (
+                "https://example.com",
+                {"text": "https://example.com", "url": "https://example.com"},
+            ),
+            (
+                "https://www.example.com",
+                {
+                    "text": "https://www.example.com",
+                    "url": "https://www.example.com",
+                },
+            ),
+            (
+                "https://example.com/path/",
+                {
+                    "text": "https://example.com",
+                    "url": "https://example.com/path/",
+                },
+            ),
+            (
+                "invalid://example.com",
+                {
+                    "text": "invalid://example.com",
+                },
+            ),
+            (
+                "example.com",
+                {
+                    "text": "example.com",
+                },
+            ),
+        ]:
+            with self.subTest(value=value, expected=expected):
+                self.assertEqual(_format_contact_website(value), expected)
+
+
+class TestRenderContactInfo(SimpleTestCase):
+    def test_render(self):
+        html = render_contact_info(
+            {
+                "website_for_consumer": "https://example.com foo.com",
+                "telephone_number_for_consumers": "212-555-1234",
+            }
+        )
+
+        self.assertEqual(len(re.findall("m-contact-hyperlink", html)), 2)
+        self.assertIn('<a href="https://example.com">', html)
+        self.assertNotIn('<a href="foo.com">', html)
+        self.assertEqual(len(re.findall("m-contact-phone", html)), 1)

--- a/cfgov/tccp/tests/test_jinja2tags.py
+++ b/cfgov/tccp/tests/test_jinja2tags.py
@@ -26,23 +26,30 @@ class FormatContactWebsiteTests(SimpleTestCase):
         for value, expected in [
             (
                 "http://example.com",
-                {"text": "http://example.com", "url": "http://example.com"},
+                {"text": "example.com", "url": "http://example.com"},
             ),
             (
                 "https://example.com",
-                {"text": "https://example.com", "url": "https://example.com"},
+                {"text": "example.com", "url": "https://example.com"},
             ),
             (
                 "https://www.example.com",
                 {
-                    "text": "https://www.example.com",
+                    "text": "example.com",
                     "url": "https://www.example.com",
+                },
+            ),
+            (
+                "https://subdomain.example.com",
+                {
+                    "text": "subdomain.example.com",
+                    "url": "https://subdomain.example.com",
                 },
             ),
             (
                 "https://example.com/path/",
                 {
-                    "text": "https://example.com",
+                    "text": "example.com",
                     "url": "https://example.com/path/",
                 },
             ),

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -16,6 +16,7 @@ from . import enums
 from .filter_backend import CardSurveyDataFilterBackend
 from .filterset import CardSurveyDataFilterSet
 from .forms import LandingPageForm
+from .jinja2tags import render_contact_info
 from .models import CardSurveyData
 from .serializers import CardSurveyDataListSerializer, CardSurveyDataSerializer
 from .situations import Situation, SituationFeatures, SituationSpeedBumps
@@ -232,6 +233,7 @@ class CardDetailView(FlaggedViewMixin, RetrieveAPIView):
                     "apr_rating_lookup": dict(enums.PurchaseAPRRatings),
                     "state_lookup": dict(enums.StateChoices),
                     "rewards_lookup": dict(enums.RewardsChoices),
+                    "render_contact_info": render_contact_info,
                 }
             )
 

--- a/cfgov/v1/jinja2/v1/includes/molecules/contact-hyperlink.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/contact-hyperlink.html
@@ -21,8 +21,8 @@
         Web
     </span>
     <p>
-        <a href="{{ value.url }}">
-            {{ value.text | default( value.url, true ) }}
-        </a>
+        {% if value.url %}<a href="{{ value.url }}">{% endif %}
+            {{- value.text | default( value.url, true ) -}}
+        {% if value.url %}</a>{% endif %}
     </p>
 </div>


### PR DESCRIPTION
The TCCP card details template currently includes various logic to format card contact information (URLs or phone numbers). This commit pulls the logic out of Jinja and into Python.

See tests in cfgov/tccp/tests/test_jinja2tags.py for examples, but the logic works as follows for URLs:

Valid schemes are http:// and https://. Valid hostnames have to have at least one ".", e.g. "https://foo" is not a valid hostname. If a URL has both of these, it is rendered as a link, with its visible text equal only to the domain, e.g. a link to https://example.com/path/ gets displayed as ~~https://~~ example.com. ~~One change from the current logic here is that we no longer strip a leading "www." from a domain, as we can't make assumptions that bare domains will work.~~

The logic works as follows for phone numbers:

Valid characters are alphanumeric, e.g. a number like "(800) 555-CFPB" will be converted to "800555CFPB" before being rendered.

Both URLs and telephone numbers support the case where the card has multiple values separated by whitespace. In both cases, each contact is listed as a separate contact info with its own icon.

## How to test this PR

Some example URLs to test with the current TCCP dataset:

-  http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/unify-financial-federal-credit-union-unify-fixed-rate-classic/ (basic example showing truncated URL and phone number)
- http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/jpmorgan-chase-bank-national-association-sapphire-reserve/ (note neither of these are clickable, this is intended as neither are valid URLs)
- http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/synchrony-financial-tjx-rewards-platinum-mastercard/ (note that the first URL is purposefully not clickable, but we display it in its entirety)

## Notes and todos

We've discussed changing phone number rendering to make numbers clickable; I'm leaving that change for a future PR that will address this capability holistically for the entire website.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets