### PR TITLE
Make Contact snippets previewable

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/contact-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/contact-preview.html
@@ -1,0 +1,9 @@
+{% extends "v1/layouts/layout-full.html" %}
+
+{% block content_main %}
+<div class="block block--flush-top">
+    {% with value = {"contact": object} %}
+        {% include "v1/includes/organisms/sidebar-contact-info.html" %}
+    {% endwith %}
+</div>
+{% endblock %}

--- a/cfgov/v1/models/snippets.py
+++ b/cfgov/v1/models/snippets.py
@@ -3,7 +3,7 @@ from django.db import models
 
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField, StreamField
-from wagtail.models import RevisionMixin
+from wagtail.models import PreviewableMixin, RevisionMixin
 
 from v1.atomic_elements import molecules
 from v1.atomic_elements.molecules import Notification
@@ -36,7 +36,7 @@ class ReusableText(RevisionMixin, models.Model):
         return self.title
 
 
-class Contact(models.Model):
+class Contact(PreviewableMixin, models.Model):
     heading = models.CharField(
         verbose_name=("Heading"),
         max_length=255,
@@ -66,6 +66,9 @@ class Contact(models.Model):
 
     class Meta:
         ordering = ["heading"]
+
+    def get_preview_template(self, request, mode_name):
+        return "v1/includes/organisms/contact-preview.html"
 
 
 class EmailSignUp(RevisionMixin, models.Model):

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
+
 from django.test import TestCase
 
 from wagtail.models import Site
@@ -13,11 +15,31 @@ from v1.models import (
 )
 
 
-class TestUnicodeCompatibility(TestCase):
+class ContactTests(TestCase):
     def test_unicode_contact_heading_unicode(self):
         contact = Contact(heading="Unicod\xeb")
         self.assertEqual(str(contact), "Unicod\xeb")
         self.assertIsInstance(str(contact), str)
+
+    def test_contact_preview(self):
+        contact = Contact(
+            heading="Contact name",
+            contact_info=json.dumps(
+                [
+                    {
+                        "type": "hyperlink",
+                        "value": {
+                            "url": "https://example.com",
+                            "text": "Example",
+                        },
+                    }
+                ]
+            ),
+        )
+
+        response = contact.make_preview_request()
+        self.assertContains(response, "<h3>Contact name</h3>")
+        self.assertContains(response, 'href="https://example.com"')
 
 
 class TestModelStrings(TestCase):


### PR DESCRIPTION
This commit makes our Contact snippet type previewable in the Wagtail admin. When editing a Contact, the right panel now allows Wagtail users to preview what the snippet will look like using our SidebarContactInfo module.

## How to test this PR

Run a local server, and edit a Contact snippet. Using a production dump, you can try these URLs to see a variety of contacts:

- http://localhost:8000/admin/snippets/v1/contact/edit/5/
- http://localhost:8000/admin/snippets/v1/contact/edit/18/
- http://localhost:8000/admin/snippets/v1/contact/edit/26/

## Screenshots

<img width="1487" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/dd1a439c-7f70-47fb-83be-bcd10baa0fe3">

## Notes and todos

I'm planning on proposing a change to make Contact phone numbers clickable links, and wanted to add this functionality to make that change easier to review. I'm opening this first as a separate PR independent from that proposal because I hope it'll be generally useful either way.

As an aside, the object usage feature (added in Wagtail 5.0 I think) has proven to be very useful and convenient when looking at snippets! When looking at a contact with unexpected data (for example http://localhost:8000/admin/snippets/v1/contact/edit/44/) it's now very easy to click on the "i" icon and see if or where a particular snippet is being used.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)