### PR TITLE
Events: Fix contrast in event-meta

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.less
+++ b/cfgov/unprocessed/css/on-demand/event.less
@@ -95,7 +95,7 @@
   }
 
   .event-meta {
-    color: var(--gray-40);
+    color: var(--gray-90);
   }
 }
 


### PR DESCRIPTION
The existing live stream inset box is very low contrast and fails color accessibility checks.

## Changes

- Events: Fix contrast in event-meta by darkening gray from gray-40 to gray-90.


## How to test this PR

1. Go to a future event in Wagtail and check the streamable option to get the live stream inset that has the `event-meta__body` class that sets the color.


## Screenshots

Before:
<img width="285" alt="Screenshot 2024-05-03 at 1 40 15 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ea582c6b-d2d3-4e4d-817b-8bb7713aea58">

After:
<img width="306" alt="Screenshot 2024-05-03 at 1 41 40 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/5dc26e3f-d580-401c-8b7e-00cdfb21de2f">
