### PR TITLE
Remove/update `m-form-field` modifiers

### DIFF
--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
@@ -3,7 +3,7 @@
                 content-l__col-1-2">
         <div class="o-form__group">
             <fieldset class="o-form__fieldset">
-                <div class="m-form-field m-form-field__select">
+                <div class="m-form-field">
                     <label class="a-label a-label--heading" for="id_geo">
                         Geographic area
                     </label>

--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -99,7 +99,7 @@ home price, down payment, and more can affect mortgage interest rates.
                     <h2>
                         Check status of properties for loans extended in
                         <small class="u-inline-select">
-                            <div class="m-form-field m-form-field__select">
+                            <div class="m-form-field">
                                 <label class="u-visually-hidden"
                                        for="year">
                                     Year of loan

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/12-affording-your-loan.html
@@ -71,7 +71,7 @@
     <div data-state-based-visibility="expenses-monthly-budget">
          <h2>2. See if the monthly payment fits in an average monthly budget for this <span data-state-based-visibility="no-program-selected">school</span><span data-state-based-visibility="program-is-selected">program</span>'s salary and region</h2>
 
-        <div class="m-form-field m-form-field__select">
+        <div class="m-form-field">
             <label class="a-label a-label--heading" for="expenses__region">
                 What part of the US do you plan to live in after graduation?
             </label>

--- a/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
+++ b/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
@@ -237,7 +237,7 @@
                   {% endfor %}
                   <h3>Select files to attach</h3>
                   <p>Please select up to 6 files. The total file size must not exceed 6MB. We accept all image files, including .jpg, .png, .pdf, .gif and .eps.</p>
-                  <div class="m-form-field m-form-field__file-input">
+                  <div class="m-form-field m-form-field--file-input">
                       <!-- Actual hidden file upload component. -->
                       <label>
                           <input class="u-hidden" multiple type="file" name="supporting_documentation" id="supporting_documentation">

--- a/cfgov/privacy/jinja2/privacy/privacy-styles.html
+++ b/cfgov/privacy/jinja2/privacy/privacy-styles.html
@@ -27,7 +27,7 @@
     #mail-target.open {
       display: block;
     }
-    .m-form-field__file-input{
+    .m-form-field--file-input{
       margin-top: 1.5em;
       margin-bottom: -1em;
     }

--- a/cfgov/privacy/jinja2/privacy/records-access-form.html
+++ b/cfgov/privacy/jinja2/privacy/records-access-form.html
@@ -211,7 +211,7 @@
                   {% endfor %}
                   <h3>Select files to attach</h3>
                   <p>Please select up to 6 files. The total file size must not exceed 6MB. We accept all image files, including .jpg, .png, .pdf, .gif and .eps.</p>
-                  <div class="m-form-field m-form-field__file-input">
+                  <div class="m-form-field m-form-field--file-input">
                       <!-- Actual hidden file upload component. -->
                       <label>
                           <input class="u-hidden" multiple type="file" name="supporting_documentation" id="supporting_documentation">

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -910,7 +910,7 @@
                     {{ _("(This will not affect your Social Security account or eligibility and it will not begin an application.)") }}
                 </small>
             </p>
-            <div class="m-form-field m-form-field__select">
+            <div class="m-form-field">
                 <div class="a-select">
                     <select id="retirement-age-selector" aria-labelledby="retirement-selector-label">
                         <option value="">{{ _("Choose age") }}</option>

--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -2,7 +2,7 @@
 {%- import 'v1/includes/molecules/notification.html' as notification -%}
 
 {%- macro render_field(field, field_type) -%}
-<div class="m-form-field m-form-field__{{ field_type }}">
+<div class="m-form-field{{ ' m-form-field--checkbox' if field_type == 'checkbox' }}">
     {# Checkboxes render the label after the input. #}
     {% if field_type == "checkbox" -%}
         {{ field }}

--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -85,7 +85,7 @@
         <form action="." method="get">
 
             <div class="o-form__group">
-                <div class="m-form-field m-form-field__select">
+                <div class="m-form-field">
                     <label
                         class="a-label a-label--heading"
                         for="{{ form.credit_tier.id_for_label}}"
@@ -104,7 +104,7 @@
             </div>
 
             <div class="o-form__group">
-                <div class="m-form-field m-form-field__select">
+                <div class="m-form-field">
                     <label
                         class="a-label a-label--heading"
                         for="{{ form.location.id_for_label}}"

--- a/cfgov/unprocessed/css/molecules/file-input.less
+++ b/cfgov/unprocessed/css/molecules/file-input.less
@@ -1,4 +1,4 @@
-.m-form-field__file-input {
+.m-form-field--file-input {
   position: relative;
   display: grid;
   grid-template-columns: auto auto 1fr;

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/data-filters.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/data-filters.js
@@ -46,7 +46,7 @@ function makeSelectFilterDOM(options, chartNode, filter) {
   )[0];
 
   const wrapper = document.createElement('div');
-  wrapper.className = 'filter-wrapper m-form-field m-form-field__select';
+  wrapper.className = 'filter-wrapper m-form-field';
 
   const label = document.createElement('label');
   label.className = 'a-label a-label--heading';

--- a/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
@@ -17,7 +17,7 @@
     ========================================================================== #}
 
 {% macro _filter_selectable(type, label_text, id, name, value, required=None, group=None) %}
-    <li class="m-form-field m-form-field__{{ type }}">
+    <li class="m-form-field m-form-field--{{ type }}">
         <input class="a-{{ type }}"
                type="{{ type }}"
                value="{{ value }}"

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
@@ -54,7 +54,7 @@
                 </div>
             </fieldset>
             <fieldset class="content-l__col content-l__col-1-2">
-                <div class="m-form-field m-form-field__select mp-line-chart-select-container u-mb30" id="mp-line-chart-state-container" style="display:none">
+                <div class="m-form-field mp-line-chart-select-container u-mb30" id="mp-line-chart-state-container" style="display:none">
                     <label class="a-label" for="mp-line-chart-state"><h4 id="mp-state-dropdown-title">Select state</h4></label>
                     <div class="a-select">
                         <select id="mp-line-chart-state">
@@ -123,7 +123,7 @@
                       States are only listed if their non-metro area has sufficient data.
                     </p>
                 </div>
-                <div class="m-form-field m-form-field__select mp-line-chart-select-container" id="mp-line-chart-metro-container" style="display:none">
+                <div class="m-form-field mp-line-chart-select-container" id="mp-line-chart-metro-container" style="display:none">
                     <label class="a-label" for="mp-line-chart-metro"><h4>Select metro area</h4></label>
                     <div class="a-select">
                         <select id="mp-line-chart-metro">
@@ -137,7 +137,7 @@
                       target="_blank" rel="noopener noreferrer">Learn why.</a>
                     </p>
                 </div>
-                <div class="m-form-field m-form-field__select mp-line-chart-select-container u-mb30" id="mp-line-chart-county-container" style="display:none">
+                <div class="m-form-field mp-line-chart-select-container u-mb30" id="mp-line-chart-county-container" style="display:none">
                     <label class="a-label" for="mp-line-chart-county"><h4>Select county</h4></label>
                     <div class="a-select">
                         <select id="mp-line-chart-county">

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
@@ -43,7 +43,7 @@
                 </div>
             </fieldset>
             <fieldset class="content-l__col content-l__col-1-2">
-                <div class="m-form-field m-form-field__select mp-map-select-container" id="mp-map-state-container">
+                <div class="m-form-field mp-map-select-container" id="mp-map-state-container">
                     <label class="a-label" for="mp-map-state"><h4>Select state to zoom</h4></label>
                     <div class="a-select">
                         <select id="mp-map-state">
@@ -102,7 +102,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="m-form-field m-form-field__select mp-map-select-container" id="mp-map-metro-container" style="display:none">
+                <div class="m-form-field mp-map-select-container" id="mp-map-metro-container" style="display:none">
                     <label class="a-label u-mt30" for="mp-map-metro"><h4>Select metro or non-metro area to highlight</h4></label>
                     <div class="a-select">
                         <select id="mp-map-metro">
@@ -110,7 +110,7 @@
                         </select>
                     </div>
                 </div>
-                <div class="m-form-field m-form-field__select mp-map-select-container" id="mp-map-county-container" style="display:none">
+                <div class="m-form-field mp-map-select-container" id="mp-map-county-container" style="display:none">
                     <label class="a-label u-mt30" for="mp-map-county"><h4>Select county to highlight</h4></label>
                     <div class="a-select">
                         <select id="mp-map-county" disabled>
@@ -122,7 +122,7 @@
             <fieldset class="content-l">
                 <h4 class="u-mt30">Select month and year to display</h4>
                 <div class="content-l__col content-l__col-1-2 u-m0">
-                    <div class="m-form-field m-form-field__select" id="mp-map-month-container">
+                    <div class="m-form-field" id="mp-map-month-container">
                         <label class="a-label u-mb15" for="mp-map-month">Month</label>
                         <div class="a-select">
                             <select id="mp-map-month">
@@ -143,7 +143,7 @@
                     </div>
                 </div>
                 <div class="content-l__col content-l__col-1-2">
-                    <div class="m-form-field m-form-field__select" id="mp-map-year-container">
+                    <div class="m-form-field" id="mp-map-year-container">
                         <label class="a-label u-mb15" for="mp-map-year">Year</label>
                         <div class="a-select">
                             <select id="mp-map-year">


### PR DESCRIPTION
There are no styles associated with `m-form-field__selectable` (should be `m-form-field--selectable`). This was likely added for consistency because we do have `m-form-field--checkbox` and `m-form-field--radio`, however, we don't have a modifier for every single type of form input (e.g. text inputs), so it's probably better if we add this back if its needed. There's an argument this could be helpful in the crawler, but in that case the internal select `a-select` or `m-multiselect` classes could be queried instead.

## Removals

- Unstyled `m-form-field__select` class.


## Changes

- Update `m-form-field__file-input` to `m-form-field--file-input` because it's a modifier not an element.


## How to test this PR

1. PR checks should pass.
