### PR TITLE
Remove unused `icon-link` class | update jump link class

### DIFF
--- a/cfgov/housing_counselor/templates/housing_counselor/pdf_selfcontained.html
+++ b/cfgov/housing_counselor/templates/housing_counselor/pdf_selfcontained.html
@@ -262,7 +262,7 @@
                                     <div class="col">
                                         <h2 class="cfpb_visually_hide">Agency</h2>
                                         <div class="hud_hca_api_counselor">
-                                            <a href="{{ counselor.weburl }}" class="icon-link icon-link__external-link"><span class="icon-link_text">{{ counselor.nme }}</span></a>
+                                            <a href="{{ counselor.weburl }}">{{ counselor.nme }}</a>
                                         </div>
                                         <div class="hud_hca_api_counselor_address">
                                             <span class="hud_hca_api_adr">
@@ -275,7 +275,7 @@
                                         </div>
                                         <div class="hud_hca_api_counselor_meta">
                                             <span class="hud_hca_api_results_listing_title">Website: <span class="hud_hca_api_site">
-                                                <a href="{{ counselor.weburl }}" class="icon-link icon-link__external-link"><span class="icon-link_text">{{ counselor.weburl }}</span></a>
+                                                <a href="{{ counselor.weburl }}">{{ counselor.weburl }}</a>
                                             </span></span>
                                             <span class="hud_hca_api_results_listing_title">Phone: <span class="hud_hca_api_tel">{{ counselor.phone1}}</span></span>
                                             <span class="hud_hca_api_results_listing_title">Email Address: <span class="hud_hca_api_email">

--- a/cfgov/jinja2/know-before-you-owe/compare/index.html
+++ b/cfgov/jinja2/know-before-you-owe/compare/index.html
@@ -96,8 +96,8 @@
                 <img src="https://files.consumerfinance.gov/f/201207_cfpb_img_t-gfe3.png" alt="Loan estimate, before, Good Faith Estimate, page 3" title="Click to enlarge"> </a>
             </div>
             <p>
-                <a href="https://files.consumerfinance.gov/f/201207_combined_til_gfe.pdf" class="jump-link icon-link icon-link__download">
-                <span class="jump-link_text">View these two forms as a PDF</span></a>
+                <a href="https://files.consumerfinance.gov/f/201207_combined_til_gfe.pdf" class="a-link a-link--jump a-link--icon-after-text">
+                <span class="a-link__text">View these two forms as a PDF</span></a>
             </p>
         </div>
         <!-- /.grid_col-6 -->
@@ -113,8 +113,8 @@
                 <img src="https://files.consumerfinance.gov/f/201311_cfpb_le_small_page3.png" alt="Loan Estimate page 3" title="Click to enlarge"> </a>
             </div>
             <p>
-                <a href="https://files.consumerfinance.gov/f/201311_cfpb_kbyo_loan-estimate.pdf" class="jump-link icon-link icon-link__download">
-                <span class="jump-link_text">View the Loan Estimate as a PDF</span></a>
+                <a href="https://files.consumerfinance.gov/f/201311_cfpb_kbyo_loan-estimate.pdf" class="a-link a-link--jump a-link--icon-after-text">
+                <span class="a-link__text">View the Loan Estimate as a PDF</span></a>
             </p>
         </div>
     </div>
@@ -136,8 +136,8 @@
                 <img src="https://files.consumerfinance.gov/f/201207_cfpb_img_t-hud1_3.png" alt="Closing disclosure, before, HUD-1, page 3" title="Click to enlarge"> </a>
             </div>
             <p>
-                <a href="https://files.consumerfinance.gov/f/201207_combined_til_hud1.pdf" class="jump-link icon-link icon-link__download">
-                <span class="jump-link_text">View these two forms as a PDF</span></a>
+                <a href="https://files.consumerfinance.gov/f/201207_combined_til_hud1.pdf" class="a-link a-link--jump a-link--icon-after-text">
+                <span class="a-link__text">View these two forms as a PDF</span></a>
             </p>
         </div>
         <div class="kbyo-compare-col">
@@ -156,8 +156,8 @@
                 <img src="https://files.consumerfinance.gov/f/201311_cfpb_cd_small_page5.png" alt="Closing Disclosure page 5" title="Click to enlarge"> </a>
             </div>
             <p>
-                <a href="https://files.consumerfinance.gov/f/201311_cfpb_kbyo_closing-disclosure.pdf" class="jump-link icon-link icon-link__download">
-                <span class="jump-link_text">View the Closing Disclosure as a PDF</span></a>
+                <a href="https://files.consumerfinance.gov/f/201311_cfpb_kbyo_closing-disclosure.pdf" class="a-link a-link--jump a-link--icon-after-text">
+                <span class="a-link__text">View the Closing Disclosure as a PDF</span></a>
             </p>
         </div>
     </div>

--- a/cfgov/jinja2/know-before-you-owe/timeline/index.html
+++ b/cfgov/jinja2/know-before-you-owe/timeline/index.html
@@ -107,7 +107,7 @@
                 <br>
                 <a class="a-link
                           a-link--icon"
-                    href="https://files.consumerfinance.gov/f/201106_cfpb_mortgage-disclosure-prototype-Round2-Redbud.pdf" class="icon-link icon-link__download">
+                    href="https://files.consumerfinance.gov/f/201106_cfpb_mortgage-disclosure-prototype-Round2-Redbud.pdf">
                     <span class="a-link__text">Prototype A</span>
                     {{ svg_icon('download') }}
                 </a>

--- a/cfgov/v1/jinja2/v1/includes/organisms/chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/chart.html
@@ -43,9 +43,8 @@
         <strong>Download:</strong>
         {# Note: link closing tag needs to be on the same line to avoid a
                  trailing space in the link. #}
-        <a class="icon-link icon-link__download"
-           href="https://files.consumerfinance.gov/data/{{ value.data_source }}">
-            <span class="icon-link_text">CSV file</span></a>
+        <a href="https://files.consumerfinance.gov/data/{{ value.data_source }}">
+            CSV file</a>
         <br>
         {% endif %}
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
@@ -172,7 +172,7 @@
     <p class="m-chart-footnote block--sub block--border-top block short-desc">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
-    <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
+    <strong>Downloads:</strong> CSV files with data by <a href="{{ state_meta['url'] }}">state</a> ({{ state_meta['size'] }}), <a href="{{ metro_meta['url'] }}">metro and non-metro areas</a> ({{ metro_meta['size'] }}), or <a href="{{ county_meta['url'] }}">county</a> ({{ county_meta['size'] }}).<br>
     {% if value.note %}<strong>Note:</strong> {{ value.note }} <a href="/data-research/mortgage-performance-trends/about-the-data/">Learn more about the data</a>.<br>{% endif %}
     </p>
 </div>

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
@@ -211,7 +211,7 @@
     <p class="m-chart-footnote block--sub block short-desc">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
-    <strong>Downloads:</strong> CSV files with data by <a class="icon-link icon-link__download" href="{{ state_meta['url'] }}" <span class="icon-link_text">state</span></a> ({{ state_meta['size'] }}), <a class="icon-link icon-link__download" href="{{ metro_meta['url'] }}" <span class="icon-link_text">metro and non-metro areas</span></a> ({{ metro_meta['size'] }}), or <a class="icon-link icon-link__download" href="{{ county_meta['url'] }}"><span class="icon-link_text">county</span></a> ({{ county_meta['size'] }}).<br>
+    <strong>Downloads:</strong> CSV files with data by <a href="{{ state_meta['url'] }}">state</a> ({{ state_meta['size'] }}), <a href="{{ metro_meta['url'] }}">metro and non-metro areas</a> ({{ metro_meta['size'] }}), or <a href="{{ county_meta['url'] }}">county</a> ({{ county_meta['size'] }}).<br>
     {% if value.note %}<strong>Note:</strong> {{ value.note }} <a href="/data-research/mortgage-performance-trends/about-the-data/">Learn more about the data</a>.<br>{% endif %}
     </p>
 </div>

--- a/cfgov/v1/jinja2/v1/includes/organisms/simple-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/simple-chart.html
@@ -66,9 +66,8 @@
           {% set href =  make_download_href(value.download_file, data_location) %}
           {% if href %}
             <strong>Download:</strong>
-            <a class="icon-link icon-link__download"
-               href="{{href}}">
-              <span class="icon-link_text">{{value.download_text}}</span></a><br>
+            <a href="{{href}}">
+              {{value.download_text}}</a><br>
           {% endif %}
         {% endif %}
         {% if value.notes%}<strong>Notes:</strong> {{value.notes}}{% endif %}


### PR DESCRIPTION
I noticed we have an `icon-link` class, that has migrated to `a-link`, and spots where the old class is used appear to be handled by the middleware for adding external-link/download icons.

One area that could be scrutinized is the find a housing counselor PDF. It looks like it had external links for website URLs at one point, but that functionality does not work anymore. Maybe @chosak knows if the middleware should work on `pdf_selfcontained.html`

## Removals

- Remove unused `icon-link` class


## Changes

- Update jump link class.
- Fix unclosed `<a>` tags in the Mortgage Performance Trends footnotes.


## How to test this PR

1. Visit http://localhost:8000/know-before-you-owe/compare/ and see that the download links are jump links at mobile size. 
2. Visit http://localhost:8000/know-before-you-owe/timeline/ and see that the "Prototype" links are styled correctly with a download icon, despite the `icon-link__download` class being removed.
3. Visit http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/ and see that the footnote links still look correct.
4. Visit https://www.consumerfinance.gov/data-research/consumer-credit-trends/auto-loans/borrower-risk-profiles/ and see that the footnote links still look correct.


## Screenshots

Before:
<img width="389" alt="Screenshot 2024-05-03 at 6 26 05 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f092c653-d3b4-48ee-b93e-92259d88e552">

After:
<img width="394" alt="Screenshot 2024-05-03 at 6 25 40 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/7fde54db-7d5c-4f24-93a5-ffd44b6f7f36">
