### PR TITLE
Include chart styling on mpt pages

### DIFF
--- a/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
@@ -1,6 +1,4 @@
-// Import external cfpb-chart-builder stylesheet
-// This is also imported by the chart block (in chart.less)
-@import url('cfpb-chart-builder.less');
+@import (reference) 'cfpb-core.less';
 
 .o-mp-map {
   border: 1px solid var(--gray-40);

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -962,7 +962,7 @@ class MortgageChartBlock(blocks.StructBlock):
 
     class Media:
         js = ["mortgage-performance-trends.js"]
-        css = ["mortgage-performance-trends.css"]
+        css = ["mortgage-performance-trends.css", "chart.css"]
 
 
 class MortgageMapBlock(MortgageChartBlock):


### PR DESCRIPTION
Closes https://github.local/CFGOV/platform/issues/4571

This includes the standard `chart.css` on MPT pages via the `Media` mechanism. Since this file has the chart-builder css included, I also pulled that (now unnecessary) import out of MPT.

## Testing
 - Pull and build
 - Visit http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/ and not the styled footnotes
 - Open dev tools network and refresh. Note the chart.css file included and the small MPT file as well