### PR TITLE
Remove `stringEscape` and `stringMatch`

### DIFF
--- a/cfgov/unprocessed/js/modules/util/strings.js
+++ b/cfgov/unprocessed/js/modules/util/strings.js
@@ -29,23 +29,4 @@ function formatTimestamp(totalSeconds) {
   return timestamp;
 }
 
-/**
- * Escapes a string.
- * @param {string} s - The string to escape.
- * @returns {string} The escaped string.
- */
-function stringEscape(s) {
-  return s.replace(/[-\\^$*+?.()|[\]{}]/g, '\\$&');
-}
-
-/**
- * Tests whether a string matches another.
- * @param {string} x - The control string.
- * @param {string} y - The comparison string.
- * @returns {boolean} True if `x` and `y` match, false otherwise.
- */
-function stringMatch(x, y) {
-  return RegExp(stringEscape(y.trim()), 'i').test(x);
-}
-
-export { formatTimestamp, stringEscape, stringMatch };
+export { formatTimestamp };

--- a/test/unit_tests/js/modules/util/strings-spec.js
+++ b/test/unit_tests/js/modules/util/strings-spec.js
@@ -1,10 +1,4 @@
-import {
-  formatTimestamp,
-  stringEscape,
-  stringMatch,
-} from '../../../../../cfgov/unprocessed/js/modules/util/strings.js';
-let string;
-let control;
+import { formatTimestamp } from '../../../../../cfgov/unprocessed/js/modules/util/strings.js';
 
 describe('Strings formatTimestamp()', () => {
   it('should convert 23 seconds into 00:23 timestamp', () => {
@@ -20,48 +14,5 @@ describe('Strings formatTimestamp()', () => {
   it('should convert 16001 seconds into 04:26:41 timestamp', () => {
     const seconds = 16001;
     expect(formatTimestamp(seconds)).toBe('04:26:41');
-  });
-});
-
-describe('Strings stringEscape()', () => {
-  it('should escape a url', () => {
-    string = 'https://google.com';
-
-    expect(stringEscape(string)).toBe('https://google\\.com');
-  });
-
-  it('should escape a hyphenated name', () => {
-    string = 'Miller-Webster';
-
-    expect(stringEscape(string)).toBe('Miller\\-Webster');
-  });
-
-  it('should escape a comma', () => {
-    string = 'Students, Parents, and Teachers';
-
-    expect(stringEscape(string)).toBe('Students, Parents, and Teachers');
-  });
-});
-
-describe('Strings stringMatch()', () => {
-  it('should return true when testing matching strings', () => {
-    string = 'Test String';
-    control = 'Test String';
-
-    expect(stringMatch(control, string)).toBe(true);
-  });
-
-  it('should return true when testing matching strings with differing casing', () => {
-    string = 'test string';
-    control = 'Test String';
-
-    expect(stringMatch(control, string)).toBe(true);
-  });
-
-  it('should return false when testing differing strings', () => {
-    string = 'Test String';
-    control = 'Result String';
-
-    expect(stringMatch(control, string)).toBe(false);
   });
 });


### PR DESCRIPTION
@lfatty noted this utility is being flagged by his tools. It's not used, so I'm removing it here.

## Removals

- Remove `stringEscape` and `stringMatch`


## How to test this PR

1. PR checks should pass.
