### PR TITLE
TCCP: Fix result links

### DIFF
--- a/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
@@ -1,4 +1,8 @@
 Lower than average interest rates.
-<a>Learn how APRs affect your monthly bill</a>
+<a
+    href="/ask-cfpb/how-does-my-credit-card-company-calculate-the-amount-of-interest-i-owe-en-51/"
+>Learn how APRs affect your monthly bill</a>
 and
-<a>about the risks of 0% offers.</a>
+<a
+    href="/ask-cfpb/i-got-a-credit-card-promising-no-interest-for-a-purchase-if-i-pay-in-full-within-12-months-how-does-this-work-en-40/"
+>about the risks of 0% offers</a>.


### PR DESCRIPTION
When users select both "Pay less interest" and "Make a big purchase", we currently show two empty links. This fixes that by pointing those links to the correct place.

## How to test this PR

To test, run a local server and visit

http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?credit_tier=Credit+scores+from+620+to+719&location=AK&situations=Pay+less+interest&situations=Make+a+big+purchase&ordering=purchase_apr

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)