### PR TITLE
Careers: Remove unused `vacancy-announcement` classes

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_details.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_details.html
@@ -65,7 +65,7 @@
                 block--flush-top
                 block--sub">
     <h1>{{ value.title }}</h1>
-    <dl class="vacancy-announcement__details">
+    <dl class="vacancy-announcement">
         <dt>Division/Office:</dt>
         <dd>{{ value.division }}</dd>
         <dt>Closing date:</dt>

--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
@@ -29,8 +29,7 @@
 
     <section class="block
                     block--padded-top
-                    block--border-top
-                    vacancy-announcement_description">
+                    block--border-top">
 
         <div class="o-summary o-summary--mobile">
             <div id="job-description-expandable"
@@ -80,8 +79,7 @@
 
     <section class="block
                     block--padded-top
-                    block--border-top
-                    vacancy-announcement_apply">
+                    block--border-top">
         <h2 id="interested">What to know if you apply</h2>
         <div class="block block--sub">
             <div class="content-l">

--- a/cfgov/unprocessed/css/on-demand/job_listing_page.less
+++ b/cfgov/unprocessed/css/on-demand/job_listing_page.less
@@ -1,6 +1,6 @@
 @import (reference) 'cfpb-core.less';
 
-dl.vacancy-announcement__details dt {
+dl.vacancy-announcement dt {
   margin-top: unit(12px / @base-font-size-px, em);
   margin-bottom: 0;
 }


### PR DESCRIPTION
I couldn't find a use for `vacancy-announcement_apply` and `vacancy-announcement_description`

## Removals

- Careers: Remove unused `vacancy-announcement` classes

## How to test this PR

1. Visit a job listing details page and it should be unchanged.
