### PR TITLE
Correctly sort rate-checker values numerically

### DIFF
--- a/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
+++ b/cfgov/unprocessed/apps/owning-a-home/js/explore-rates/rate-checker.js
@@ -137,7 +137,7 @@ function updateView() {
           }
         }
 
-        sortedKeys.sort();
+        sortedKeys.sort((a, b) => a - b);
 
         const len = sortedKeys.length;
         for (let x = 0; x < len; x++) {


### PR DESCRIPTION
We had bug reports that interest rates 10% or great were coming before the lower rates. Upon inspection, the existing sort was sorting string keys alphabetically instead of numerically.

This fixes that.

A bit finicky to test since there aren't any active rates over 10 right now, but http://localhost:8000/owning-a-home/explore-rates/ should appear normal.