### PR TITLE
Make Contact phone numbers clickable links

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/macros/util/format/contact.html
+++ b/cfgov/v1/jinja2/v1/includes/macros/util/format/contact.html
@@ -22,7 +22,7 @@
         {{ char }}
         {{- ') ' if loop.index == 3 else '' -}}
         {{- '-' if loop.index == 6 else '' -}}
-    {%- endfor %}
+    {%- endfor -%}
 {% endmacro %}
 
 

--- a/cfgov/v1/jinja2/v1/includes/molecules/contact-phone.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/contact-phone.html
@@ -7,7 +7,6 @@
    Description:
 
    Create a Contact-Phone molecule.
-   See [GHE]/flapjack/Modules-V1/wiki/Contact:-Phone
 
    value:                  Object defined from a StreamField block.
 
@@ -36,17 +35,23 @@
     <span class="h5">{{ svg_icon(icon) }} {{ label }}</span>
     {% for phone in value.phones %}
     <p>
-        <b>
-            {{ format_phone(phone.number) }}
-            {{ 'Ext. ' ~ phone.extension if phone.extension else '' }}
-        </b>
+        <a href="tel:{{ phone.number }}">
+            {{- format_phone(phone.number) -}}
+        </a>
+        {{ 'Ext. ' ~ phone.extension if phone.extension }}
         {% if phone.vanity %}
         <br>
         <span>{{ phone.vanity }}</span>
         {% endif %}
         {% if phone.tty %}
         <br>
-        <span>TTY/TDD: {{ format_phone(phone.tty) }}{{ ' Ext. ' ~ phone.tty_ext if phone.tty_ext else '' }}</span>
+        <span>
+            TTY/TDD:
+            <a href="tel:{{ phone.tty }}">
+                {{- format_phone(phone.tty) -}}
+            </a>
+            {{ 'Ext. ' ~ phone.tty_ext if phone.tty_ext }}
+        </span>
         {% endif %}
     </p>
     {% endfor %}


### PR DESCRIPTION
This commit alters our template for the ContactPhone molecule such that phone numbers are rendered as clickable links.

The regular phone number and TTY phone numbers are both already required to be a string containing only numbers, which complies with [the RFC for tel: links](https://datatracker.ietf.org/doc/html/rfc3966). The vanity number may contain letters, which are not supported by the RFC, and so is not made into a clickable link.

As part of this change I removed the bolding we currently have for phone numbers to make the weight more consistent with the rest of the text.

## How to test this PR

Run a local server, and preview these Contact snippets (using the "phone" icon in the upper right):

- http://localhost:8000/admin/snippets/v1/contact/edit/26/
- http://localhost:8000/admin/snippets/v1/contact/edit/28/

Optionally edit a snippet in that view to see changes reflected in the preview window.

## Screenshots

|Before|After|
|-|-|
|<img width="270" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/94f94507-cac0-4f33-ac4c-caffd56213e3">|<img width="254" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/ebca31af-44fe-495b-8da7-8e26b414a949">|
|<img width="317" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/14fe11c3-c3b3-4568-9859-b302e76f1cc1">|<img width="314" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/ea1a2774-d94d-4dce-af13-1327ccd495d7">|

Here's how the links render in HTML:

<img width="619" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/29e8ce34-243e-4d0e-90c3-d89bc45abba1">

## Notes and todos

I'm tagging in people from multiple teams as this is proposing a site-wide change.

By default Mobile Safari already detects any text formatted like a phone number and convert them to clickable links (for example compare https://www.consumerfinance.gov/about-us/contact-us/ on an iPhone vs desktop). Apple documents a [`format-detection`](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html) meta tag that can be used to control this behavior.

Per [this article](https://web.dev/articles/click-to-call#disable_auto-detection_when_necessary):

> Chrome for Android automatically detects phone numbers and allows users to click to call, but does not wrap the phone numbers in hyperlinks or apply any special styles.

I don't have an Android device to test this on; do we have any way to simulate this and see how things look now/with this change?

Per that article it's best practice to use `tel:` links regardless of device support. That article also suggests disabling automatic detection in Mobile Safari, I'm guessing to prevent Apple's link styling if you have your own. With the changes in this PR I think our link style matches the default so maybe that wouldn't have an impact. We could consider adding `<meta name="format-detection" content="telephone=no" />` to our pages but then that would disable auto-formatting of phone numbers that aren't being rendered by the contact template (for example in blog posts).

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)