### PR TITLE
TCCP: Tidy up detail page "other fees" Jinja

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -487,14 +487,26 @@
             <p>{{ card.fee_explanation }}</p>
         {% endif %}
         <div class="o-additional-details">
-            {% set other_fees = [card.other_fee_name, card.other_fee_name_2,
-                card.other_fee_name_3, card.other_fee_name_4, card.other_fee_name_5
-            ] %}
-            {% set other_fees_count = other_fees | length - other_fees.count('') %}
-            {% if other_fees_count == 1 %}
-                {% set other_fees_label = 'Late, over-limit, and 1 other fee' %}
-            {% elif other_fees_count > 1 %}
-                {% set other_fees_label = 'Late, over-limit, and ' ~ other_fees_count ~ ' other fees' %}
+            {% set other_fees = [] %}
+            {% for i in range(5) %}
+                {% set loop_suffix = ('_' ~ (i + 1)) if i else '' %}
+                {% set other_fee_name = card['other_fee_name' ~ loop_suffix] %}
+                {% if other_fee_name %}
+                    {% do other_fees.append({
+                        "name": other_fee_name,
+                        "amount": card['other_fee_amount' ~ loop_suffix],
+                        "explanation": card['other_fee_explanation' ~ loop_suffix]
+                    }) %}
+                {% endif %}
+            {% endfor %}
+
+            {% if other_fees %}
+                {% set other_fees_label = (
+                    'Late, over-limit, and '
+                    ~ other_fees | length
+                    ~ ' other fee'
+                    ~ ('s' if other_fees | length > 1)
+                ) %}
             {% else %}
                 {% set other_fees_label = 'Late and over-limit fees' %}
             {% endif %}
@@ -573,25 +585,17 @@
                         <dt>Over-limit fee details</dt>
                         <dd>{{ card.overlimit_fee_detail }}</dd>
                     {% endif %}
-                    {% if card.other_fees %}
-                        {% for fee_name in other_fees %}
-                            {% if fee_name %}
-                                <dt>{{ fee_name }}</dt>
-                                <dd>
-                                    {% if loop.first %}
-                                        {{ currency(card.other_fee_amount) ~ ' (' ~
-                                            card.other_fee_explanation ~ ')'
-                                        }}
-                                    {% else %}
-                                        {{ currency(card['other_fee_amount_' ~ loop.index]) ~ ' (' ~
-                                            card['other_fee_explanation_' ~ loop.index] ~
-                                            ')'
-                                        }}
-                                    {% endif %}
-                                </dd>
-                            {% endif %}
-                        {% endfor %}
-                    {% endif %}
+                    {% for other_fee in other_fees %}
+                        <dt>{{ other_fee.name }}</dt>
+                        <dd>
+                            {{-
+                                currency(other_fee.amount)
+                                ~ ' ('
+                                ~ other_fee.explanation
+                                ~ ')'
+                            -}}
+                        </dd>
+                    {% endfor %}
                 </dl>
             {% endcall %}
         </div>


### PR DESCRIPTION
This commit tidies up the Jinja logic for "other fees" in the card details page. It has no impact on the visible rendering of the content.

## How to test this PR

Running a local server with the latest dataset, here are some pages to check:

- [No other fees](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/canvas-credit-union-platinum-elite-credit-card/)
- [1 other fee](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/barclays-bank-delaware-jetblue-mastercard/)
- [5 other fees](http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/cadence-bank-platinum/) (the maximum possible)

## Screenshots

|No fees|1 fee|5 fees|
|-|-|-|
|<img width="759" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/549287ca-2fed-4943-b5b3-a6181a1bd7b9">|<img width="752" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/1d081bd3-9811-4c83-b2ce-ef08d4b7d840">|<img width="750" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/fddc8d04-7d65-4ca1-a9c6-c61790cb4731">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)