### PR TITLE
Add VSCode debugger launch configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Django runserver",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["runserver"],
+      "django": true,
+      "autoStartBrowser": false,
+      "program": "${workspaceFolder}/cfgov/manage.py"
+    }
+  ]
+}


### PR DESCRIPTION
Allows for running the Django dev server in the VSCode debugger. For documentation on this file see:

https://code.visualstudio.com/docs/editor/debugging#_launch-configurations

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)