### PR TITLE
Ask Cards: Remove right-hand padding

### DIFF
--- a/cfgov/unprocessed/apps/ask-cfpb/css/main.less
+++ b/cfgov/unprocessed/apps/ask-cfpb/css/main.less
@@ -211,13 +211,6 @@
     }
   });
 
-  .question-categories {
-    // Tablet and above.
-    .respond-to-min(@bp-sm-min, {
-      padding-right: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
-    });
-  }
-
   .o-search-bar__input {
     max-width: 31.25rem;
   }

--- a/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/feature-cards.html
@@ -34,7 +34,7 @@
      {% endfor %}
      </ul>
 
-     <div class="u-hide-on-mobile question-categories u-mb30">
+     <div class="u-hide-on-mobile u-mb30">
          <div class="o-card-group o-card-group--column-2">
              <div class="o-card-group__cards">
 


### PR DESCRIPTION
This right-hand margin was added in https://github.com/cfpb/consumerfinance.gov/commit/0877172cb6b0bddfbfecffce65bb9072b0c2013a, perhaps to make the right-hand gap and the gap between the cards and search the same? At any rate, if https://github.com/cfpb/consumerfinance.gov/pull/8401 goes ahead, the search will be full width, and removal of this padding on the cards make them align with the search on the right-hand side.

## Removals

- Ask Cards: Remove right-hand padding and `question-categories` class.


## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/ and see that the right-hand gap after the cards is narrower than prod.


## Screenshots

Before:
<img width="611" alt="Screenshot 2024-05-10 at 3 00 20 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ae37d45a-3876-4ab2-bdbd-16af3f0c162d">


After:
<img width="485" alt="Screenshot 2024-05-10 at 3 00 08 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/bbdeb7f3-4798-4a9b-b9cf-6995291ca98c">

