### PR TITLE
Remove need for data-language attribute

### DIFF
--- a/cfgov/unprocessed/apps/ask-cfpb/js/ask-autocomplete.js
+++ b/cfgov/unprocessed/apps/ask-cfpb/js/ask-autocomplete.js
@@ -49,8 +49,7 @@ function handleMaxCharacters(event) {
 }
 
 if (autocompleteContainer) {
-  const language = autocompleteContainer.getAttribute('data-language');
-
+  const language = document.documentElement.getAttribute('lang')
   const autocomplete = new Autocomplete(autocompleteContainer, {
     url: language === 'es' ? URLS.es : URLS.en,
     onSubmit: function (event, selected) {

--- a/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
@@ -30,9 +30,6 @@
 
 <div class="o-search-input">
     <div class="o-search-input__input{% if value.has_autocomplete %} m-autocomplete{% endif %}"
-         {% if language %}
-         data-language="{{ language }}"
-         {% endif %}>
         <label for="{{ value.input_id }}"
                class="o-search-input__input-label"
                aria-label="{{ value.input_aria_label }}">

--- a/test/unit_tests/apps/teachers-digital-platform/js/search-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/search-spec.js
@@ -7,7 +7,7 @@ import { init as searchInit } from '../../../../../cfgov/unprocessed/apps/teache
 const HTML_SNIPPET = `
   <form class="tdp-activity-search" id="search-form" action="." data-js-hook="behavior_submit-search">
     <div class="o-search-input">
-      <div class="o-search-input__input" data-language="en">
+      <div class="o-search-input__input">
           <label for="search-text" class="o-search-input__input-label" aria-label="Search for a term">
             <svg xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg cf-icon-svg--search" viewBox="0 0 15 19"><path d="M14.147 15.488a1.11 1.11 0 0 1-1.567 0l-3.395-3.395a5.575 5.575 0 1 1 1.568-1.568l3.394 3.395a1.11 1.11 0 0 1 0 1.568m-6.361-3.903a4.488 4.488 0 1 0-1.681.327 4.4 4.4 0 0 0 1.68-.327z"></path></svg>
           </label>


### PR DESCRIPTION
This attribute is only used for keying ask search on the english or spanish index. Instead of passing down the language through context and setting it on a data attribute, imo it's better to just access the `lang` attribute set on the documentElement.

This will also allow us to not have to import the search organism `with context`