### PR TITLE
TCCP: Consolidate card rating markup 

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -148,7 +148,6 @@
 
         {% if not card.top_25_institution %}
             <div class="u-mt30">
-                {# TODO: Maybe unify this content with the card list version? #}
                 {{ speed_bump( {
                     'content': (
                         'This card is from a ' ~

--- a/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
@@ -1,0 +1,23 @@
+{%- macro apr_rating(rating, count=none) -%}
+    {%- set label = apr_rating_lookup[rating] -%}
+
+    <div class="m-apr-rating m-apr-rating--{{ label }}">
+        <dt>
+            {% for i in range(rating + 1) -%}
+                {{ svg_icon("dollar-round") }}
+            {%- endfor %}
+        </dt>
+        <dd>
+            Pay {{ label }} interest
+            {{-
+                (
+                    ' ('
+                    ~ count
+                    ~ ' card'
+                    ~ count | pluralize()
+                    ~ ')'
+                ) if count is not none
+            }}
+        </dd>
+    </div>
+{%- endmacro -%}

--- a/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
@@ -6,6 +6,9 @@
             {% for i in range(rating + 1) -%}
                 {{ svg_icon("dollar-round") }}
             {%- endfor %}
+            <span class="u-visually-hidden">
+                {{ rating + 1 }} dollar sign symbol{{ (rating + 1) | pluralize() }}
+            </span>
         </dt>
         <dd>
             Pay {{ label }} interest

--- a/cfgov/tccp/jinja2/tccp/includes/apr_table.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_table.html
@@ -38,7 +38,9 @@
                     {% if show_comparison %}
                     <td>
                         {% if tier_apr_rating is not none -%}
+                        <dl>
                             {{ apr_rating(tier_apr_rating) }}
+                        </dl>
                         {%- endif %}
                     </td>
                     {% endif %}

--- a/cfgov/tccp/jinja2/tccp/includes/apr_table.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_table.html
@@ -1,3 +1,4 @@
+{% from 'tccp/includes/apr_rating.html' import apr_rating with context %}
 {% from 'tccp/includes/fields.html' import apr, apr_range %}
 
 {% macro apr_table(
@@ -36,16 +37,9 @@
                     <td>{{ tier_apr_str }}</td>
                     {% if show_comparison %}
                     <td>
-                        {% if tier_apr_rating is not none %}
-                            {% set label = apr_rating_lookup[tier_apr_rating] %}
-                            <span class="m-apr-rating--{{ label }}">
-                                {%- for i in range(tier_apr_rating + 1) %}
-                                    {{ svg_icon("dollar-round") }}
-                                {% endfor -%}
-
-                                Pay {{ label }} interest
-                            </span>
-                        {% endif %}
+                        {% if tier_apr_rating is not none -%}
+                            {{ apr_rating(tier_apr_rating) }}
+                        {%- endif %}
                     </td>
                     {% endif %}
                 </tr>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -74,7 +74,9 @@
                     <h3 class="m-card__heading">{{ card.institution_name }}</h3>
                     <p class="m-card__subtitle">{{ card.product_name }}</p>
                 </div>
-                {{ apr_rating(card.purchase_apr_for_tier_rating) }}
+                <dl>
+                    {{ apr_rating(card.purchase_apr_for_tier_rating) }}
+                </dl>
                 <dl class="m-data-specs">
                     <div class="m-data-spec m-data-spec--apr">
                         <dt><strong>Purchase APR</strong></dt>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -1,3 +1,4 @@
+{% from 'tccp/includes/apr_rating.html' import apr_rating with context %}
 {% from 'tccp/includes/data_published.html' import data_published %}
 {% from 'tccp/includes/fields.html' import apr, apr_range, currency %}
 {% from 'tccp/includes/speed_bump.html' import speed_bump %}
@@ -41,19 +42,8 @@
         Use the ratings to compare your results:
     </p>
     <dl>
-        {% for label, label_count in purchase_apr_rating_counts.items() %}
-        <div class="m-apr-rating m-apr-rating--{{ label }}">
-            <dt>
-                {%- for i in range(loop.index) -%}
-                    {{ svg_icon("dollar-round") }}
-                {%- endfor -%}
-            </dt>
-            <dd>
-                Pay {{ label }} interest (
-                    {{- label_count ~ ' card' ~ label_count | pluralize() -}}
-                )
-            </dd>
-        </div>
+        {% for rating, rating_count in purchase_apr_rating_counts.items() %}
+            {{ apr_rating(rating, count=rating_count) }}
         {% endfor %}
     </dl>
 </div>
@@ -63,18 +53,6 @@
 {% if stats_all.first_report_date -%}
 {{ data_published(stats_all.first_report_date) }}
 {%- endif %}
-
-{%- macro card_rating(card) -%}
-    {%- set label = purchase_apr_rating_labels[card.purchase_apr_for_tier_rating] -%}
-
-    <div class="m-apr-rating m-apr-rating--{{ label }}">
-        {%- for i in range(card.purchase_apr_for_tier_rating + 1) %}
-            {{ svg_icon("dollar-round") }}
-        {% endfor -%}
-
-        Pay {{ label }} interest
-    </div>
-{%- endmacro -%}
 
 {%- macro card_rewards(card) -%}
     {%- set rewards = [] -%}
@@ -96,7 +74,7 @@
                     <h3 class="m-card__heading">{{ card.institution_name }}</h3>
                     <p class="m-card__subtitle">{{ card.product_name }}</p>
                 </div>
-                {{ card_rating(card) | safe }}
+                {{ apr_rating(card.purchase_apr_for_tier_rating) }}
                 <dl class="m-data-specs">
                     <div class="m-data-spec m-data-spec--apr">
                         <dt><strong>Purchase APR</strong></dt>
@@ -131,7 +109,7 @@
                     <div class="m-data-spec m-data-spec--rewards">
                         <dt>Rewards</dt>
                         <dd>
-                            {{ card_rewards(card) | safe }}
+                            {{ card_rewards(card) }}
                         </dd>
                     </div>
                     {%- if

--- a/cfgov/tccp/management/commands/validate_tccp.py
+++ b/cfgov/tccp/management/commands/validate_tccp.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 import matplotlib.pyplot as plt
 
-from tccp.enums import CreditTierColumns
+from tccp.enums import CreditTierColumns, PurchaseAPRRatings
 from tccp.filterset import CardSurveyDataFilterSet
 from tccp.models import CardSurveyData
 from tccp.situations import SITUATIONS
@@ -48,6 +48,8 @@ class Command(BaseCommand):
             summary_stats=summary_stats
         )
 
+        apr_rating_lookup = dict(PurchaseAPRRatings)
+
         for tier_name, tier_column in CreditTierColumns:
             self.stdout.write(tier_name.upper())
             self.stdout.write("-" * len(tier_name))
@@ -76,10 +78,12 @@ class Command(BaseCommand):
 
             # Write out counts for each rating label.
             for (
-                rating_label,
+                rating,
                 rating_count,
             ) in purchase_apr_rating_counts.items():
-                self.stdout.write(f"{rating_label}: {rating_count}")
+                self.stdout.write(
+                    f"{apr_rating_lookup[rating]}: {rating_count}"
+                )
 
             self.stdout.write()
 

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -149,9 +149,6 @@ class CardListView(FlaggedViewMixin, ListAPIView):
             purchase_apr_rating_counts = self.get_purchase_apr_rating_counts(
                 cards
             )
-            purchase_apr_rating_labels = list(
-                purchase_apr_rating_counts.keys()
-            )
 
             response.data.update(
                 {
@@ -162,8 +159,8 @@ class CardListView(FlaggedViewMixin, ListAPIView):
                     "situations": situations,
                     "situation_features": SituationFeatures(situations),
                     "speed_bumps": SituationSpeedBumps(situations),
-                    "purchase_apr_rating_labels": purchase_apr_rating_labels,
                     "purchase_apr_rating_counts": purchase_apr_rating_counts,
+                    "apr_rating_lookup": dict(enums.PurchaseAPRRatings),
                     "rewards_lookup": dict(enums.RewardsChoices),
                 }
             )
@@ -179,14 +176,14 @@ class CardListView(FlaggedViewMixin, ListAPIView):
         # database query but the size of the data is small enough that we
         # can just as easily do it in Python.
         return {
-            rating_label: len(
+            rating_score: len(
                 [
                     card
                     for card in cards
                     if card["purchase_apr_for_tier_rating"] == rating_score
                 ]
             )
-            for rating_score, rating_label in enums.PurchaseAPRRatings
+            for rating_score, _ in enums.PurchaseAPRRatings
         }
 
 

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -116,6 +116,35 @@
   }
 }
 
+.m-apr-rating {
+  &--less .cf-icon-svg {
+    color: var(--green);
+  }
+
+  &--average .cf-icon-svg {
+    color: var(--gold);
+  }
+
+  &--more .cf-icon-svg {
+    color: var(--red);
+  }
+}
+
+.heading-4-size-only() {
+  @h4-font-size: @size-iv;
+
+  font-size: @h4-font-size;
+  line-height: 1.25;
+
+  // Mobile only.
+  .respond-to-max(@bp-xs-max, {
+    @h4-font-size-on-xs: @base-font-size-px;
+
+    font-size: unit(@h4-font-size-on-xs / @base-font-size-px, em);
+    line-height: unit(18px /  @base-font-size-px);
+  });
+}
+
 .m-card.m-card--tabular {
   padding: 0;
   border: 0;
@@ -180,6 +209,12 @@
   .m-card__footer {
     margin-top: unit((5px / @base-font-size-px), rem);
   }
+
+  .m-apr-rating {
+    .heading-4-size-only();
+    margin-bottom: unit((20px / @base-font-size-px), rem);
+    font-weight: 600;
+  }
 }
 
 .o-apr-rating-group {
@@ -195,6 +230,9 @@
     gap: unit(5px / @base-font-size-px, em);
     font-weight: 500;
 
+    .heading-4-size-only();
+
+    // Tablet and above.
     .respond-to-min(@bp-sm-min, {
       margin-bottom: 0;
     });
@@ -202,24 +240,6 @@
 
   dt {
     justify-self: right;
-  }
-}
-
-.m-apr-rating {
-  .h4();
-  margin-bottom: unit((20px / @base-font-size-px), rem);
-  font-weight: 600;
-
-  &--less .cf-icon-svg {
-    color: var(--green);
-  }
-
-  &--average .cf-icon-svg {
-    color: var(--gold);
-  }
-
-  &--more .cf-icon-svg {
-    color: var(--red);
   }
 }
 

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -161,6 +161,11 @@
       padding-bottom: unit((20px / @base-font-size-px), rem);
     });
   }
+
+  dl {
+    margin-bottom: 0;
+  }
+
   &:hover {
     > a {
       box-shadow:
@@ -204,6 +209,11 @@
 
   .m-card__footer {
     margin-top: unit((5px / @base-font-size-px), rem);
+
+    // Tablet and above.
+    .respond-to-min(@bp-sm-min, {
+      margin-top: unit((20px / @base-font-size-px), rem);
+    });
   }
 
   .m-apr-rating {
@@ -253,12 +263,10 @@
   grid-template-columns: 2fr 3fr;
   column-gap: 20px;
   row-gap: 15px;
-  margin-bottom: 0;
 
   .respond-to-min(@bp-sm-min, {
     grid-template-areas: 'apr fee transfer rewards requirements';
     grid-template-columns: 5fr 4fr 6fr 7fr 7fr;
-    margin-bottom: unit((15px / @base-font-size-px), rem);
   });
 }
 

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -130,17 +130,13 @@
   }
 }
 
-.heading-4-size-only() {
-  @h4-font-size: @size-iv;
-
-  font-size: @h4-font-size;
+.u-heading-4-size-only() {
+  font-size: @size-iv;
   line-height: 1.25;
 
   // Mobile only.
   .respond-to-max(@bp-xs-max, {
-    @h4-font-size-on-xs: @base-font-size-px;
-
-    font-size: unit(@h4-font-size-on-xs / @base-font-size-px, em);
+    font-size: unit(16px / @base-font-size-px, rem);
     line-height: unit(18px /  @base-font-size-px);
   });
 }
@@ -211,9 +207,14 @@
   }
 
   .m-apr-rating {
-    .heading-4-size-only();
-    margin-bottom: unit((20px / @base-font-size-px), rem);
+    .u-heading-4-size-only();
+    margin-bottom: unit(20px / @base-font-size-px, rem);
     font-weight: 600;
+
+    // Mobile only.
+    .respond-to-max(@bp-xs-max, {
+      margin-bottom: unit(10px / @base-font-size-px, rem);
+    });
   }
 }
 
@@ -223,14 +224,14 @@
   }
 
   .m-apr-rating {
-    margin-bottom: unit((5px / @base-font-size-px), rem);
+    margin-bottom: unit(5px / @base-font-size-px, rem);
     display: grid;
     grid-template-columns: unit(45px / @base-font-size-px, em) 1fr;
     align-items: baseline;
     gap: unit(5px / @base-font-size-px, em);
     font-weight: 500;
 
-    .heading-4-size-only();
+    .u-heading-4-size-only();
 
     // Tablet and above.
     .respond-to-min(@bp-sm-min, {


### PR DESCRIPTION
This commit consolidates several different ways that we markup TCCP card ratings (the colored icon next to a description like "Pay less interest").

The new apr_rating macro can be used to render just this bit; various places on the card list and details view now use this macro.

Styles have been reworked to support this new approach.

## How to test this PR

To test, run a local server and visit pages like:

- http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/
- http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/vinton-county-national-bank-consumer-credit-card/

Check sizing on mobile and desktop widths.

## Screenshots

Display should be unchanged from before:

<img width="476" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/5167429d-35e6-42f4-980b-93ea929c62c7">

<img width="270" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/2ef0f66c-f108-4713-94de-3ee6f1d0be3b">

<img width="253" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/b3671d8e-b9c4-4633-93e4-c3262b3b11f5">

## Notes and todos

An unrelated obsolete comment has also been removed from the detail page template; see internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/306#issuecomment-354312 for context.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)