### PR TITLE
Ask CFPB: Remove unused `complaint_link`

### DIFF
--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/_ask-search.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/_ask-search.html
@@ -24,10 +24,6 @@
 
    max_length:     Integer; the maximum length of a query string, in characters
 
-   complaint_link: Boolean; whether to add a link to the complaint submission
-                   page to the end of the error message for searches over the
-                   max length
-
    ========================================================================== #}
 
 {% macro render(
@@ -37,8 +33,7 @@
     autocomplete=True,
     placeholder='',
     is_subsection=True,
-    max_length=autocomplete_max_chars,
-    complaint_link=False
+    max_length=autocomplete_max_chars
 ) %}
 <div class="o-search-bar">
     <form method="get" action="{{ _('/ask-cfpb/search/') }}">
@@ -79,11 +74,6 @@
                         <p class="a-form-alert__text">
                             Searches are limited to {{ autocomplete_max_chars }}
                             characters.
-                            {% if complaint_link %}
-                            Are you trying to
-                            <a href="/complaint/getting-started/">
-                                submit a complaint</a>?
-                            {% endif %}
                         </p>
                     </div>
                 </div>
@@ -108,8 +98,7 @@
       value.autocomplete | default( True ),
       value.placeholder | default( '' ),
       value.is_subsection | default( True ),
-      value.max_length | default( autocomplete_max_chars ),
-      value.complaint_link | default( False )
+      value.max_length | default( autocomplete_max_chars )
     )
   }}
 {% endif %}


### PR DESCRIPTION
`complaint_link` was added in https://github.com/cfpb/consumerfinance.gov/commit/139ab186f7005f52d1bf6b70e4d6c809d7dfd83c#diff-78223a1f2676248e59578ecf7984d406bebaf3c9eb322b8ae70d89103206c234 as an option in Wagtail, but was removed in https://github.com/cfpb/consumerfinance.gov/pull/8312 because the underlying `WellWithAskSearch` used in Wagtail had been removed. 

## Removals

- Remove `complaint_link` from jinja template


## How to test this PR

1. PR checks should pass. Search codebase for `complaint_link` and see that the only reference is in the template where it's set to False.
