### PR TITLE
TCCP: Consolidate card detail headings into macro

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -35,6 +35,25 @@
     <link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">
 {% endblock %}
 
+{% macro data_section(
+    heading,
+    heading_classes="h2 u-mb0",
+    subheading_classes="h4 u-mt0"
+) %}
+<div
+    {%- if heading_classes %} class="{{ heading_classes }}"{% endif -%}
+>
+    {{ caller() }}
+    <span class="u-visually-hidden">{{ heading }}</span>
+</div>
+<div
+    {%- if subheading_classes %} class="{{ subheading_classes }}"{% endif %}
+    aria-hidden="true"
+>
+    {{- heading -}}
+</div>
+{% endmacro %}
+
 {% block content_main %}
 <div class="block block--flush-top">
 
@@ -192,7 +211,7 @@
             {% elif card.purchase_apr_median is not none %}
                 {% set purchase_apr_term = 'Median purchase APR' %}
             {% endif %}
-            <div class="h2 u-mb0">
+            {% call data_section(purchase_apr_term) %}
                 {% if card.purchase_apr_min is not none
                     and card.purchase_apr_max is not none
                 %}
@@ -200,11 +219,7 @@
                 {% elif card.purchase_apr_median is not none %}
                     {{ apr(card.purchase_apr_median) }}
                 {% endif %}
-                <span class="u-visually-hidden">{{ purchase_apr_term }}</span>
-            </div>
-            <div class="h4 u-mt0" aria-hidden="true">
-                {{ purchase_apr_term }}
-            </div>
+            {% endcall %}
             <p>
                 An APR, or annual percentage rate, is the interest you‘ll pay
                 on purchases.
@@ -243,7 +258,11 @@
             {% elif card.intro_apr_median is not none %}
                 {% set introductory_apr_term = 'Median introductory APR' %}
             {% endif %}
-            <div class="h3 u-mb0 u-mt30">
+            {% call data_section(
+                introductory_apr_term,
+                heading_classes="h3 u-mb0 u-mt30",
+                subheading_classes="u-mb15"
+            ) %}
                 {% if card.intro_apr_min is not none
                     and card.intro_apr_max is not none
                 %}
@@ -254,11 +273,7 @@
                 for
                 {{ '%.0f' | format(card.median_length_of_introductory_apr ) }}
                 months
-                <span class="u-visually-hidden">{{ introductory_apr_term }}</span>
-            </div>
-            <div class="u-mb15" aria-hidden="true">
-                {{ introductory_apr_term }}
-            </div>
+            {% endcall %}
             {% if card.introductory_apr_vary_by_credit_tier %}
                 <p>
                     Your introductory APR will vary based on your credit score.
@@ -389,13 +404,13 @@
         <div class="m-payment-calculation u-mb15">
             {% if card.annual_fee %}
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt0">
-                        {{ currency(card.annual_fee) if card.annual_fee else currency(0) }}
-                        <span class="u-visually-hidden">Annual fee</span>
-                    </div>
-                    <div class="h4 u-mt0 u-mb0" aria-hidden="true">
-                        Annual fee
-                    </div>
+                    {% call data_section(
+                        'Annual fee',
+                        heading_classes="h2 u-mb0 u-mt0",
+                        subheading_classes="h4 u-mt0 u-mb0"
+                    ) %}
+                        {{ currency(card.annual_fee) }}
+                    {% endcall %}
                 </div>
             {% endif %}
             {% if card.monthly_fee %}
@@ -403,13 +418,13 @@
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt0">
-                        {{ currency(card.monthly_fee) if card.monthly_fee else currency(0) }}
-                        <span class="u-visually-hidden">Monthly fee</span>
-                    </div>
-                    <div class="h4 u-mt0 u-mb0" aria-hidden="true">
-                        Monthly fee
-                    </div>
+                    {% call data_section(
+                        'Monthly fee',
+                        heading_classes="h2 u-mb0 u-mt0",
+                        subheading_classes="h4 u-mt0 u-mb0"
+                    ) %}
+                        {{ currency(card.monthly_fee) }}
+                    {% endcall %}
                 </div>
             {% endif %}
             {% if card.weekly_fee %}
@@ -417,13 +432,13 @@
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt0">
+                    {% call data_section(
+                        'Weekly fee',
+                        heading_classes="h2 u-mb0 u-mt0",
+                        subheading_classes="h4 u-mt0 u-mb0"
+                    ) %}
                         {{ currency(card.weekly_fee) }}
-                        <span class="u-visually-hidden">Weekly fee</span>
-                    </div>
-                    <div class="h4 u-mt0 u-mb0" aria-hidden="true">
-                        Weekly fee
-                    </div>
+                    {% endcall %}
                 </div>
             {% endif %}
             {% if card.other_periodic_fee_amount %}
@@ -435,17 +450,15 @@
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0 u-mt0">
+                    {% call data_section(
+                        (card.other_periodic_fee_name | capitalize) ~
+                        ', ' ~
+                        (card.other_periodic_fee_frequency | lower),
+                        heading_classes="h2 u-mb0 u-mt0",
+                        subheading_classes="h4 u-mt0 u-mb0"
+                    ) %}
                         {{ currency(card.other_periodic_fee_amount) }}
-                        <span class="u-visually-hidden">
-                            {{ card.other_periodic_fee_name | capitalize }},
-                            {{ card.other_periodic_fee_frequency | lower }}
-                        </span>
-                    </div>
-                    <div class="h4 u-mt0 u-mb0" aria-hidden="true">
-                        {{ card.other_periodic_fee_name | capitalize }},
-                        {{ card.other_periodic_fee_frequency | lower }}
-                    </div>
+                    {% endcall %}
                 </div>
             {% endif %}
         </div>
@@ -576,17 +589,13 @@
             Rewards and perks
         </h2>
         {% if card.rewards %}
-            <div class="h2 u-mb0">
+            {% call data_section('Rewards') %}
                 {%- set rewards = [] -%}
                 {%- for reward in card.rewards -%}
                     {%- do rewards.append(rewards_lookup[reward]) -%}
                 {%- endfor -%}
                 {{ oxfordize(rewards) | capitalize }}
-                <span class="u-visually-hidden">Rewards</span>
-            </div>
-            <div class="h4 u-mt0" aria-hidden="true">
-                Rewards
-            </div>
+            {% endcall %}
         {% else %}
             <p>This card does not offer cash back, travel, or other rewards.</p>
         {% endif %}
@@ -659,7 +668,12 @@
             {% endif %}
             <div class="m-payment-calculation u-mb15">
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0">
+                    {% call data_section(
+                        balance_transfer_apr_term ~
+                        ' for ' ~
+                        '%.0f' | format(card.median_length_of_balance_transfer_apr) ~
+                        ' months'
+                    ) %}
                         {% if card.transfer_apr_min is not none
                             and card.transfer_apr_max is not none
                         %}
@@ -667,19 +681,14 @@
                         {% elif card.transfer_apr_median is not none %}
                             {{ apr(card.transfer_apr_median) }}
                         {% endif %}
-                        <span class="u-visually-hidden">
-                            {{ balance_transfer_apr_term }} for {{ '%.0f' | format(card.median_length_of_balance_transfer_apr ) }}
-                        months
-                        </span>
-                    </div>
-                    <div class="h4 u-mt0" aria-hidden="true">
-                        {{ balance_transfer_apr_term }} for {{ '%.0f' | format(card.median_length_of_balance_transfer_apr ) }}
-                        months
-                    </div>
+                    {% endcall %}
                 </div>
                 <div class="m-payment-calculation__operator h2">+</div>
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0">
+                    {% call data_section(
+                        'Balance transfer fee'
+                        ~ (', see details' if card.balance_transfer_fee_calculation)
+                    )%}
                         {{ currency(card.balance_transfer_fee_dollars) if
                             card.balance_transfer_fee_dollars is not none
                         }}
@@ -699,15 +708,7 @@
                             and card.balance_transfer_fee_percentage is none
                         }}
                         {{ currency(0) if not card.balance_transfer_fees }}
-                        <span class="u-visually-hidden">
-                            Balance transfer fee
-                            {{- ', see details' if card.balance_transfer_fee_calculation }}
-                        </span>
-                    </div>
-                    <div class="h4 u-mt0" aria-hidden="true">
-                        Balance transfer fee
-                        {{- ', see details' if card.balance_transfer_fee_calculation }}
-                    </div>
+                     {% endcall %}
                 </div>
             </div>
             {% if card.balance_transfer_fee_calculation %}
@@ -759,7 +760,7 @@
             {% endif %}
             <div class="m-payment-calculation u-mb15">
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0">
+                    {% call data_section(cash_advance_apr_term) %}
                         {% if card.advance_apr_min is not none
                             and card.advance_apr_max is not none
                         %}
@@ -769,15 +770,14 @@
                         {% else %}
                             N/A
                         {% endif %}
-                        <span class="u-visually-hidden">{{ cash_advance_apr_term }}</span>
-                    </div>
-                    <div class="h4 u-mt0" aria-hidden="true">
-                        {{ cash_advance_apr_term }}
-                    </div>
+                    {% endcall %}
                 </div>
                 <div class="m-payment-calculation__operator h2">+</div>
                 <div class="m-payment-calculation__part">
-                    <div class="h2 u-mb0">
+                    {% call data_section(
+                        'Cash advance fee'
+                        ~ (', see details' if card.cash_advance_fee_calculation)
+                    ) %}
                         {{ currency(card.cash_advance_fee_dollars) if
                             card.cash_advance_fee_dollars is not none
                         }}
@@ -797,15 +797,7 @@
                             and card.cash_advance_fee_percentage is none
                         }}
                         {{ currency(0) if not card.cash_advance_fees }}
-                        <span class="u-visually-hidden">
-                            Cash advance fee
-                            {{- ', see details' if card.cash_advance_fee_calculation }}
-                        </span>
-                    </div>
-                    <div class="h4 u-mt0" aria-hidden="true">
-                        Cash advance fee
-                        {{- ', see details' if card.cash_advance_fee_calculation }}
-                    </div>
+                    {% endcall %}
                 </div>
             </div>
             {% if card.cash_advance_fee_calculation %}


### PR DESCRIPTION
This commit creates a new `data_section` macro in the TCCP card details page template, removing some boilerplate used repeatedly to render this page.

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/306 for context.

## How to test this PR

To test, run a local server with the latest data and visit pages like: http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/vinton-county-national-bank-consumer-credit-card/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)