### PR TITLE
TCCP: Cleanup detail page fee logic

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -386,31 +386,12 @@
             - Other fee: "$50 {fee name, period}"
             - Annual and other fee: "$495 annual fee + $50 {fee name, period}"
             - No periodic fee: "$0 annual fee"
-            - Fee that varies: "$25 - $55 annual/monthly fee"
         #}
         <div class="m-payment-calculation u-mb15">
             {% if card.annual_fee or not card.periodic_fee_type %}
                 <div class="m-payment-calculation__part">
                     <div class="h2 u-mb0 u-mt0">
-                        {# A handful of cards have both an annual and monthly
-                            fee with one of those fees varying. Because of how
-                            the data is (not) structured, we can only tell which
-                            fee varies by looking for either "annual" or
-                            "monthly" in the text of the fee explanation.
-                        #}
-                        {% if card.fee_varies %}
-                            {% if card.periodic_fee_type | join == "Annual" %}
-                                {{ currency(card.periodic_min) ~ ' - '
-                                    ~ currency(card.periodic_max) }}
-                            {% elif card.fee_explanation.lower().count('annual') %}
-                                {{ currency(card.periodic_min) ~ ' - '
-                                    ~ currency(card.periodic_max) }}
-                            {% else %}
-                                {{ currency(card.annual_fee) }}
-                            {% endif %}
-                        {% else %}
-                            {{ currency(card.annual_fee) if card.annual_fee else currency(0) }}
-                        {% endif %}
+                        {{ currency(card.annual_fee) if card.annual_fee else currency(0) }}
                         <span class="u-visually-hidden">Annual fee</span>
                     </div>
                     <div class="h4 u-mt0 u-mb0" aria-hidden="true">
@@ -419,30 +400,12 @@
                 </div>
             {% endif %}
             {% if card.monthly_fee %}
-                {% if card.annual_fee %}
+                {% if card.annual_fee or not card.periodic_fee_type %}
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
                     <div class="h2 u-mb0 u-mt0">
-                        {# A handful of cards have both an annual and monthly
-                            fee with one of those fees varying. Because of how
-                            the data is (not) structured, we can only tell which
-                            fee varies by looking for either "annual" or
-                            "monthly" in the text of the fee explanation.
-                        #}
-                        {% if card.fee_varies %}
-                            {% if card.periodic_fee_type | join == "Monthly" %}
-                                {{ currency(card.periodic_min) ~ ' - '
-                                    ~ currency(card.periodic_max) }}
-                            {% elif card.fee_explanation.lower().count('monthly') %}
-                                {{ currency(card.periodic_min) ~ ' - '
-                                    ~ currency(card.periodic_max) }}
-                            {% else %}
-                                {{ currency(card.monthly_fee) }}
-                            {% endif %}
-                        {% else %}
-                            {{ currency(card.monthly_fee) }}
-                        {% endif %}
+                        {{ currency(card.monthly_fee) if card.monthly_fee else currency(0) }}
                         <span class="u-visually-hidden">Monthly fee</span>
                     </div>
                     <div class="h4 u-mt0 u-mb0" aria-hidden="true">
@@ -451,7 +414,11 @@
                 </div>
             {% endif %}
             {% if card.weekly_fee %}
-                {% if card.annual_fee or card.monthly_fee %}
+                {% if
+                    card.annual_fee
+                    or not card.periodic_fee_type
+                    or card.monthly_fee
+                %}
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
@@ -465,7 +432,12 @@
                 </div>
             {% endif %}
             {% if card.other_periodic_fee_amount %}
-                {% if card.annual_fee or card.monthly_fee or card.weekly_fee %}
+                {% if
+                    card.annual_fee
+                    or not card.periodic_fee_type
+                    or card.monthly_fee
+                    or card.weekly_fee
+                %}
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">

--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -388,7 +388,7 @@
             - No periodic fee: "$0 annual fee"
         #}
         <div class="m-payment-calculation u-mb15">
-            {% if card.annual_fee or not card.periodic_fee_type %}
+            {% if card.annual_fee %}
                 <div class="m-payment-calculation__part">
                     <div class="h2 u-mb0 u-mt0">
                         {{ currency(card.annual_fee) if card.annual_fee else currency(0) }}
@@ -400,7 +400,7 @@
                 </div>
             {% endif %}
             {% if card.monthly_fee %}
-                {% if card.annual_fee or not card.periodic_fee_type %}
+                {% if card.annual_fee %}
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
@@ -414,11 +414,7 @@
                 </div>
             {% endif %}
             {% if card.weekly_fee %}
-                {% if
-                    card.annual_fee
-                    or not card.periodic_fee_type
-                    or card.monthly_fee
-                %}
+                {% if card.annual_fee or card.monthly_fee %}
                     <div class="m-payment-calculation__operator h2">+</div>
                 {% endif %}
                 <div class="m-payment-calculation__part">
@@ -434,7 +430,6 @@
             {% if card.other_periodic_fee_amount %}
                 {% if
                     card.annual_fee
-                    or not card.periodic_fee_type
                     or card.monthly_fee
                     or card.weekly_fee
                 %}


### PR DESCRIPTION
This PR simplifies some of the logic on the TCCP card detail page, removing code that tried to determine if a card has a varying periodic fee. The dataset schema doesn't provide enough information for us to reliably report this to users.

This change simplifies the fee rendering so that we only show annual, monthly, and weekly fees, without information on periodic changes.

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/306#issuecomment-354469 for additional context behind this change.

## How to test this PR

To test, run a local server with the latest data and visit a card page with fees, for example
http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/credit-one-bank-national-association-platinum-visa-for-rebuilding-credit/.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)