### PR TITLE
TCCP: Don't hardcode fee strings

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -530,27 +530,28 @@
                                 ' for a late payment within six billing cycles of another
                                 late payment' if card.late_fee_six_month_billing_cycle
                             }}
-                            {# A handful of cards specify neither a first nor repeat late
-                                fee and put all late fee info in the late_fee_policy_details
-                                field. For cards like that, we'll show the details here and
-                                not show the "Late fee policy details" item.
+                            {#
+                                A handful of cards specify neither a first nor repeat
+                                late fee and put all late fee info in the
+                                late_fee_policy_details field. For cards like that,
+                                we'll show the details here and not show the "Late fee
+                                policy details" item.
                             #}
-                            {# TODO: Refactor to not use the exact string #}
-                            {{ card.late_fee_policy_details if card.late_fee_types ==
-                                ['3. If you charge late fees that are not fixed dollar amounts, please explain your late fee policy here.']
+                            {{
+                                card.late_fee_policy_details
+                                if card.has_only_variable_late_fees
                             }}
                         {% else %}
                             None
                         {% endif %}
                     </dd>
-                    {# See the comment above: we won't show this if we're already showing
-                        late fee details in the "Late fee" item, i.e. if the card has *only*
-                        policy details chosen in late_fee_types
+                    {#
+                        See the comment above: we won't show this if we're already
+                        showing late fee details in the "Late fee" item, i.e. if the
+                        card has *only* policy details chosen in late_fee_types.
                     #}
-                    {# TODO: Refactor to not use the exact string #}
                     {% if card.late_fee_policy_details
-                        and card.late_fee_types !=
-                        ['3. If you charge late fees that are not fixed dollar amounts, please explain your late fee policy here.']
+                        and not card.has_only_variable_late_fees
                     %}
                         <dt>Late fee policy details</dt>
                         <dd>{{ card.late_fee_policy_details }}</dd>
@@ -561,26 +562,28 @@
                             {{ currency(card.over_limit_fee_dollars) if
                                 card.over_limit_fee_dollars
                             }}
-                            {# A handful of cards specify only over-limit fee details and
-                                not a fixed dollar amount. For cards like that, we'll show
-                                the details here and not show the "Over-limit fee details."
+                            {#
+                                A handful of cards specify only over-limit fee details
+                                and not a fixed dollar amount. For cards like that,
+                                we'll show the details here and not show the
+                                "Over-limit fee details."
                             #}
-                            {# TODO: Refactor to not use the exact string #}
-                            {{ card.overlimit_fee_detail if card.over_limit_fee_types ==
-                                ['2. If you charge overlimit fees that are not fixed dollar amounts, please explain what overlimit fees you charge here:']
+                            {{
+                                card.overlimit_fee_detail
+                                if card.has_only_variable_over_limit_fees
                             }}
                         {% else %}
                             None
                         {% endif %}
                     </dd>
-                    {# See the comment above: we won't show this if we're already showing
-                        over-limit fee details in the "Over-limit fee" item, i.e. if the
-                        card has *only* details chosen in over_limit_fee_types.
+                    {#
+                        See the comment above: we won't show this if we're already
+                        showing over-limit fee details in the "Over-limit fee" item,
+                        i.e. if the card has *only* details chosen in
+                        over_limit_fee_types.
                     #}
-                    {# TODO: Refactor to not use the exact string #}
                     {% if card.overlimit_fee_detail
-                        and card.over_limit_fee_types !=
-                        ['2. If you charge overlimit fees that are not fixed dollar amounts, please explain what overlimit fees you charge here:']
+                        and not card.has_only_variable_over_limit_fees
                     %}
                         <dt>Over-limit fee details</dt>
                         <dd>{{ card.overlimit_fee_detail }}</dd>

--- a/cfgov/tccp/models.py
+++ b/cfgov/tccp/models.py
@@ -745,3 +745,13 @@ class CardSurveyData(models.Model):
     @property
     def issued_by_credit_union(self):
         return self.institution_type == "CU"
+
+    @property
+    def has_only_variable_late_fees(self):
+        return [enums.LateFeeTypeChoices[2][0]] == self.late_fee_types
+
+    @property
+    def has_only_variable_over_limit_fees(self):
+        return [
+            enums.OverlimitFeeTypeChoices[1][0]
+        ] == self.over_limit_fee_types

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -16,6 +16,8 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
     purchase_apr_poor_rating = serializers.IntegerField()
     purchase_apr_data_incomplete = serializers.BooleanField()
     issued_by_credit_union = serializers.BooleanField()
+    has_only_variable_late_fees = serializers.BooleanField()
+    has_only_variable_over_limit_fees = serializers.BooleanField()
 
     class Meta:
         model = CardSurveyData

--- a/cfgov/tccp/tests/test_models.py
+++ b/cfgov/tccp/tests/test_models.py
@@ -3,7 +3,11 @@ from itertools import product
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
-from tccp.enums import CreditTierColumns
+from tccp.enums import (
+    CreditTierColumns,
+    LateFeeTypeChoices,
+    OverlimitFeeTypeChoices,
+)
 from tccp.models import CardSurveyData
 
 from .baker import baker
@@ -221,4 +225,34 @@ class CardSurveyDataTests(SimpleTestCase):
         )
         self.assertFalse(
             CardSurveyData(institution_type="Bank").issued_by_credit_union
+        )
+
+    def test_has_only_variable_late_fees(self):
+        self.assertFalse(
+            CardSurveyData(
+                late_fee_types=[
+                    LateFeeTypeChoices[0][0],
+                    LateFeeTypeChoices[2][0],
+                ]
+            ).has_only_variable_late_fees
+        )
+        self.assertTrue(
+            CardSurveyData(
+                late_fee_types=[LateFeeTypeChoices[2][0]]
+            ).has_only_variable_late_fees
+        )
+
+    def test_has_only_variable_over_limit_fees(self):
+        self.assertFalse(
+            CardSurveyData(
+                over_limit_fee_types=[
+                    OverlimitFeeTypeChoices[0][0],
+                    OverlimitFeeTypeChoices[1][0],
+                ]
+            ).has_only_variable_over_limit_fees
+        )
+        self.assertTrue(
+            CardSurveyData(
+                over_limit_fee_types=[OverlimitFeeTypeChoices[1][0]]
+            ).has_only_variable_over_limit_fees
         )


### PR DESCRIPTION
Minor update to TCCP card detail page to avoid hardcoding strings related to fee types. This has no impact on visible content.

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/306 for additional context.

## How to test this PR

To test, run a local server with the latest dataset and visit:

- Late fee details only: http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/pennsylvania-state-employees-cu-classic-visa/
- Late fee + details: http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ally-bank-ally-everyday-cash-back-mastercard_1/
- Over limit fee only: http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/university-bank-university-bank-visa-credit-card/
- Over limit fee + details: http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/idaho-central-credit-union-visa-platinum/

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)