### PR TITLE
TCCP: Make institution names uppercase in results

### DIFF
--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -169,6 +169,7 @@
     color: var(--gray);
     font-size: unit((16px / @base-font-size-px), rem);
     font-weight: 400;
+    text-transform: uppercase;
   }
 
   .m-card__subtitle {


### PR DESCRIPTION
When we list cards on the TCCP results view, we want the institution names to be uppercase. Previously we were counting on their names being uppercase in the source dataset, but the most recent dataset have some that are mixed case.

## How to test this PR

To test, sort alphabetically using the latest dataset:

http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?credit_tier=Credit%20scores%20from%20620%20to%20719&location=&ordering=product_name

## Screenshots

|Before|After|
|-|-|
|<img width="370" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/3ead022e-9118-4253-9e81-1cd33358aaed">|<img width="364" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/2b1155d2-077d-4777-91ef-b8d9b12aa2d3">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)