### PR TITLE
Remove COVID sidebar from find-a-housing-counselor

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -72,27 +72,6 @@
                         each agency.</strong>
                     </p>
                 </div>
-                <aside class="o-sidebar-breakout__col
-                                content-l__col
-                                content-l__col-1-3">
-                    <header class="m-slug-header">
-                        <h2 class="m-slug-header__heading">
-                            Coronavirus affecting your mortgage or housing?
-                        </h2>
-                    </header>
-                    <div class="o-sidebar-breakout__text-container">
-                        <div class="o-sidebar-breakout__text-body">
-                            <p>
-                                We have resources from multiple federal agencies to help homeowners and renters understand options for relief and protection in light of the coronavirus emergency.
-                            </p>
-                            <p>
-                                <a href="/coronavirus/mortgage-and-housing-assistance/">
-                                    See mortgage and housing assistance resources
-                                </a>
-                            </p>
-                        </div>
-                    </div>
-                </aside>
             </div>
         </div>
 


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR removes the coronavirus sidebar from `/find-a-housing-counselor`, as part of a larger COVID content cleanup initiative.

---

## How to test this PR

1. localhost
2. View `/find-a-housing-counselor`


## Screenshots
| Before | After | 
| - | - |
| <img width="1182" alt="Screenshot 2024-05-15 at 2 56 37 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/639c4680-1b7b-4abf-8472-190bb02d8474"> | <img width="1180" alt="Screenshot 2024-05-15 at 2 56 21 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/c2dc9875-5bd4-4121-8372-dccfe2c06380"> |



## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
