### PR TITLE
Find a Housing Counselor: Remove sidebar breakout and content-l column classes post-covid sidebar breakout removal

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -42,37 +42,30 @@
 
         <div class="block
                     block--flush-top
-                    u-screen-only
-                    o-sidebar-breakout">
-            <div class="content-l">
-                <div class="o-sidebar-breakout__col
-                            content-l__col
-                            content-l__col-2-3">
-                    <h1>Find a housing counselor</h1>
-                    <p>
-                        Housing counselors throughout the country can
-                        provide advice on buying a home, renting,
-                        defaults, forbearances, foreclosures, and
-                        credit issues. This list will show you
-                        several approved agencies in your area.
-                        The counseling agencies on this list are
-                        approved by the U.S. Department of Housing
-                        and Urban Development (HUD) and they can
-                        offer independent advice, often at little or
-                        no cost to you. There is also a
-                        <a class="a-link a-link--icon"
-                            href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
-                            <span class="a-link__text">list of nationwide HUD-approved counseling agencies</span></a>.
-                    </p>
-                    <p>
-                        Using the search box below, you can find one
-                        near you. <strong>Not every housing
-                        counselor offers all services, so please
-                        look at the list of services offered by
-                        each agency.</strong>
-                    </p>
-                </div>
-            </div>
+                    u-screen-only">
+            <h1>Find a housing counselor</h1>
+            <p>
+                Housing counselors throughout the country can
+                provide advice on buying a home, renting,
+                defaults, forbearances, foreclosures, and
+                credit issues. This list will show you
+                several approved agencies in your area.
+                The counseling agencies on this list are
+                approved by the U.S. Department of Housing
+                and Urban Development (HUD) and they can
+                offer independent advice, often at little or
+                no cost to you. There is also a
+                <a class="a-link a-link--icon"
+                    href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
+                    <span class="a-link__text">list of nationwide HUD-approved counseling agencies</span></a>.
+            </p>
+            <p>
+                Using the search box below, you can find one
+                near you. <strong>Not every housing
+                counselor offers all services, so please
+                look at the list of services offered by
+                each agency.</strong>
+            </p>
         </div>
 
         <div class="block block--border u-screen-only">


### PR DESCRIPTION
Follow-on to https://github.com/cfpb/consumerfinance.gov/pull/8421

With the removal of the covid breakout sidebar, we need to also delete some corresponding column classes that expect a second column.

## Removals

- Find a Housing Counselor: Removes heading area `content-l` columns and `o-sidebar-breakout` 

## How to test this PR

1. Visit http://localhost:8000/find-a-housing-counselor/ and resize to mobile and see that intro content extends full width.


## Screenshots

Before:

<img width="765" alt="Screenshot 2024-05-15 at 3 34 13 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/ed8f613b-fd2e-4721-90df-fb31458b43e8">

After:
<img width="767" alt="Screenshot 2024-05-15 at 3 33 47 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/27bb243e-6554-479e-b338-b3bfb0a13a3d">
