### PR TITLE
Move the financial wellbeing tool to the standard /es/-first format

### DIFF
--- a/cfgov/apache/conf.d/redirects.conf
+++ b/cfgov/apache/conf.d/redirects.conf
@@ -256,6 +256,9 @@ RedirectMatch permanent (?i)^/retirement/claiming-social-security/?$ /retirement
 RedirectMatch permanent (?i)^/jubilacion/?$  /retirement/before-you-claim/es/
 RedirectMatch permanent (?i)^/retirement/?$  /retirement/before-you-claim/
 
+# Redirect from /es/ suffix urls
+RedirectMatch permanent (?i)^/consumer-tools/financial-well-being/es/ /es/herramientas-del-consumidor/bienestar-financiero/
+
 # Owning a Home redirects
 RewriteRule ^owningahome$ /owning-a-home$1 [L,R=301]
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -371,6 +371,10 @@ urlpatterns = [
         r"^consumer-tools/financial-well-being/", include("wellbeing.urls")
     ),
     re_path(
+        r"^es/herramientas-del-consumidor/bienestar-financiero/",
+        include("wellbeing.es_urls"),
+    ),
+    re_path(
         r"^about-us/diversity-and-inclusion/",
         include(
             ("diversity_inclusion.urls", "diversity_inclusion"),

--- a/cfgov/wellbeing/es_urls.py
+++ b/cfgov/wellbeing/es_urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
         name="fwb_results_es",
     ),
     re_path(
-        r"^sobre/$",
+        r"^mas-sobre/$",
         TranslatedTemplateView.as_view(
             template_name="wellbeing/about.html", language="es"
         ),

--- a/cfgov/wellbeing/es_urls.py
+++ b/cfgov/wellbeing/es_urls.py
@@ -1,0 +1,38 @@
+from core.views import TranslatedTemplateView
+from wellbeing.views import ResultsView
+
+
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
+
+
+urlpatterns = [
+    re_path(
+        r"^$",
+        TranslatedTemplateView.as_view(
+            template_name="wellbeing/home.html", language="es"
+        ),
+        name="fwb_home_es",
+    ),
+    re_path(
+        r"^resultados/$",
+        ResultsView.as_view(language="es"),
+        name="fwb_results_es",
+    ),
+    re_path(
+        r"^sobre/$",
+        TranslatedTemplateView.as_view(
+            template_name="wellbeing/about.html", language="es"
+        ),
+        name="fwb_about_es",
+    ),
+    re_path(
+        r"^error/$",
+        TranslatedTemplateView.as_view(
+            template_name="wellbeing/error.html", language="es"
+        ),
+        name="fwb_error_es",
+    ),
+]

--- a/cfgov/wellbeing/urls.py
+++ b/cfgov/wellbeing/urls.py
@@ -25,30 +25,4 @@ urlpatterns = [
         TranslatedTemplateView.as_view(template_name="wellbeing/error.html"),
         name="fwb_error_en",
     ),
-    re_path(
-        r"^es/$",
-        TranslatedTemplateView.as_view(
-            template_name="wellbeing/home.html", language="es"
-        ),
-        name="fwb_home_es",
-    ),
-    re_path(
-        r"^results/es/$",
-        ResultsView.as_view(language="es"),
-        name="fwb_results_es",
-    ),
-    re_path(
-        r"^about/es/$",
-        TranslatedTemplateView.as_view(
-            template_name="wellbeing/about.html", language="es"
-        ),
-        name="fwb_about_es",
-    ),
-    re_path(
-        r"^error/es/$",
-        TranslatedTemplateView.as_view(
-            template_name="wellbeing/error.html", language="es"
-        ),
-        name="fwb_error_es",
-    ),
 ]


### PR DESCRIPTION
## Testing

- Visit http://localhost:8000/consumer-tools/financial-well-being/
- Click over to spanish with the language picker
- Note the url
- The tool should function and bring you to the result page