### PR TITLE
Some doc updates

### DIFF
--- a/docs/contributing-docs.md
+++ b/docs/contributing-docs.md
@@ -43,16 +43,7 @@ nav:
 
 ## Running the docs locally
 
-With a
-[stand-alone Python virtualenv for consumerfinance.gov](installation.md#set-up-a-local-python-environment-optional):
-
-```bash
-pyenv activate consumerfinance.gov
-pip install -r requirements/docs.txt
-mkdocs serve -a :8888
-```
-
-Once running, they are accessible at http://localhost:8888.
+See [Running documentation site locally](running-docs.md).
 
 ## Deploying the docs to GitHub Pages
 
@@ -79,8 +70,12 @@ for more information.
 
 Some internal documentation is not suitable for inclusion in the public docs.
 
-Internal documentation can be linked from publicly-viewable documentation only
-if internal domain names and URLs are not shared publicly. To support such linking,
+!!! warning
+
+    Internal documentation can be linked from publicly-viewable documentation only
+    if internal domain names and URLs are not shared publicly.
+
+To support such linking,
 the consumerfinance.gov Wagtail admin has a custom "Internal documentation" setting
 that allows for dynamic linking to an internal URL without exposing that URL in
 public source code or documentation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ Using the console, navigate to the root directory in which your projects
 live and clone this project's repository:
 
 ```sh
-git clone git@github.com:cfpb/consumerfinance.gov.git
+git clone https://github.com/cfpb/consumerfinance.gov.git
 cd consumerfinance.gov
 ```
 

--- a/docs/javascript-unit-tests.md
+++ b/docs/javascript-unit-tests.md
@@ -30,29 +30,6 @@ it would be a good idea to peruse their docs before diving in here.
 
 ## Running unit tests
 
-### Run a single test file
-
-To run a single test file, pass the name (or path) of the spec:
-
-```bash
-yarn jest Notification-spec.js
-# Equivalent to:
-yarn jest test/unit_tests/js/molecules/Notification-spec.js
-# The name argument would technically would match all Notification-spec.js files
-# This usually isn't a problem in our codebase (and you can always get more specific if needed)
-```
-
-### Run a directory of unit tests
-
-A directory of unit tests can be run by passing its name or path:
-
-```bash
-yarn jest organisms
-yarn jest test/unit_tests/js/organisms
-```
-
-### Run all unit tests
-
 To run all of the unit tests:
 
 ```bash
@@ -64,6 +41,23 @@ To first lint all files and then run tests:
 ```bash
 yarn test
 ```
+
+!!! note
+
+    To run a single test, or a directory of tests, you can run, for example:
+
+    ```bash
+    # Single test file:
+    yarn jest Notification-spec.js
+    # Equivalent to:
+    yarn jest test/unit_tests/js/molecules/Notification-spec.js
+
+    # Directory:
+    yarn jest organisms
+    # Equivalent to:
+    yarn jest test/unit_tests/js/organisms
+
+    ```
 
 Because we invoke jest directly, you can pass any command-line args it accepts
 to filter your output or to target specific tests [see the docs for more](https://jestjs.io/docs/cli).


### PR DESCRIPTION
There are redundant running the docs locally instructions, one of which doesn't work any longer. This PR points to one instruction and does some other minor cleanup.

## Changes

- Point to one "running the docs locally" instruction.
- Update git clone commands for cfgov to use HTTPS consistently.
- Move internal link text to a warning box.
- Consolidate JS testing instructions.
- 


## How to test this PR

1. `mkdocs serve` and check out the new docs locally!
