### PR TITLE
Limit related posts to those in the same language

### DIFF
--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -252,6 +252,7 @@ class RelatedPosts(blocks.StructBlock):
         queryset = (
             AbstractFilterPage.objects.live()
             .exclude(id=page.id)
+            .filter(language=page.language)
             .order_by("-date_published")
             .distinct()
             .specific()

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-posts.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-posts.html
@@ -76,32 +76,34 @@
    ========================================================================== #}
 
 {% macro render( value ) %}
-<div class="m-related-posts">
-    <header class="m-slug-header">
-        <h2 class="m-slug-header__heading">
-            {{ value.header_title }}
-        </h2>
-    </header>
-    {% for subposts in value.posts %}
-        <div class="m-related-posts__list-container">
-            {% if value.show_heading %}
-                <h3 class="h4">
-                    {% if subposts.icon %}{{ svg_icon( subposts.icon ) }}{% endif %}
-                    {{ subposts.title }}
-                </h3>
-            {% endif %}
-            {{ _related_posts_list( subposts.posts, value.limit ) }}
-        </div>
-    {% endfor %}
+{% if value.posts | length > 0 %}
+  <div class="m-related-posts">
+      <header class="m-slug-header">
+          <h2 class="m-slug-header__heading">
+              {{ value.header_title }}
+          </h2>
+      </header>
+      {% for subposts in value.posts %}
+          <div class="m-related-posts__list-container">
+              {% if value.show_heading %}
+                  <h3 class="h4">
+                      {% if subposts.icon %}{{ svg_icon( subposts.icon ) }}{% endif %}
+                      {{ subposts.title }}
+                  </h3>
+              {% endif %}
+              {{ _related_posts_list( subposts.posts, value.limit ) }}
+          </div>
+      {% endfor %}
 
-    <a class="a-link a-link--jump"
-       href="{{ value.view_more_url }}"
-       aria-label="{{ _('View more related posts') }}">
-        <span class="a-link__text">
-            {{ _('View more') }}
-        </span>
-    </a>
-</div>
+      <a class="a-link a-link--jump"
+         href="{{ value.view_more_url }}"
+         aria-label="{{ _('View more related posts') }}">
+          <span class="a-link__text">
+              {{ _('View more') }}
+          </span>
+      </a>
+  </div>
+{% endif %}
 {% endmacro %}
 
 {%- if value %}


### PR DESCRIPTION
## Testing

- Visit http://localhost:8000/about-us/blog/whats-ahead-for-bank-of-america-and-its-customers-zh/
  - Note the "Further Reading" section is all in Chinese
- Visit http://localhost:8000/about-us/blog/strengthening-information-accessibility-for-consumers-limited-english-proficiency-zh/ and note that the "Further Reading" section is gone.
  - Unfortunately due to how we add spacing in the streamfield-sidefoot, the EmailSignup block is unable to get `flush-top` at this time. I don't foresee this being too big of an issue, because most things have RelatedPosts
- Visit http://localhost:8000/about-us/events/archive-past-events/special-populations-presentation/
  - Note that "Further Reading" is all in English