### PR TITLE
Fix: EventPage previews without a location

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
@@ -128,13 +128,9 @@
                 {% set event = post.specific %}
                 {% if event.start_dt %}
                     <div class="o-post-preview__subtitle">
-                    {% if event.venue_city and event.venue_state %}
-                        {{ event.venue_city }}, {{ event.venue_state }}
-                    {% endif %}
-                            {{ event.venue_name if event.venue_name else '' }}
-                    {{ 'Livecast' if event.live_video_id else '' }}
-                     -
-                    {{ time.render(event.start_dt) }}
+                        {{ event.location_str }}
+                        {{- " - " if event.location_str -}}
+                        {{ time.render(event.start_dt) }}
                     </div>
                 {% endif %}
             {% endif %}

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -373,13 +373,13 @@ class EventPage(AbstractFilterPage):
         parts = []
 
         if self.venue_city and self.venue_state:
-            parts.append(f"{self.venue_city}, {self.venue_state}")
+            parts.extend([self.venue_city, self.venue_state])
         if self.venue_name:
             parts.append(self.venue_name)
         if self.live_video_id:
             parts.append("Livecast")
 
-        return " ".join(parts)
+        return ", ".join(parts)
 
     @property
     def page_js(self):

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -368,6 +368,19 @@ class EventPage(AbstractFilterPage):
 
         return "future"
 
+    @cached_property
+    def location_str(self):
+        parts = []
+
+        if self.venue_city and self.venue_state:
+            parts.append(f"{self.venue_city}, {self.venue_state}")
+        if self.venue_name:
+            parts.append(self.venue_name)
+        if self.live_video_id:
+            parts.append("Livecast")
+
+        return " ".join(parts)
+
     @property
     def page_js(self):
         if (self.live_stream_date and self.event_state == "present") or (

--- a/cfgov/v1/tests/models/test_event_page.py
+++ b/cfgov/v1/tests/models/test_event_page.py
@@ -2,7 +2,7 @@ import datetime
 import re
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
 import responses
@@ -174,6 +174,8 @@ class EventPageTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("Expires", response)
 
+
+class EventPageNoDBTests(SimpleTestCase):
     def assertValidationFails(self, expected_msg, **kwargs):
         page = EventPage(
             title="test",
@@ -182,7 +184,7 @@ class EventPageTests(TestCase):
         )
 
         with self.assertRaisesRegex(ValidationError, expected_msg):
-            save_new_page(page)
+            page.clean()
 
     def test_failing_validation_venue_image(self):
         self.assertValidationFails(
@@ -204,4 +206,16 @@ class EventPageTests(TestCase):
             live_stream_availability=True,
             live_stream_date=datetime.datetime.now(datetime.timezone.utc)
             + datetime.timedelta(hours=2),
+        )
+
+    def test_location_str(self):
+        self.assertEqual(EventPage().location_str, "")
+        self.assertEqual(
+            EventPage(
+                venue_city="Washington",
+                venue_state="DC",
+                venue_name="CFPB HQ",
+                live_video_id="abcde",
+            ).location_str,
+            "Washington, DC CFPB HQ Livecast",
         )

--- a/cfgov/v1/tests/models/test_event_page.py
+++ b/cfgov/v1/tests/models/test_event_page.py
@@ -217,5 +217,13 @@ class EventPageNoDBTests(SimpleTestCase):
                 venue_name="CFPB HQ",
                 live_video_id="abcde",
             ).location_str,
-            "Washington, DC CFPB HQ Livecast",
+            "Washington, DC, CFPB HQ, Livecast",
+        )
+        self.assertEqual(
+            EventPage(live_video_id="abcde").location_str,
+            "Livecast",
+        )
+        self.assertEqual(
+            EventPage(venue_name="CFPB HQ").location_str,
+            "CFPB HQ",
         )


### PR DESCRIPTION
EventPages that don't specify a location currently render with an extra leading dash, for example:

\- MAY 30, 2024 @ 01:00 PM EDT

This commit fixes that and adds some tests around how the preview location string renders.

See https://www.consumerfinance.gov/about-us/events/ for a live example of this bug right now.

## How to test this PR

Run a local server and visit http://localhost:8000/about-us/events/ and http://localhost:8000/about-us/events/archive-past-events/, and compare against production.

## Screenshots

|Before|After|
|-|-|
|<img width="745" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/d4197dce-3867-4145-8b6c-aac3b1162b63">|<img width="753" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/0a57e77a-3065-4715-9f75-36bee37e4c31">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)