### PR TITLE
Fix broken tag in password reset confirm template

### DIFF
--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/account/password_reset/confirm.html
@@ -27,8 +27,8 @@
             <form method="post" novalidate>
                 {% csrf_token %}
 
-                {% field field=form.new_password1 %}{% endfield %}
-                {% field field=form.new_password2 %}{% endfield %}
+                {% rawformattedfield field=form.new_password1 %}{% endrawformattedfield %}
+                {% rawformattedfield field=form.new_password2 %}{% endrawformattedfield %}
 
                 <footer class="form-actions">
                     <button type="submit" class="button">{% trans 'Reset password' %}</button>


### PR DESCRIPTION
Wagtail 6.0 included this change to the password reset confirmation template:

https://github.com/wagtail/wagtail/commit/84f885ff17056c0c01954637d645dc50cbcb77bb

This broke our template override, which you can see if you try to reset a password. This commit fixes that.

## Notes and todos

See also https://github.com/wagtail/wagtail/issues/11550 which discusses why this wasn't documented.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)