### PR TITLE
Switch to ruff for all our Python linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,17 @@ exclude: .+\/migrations\/.+\.py
 default_language_version:
   python: python3.8
 repos:
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
-    hooks:
-      - id: black
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.3.0
-    hooks:
-      - id: ruff
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: isort (python)
-        args: ['cfgov']
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7
-    hooks:
-      - id: bandit
-        args: ['-c', 'pyproject.toml', '--recursive']
-        additional_dependencies: ['bandit[toml]']
+-  repo: https://github.com/charliermarsh/ruff-pre-commit
+   rev: v0.4.5
+   hooks:
+     # Run the linter.
+     - id: ruff
+       args: ['--fix']
+     # Run the formatter.
+     - id: ruff-format
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.7.8
+  hooks:
+    - id: bandit
+      args: ['-c', 'pyproject.toml', '--recursive']
+      additional_dependencies: ['bandit[toml]']

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "editor.formatOnSave": true,
   "editor.formatOnPaste": false,
   "[python]": {
-    "editor.defaultFormatter": "ms-python.black-formatter"
-  }
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "ruff.importStrategy": "useBundled",
+  "ruff.lint.run": "onSave"
 }

--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -59,7 +59,7 @@ def save_agreement(agreements_zip, pdf_path, outfile, upload=False):
         issuer_name = Path(path).parts[-2]
     except ValueError:
         # too many slashes...
-        outfile.write("%s Does not match issuer/file.pdf pattern" % path)
+        outfile.write(f"{path} Does not match issuer/file.pdf pattern")
         return
 
     issuer = get_issuer(issuer_name)

--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -76,8 +76,6 @@ def save_agreement(agreements_zip, pdf_path, outfile, upload=False):
     if upload:
         pdf_file = agreements_zip.open(zipinfo)
         upload_to_s3(pdf_file, s3_key)
-        outfile.write(
-            f"{repr(s3_key)} uploaded"
-        )
+        outfile.write(f"{repr(s3_key)} uploaded")
 
     return agreement

--- a/cfgov/agreements/management/commands/_util.py
+++ b/cfgov/agreements/management/commands/_util.py
@@ -68,7 +68,7 @@ def save_agreement(agreements_zip, pdf_path, outfile, upload=False):
     agreement = issuer.agreement_set.create(
         file_name=filename,
         size=int(zipinfo.file_size),
-        uri="{}/{}".format(uri_hostname, s3_key),
+        uri=f"{uri_hostname}/{s3_key}",
         description=filename,
     )
     agreement.save()
@@ -77,9 +77,7 @@ def save_agreement(agreements_zip, pdf_path, outfile, upload=False):
         pdf_file = agreements_zip.open(zipinfo)
         upload_to_s3(pdf_file, s3_key)
         outfile.write(
-            "{} uploaded".format(
-                repr(s3_key),
-            )
+            f"{repr(s3_key)} uploaded"
         )
 
     return agreement

--- a/cfgov/agreements/management/commands/import_agreements.py
+++ b/cfgov/agreements/management/commands/import_agreements.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import nullcontext
 from pathlib import Path
 from zipfile import ZipFile
 
@@ -71,11 +72,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if options["verbosity"] >= 1:
-            output_file = self.stdout
-        else:
-            output_file = open(os.devnull, "a")
-
         # maybe this should be replaced with a CLI options:
         do_upload = os.environ.get("AGREEMENTS_S3_UPLOAD_ENABLED", False)
 
@@ -93,7 +89,11 @@ class Command(BaseCommand):
         Agreement.objects.all().delete()
         Issuer.objects.all().delete()
 
-        for pdf_path in all_pdfs:
-            _util.save_agreement(
-                agreements_zip, pdf_path, output_file, upload=do_upload
-            )
+        with (
+            nullcontext(self.stdout) if options["verbosity"] >= 1
+            else open(os.devnull, "a")
+        ) as output_file:
+            for pdf_path in all_pdfs:
+                _util.save_agreement(
+                    agreements_zip, pdf_path, output_file, upload=do_upload
+                )

--- a/cfgov/agreements/management/commands/import_agreements.py
+++ b/cfgov/agreements/management/commands/import_agreements.py
@@ -90,7 +90,8 @@ class Command(BaseCommand):
         Issuer.objects.all().delete()
 
         with (
-            nullcontext(self.stdout) if options["verbosity"] >= 1
+            nullcontext(self.stdout)
+            if options["verbosity"] >= 1
             else open(os.devnull, "a")
         ) as output_file:
             for pdf_path in all_pdfs:

--- a/cfgov/agreements/tests/test_views.py
+++ b/cfgov/agreements/tests/test_views.py
@@ -31,7 +31,7 @@ class TestIssuerSearch(TestCase):
     def test_issuer_has_agreements(self):
         issuer = Issuer.objects.create(name="A & B Bank", slug="a-b-bank")
         for i in range(2):
-            filename = "agreement{}.pdf".format(i + 1)
+            filename = f"agreement{i + 1}.pdf"
             Agreement.objects.create(
                 issuer=issuer, description=filename, file_name=filename, size=0
             )

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -32,7 +32,7 @@ class CFGovErrorHandler(logging.Handler):
     def emit(self, record):
         title = self.format_title(record)
         body = self.format_body(record)
-        message = "{title} - {body}".format(title=title, body=body)
+        message = f"{title} - {body}"
         self.sqs_queue.post(message=message)
 
     def format_title(self, record):

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -44,7 +44,7 @@ class CFGovErrorHandler(logging.Handler):
         except AttributeError:
             request = None
 
-        return f"{self.format(record)}\n\nRequest repr(): \n{self._get_request_repr(request)}"
+        return f"{self.format(record)}\n\nRequest repr(): \n{self._get_request_repr(request)}"  # noqa: E501
 
     def _get_request_repr(self, request):
         """

--- a/cfgov/alerts/logging_handlers.py
+++ b/cfgov/alerts/logging_handlers.py
@@ -44,10 +44,7 @@ class CFGovErrorHandler(logging.Handler):
         except AttributeError:
             request = None
 
-        return "%s\n\nRequest repr(): \n%s" % (
-            self.format(record),
-            self._get_request_repr(request),
-        )
+        return f"{self.format(record)}\n\nRequest repr(): \n{self._get_request_repr(request)}"
 
     def _get_request_repr(self, request):
         """
@@ -113,13 +110,5 @@ class CFGovErrorHandler(logging.Handler):
         path = request.path
 
         return force_str(
-            "<%s\npath:%s,\nGET:%s,\nPOST:%s,\nCOOKIES:%s,\nMETA:%s>"
-            % (
-                request.__class__.__name__,
-                path,
-                str(get),
-                str(post),
-                str(cookies),
-                str(meta),
-            )
+            f"<{request.__class__.__name__}\npath:{path},\nGET:{str(get)},\nPOST:{str(post)},\nCOOKIES:{str(cookies)},\nMETA:{str(meta)}>"
         )

--- a/cfgov/alerts/newrelic_alerts.py
+++ b/cfgov/alerts/newrelic_alerts.py
@@ -71,8 +71,8 @@ class NewRelicAlertViolations:
         )
         incidents_link = (
             "https://alerts.newrelic.com/accounts/"
-            "{account_number}/incidents"
-        ).format(account_number=self.account_number)
+            f"{self.account_number}/incidents"
+        )
         body = (
             "New Relic {product}, {name}, {label} "
             "({priority}, opened {opened}, incident ID {incident_id})."
@@ -86,5 +86,5 @@ class NewRelicAlertViolations:
             opened=opened_str,
             link=incidents_link,
         )
-        message_body = "{title} - {body}".format(title=title, body=body)
+        message_body = f"{title} - {body}"
         return message_body

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -64,7 +64,8 @@ def cleanup_message(message):
     return message.replace(
         "#", "# "
     ).replace(  # Avoids erroneous Github issue link
-        "[Open]", ""  # We want to expand the link
+        "[Open]",
+        "",  # We want to expand the link
     )
 
 

--- a/cfgov/alerts/post_sqs_messages.py
+++ b/cfgov/alerts/post_sqs_messages.py
@@ -72,16 +72,14 @@ def process_sqs_message(message, github_alert, mattermost_alert):
     body = cleanup_message(message.get("Body"))
     title = body.split(" - ")[0]
 
-    logger.debug("Retrieved message {} from SQS".format(body))
+    logger.debug(f"Retrieved message {body} from SQS")
 
     issue = github_alert.post(title=title, body=body)
 
     if mattermost_alert:
         try:
             mattermost_alert.post(
-                text="Alert: {}. Github issue at {}".format(
-                    title, issue.html_url
-                )
+                text=f"Alert: {title}. Github issue at {issue.html_url}"
             )
         except Exception:
             # Mattermost failures should be considered non-fatal, as the alert

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -68,9 +68,7 @@ parser.add_argument(
 
 def cache_known_violations(known_violations_filename, known_violations):
     with open(known_violations_filename, "w") as known_violations_file:
-        known_violations_file.writelines(
-            [f"{v}\n" for v in known_violations]
-        )
+        known_violations_file.writelines([f"{v}\n" for v in known_violations])
 
     logger.info(f"cached known violations {known_violations}")
 

--- a/cfgov/alerts/send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/send_new_relic_messages_to_sqs.py
@@ -69,22 +69,22 @@ parser.add_argument(
 def cache_known_violations(known_violations_filename, known_violations):
     with open(known_violations_filename, "w") as known_violations_file:
         known_violations_file.writelines(
-            ["{}\n".format(v) for v in known_violations]
+            [f"{v}\n" for v in known_violations]
         )
 
-    logger.info("cached known violations {}".format(known_violations))
+    logger.info(f"cached known violations {known_violations}")
 
 
 def read_known_violations(known_violations_filename):
     try:
-        with open(known_violations_filename, "r") as known_violations_file:
+        with open(known_violations_filename) as known_violations_file:
             known_violations = [
                 int(v) for v in known_violations_file.readlines()
             ]
-    except IOError:
+    except OSError:
         logger.warning("Known violations file does not exist")
         known_violations = []
-    logger.info("read known violations {}".format(known_violations))
+    logger.info(f"read known violations {known_violations}")
     return known_violations
 
 
@@ -120,7 +120,7 @@ if __name__ == "__main__":
         response = sqs_queue.post(message)
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             sys.exit(1)
-        logger.info("Sent message '{}' to SQS".format(message))
+        logger.info(f"Sent message '{message}' to SQS")
 
     # Cache known violations
     cache_known_violations(

--- a/cfgov/alerts/tests/test_github_alert.py
+++ b/cfgov/alerts/tests/test_github_alert.py
@@ -18,17 +18,14 @@ class TestGithubAlert(TestCase):
     session = GitHubSession()
     session.basic_auth("test", "test")
 
-    repository = ShortRepository(
-        json.load(open(f"{JSON_DIR}/github_repository.json")), session
-    )
+    with open(f"{JSON_DIR}/github_repository.json") as f:
+        repository = ShortRepository(json.load(f), session)
 
-    closed_issue = ShortIssue(
-        json.load(open(f"{JSON_DIR}/github_closed_issue.json")), session
-    )
+    with open(f"{JSON_DIR}/github_closed_issue.json") as f:
+        closed_issue = ShortIssue(json.load(f), session)
 
-    open_issue = ShortIssue(
-        json.load(open(f"{JSON_DIR}/github_open_issue.json")), session
-    )
+    with open(f"{JSON_DIR}/github_open_issue.json") as f:
+        open_issue = ShortIssue(json.load(f), session)
 
     def setUp(self):
         self.text = "foö"

--- a/cfgov/alerts/tests/test_github_alert.py
+++ b/cfgov/alerts/tests/test_github_alert.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest.mock import patch

--- a/cfgov/alerts/tests/test_logging_handlers.py
+++ b/cfgov/alerts/tests/test_logging_handlers.py
@@ -38,7 +38,7 @@ class TestLoggingHandlers(TestCase):
                     "handlers": {
                         "cfgov": {
                             "level": "ERROR",
-                            "class": "alerts.logging_handlers.CFGovErrorHandler",
+                            "class": "alerts.logging_handlers.CFGovErrorHandler",  # noqa: E501
                         },
                     },
                     "loggers": {

--- a/cfgov/alerts/tests/test_mattermost_alert.py
+++ b/cfgov/alerts/tests/test_mattermost_alert.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import patch
 
 from django.test import TestCase

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -19,9 +19,8 @@ class TestPostSQSMessages(TestCase):
     session = GitHubSession()
     session.basic_auth("test", "test")
 
-    issue = ShortIssue(
-        json.load(open(f"{JSON_DIR}/github_open_issue.json")), session
-    )
+    with open(f"{JSON_DIR}/github_open_issue.json") as f:
+        issue = ShortIssue(json.load(f), session)
 
     @patch("alerts.mattermost_alert.MattermostAlert.post")
     @patch("alerts.github_alert.GithubAlert.post", return_value=issue)

--- a/cfgov/alerts/tests/test_post_sqs_messages.py
+++ b/cfgov/alerts/tests/test_post_sqs_messages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from unittest.mock import patch

--- a/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
+++ b/cfgov/alerts/tests/test_send_new_relic_messages_to_sqs.py
@@ -28,6 +28,6 @@ class TestSendNewRelicMessagesToSQS(unittest.TestCase):
 
     def test_read_known_violations_nonexisting(self):
         with mock.patch("builtins.open", create=True) as mock_open:
-            mock_open.side_effect = IOError()
+            mock_open.side_effect = OSError()
             known_violations = read_known_violations("/some/file.json")
         self.assertEqual([], known_violations)

--- a/cfgov/ask_cfpb/models/django.py
+++ b/cfgov/ask_cfpb/models/django.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.contrib.auth.models import User
 from django.db import models
 

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -366,7 +366,7 @@ class AnswerResultsPage(CFGOVPage):
     template = "ask-cfpb/answer-search-results.html"
 
     def get_context(self, request, **kwargs):
-        context = super(AnswerResultsPage, self).get_context(request, **kwargs)
+        context = super().get_context(request, **kwargs)
         context.update(**kwargs)
         paginator = Paginator(self.answers, 25)
         page_number = validate_page_number(request, paginator)
@@ -393,7 +393,7 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
             activate(self.language)
         else:
             deactivate_all()
-        context = super(TagResultsPage, self).get_context(
+        context = super().get_context(
             request, *args, **kwargs
         )
         return context

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -245,7 +245,7 @@ class PortalSearchPage(RoutablePageMixin, CFGOVPage):
         sorted_categories = [
             {
                 "title": category.title(self.language),
-                "url": "{}{}/".format(url, slug),
+                "url": f"{url}{slug}/",
                 "active": (
                     False
                     if not self.portal_category
@@ -316,10 +316,7 @@ class PortalSearchPage(RoutablePageMixin, CFGOVPage):
         if self.category_slug not in self.category_map:
             raise Http404
         self.portal_category = self.category_map.get(self.category_slug)
-        self.title = "{} {}".format(
-            self.portal_topic.title(self.language),
-            self.portal_category.title(self.language).lower(),
-        )
+        self.title = f"{self.portal_topic.title(self.language)} {self.portal_category.title(self.language).lower()}"
         if self.portal_category.heading == "Key terms":
             self.glossary_terms = self.get_glossary_terms()
             return TemplateResponse(

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -259,7 +259,7 @@ class PortalSearchPage(RoutablePageMixin, CFGOVPage):
             {
                 "title": self.portal_topic.title(self.language),
                 "url": url,
-                "active": False if self.portal_category else True,
+                "active": not self.portal_category,
                 "expanded": True,
                 "children": sorted_categories,
             }

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -393,9 +393,7 @@ class TagResultsPage(RoutablePageMixin, AnswerResultsPage):
             activate(self.language)
         else:
             deactivate_all()
-        context = super().get_context(
-            request, *args, **kwargs
-        )
+        context = super().get_context(request, *args, **kwargs)
         return context
 
     @route(r"^$")

--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -316,7 +316,7 @@ class PortalSearchPage(RoutablePageMixin, CFGOVPage):
         if self.category_slug not in self.category_map:
             raise Http404
         self.portal_category = self.category_map.get(self.category_slug)
-        self.title = f"{self.portal_topic.title(self.language)} {self.portal_category.title(self.language).lower()}"
+        self.title = f"{self.portal_topic.title(self.language)} {self.portal_category.title(self.language).lower()}"  # noqa: E501
         if self.portal_category.heading == "Key terms":
             self.glossary_terms = self.get_glossary_terms()
             return TemplateResponse(

--- a/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
+++ b/cfgov/ask_cfpb/scripts/replace_unsupported_characters.py
@@ -9,12 +9,12 @@ from ask_cfpb.models.answer_page import AnswerPage
 unicode_swaps = {
     "\x91": "\u2018",  # Left Single Quotation Mark
     "\x92": "\u2019",  # Right Single Quotation Mark
-    "\x93": "\u201C",  # Left Double Quotation Mark
-    "\x94": "\u201D",  # Right Double Quotation Mark
+    "\x93": "\u201c",  # Left Double Quotation Mark
+    "\x94": "\u201d",  # Right Double Quotation Mark
     "\x95": "\u2022",  # Bullet
     "\x96": "\u2013",  # En Dash
     "\x97": "\u2014",  # Em Dash
-    "\x98": "\u02DC",  # Small Tilde
+    "\x98": "\u02dc",  # Small Tilde
     "\x99": "\u2122",  # Trade Mark Sign
     "\xac": "-",  # Not Sign (a dash with a hook on end)
     "\u200b": "",  # Zero Width Space (We neve want this)

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -880,9 +880,7 @@ class AnswerPageTest(TestCase):
         page = self.page1
         self.assertTrue(page.answer_base)
         result = page.__str__()
-        self.assertEqual(
-            result, f"{page.answer_base.pk}: {page.title}"
-        )
+        self.assertEqual(result, f"{page.answer_base.pk}: {page.title}")
 
     def test_search_tags(self):
         """Test the list produced by page.clean_search_tags()."""

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -690,10 +690,11 @@ class AnswerPageTest(TestCase):
                         "content": (
                             "<p><span>"
                             "This is more than forty words: "
-                            "word word word word word word word word word word "
-                            "word word word word word word word word word word "
-                            "word word word word word word word word word word "
-                            "word word word word word word too-many."
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "too-many."
                             "</span></p>"
                         )
                     },
@@ -732,10 +733,11 @@ class AnswerPageTest(TestCase):
                             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
                             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
                             "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
-                            "char char char char char char char char char char "
-                            "char char char char char char char char char char "
-                            "char char char char char char char char char char "
-                            "char char char char char char too-many."
+                            "char char char char char char char char char "
+                            "char char char char char char char char char "
+                            "char char char char char char char char char "
+                            "char char char char char char char char char "
+                            "too-many."
                             "</span></p>"
                         )
                     },
@@ -781,10 +783,11 @@ class AnswerPageTest(TestCase):
                         "content": (
                             "<p><span>"
                             "This is more than forty words: "
-                            "word word word word word word word word word word "
-                            "word word word word word word word word word word "
-                            "word word word word word word word word word word "
-                            "word word word word word word too-many."
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "word word word word word word word word word "
+                            "too-many."
                             "</span></p>"
                         )
                     },

--- a/cfgov/ask_cfpb/tests/models/test_pages.py
+++ b/cfgov/ask_cfpb/tests/models/test_pages.py
@@ -451,7 +451,7 @@ class PortalSearchPageTest(TestCase):
             portal_topic=page.portal_topic,
         )
         glossary_term.save()
-        url = "{}key-terms/".format(page.url)
+        url = f"{page.url}key-terms/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Amortization")
@@ -465,7 +465,7 @@ class PortalSearchPageTest(TestCase):
             portal_topic=page.portal_topic,
         )
         glossary_term.save()
-        url = "{}palabras-claves/".format(page.url)
+        url = f"{page.url}palabras-claves/"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Amortización")
@@ -881,7 +881,7 @@ class AnswerPageTest(TestCase):
         self.assertTrue(page.answer_base)
         result = page.__str__()
         self.assertEqual(
-            result, "{}: {}".format(page.answer_base.pk, page.title)
+            result, f"{page.answer_base.pk}: {page.title}"
         )
 
     def test_search_tags(self):

--- a/cfgov/ask_cfpb/tests/models/test_snippets.py
+++ b/cfgov/ask_cfpb/tests/models/test_snippets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from django.test import TestCase
 

--- a/cfgov/ask_cfpb/tests/models/test_snippets.py
+++ b/cfgov/ask_cfpb/tests/models/test_snippets.py
@@ -1,4 +1,3 @@
-
 from django.test import TestCase
 
 from ask_cfpb.models.snippets import GlossaryTerm

--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -34,7 +34,7 @@ class AskBlocksTestCase(TestCase):
         block = AskAnswerContent()
         value = block.to_python([self.tip_data, self.text_data])
         html = block.render(value)
-        expected_html = f'<div class="row">{self.expected_tip_html}{self.expected_text_html}</div>'
+        expected_html = f'<div class="row">{self.expected_tip_html}{self.expected_text_html}</div>'  # noqa: E501
         self.assertHTMLEqual(html, expected_html)
 
     def test_content_block_does_not_apply_wrapper_without_tip(self):

--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -27,27 +27,21 @@ class AskBlocksTestCase(TestCase):
         block = AskAnswerContent()
         value = block.to_python([self.tip_data])
         html = block.render(value)
-        expected_html = '<div class="row">{}</div>'.format(
-            self.expected_tip_html
-        )
+        expected_html = f'<div class="row">{self.expected_tip_html}</div>'
         self.assertHTMLEqual(html, expected_html)
 
     def test_content_block_applies_wrapper_to_tip_and_next_block(self):
         block = AskAnswerContent()
         value = block.to_python([self.tip_data, self.text_data])
         html = block.render(value)
-        expected_html = '<div class="row">{}{}</div>'.format(
-            self.expected_tip_html, self.expected_text_html
-        )
+        expected_html = f'<div class="row">{self.expected_tip_html}{self.expected_text_html}</div>'
         self.assertHTMLEqual(html, expected_html)
 
     def test_content_block_does_not_apply_wrapper_without_tip(self):
         block = AskAnswerContent()
         value = block.to_python([self.text_data])
         html = block.render(value)
-        expected_html = '<div class="row">{}</div>'.format(
-            self.expected_text_html
-        )
+        expected_html = f'<div class="row">{self.expected_text_html}</div>'
         self.assertNotIn('<div class="row">', html)
         self.assertHTMLEqual(html, expected_html)
 

--- a/cfgov/ask_cfpb/tests/test_documents.py
+++ b/cfgov/ask_cfpb/tests/test_documents.py
@@ -158,7 +158,6 @@ class AnswerPageDocumentTest(TestCase):
             )
 
     def test_mapping(self):
-
         self.assertEqual(
             AnswerPageDocument._doc_type.mapping.to_dict(),
             {

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -51,7 +51,7 @@ class AnswerPagePreviewTestCase(TestCase):
         self.english_answer_page = AnswerPage(
             answer_base=self.test_answer,
             language="en",
-            slug="test-question1-en-{}".format(self.test_answer.pk),
+            slug=f"test-question1-en-{self.test_answer.pk}",
             title="Test question1",
             answer_content=json.dumps(
                 [
@@ -71,7 +71,7 @@ class AnswerPagePreviewTestCase(TestCase):
         self.english_answer_page2 = AnswerPage(
             answer_base=self.test_answer2,
             language="en",
-            slug="test-question2-en-{}".format(self.test_answer2.pk),
+            slug=f"test-question2-en-{self.test_answer2.pk}",
             title="Test question2",
             answer_content=json.dumps(
                 [

--- a/cfgov/ask_cfpb/wagtail_hooks.py
+++ b/cfgov/ask_cfpb/wagtail_hooks.py
@@ -49,7 +49,7 @@ def create_answer_id(request, page):
         sister_page = create_sister_page(page, new_answer_base)
         sister_page.save()
         sister_page.save_revision(user=request.user)
-        page.title = "{}-{}-{}".format(page.title, page.language, new_id)
-        page.slug = "{}-{}-{}".format(page.slug, page.language, new_id)
+        page.title = f"{page.title}-{page.language}-{new_id}"
+        page.slug = f"{page.slug}-{page.language}-{new_id}"
         page.save()
         page.save_revision(user=request.user)

--- a/cfgov/cfgov/tests/test_urls.py
+++ b/cfgov/cfgov/tests/test_urls.py
@@ -59,7 +59,7 @@ def extract_regexes_from_urlpatterns(urlpatterns, base=""):
                     )
                 )
         else:
-            raise TypeError("%s does not appear to be a urlpattern object" % p)
+            raise TypeError(f"{p} does not appear to be a urlpattern object")
     return regexes
 
 

--- a/cfgov/cfgov/tests/test_util.py
+++ b/cfgov/cfgov/tests/test_util.py
@@ -8,7 +8,6 @@ from cfgov.util import admin_emails, environment_json
 
 
 class AdminEmailsTestCase(SimpleTestCase):
-
     def test_empty(self):
         self.assertEqual(admin_emails(""), [])
 
@@ -20,7 +19,6 @@ class AdminEmailsTestCase(SimpleTestCase):
 
 
 class EnvironmentJsonTestCase(SimpleTestCase):
-
     @mock.patch.dict(os.environ, {})
     def test_with_variable_dne(self):
         with self.assertRaises(ImproperlyConfigured):

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -54,7 +54,7 @@ def flagged_wagtail_only_view(flag_name, regex_path, url_name=None):
     """If flag is set, serve page from Wagtail, otherwise raise 404."""
 
     def this_view_always_raises_http404(request, *args, **kwargs):
-        raise Http404("flag {} not set".format(flag_name))
+        raise Http404(f"flag {flag_name} not set")
 
     return flagged_re_path(
         flag_name,

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -612,7 +612,7 @@ def handle_error(code, request, exception=None):
     try:
         return render(
             request,
-            "v1/layouts/%s.html" % code,
+            f"v1/layouts/{code}.html",
             context={"request": request},
             status=code,
         )
@@ -623,7 +623,7 @@ def handle_error(code, request, exception=None):
 
         return HttpResponse(
             "This request could not be processed, "
-            "HTTP Error %s." % str(code),
+            f"HTTP Error {str(code)}.",
             status=code,
         )
 

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -622,8 +622,7 @@ def handle_error(code, request, exception=None):
         # the results of a security scan, or a malformed static file reference.
 
         return HttpResponse(
-            "This request could not be processed, "
-            f"HTTP Error {str(code)}.",
+            "This request could not be processed, " f"HTTP Error {str(code)}.",
             status=code,
         )
 

--- a/cfgov/core/govdelivery.py
+++ b/cfgov/core/govdelivery.py
@@ -99,9 +99,7 @@ class LoggingMockGovDelivery(MockGovDelivery):
                 account_code=self.account_code,
                 method=method,
                 args=", ".join(map(str, args)),
-                kwargs=", ".join(
-                    f"{k}={v}" for k, v in kwargs.items()
-                ),
+                kwargs=", ".join(f"{k}={v}" for k, v in kwargs.items()),
             )
         )
 

--- a/cfgov/core/govdelivery.py
+++ b/cfgov/core/govdelivery.py
@@ -100,7 +100,7 @@ class LoggingMockGovDelivery(MockGovDelivery):
                 method=method,
                 args=", ".join(map(str, args)),
                 kwargs=", ".join(
-                    "{k}={v}".format(k=k, v=v) for k, v in kwargs.items()
+                    f"{k}={v}" for k, v in kwargs.items()
                 ),
             )
         )

--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -83,8 +83,9 @@ class Command(BaseCommand):
             # Notify specified emails (e.g. system admins)
             if len(emails) > 0:
                 self.stdout.write(
-                    "Sending inactive user list to "
-                    "{}\n".format(",".join(emails))
+                    "Sending inactive user list to " "{}\n".format(
+                        ",".join(emails)
+                    )
                 )
                 self.send_email(emails, period, inactive_users)
 
@@ -161,7 +162,9 @@ class Command(BaseCommand):
     def send_user_deactivation_email(self, user, period):
         """Send the specified user a warning that the have been deactivated
         due to inactivity"""
-        subject = f"{settings.EMAIL_SUBJECT_PREFIX}Wagtail account deactivation"
+        subject = (
+            f"{settings.EMAIL_SUBJECT_PREFIX}Wagtail account deactivation"
+        )
         msg = (
             "Hello,\n\n"
             + "Your Wagtail account has not been accessed for more than "

--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -74,10 +74,10 @@ class Command(BaseCommand):
         inactive_users = _get_inactive_users(period)
 
         if len(inactive_users) == 0:
-            self.stdout.write("No users are inactive {}+ days".format(period))
+            self.stdout.write(f"No users are inactive {period}+ days")
         else:
             # List inactive users and then deactivate them
-            self.stdout.write("Users inactive for {}+ days:\n".format(period))
+            self.stdout.write(f"Users inactive for {period}+ days:\n")
             self.stdout.write(self.format_inactive_users(inactive_users))
 
             # Notify specified emails (e.g. system admins)
@@ -96,10 +96,8 @@ class Command(BaseCommand):
 
                 # Deactivate and notify inactive users
                 self.stdout.write(
-                    "Deactivating and emailing {} users who "
-                    "have been inactive for {} days".format(
-                        len(inactive_users), period
-                    )
+                    f"Deactivating and emailing {len(inactive_users)} users who "
+                    f"have been inactive for {period} days"
                 )
 
         if warn_users_flag_set:
@@ -110,8 +108,8 @@ class Command(BaseCommand):
 
             # Notify users approaching deactivation
             self.stdout.write(
-                "Emailing {} users who have been "
-                "inactive for {} days".format(len(warn_users), warn_period)
+                f"Emailing {len(warn_users)} users who have been "
+                f"inactive for {warn_period} days"
             )
 
             for user in warn_users:
@@ -128,9 +126,7 @@ class Command(BaseCommand):
             else:
                 last_login = "never"
 
-            inactive_users_str += "\t{username}: {last_login}\n".format(
-                username=user.username, last_login=last_login
-            )
+            inactive_users_str += f"\t{user.username}: {last_login}\n"
 
         return inactive_users_str
 
@@ -138,12 +134,10 @@ class Command(BaseCommand):
         """Sends a report email to specified emails listing the users who have
         been inactive for the specified time period."""
         now = date_format(timezone.now(), "SHORT_DATETIME_FORMAT")
-        subject = "{prefix}Inactive users as of {now}".format(
-            prefix=settings.EMAIL_SUBJECT_PREFIX, now=now
-        )
+        subject = f"{settings.EMAIL_SUBJECT_PREFIX}Inactive users as of {now}"
         msg = (
             "The following active users have not logged in for "
-            "{period}+ days:\n".format(period=period)
+            f"{period}+ days:\n"
         )
         msg += self.format_inactive_users(inactive_users)
         email_message = mail.EmailMessage(subject, msg, None, emails)
@@ -151,9 +145,7 @@ class Command(BaseCommand):
 
     def send_user_warning_email(self, user, warn_period, period):
         """Send the specified user a warning that they have been inactive"""
-        subject = "{prefix}Wagtail account inactivity".format(
-            prefix=settings.EMAIL_SUBJECT_PREFIX
-        )
+        subject = f"{settings.EMAIL_SUBJECT_PREFIX}Wagtail account inactivity"
         msg = (
             "Hello,\n\n"
             + "Your consumerfinance.gov Wagtail account has not been "
@@ -169,9 +161,7 @@ class Command(BaseCommand):
     def send_user_deactivation_email(self, user, period):
         """Send the specified user a warning that the have been deactivated
         due to inactivity"""
-        subject = "{prefix}Wagtail account deactivation".format(
-            prefix=settings.EMAIL_SUBJECT_PREFIX
-        )
+        subject = f"{settings.EMAIL_SUBJECT_PREFIX}Wagtail account deactivation"
         msg = (
             "Hello,\n\n"
             + "Your Wagtail account has not been accessed for more than "

--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -97,8 +97,8 @@ class Command(BaseCommand):
 
                 # Deactivate and notify inactive users
                 self.stdout.write(
-                    f"Deactivating and emailing {len(inactive_users)} users who "
-                    f"have been inactive for {period} days"
+                    f"Deactivating and emailing {len(inactive_users)} users "
+                    f"who have been inactive for {period} days"
                 )
 
         if warn_users_flag_set:

--- a/cfgov/core/templatetags/svg_icon.py
+++ b/cfgov/core/templatetags/svg_icon.py
@@ -28,7 +28,7 @@ def load_svg(name: str) -> str:
     if not (static_filename := finders.find(relative_path)):
         raise FileNotFoundError(f"{relative_path} not found in staticfiles.")
 
-    with open(static_filename, "r") as f:
+    with open(static_filename) as f:
         content = f.read()
         if not SVG_REGEX.match(content):
             raise ValueError(f"{static_filename} not a valid SVG.")

--- a/cfgov/core/tests/test_decorators.py
+++ b/cfgov/core/tests/test_decorators.py
@@ -23,9 +23,9 @@ class DecoratorTests(SimpleTestCase):
 
         wrapped_view = add_headers(view, {"Test-Header": "test"})
         response_with_headers = wrapped_view(self.request)
-        self.assertEquals(response_with_headers["Test-Header"], "test")
+        self.assertEqual(response_with_headers["Test-Header"], "test")
 
     def test_akamai_no_store(self):
         response = view_no_store(self.request)
-        self.assertEquals(response["Edge-Control"], "no-store")
-        self.assertEquals(response["Akamai-Cache-Control"], "no-store")
+        self.assertEqual(response["Edge-Control"], "no-store")
+        self.assertEqual(response["Akamai-Cache-Control"], "no-store")

--- a/cfgov/core/tests/test_management_inactive_users.py
+++ b/cfgov/core/tests/test_management_inactive_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import timedelta
 from io import StringIO
 
@@ -91,7 +90,7 @@ class InactiveUsersTestCase(TestCase):
         )
         self.assertEqual(
             Command().format_inactive_users([self.user_1]),
-            "\tuser_1: {}\n".format(short_date),
+            f"\tuser_1: {short_date}\n",
         )
 
     def test_format_inactive_users_never_logged_in(self):

--- a/cfgov/core/tests/test_middleware.py
+++ b/cfgov/core/tests/test_middleware.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import mock
 
 from django.http import HttpResponse

--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -178,7 +178,7 @@ class LinkUtilsTests(SimpleTestCase):
 
     def test_content_cfgov(self):
         url = "http://content.cfpb.gov"
-        tag = "<a href='{}'>foo</a>".format(url)
+        tag = f"<a href='{url}'>foo</a>"
         path = "/"
         self.assertIsNone(add_link_markup(tag, path))
 
@@ -226,7 +226,7 @@ class LinkUtilsTests(SimpleTestCase):
         ]
         path = "/"
         for url in urls:
-            tag = "<a href='{}'>foo</a>".format(url)
+            tag = f"<a href='{url}'>foo</a>"
             self.assertIn(
                 'data-pretty-href="cfpb.gov/askcfpb/108"',
                 add_link_markup(tag, path),
@@ -240,7 +240,7 @@ class LinkUtilsTests(SimpleTestCase):
             "https://consumerfinance.gov/ask-cfpb-in-the-url/123",
         ]
         for url in urls:
-            tag = "<a href='{}'>foo</a>".format(url)
+            tag = f"<a href='{url}'>foo</a>"
             self.assertIsNone(add_link_markup(tag, path))
 
     def test_link_button(self):

--- a/cfgov/core/testutils/mock_staticfiles.py
+++ b/cfgov/core/testutils/mock_staticfiles.py
@@ -45,12 +45,12 @@ class MockStaticfilesFinder(BaseFinder):
             patterns = getattr(settings, self.setting)
         except AttributeError as err:
             raise ImproperlyConfigured(
-                "settings.{} must be defined".format(self.setting)
+                f"settings.{self.setting} must be defined"
             ) from err
 
         if not isinstance(patterns, dict):
             raise ImproperlyConfigured(
-                "settings.{} must be a dict".format(self.setting)
+                f"settings.{self.setting} must be a dict"
             )
 
         return patterns

--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -122,9 +122,7 @@ class StdoutCapturingTestRunner(TestRunner):
 
         if captured_stdout.getvalue():
             raise RuntimeError(
-                "unit tests should avoid writing to stdout: {}".format(
-                    captured_stdout.getvalue()
-                )
+                f"unit tests should avoid writing to stdout: {captured_stdout.getvalue()}"
             )
 
         return return_value

--- a/cfgov/core/testutils/runners.py
+++ b/cfgov/core/testutils/runners.py
@@ -122,7 +122,8 @@ class StdoutCapturingTestRunner(TestRunner):
 
         if captured_stdout.getvalue():
             raise RuntimeError(
-                f"unit tests should avoid writing to stdout: {captured_stdout.getvalue()}"
+                "unit tests should avoid writing to stdout: "
+                f"{captured_stdout.getvalue()}"
             )
 
         return return_value

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -64,7 +64,7 @@ ICONLESS_LINK_CHILD_ELEMENTS = [
 def ask_short_url(url):
     match = ASK_CFPB_LINKS.search(url)
     ask_id = match.groupdict().get("ask_id")
-    return "cfpb.gov/askcfpb/{}".format(ask_id)
+    return f"cfpb.gov/askcfpb/{ask_id}"
 
 
 def extract_answers_from_request(request):
@@ -80,7 +80,7 @@ def format_file_size(bytecount, suffix="B"):
     """Convert a byte count into a rounded human-friendly file size."""
     for unit in ["", "K", "M", "G"]:
         if abs(bytecount) < 1024.0:
-            return "{:1.0f} {}{}".format(bytecount, unit, suffix)
+            return f"{bytecount:1.0f} {unit}{suffix}"
         bytecount /= 1024.0
     return "{:.0f} {}{}".format(bytecount, "T", suffix)
 

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -32,7 +32,7 @@ class MortgageDataConstant(models.Model):
     updated = models.DateField(auto_now=True)
 
     def __str__(self):
-        return "{} ({}), updated {}".format(self.name, self.slug, self.updated)
+        return f"{self.name} ({self.slug}), updated {self.updated}"
 
     @classmethod
     def get_thresholds(cls):
@@ -56,7 +56,7 @@ class MortgageMetaData(models.Model):
     updated = models.DateField(auto_now=True)
 
     def __str__(self):
-        return "{}, updated {}".format(self.name, self.updated)
+        return f"{self.name}, updated {self.updated}"
 
     class Meta:
         ordering = ["name"]
@@ -83,7 +83,7 @@ class State(models.Model):
     non_msa_valid = models.BooleanField(default=False)
 
     def __str__(self):
-        return "{} ({})".format(self.name, self.fips)
+        return f"{self.name} ({self.fips})"
 
     def validate_non_msas(self):
         """
@@ -144,7 +144,7 @@ class MetroArea(models.Model):
         self.save()
 
     def __str__(self):
-        return "{} ({})".format(self.name, self.fips)
+        return f"{self.name} ({self.fips})"
 
     class Meta:
         ordering = ["name"]
@@ -181,7 +181,7 @@ class County(models.Model):
         self.save()
 
     def __str__(self):
-        return "{}, {} ({})".format(self.name, self.state.abbr, self.fips)
+        return f"{self.name}, {self.state.abbr} ({self.fips})"
 
 
 # mortgage data models for counts, aggregations and averages
@@ -376,7 +376,5 @@ def validate_counties():
     valid = County.objects.filter(valid=True).count()
     if total != 0:
         logger.info(
-            "{} counties of {} were found to be valid -- {}%)".format(
-                valid, total, round((valid * 100.0 / total), 1)
-            )
+            f"{valid} counties of {total} were found to be valid -- {round((valid * 100.0 / total), 1)}%)"
         )

--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -376,5 +376,6 @@ def validate_counties():
     valid = County.objects.filter(valid=True).count()
     if total != 0:
         logger.info(
-            f"{valid} counties of {total} were found to be valid -- {round((valid * 100.0 / total), 1)}%)"
+            f"{valid} counties of {total} were found to be valid -- "
+            f"{round((valid * 100.0 / total), 1)}%)"
         )

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -1,3 +1,4 @@
+import contextlib
 import csv
 import logging
 
@@ -5,7 +6,6 @@ from django.conf import settings
 from django.db import transaction
 
 from data_research.models import County, State
-import contextlib
 
 
 PROJECT_ROOT = settings.PROJECT_ROOT

--- a/cfgov/data_research/mortgage_utilities/fips_meta.py
+++ b/cfgov/data_research/mortgage_utilities/fips_meta.py
@@ -8,7 +8,7 @@ from data_research.models import County, State
 
 
 PROJECT_ROOT = settings.PROJECT_ROOT
-FIPS_DATA_PATH = "{}/data_research/data".format(PROJECT_ROOT)
+FIPS_DATA_PATH = f"{PROJECT_ROOT}/data_research/data"
 
 # We have minimal data for smaller territories, so we exclude them.
 # For project launch, we also excluded Puerto Rico (72) as out of scope.
@@ -189,7 +189,7 @@ def validate_fips(raw_fips, keep_outdated=False):
     if raw_fips in FIPS_SWAP:
         return FIPS_SWAP[raw_fips]
     if len(raw_fips) == 4:
-        new_fips = "0{}".format(raw_fips)
+        new_fips = f"0{raw_fips}"
     else:
         new_fips = raw_fips
     if keep_outdated is False and new_fips in IGNORE_FIPS:
@@ -287,7 +287,7 @@ def load_constants():
         value = MortgageDataConstant.objects.get(name=threshold).value
         setattr(FIPS, threshold, value)
     dates = MortgageMetaData.objects.get(name="sampling_dates").json_value
-    FIPS.dates = ["{}".format(date) for date in dates]
+    FIPS.dates = [f"{date}" for date in dates]
     FIPS.short_dates = [date[:-3] for date in FIPS.dates]
 
 
@@ -309,7 +309,7 @@ def load_fips_meta(counties=True):
         4: county_name
     """
     for filename in ["state_county_fips.csv", "msa_county_crosswalk.csv"]:
-        with open("{}/{}".format(FIPS_DATA_PATH, filename), "r") as f:
+        with open(f"{FIPS_DATA_PATH}/{filename}") as f:
             reader = csv.DictReader(f)
             fips_data = list(reader)
             if "state" in filename:
@@ -339,7 +339,7 @@ def load_states():
     State.objects.all().delete()
     states = {}
 
-    with open("{}/states.csv".format(FIPS_DATA_PATH), "r") as f:
+    with open(f"{FIPS_DATA_PATH}/states.csv") as f:
         reader = csv.DictReader(f)
         for row in list(reader):
             if row["abbr"] not in NON_STATES:
@@ -352,7 +352,7 @@ def load_states():
                     "non_msa_counties": [],
                 }
 
-    with open("{}/state_county_fips.csv".format(FIPS_DATA_PATH), "r") as f:
+    with open(f"{FIPS_DATA_PATH}/state_county_fips.csv") as f:
         reader = csv.DictReader(f)
         counties = list(reader)
         for row in counties:
@@ -362,7 +362,7 @@ def load_states():
                     row["complete_fips"]
                 )
 
-    with open("{}/msa_county_crosswalk.csv".format(FIPS_DATA_PATH), "r") as f:
+    with open(f"{FIPS_DATA_PATH}/msa_county_crosswalk.csv") as f:
         reader = csv.DictReader(f)
         msas = list(reader)
         for row in msas:
@@ -382,7 +382,7 @@ def load_counties():
     Load County objects from state_county_fips.csv
     """
     County.objects.all().delete()
-    with open("{}/state_county_fips.csv".format(FIPS_DATA_PATH), "r") as f:
+    with open(f"{FIPS_DATA_PATH}/state_county_fips.csv") as f:
         reader = csv.DictReader(f)
         fips_data = list(reader)
         counties = [

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -11,11 +11,9 @@ import requests
 # bake_to_s3 functions require S3 secrets to be stored in the env
 BASE_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
 MORTGAGE_SUB_BUCKET = "data/mortgage-performance"
-PUBLIC_ACCESS_BASE = "https://s3.amazonaws.com/{}/{}".format(
-    BASE_BUCKET, MORTGAGE_SUB_BUCKET
-)
-S3_MORTGAGE_DOWNLOADS_BASE = "{}/downloads".format(PUBLIC_ACCESS_BASE)
-S3_SOURCE_BUCKET = "{}/source".format(PUBLIC_ACCESS_BASE)
+PUBLIC_ACCESS_BASE = f"https://s3.amazonaws.com/{BASE_BUCKET}/{MORTGAGE_SUB_BUCKET}"
+S3_MORTGAGE_DOWNLOADS_BASE = f"{PUBLIC_ACCESS_BASE}/downloads"
+S3_SOURCE_BUCKET = f"{PUBLIC_ACCESS_BASE}/source"
 S3_SOURCE_FILE = "latest_county_delinquency.csv"
 
 
@@ -44,7 +42,7 @@ def bake_csv_to_s3(slug, csv_file_obj, sub_bucket=None):
     s3 = boto3.client("s3")
     s3.put_object(
         Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-        Key="{}/{}.csv".format(sub_bucket, slug),
+        Key=f"{sub_bucket}/{slug}.csv",
         ACL="public-read",
         ContentType="text/csv",
         Body=csv_file_obj.getvalue(),

--- a/cfgov/data_research/mortgage_utilities/s3_utils.py
+++ b/cfgov/data_research/mortgage_utilities/s3_utils.py
@@ -11,7 +11,9 @@ import requests
 # bake_to_s3 functions require S3 secrets to be stored in the env
 BASE_BUCKET = settings.AWS_STORAGE_BUCKET_NAME
 MORTGAGE_SUB_BUCKET = "data/mortgage-performance"
-PUBLIC_ACCESS_BASE = f"https://s3.amazonaws.com/{BASE_BUCKET}/{MORTGAGE_SUB_BUCKET}"
+PUBLIC_ACCESS_BASE = (
+    f"https://s3.amazonaws.com/{BASE_BUCKET}/{MORTGAGE_SUB_BUCKET}"
+)
 S3_MORTGAGE_DOWNLOADS_BASE = f"{PUBLIC_ACCESS_BASE}/downloads"
 S3_SOURCE_BUCKET = f"{PUBLIC_ACCESS_BASE}/source"
 S3_SOURCE_FILE = "latest_county_delinquency.csv"

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -66,8 +66,8 @@ def save_metadata(csv_size, slug, thru_month, days_late, geo_type):
         }
     else:
         current = download_meta_file.json_value
-        if thru_month in current.keys():
-            if days_late in current[thru_month].keys():
+        if thru_month in current:
+            if days_late in current[thru_month]:
                 current[thru_month][days_late].update(new_posting)
             else:
                 current[thru_month][days_late] = new_posting

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -183,7 +183,7 @@ def export_downloadable_csv(geo_type, late_value):
             ),
         },
     }
-    slug = f"{geo_type}Mortgages{LATE_VALUE_TITLE[late_value]}DaysLate-thru-{thru_month}"
+    slug = f"{geo_type}Mortgages{LATE_VALUE_TITLE[late_value]}DaysLate-thru-{thru_month}"  # noqa: E501
     _map = geo_dict.get(geo_type)
     fips_list = _map["fips_list"]
     csvfile = StringIO()

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -91,7 +91,9 @@ def round_pct(value):
 
 
 def row_starter(geo_type, obj):
-    if geo_type == "County":
+    # flake8-simplify flags this with SIM116, and wants it to be a
+    # dict-lookup. That would make the logic here less readable.
+    if geo_type == "County":  # noqa: SIM116
         return [
             geo_type,
             obj.county.state.abbr,

--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -51,7 +51,7 @@ def save_metadata(csv_size, slug, thru_month, days_late, geo_type):
     """Save slug, URL, thru_month and file size of a new CSV download file."""
     pub_date = datetime.date.today().strftime("%B %Y")
     thru_month_formatted = parser.parse(thru_month).strftime("%B %Y")
-    csv_url = "{}/{}.csv".format(S3_MORTGAGE_DOWNLOADS_BASE, slug)
+    csv_url = f"{S3_MORTGAGE_DOWNLOADS_BASE}/{slug}.csv"
     download_meta_file, cr = MortgageMetaData.objects.get_or_create(
         name="download_files"
     )
@@ -83,7 +83,7 @@ def save_metadata(csv_size, slug, thru_month, days_late, geo_type):
             )
         download_meta_file.json_value = current
     download_meta_file.save()
-    logger.info("Saved metadata for {}".format(slug))
+    logger.info(f"Saved metadata for {slug}")
 
 
 def round_pct(value):
@@ -96,12 +96,12 @@ def row_starter(geo_type, obj):
             geo_type,
             obj.county.state.abbr,
             obj.county.name,
-            "'{}'".format(obj.fips),
+            f"'{obj.fips}'",
         ]
     elif geo_type == "MetroArea":
         return [geo_type, obj.msa.name, obj.fips]
     elif geo_type == "State":
-        return [geo_type, obj.state.name, "'{}'".format(obj.fips)]
+        return [geo_type, obj.state.name, f"'{obj.fips}'"]
     else:
         return [geo_type, obj.state.name, obj.fips]
 
@@ -163,7 +163,7 @@ def export_downloadable_csv(geo_type, late_value):
             "headings": ["RegionType", "Name", "CBSACode"],
             "fips_list": sorted(
                 [
-                    "{}-non".format(state.fips)
+                    f"{state.fips}-non"
                     for state in State.objects.filter(non_msa_valid=True)
                 ]
             ),
@@ -181,9 +181,7 @@ def export_downloadable_csv(geo_type, late_value):
             ),
         },
     }
-    slug = "{}Mortgages{}DaysLate-thru-{}".format(
-        geo_type, LATE_VALUE_TITLE[late_value], thru_month
-    )
+    slug = f"{geo_type}Mortgages{LATE_VALUE_TITLE[late_value]}DaysLate-thru-{thru_month}"
     _map = geo_dict.get(geo_type)
     fips_list = _map["fips_list"]
     csvfile = StringIO()
@@ -209,9 +207,9 @@ def export_downloadable_csv(geo_type, late_value):
             ]
             writer.writerow(record_starter + record_ender)
     bake_csv_to_s3(
-        slug, csvfile, sub_bucket="{}/downloads".format(MORTGAGE_SUB_BUCKET)
+        slug, csvfile, sub_bucket=f"{MORTGAGE_SUB_BUCKET}/downloads"
     )
-    logger.info("Baked {} to S3".format(slug))
+    logger.info(f"Baked {slug} to S3")
     csvfile.seek(0, 2)
     bytecount = csvfile.tell()
     csv_size = format_file_size(bytecount)
@@ -227,6 +225,6 @@ def run(prep_only=False):
         logger.info("Exporting public CSVs to S3 ...")
         for geo in ["County", "MetroArea", "State"]:
             export_downloadable_csv(geo, "percent_30_60")
-            logger.info("Exported 30-89-day {} CSV".format(geo))
+            logger.info(f"Exported 30-89-day {geo} CSV")
             export_downloadable_csv(geo, "percent_90")
-            logger.info("Exported 90-day {} CSV".format(geo))
+            logger.info(f"Exported 90-day {geo} CSV")

--- a/cfgov/data_research/scripts/load_mortgage_aggregates.py
+++ b/cfgov/data_research/scripts/load_mortgage_aggregates.py
@@ -129,6 +129,4 @@ def run():
         metro.validate()
     for state in State.objects.all():
         state.validate_non_msas()
-    logger.info(
-        f"{script} took {datetime.datetime.now() - starter} to run."
-    )
+    logger.info(f"{script} took {datetime.datetime.now() - starter} to run.")

--- a/cfgov/data_research/scripts/load_mortgage_aggregates.py
+++ b/cfgov/data_research/scripts/load_mortgage_aggregates.py
@@ -33,7 +33,8 @@ def update_sampling_dates():
     date_list_obj.json_value = date_list
     date_list_obj.save()
     logger.info(
-        f"Sampling dates updated; the {len(date_list)} dates now range from {date_list[0]} to {date_list[-1]}"
+        f"Sampling dates updated; the {len(date_list)} dates now range from "
+        f"{date_list[0]} to {date_list[-1]}"
     )
 
 

--- a/cfgov/data_research/scripts/load_mortgage_aggregates.py
+++ b/cfgov/data_research/scripts/load_mortgage_aggregates.py
@@ -26,16 +26,14 @@ def update_sampling_dates():
     Update our metadata list of sampling dates.
     """
     dates = sorted(set([obj.date for obj in CountyMortgageData.objects.all()]))
-    date_list = ["{}".format(date) for date in dates]
+    date_list = [f"{date}" for date in dates]
     date_list_obj, cr = MortgageMetaData.objects.get_or_create(
         name="sampling_dates"
     )
     date_list_obj.json_value = date_list
     date_list_obj.save()
     logger.info(
-        "Sampling dates updated; the {} dates now range from {} to {}".format(
-            len(date_list), date_list[0], date_list[-1]
-        )
+        f"Sampling dates updated; the {len(date_list)} dates now range from {date_list[0]} to {date_list[-1]}"
     )
 
 
@@ -87,7 +85,7 @@ def load_state_values(date):
 def load_non_msa_state_values(date):
     for state in State.objects.all():
         record, cr = NonMSAMortgageData.objects.get_or_create(
-            date=date, state=state, fips="{}-non".format(state.fips)
+            date=date, state=state, fips=f"{state.fips}-non"
         )
         record.aggregate_data()
 
@@ -121,7 +119,7 @@ def run():
     dates = MortgageMetaData.objects.get(name="sampling_dates").json_value
     for date_string in dates:
         date = parser.parse(date_string).date()
-        logger.info("Aggregating data for {}".format(date))
+        logger.info(f"Aggregating data for {date}")
         load_msa_values(date)
         load_state_values(date)
         load_non_msa_state_values(date)
@@ -132,7 +130,5 @@ def run():
     for state in State.objects.all():
         state.validate_non_msas()
     logger.info(
-        "{} took {} to run.".format(
-            script, (datetime.datetime.now() - starter)
-        )
+        f"{script} took {datetime.datetime.now() - starter} to run."
     )

--- a/cfgov/data_research/scripts/load_mortgage_performance_csv.py
+++ b/cfgov/data_research/scripts/load_mortgage_performance_csv.py
@@ -51,7 +51,8 @@ def load_values(return_fips=False):
     logger.info("Deleting CountyMortgageData objects.")
     CountyMortgageData.objects.all().delete()
     logger.info(
-        f"CountyMorgtgageData count is now {CountyMortgageData.objects.count()}"
+        "CountyMorgtgageData count is now "
+        f"{CountyMortgageData.objects.count()}"
     )
     for row in raw_data:
         sampling_date = parser.parse(row.get("date")).date()
@@ -78,7 +79,8 @@ def load_values(return_fips=False):
                 if counter % 100000 == 0:  # pragma: no cover
                     logger.info(f"\n{counter}")
     logger.info(
-        f"\nCreated {CountyMortgageData.objects.count()} CountyMortgageData objects"
+        f"\nCreated {CountyMortgageData.objects.count()} CountyMortgageData "
+        "objects"
     )
 
 

--- a/cfgov/data_research/scripts/load_mortgage_performance_csv.py
+++ b/cfgov/data_research/scripts/load_mortgage_performance_csv.py
@@ -36,7 +36,7 @@ def load_values(return_fips=False):
     """
 
     counter = 0
-    source_url = "{}/{}".format(S3_SOURCE_BUCKET, S3_SOURCE_FILE)
+    source_url = f"{S3_SOURCE_BUCKET}/{S3_SOURCE_FILE}"
     starting_date = MortgageDataConstant.objects.get(
         name="starting_date"
     ).date_value
@@ -51,9 +51,7 @@ def load_values(return_fips=False):
     logger.info("Deleting CountyMortgageData objects.")
     CountyMortgageData.objects.all().delete()
     logger.info(
-        "CountyMorgtgageData count is now {}".format(
-            CountyMortgageData.objects.count()
-        )
+        f"CountyMorgtgageData count is now {CountyMortgageData.objects.count()}"
     )
     for row in raw_data:
         sampling_date = parser.parse(row.get("date")).date()
@@ -78,11 +76,9 @@ def load_values(return_fips=False):
                     sys.stdout.write(".")
                     sys.stdout.flush()
                 if counter % 100000 == 0:  # pragma: no cover
-                    logger.info("\n{}".format(counter))
+                    logger.info(f"\n{counter}")
     logger.info(
-        "\nCreated {} CountyMortgageData objects".format(
-            CountyMortgageData.objects.count()
-        )
+        f"\nCreated {CountyMortgageData.objects.count()} CountyMortgageData objects"
     )
 
 

--- a/cfgov/data_research/scripts/process_mortgage_data.py
+++ b/cfgov/data_research/scripts/process_mortgage_data.py
@@ -49,7 +49,7 @@ def dump_as_csv(rows_out, dump_slug):
     Sample output row:
     1,01001,2008-01-01,268,260,4,1,0,3,2891
     """
-    with open("{}.csv".format(dump_slug), "w") as f:
+    with open(f"{dump_slug}.csv", "w") as f:
         writer = csv.writer(f)
         for row in rows_out:
             writer.writerow(row)
@@ -80,7 +80,7 @@ def process_source(starting_date, through_date, dump_slug=None):
     # truncate table
     CountyMortgageData.objects.all().delete()
 
-    source_url = "{}/{}".format(S3_SOURCE_BUCKET, S3_SOURCE_FILE)
+    source_url = f"{S3_SOURCE_BUCKET}/{S3_SOURCE_FILE}"
     raw_data = read_in_s3_csv(source_url)
 
     # Ensure state objects are up to date
@@ -117,13 +117,11 @@ def process_source(starting_date, through_date, dump_slug=None):
                     sys.stdout.write(".")
                     sys.stdout.flush()
                 if counter % 100000 == 0:  # pragma: no cover
-                    logger.info("\n{}".format(counter))
+                    logger.info(f"\n{counter}")
     CountyMortgageData.objects.bulk_create(new_objects)
     logger.info(
-        "\n{} took {} "
-        "to create {} countymortgage records".format(
-            SCRIPT_NAME, (datetime.datetime.now() - starter), len(new_objects)
-        )
+        f"\n{SCRIPT_NAME} took {datetime.datetime.now() - starter} "
+        f"to create {len(new_objects)} countymortgage records"
     )
     if dump_slug:
         dump_as_csv(
@@ -131,7 +129,7 @@ def process_source(starting_date, through_date, dump_slug=None):
                 (
                     obj.pk,
                     obj.fips,
-                    "{}".format(obj.date),
+                    f"{obj.date}",
                     obj.total,
                     obj.current,
                     obj.thirty,

--- a/cfgov/data_research/scripts/update_county_msa_meta.py
+++ b/cfgov/data_research/scripts/update_county_msa_meta.py
@@ -20,7 +20,7 @@ def update_allowlist():
         state.fips for state in State.objects.exclude(fips__in=NON_STATE_FIPS)
     ]
     non_msa_list = [
-        "{}-non".format(state.fips)
+        f"{state.fips}-non"
         for state in State.objects.filter(fips__in=state_list)
         if state.non_msa_valid is True
     ]
@@ -150,17 +150,17 @@ def update_state_to_geo_meta(geo):
             fips for fips in FIPS.state_fips if fips not in NON_STATE_FIPS
         ]
         for state_fips in live_fips:
-            non_fips = "{}-non".format(state_fips)
+            non_fips = f"{state_fips}-non"
             s_dict = FIPS.state_fips[state_fips]
             state_abbr = s_dict["abbr"]
             state_name = s_dict["name"]
-            non_fips_name = "Non-metro area of {}".format(state_name)
+            non_fips_name = f"Non-metro area of {state_name}"
             non_valid = non_fips in FIPS.allowlist
             setup[state_abbr][geo_list].append(
                 {
                     "fips": non_fips,
                     "valid": non_valid,
-                    "name": "Non-metro area of {}".format(state_name),
+                    "name": f"Non-metro area of {state_name}",
                 }
             )
             non_msa_fips_output.append(
@@ -177,7 +177,7 @@ def update_state_to_geo_meta(geo):
     meta_obj, cr = MortgageMetaData.objects.get_or_create(name=slug)
     meta_obj.json_value = setup
     meta_obj.save()
-    logger.info("Saved metadata object '{}.'".format(slug))
+    logger.info(f"Saved metadata object '{slug}.'")
     if non_msa_fips_output:
         non_msa_fips_output.sort(key=lambda k: k["state_name"])
         non_meta_obj, cr = MortgageMetaData.objects.get_or_create(

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -258,15 +258,11 @@ class GeoValidationTests(django.test.TestCase):
 
     def test_state_name_string(self):
         state = State.objects.get(fips="12")
-        self.assertEqual(
-            state.__str__(), f"{state.name} ({state.fips})"
-        )
+        self.assertEqual(state.__str__(), f"{state.name} ({state.fips})")
 
     def test_metro_name_string(self):
         metro = MetroArea.objects.get(fips="35840")
-        self.assertEqual(
-            metro.__str__(), f"{metro.name} ({metro.fips})"
-        )
+        self.assertEqual(metro.__str__(), f"{metro.name} ({metro.fips})")
 
     def test_county_name_string(self):
         county = County.objects.get(fips="12081")

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -339,7 +339,7 @@ class ModelStringTest(django.test.TestCase):
                     len(lister)
                     for lister in [
                         ", ".join(FIPS.msa_fips[each]["county_list"])
-                        for each in FIPS.msa_fips.keys()
+                        for each in FIPS.msa_fips
                     ]
                 ]
             )

--- a/cfgov/data_research/tests/test_models.py
+++ b/cfgov/data_research/tests/test_models.py
@@ -259,20 +259,20 @@ class GeoValidationTests(django.test.TestCase):
     def test_state_name_string(self):
         state = State.objects.get(fips="12")
         self.assertEqual(
-            state.__str__(), "{} ({})".format(state.name, state.fips)
+            state.__str__(), f"{state.name} ({state.fips})"
         )
 
     def test_metro_name_string(self):
         metro = MetroArea.objects.get(fips="35840")
         self.assertEqual(
-            metro.__str__(), "{} ({})".format(metro.name, metro.fips)
+            metro.__str__(), f"{metro.name} ({metro.fips})"
         )
 
     def test_county_name_string(self):
         county = County.objects.get(fips="12081")
         self.assertEqual(
             county.__str__(),
-            "{}, {} ({})".format(county.name, county.state.abbr, county.fips),
+            f"{county.name}, {county.state.abbr} ({county.fips})",
         )
 
 
@@ -392,11 +392,11 @@ class MortgageModelTests(django.test.TestCase):
 
     def test_constant_string(self):
         constant = MortgageDataConstant.objects.first()
-        self.assertEqual(constant.__str__(), "{}".format(constant))
+        self.assertEqual(constant.__str__(), f"{constant}")
 
     def test_meta_string(self):
         meta = MortgageMetaData.objects.first()
-        self.assertEqual(meta.__str__(), "{}".format(meta))
+        self.assertEqual(meta.__str__(), f"{meta}")
 
     def test_base_data_properties(self):
         """Test basic calculation functions"""

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -28,32 +28,28 @@ from data_research.scripts.export_public_csvs import (
     export_downloadable_csv,
     round_pct,
     row_starter,
+    save_metadata,
 )
 from data_research.scripts.export_public_csvs import run as run_export
-from data_research.scripts.export_public_csvs import save_metadata
 from data_research.scripts.load_mortgage_aggregates import (
     load_msa_values,
     load_national_values,
     load_non_msa_state_values,
     load_state_values,
     merge_the_dades,
+    update_sampling_dates,
 )
 from data_research.scripts.load_mortgage_aggregates import (
     run as run_aggregates,
-)
-from data_research.scripts.load_mortgage_aggregates import (
-    update_sampling_dates,
 )
 from data_research.scripts.load_mortgage_performance_csv import load_values
 from data_research.scripts.process_mortgage_data import (
     dump_as_csv,
     process_source,
+    update_through_date_constant,
 )
 from data_research.scripts.process_mortgage_data import (
     run as run_process_mortgage_data,
-)
-from data_research.scripts.process_mortgage_data import (
-    update_through_date_constant,
 )
 from data_research.scripts.update_county_msa_meta import run as run_update
 from data_research.scripts.update_county_msa_meta import (

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -492,7 +492,7 @@ class DataExportTest(django.test.TestCase):
                 "County",
                 county.state.abbr,
                 county.name,
-                "'{}'".format(county_data.fips),
+                f"'{county_data.fips}'",
             ],
         )
         metro_data = MSAMortgageData.objects.filter(fips="35840").first()
@@ -506,7 +506,7 @@ class DataExportTest(django.test.TestCase):
         state_starter = row_starter("State", state_data)
         self.assertEqual(
             state_starter,
-            ["State", state.name, "'{}'".format(state_data.fips)],
+            ["State", state.name, f"'{state_data.fips}'"],
         )
         non_metro_data = NonMSAMortgageData.objects.get(fips="12-non")
         non_metro_starter = row_starter("NonMetroArea", non_metro_data)

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -126,11 +126,13 @@ class SourceToTableTest(django.test.TestCase):
         )
 
     def test_dump_as_csv(self):
-        with tempfile.NamedTemporaryFile(suffix=".csv") as f:
+        with tempfile.NamedTemporaryFile(suffix=".csv") as tf:
             # dump_as_csv appends .csv to the destination file.
-            dump_as_csv([self.data_row], f.name[:-4])
+            dump_as_csv([self.data_row], tf.name[:-4])
 
-            content = open(f.name).read()
+            with open(tf.name) as f:
+                content = f.read()
+
             self.assertEqual(content.strip(), ",".join(self.data_row))
 
     @mock.patch(

--- a/cfgov/data_research/views.py
+++ b/cfgov/data_research/views.py
@@ -95,9 +95,7 @@ class TimeSeriesData(APIView):
             data = {
                 "meta": {
                     "fips": fips,
-                    "name": "Non-metro area of {}".format(
-                        records.first().state.name
-                    ),
+                    "name": f"Non-metro area of {records.first().state.name}",
                     "fips_type": "non_msa",
                 },
                 "data": [record.time_series(days_late) for record in records],
@@ -122,7 +120,7 @@ class TimeSeriesData(APIView):
             except County.DoesNotExist:
                 return Response("County is below display threshold.")
             records = CountyMortgageData.objects.filter(fips=fips)
-            name = "{}, {}".format(county.name, county.state.abbr)
+            name = f"{county.name}, {county.state.abbr}"
             data = {
                 "meta": {"fips": fips, "name": name, "fips_type": "county"},
                 "data": [record.time_series(days_late) for record in records],
@@ -195,7 +193,7 @@ class MapData(APIView):
             payload = {
                 "meta": {
                     "fips_type": geo_dict[geo]["fips_type"],
-                    "date": "{}".format(date),
+                    "date": f"{date}",
                 },
                 "data": {},
             }
@@ -207,7 +205,7 @@ class MapData(APIView):
             payload = {
                 "meta": {
                     "fips_type": geo_dict[geo]["fips_type"],
-                    "date": "{}".format(date),
+                    "date": f"{date}",
                     "national_average": nat_data_series["value"],
                 },
                 "data": {},
@@ -216,9 +214,7 @@ class MapData(APIView):
                 data_series = record.time_series(days_late)
                 geo_parent = getattr(record, geo_dict[geo]["geo_obj"])
                 if geo == "counties":
-                    name = "{}, {}".format(
-                        geo_parent.name, geo_parent.state.abbr
-                    )
+                    name = f"{geo_parent.name}, {geo_parent.state.abbr}"
                 else:
                     name = geo_parent.name
                 data_series.update({"name": name})
@@ -231,7 +227,7 @@ class MapData(APIView):
                     non_data_series = record.time_series(days_late)
                     if record.state.non_msa_valid is False:
                         non_data_series["value"] = None
-                    non_name = "Non-metro area of {}".format(record.state.name)
+                    non_name = f"Non-metro area of {record.state.name}"
                     non_data_series.update({"name": non_name})
                     del non_data_series["date"]
                     payload["data"].update({record.fips: non_data_series})

--- a/cfgov/deployable_zipfile/create.py
+++ b/cfgov/deployable_zipfile/create.py
@@ -33,8 +33,8 @@ def save_wheels(python_executable, destination, *args):
     """
     subprocess.check_call(  # nosec
         [python_executable, "-m", "pip", "wheel"]
-        + ["--wheel-dir=%s" % destination]
-        + ["--find-links=%s" % destination]
+        + [f"--wheel-dir={destination}"]
+        + [f"--find-links={destination}"]
         + list(args)
     )
 
@@ -50,7 +50,7 @@ def create_project_pth_file(project_name, target_directory):
     project_pth = project_pth_template.substitute(project_name=project_name)
 
     project_pth_filename = os.path.join(
-        target_directory, "%s.pth" % project_name
+        target_directory, f"{project_name}.pth"
     )
 
     with open(project_pth_filename, "w") as f:
@@ -71,7 +71,7 @@ def create_zipfile(
         # Other wheels get stored in the zip under /wheels/.
         wheel_dir = os.path.join(temp_dir, "wheels")
 
-        save_wheels(sys.executable, wheel_dir, "-r%s" % requirements_file)
+        save_wheels(sys.executable, wheel_dir, f"-r{requirements_file}")
 
         # Copy the project code into the zip.
         project_name = os.path.basename(os.path.realpath(project_path))
@@ -100,7 +100,7 @@ def create_zipfile(
         # Add any static file directories, if provided.
         for i, static_dir in enumerate(extra_static or []):
             shutil.copytree(
-                static_dir, os.path.join(temp_dir, "static.in/%s/" % i)
+                static_dir, os.path.join(temp_dir, f"static.in/{i}/")
             )
 
         zipfile = shutil.make_archive(zipfile_basename, "zip", temp_dir)

--- a/cfgov/deployable_zipfile/extract.py
+++ b/cfgov/deployable_zipfile/extract.py
@@ -43,7 +43,7 @@ def extract_zipfile(zipfile_filename, extract_location):
             "virtualenv",
             "--never-download",
             "--no-wheel",
-            "--extra-search-dir=%s" % bootstrap_wheels,
+            f"--extra-search-dir={bootstrap_wheels}",
             virtualenv_dir,
         ]
     )
@@ -70,7 +70,7 @@ def extract_zipfile(zipfile_filename, extract_location):
 
     # Move .pth files into the virtual environment site-packages so that they
     # they get processed on Python startup.
-    for pth_file in glob("%s/*.pth" % extract_location):
+    for pth_file in glob(f"{extract_location}/*.pth"):
         shutil.move(pth_file, site_packages)
 
     # Also move the loadenv.py script to support automatic loading of

--- a/cfgov/deployable_zipfile/tests/test_create.py
+++ b/cfgov/deployable_zipfile/tests/test_create.py
@@ -68,7 +68,7 @@ class TestCreateDeployableZip(TestCase):
         # requirements file.
         self.assertEqual(save_wheels.call_count, 2)
 
-        self.assertEqual(zipfile_filename, "%s.zip" % zipfile_basename)
+        self.assertEqual(zipfile_filename, f"{zipfile_basename}.zip")
 
         archive = ZipFile(zipfile_filename)
         self.assertCountEqual(

--- a/cfgov/filing_instruction_guide/models.py
+++ b/cfgov/filing_instruction_guide/models.py
@@ -90,7 +90,7 @@ class FIGContentPage(CFGOVPage, ClusterableModel):
                 StreamBlock(
                     content_block_options,
                     required=False,
-                    help_text="Content that will appear above the first FIG section",
+                    help_text="Content that will appear above the first FIG section",  # noqa: E501
                 ),
             )
         ],
@@ -176,8 +176,8 @@ class FIGContentPage(CFGOVPage, ClusterableModel):
                     y.block_type == "data_points_block"
                     for y in section.value["content"]
                 ):
-                    # If a data_points_block is part of this section's contents,
-                    # add the data points to the headers collection
+                    # If a data_points_block is part of this section's
+                    # contents, add the data points to the headers collection
                     for p in self.data_points.order_by("number"):
                         parent["children"].append(
                             {

--- a/cfgov/hmda/models/pages.py
+++ b/cfgov/hmda/models/pages.py
@@ -56,7 +56,7 @@ class HmdaHistoricDataPage(LearnPage):
             return "Showing nationwide records"
         else:
             location_name = dict(HMDA_GEO_OPTIONS).get(geo, "State")
-            return "Showing records for {}".format(location_name)
+            return f"Showing records for {location_name}"
 
     def value_or_default(self, options, user_input):
         options_dict = dict(options)

--- a/cfgov/housing_counselor/generator.py
+++ b/cfgov/housing_counselor/generator.py
@@ -107,7 +107,7 @@ def generate_counselor_json(counselors, zipcodes, target):
             "counseling_agencies": counselors,
         }
 
-        json_filename = os.path.join(target, "{}.json".format(zipcode))
+        json_filename = os.path.join(target, f"{zipcode}.json")
 
         with open(json_filename, "w") as f:
             f.write(json.dumps(zipcode_data))
@@ -118,7 +118,7 @@ def generate_counselor_html(source_dir, target_dir):
     template = loader.get_template(template_name)
 
     for zipcode, filename in get_counselor_json_files(source_dir):
-        with open(filename, "r") as f:
+        with open(filename) as f:
             zipcode_data = json.loads(f.read())
 
         html = template.render(
@@ -129,7 +129,7 @@ def generate_counselor_html(source_dir, target_dir):
             }
         )
 
-        html_filename = os.path.join(target_dir, "{}.html".format(zipcode))
+        html_filename = os.path.join(target_dir, f"{zipcode}.html")
 
         with open(html_filename, "w") as f:
             f.write(html)
@@ -146,7 +146,7 @@ def get_counselor_json_files(directory):
     )
 
     if not filenames:
-        raise RuntimeError("no input files found in {}".format(directory))
+        raise RuntimeError(f"no input files found in {directory}")
 
     logger.info("Found %d input files", len(filenames))
 

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -43,7 +43,7 @@ class ZipCodeBasedCounselorGeocoder:
         logger.warning("need to geocode counselor with zipcode %s", zipcode)
 
         if zipcode not in self.zipcodes:
-            raise KeyError("{} not in zipcodes".format(zipcode))
+            raise KeyError(f"{zipcode} not in zipcodes")
 
         coordinates = self.zipcodes[zipcode]
         counselor.update(zip(lat_lng_keys, coordinates))
@@ -103,7 +103,7 @@ class BulkZipCodeGeocoder:
     @staticmethod
     def generate_possible_zipcodes(start=0):
         for n in range(start, 100000):
-            yield "{:05d}".format(n)
+            yield f"{n:05d}"
 
     def mapbox_geocode_zipcodes(self, zipcodes):
         """Geocode an iterable list of string zipcodes using Mapbox.
@@ -122,7 +122,7 @@ class BulkZipCodeGeocoder:
             time_now = time.time()
             if time_now - request_start_time > rate_limit_timeout:
                 raise RuntimeError(
-                    "rate limit timeout {} exceeded".format(rate_limit_timeout)
+                    f"rate limit timeout {rate_limit_timeout} exceeded"
                 )
 
             response = requests.get(url)
@@ -184,13 +184,13 @@ class GeocodedZipCodeCsv:
     Each line in the file is: zipcode,latitude_degrees,longitude_degrees
     """
 
-    DELIMITER = str(",")
+    DELIMITER = ","
 
     @classmethod
     def read(cls, filename):
         """Returns dictionary of zipcode, (latitude, longitude) pairs."""
         logger.info("Reading zipcodes from %s", filename)
-        with open(filename, "r") as f:
+        with open(filename) as f:
             reader = csv.reader(f, delimiter=cls.DELIMITER)
             zipcodes = dict(
                 (zipcode, (float(latitude), float(longitude)))
@@ -220,13 +220,13 @@ class GazetteerZipCodeFile:
     See https://www.census.gov/geo/maps-data/data/gazetteer2016.html
     """
 
-    DELIMITER = str("\t")
+    DELIMITER = "\t"
 
     @classmethod
     def read(cls, filename):
         """Returns dictionary of zipcode, (latitude, longitude) pairs."""
         logger.info("Reading zipcodes from %s", filename)
-        with open(filename, "r") as f:
+        with open(filename) as f:
             reader = csv.reader(f, delimiter=cls.DELIMITER)
             next(reader)
 

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -127,7 +127,7 @@ class BulkZipCodeGeocoder:
             response = requests.get(url)
 
             # Handle rate limiting
-            if 429 == response.status_code:
+            if response.status_code == 429:
                 logger.info(
                     "rate limited, url %s, headers: %s", url, response.headers
                 )

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -85,8 +85,7 @@ class BulkZipCodeGeocoder:
         longitude) in degrees.
         """
         for chunk in self.chunker(zipcodes, chunk_size):
-            for zipcode, coordinates in self.mapbox_geocode_zipcodes(chunk):
-                yield zipcode, coordinates
+            yield from self.mapbox_geocode_zipcodes(chunk)
 
     @staticmethod
     def chunker(it, n):

--- a/cfgov/jobmanager/models/pages.py
+++ b/cfgov/jobmanager/models/pages.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     from backports import zoneinfo
 
+import contextlib
+
 from modelcluster.fields import ParentalManyToManyField
 
 from jobmanager.models.django import (
@@ -235,12 +237,10 @@ class JobListingPage(CFGOVPage):
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request)
 
-        try:
+        with contextlib.suppress(ReusableText.DoesNotExist):
             context["about_us"] = ReusableText.objects.get(
                 title="About us (For consumers)"
             )
-        except ReusableText.DoesNotExist:
-            pass
 
         context.update(
             {

--- a/cfgov/jobmanager/models/panels.py
+++ b/cfgov/jobmanager/models/panels.py
@@ -28,9 +28,7 @@ class EmailApplicationLink(Orderable, models.Model):
 
     @property
     def mailto_link(self):
-        return "mailto:{0}?subject=Application for Position: {1}".format(
-            self.address, urlquote(self.job_listing.title)
-        )
+        return f"mailto:{self.address}?subject=Application for Position: {urlquote(self.job_listing.title)}"
 
 
 class USAJobsApplicationLink(Orderable, models.Model):

--- a/cfgov/jobmanager/models/panels.py
+++ b/cfgov/jobmanager/models/panels.py
@@ -28,7 +28,7 @@ class EmailApplicationLink(Orderable, models.Model):
 
     @property
     def mailto_link(self):
-        return f"mailto:{self.address}?subject=Application for Position: {urlquote(self.job_listing.title)}"
+        return f"mailto:{self.address}?subject=Application for Position: {urlquote(self.job_listing.title)}"  # noqa: E501
 
 
 class USAJobsApplicationLink(Orderable, models.Model):

--- a/cfgov/jobmanager/tests/test_blocks.py
+++ b/cfgov/jobmanager/tests/test_blocks.py
@@ -48,7 +48,7 @@ class JobListingListTestCase(JobListingBlockTestUtils, TestCase):
     def test_shows_jobs(self):
         self.make_job("live1")
         # This job should not show up because it is closed.
-        self.make_job("live_closed", close_date=date(1970, 1, 1)),
+        self.make_job("live_closed", close_date=date(1970, 1, 1))
         self.make_job("live2")
         # This job should not show up because it is not live.
         self.make_job("draft", live=False)
@@ -95,7 +95,7 @@ class JobListingTableTestCase(JobListingBlockTestUtils, TestCase):
     def test_shows_jobs(self):
         self.make_job("live1")
         # This job should not show up because it is closed.
-        self.make_job("live_closed", close_date=date(1970, 1, 1)),
+        self.make_job("live_closed", close_date=date(1970, 1, 1))
         self.make_job("live2")
         # This job should not show up because it is not live.
         self.make_job("draft", live=False)

--- a/cfgov/jobmanager/tests/test_views.py
+++ b/cfgov/jobmanager/tests/test_views.py
@@ -15,7 +15,11 @@ class RegionViewSetTests(WagtailTestUtils, TestCase):
         texas = State.objects.create(
             name="Texas", abbreviation="TX", region_id=usa.pk
         )
-        State.objects.create(name="Utah", abbreviation="UT", region_id=usa.pk),
+        (
+            State.objects.create(
+                name="Utah", abbreviation="UT", region_id=usa.pk
+            ),
+        )
         MajorCity.objects.create(
             name="Dallas", state_id=texas.pk, region_id=usa.pk
         )

--- a/cfgov/login/auth.py
+++ b/cfgov/login/auth.py
@@ -80,7 +80,6 @@ def process_family_name_claim(user, family_name):
 
 
 class CFPBOIDCAuthenticationBackend(OIDCAuthenticationBackend):
-
     def get_userinfo(self, access_token, id_token, payload):
         # Roles are part of the parent payload here, and not the userinfo.
         # Preserve them if we can.

--- a/cfgov/login/tests/test_auth.py
+++ b/cfgov/login/tests/test_auth.py
@@ -24,13 +24,11 @@ User = get_user_model()
 
 
 class UsernameFromEmailTestCase(TestCase):
-
     def test_email_address(self):
         self.assertEqual(username_from_email("test@example.com"), "test")
 
 
 class ProcessRolesClaimTestCase(TestCase):
-
     def setUp(self):
         self.user = User.objects.create(
             username="user1", email="email@example.com", first_name="User"
@@ -130,7 +128,6 @@ class ProcessRolesClaimTestCase(TestCase):
 
 
 class CFPBOIDCAuthenticationBackendTestCase(TestCase):
-
     @override_settings(
         OIDC_OP_TOKEN_ENDPOINT="https://server.example.com/token"
     )

--- a/cfgov/login/tests/test_checks.py
+++ b/cfgov/login/tests/test_checks.py
@@ -6,7 +6,6 @@ from login.checks import check_oidc_admin_role_setting
 
 
 class ChecksTestCase(TestCase):
-
     @override_settings(ENABLE_SSO=True, OIDC_OP_ADMIN_ROLE=None)
     def test_check_oidc_admin_role_setting(self):
         errors = check_oidc_admin_role_setting(apps.get_app_configs())

--- a/cfgov/login/tests/test_views.py
+++ b/cfgov/login/tests/test_views.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 
 
 class LoginViewTestCase(TestCase):
-
     @override_settings(ENABLE_SSO=True)
     def test_view_gets_sso_enabled_context(self):
         response = self.client.get(reverse("cfgov_login"))

--- a/cfgov/mega_menu/management/commands/import_mega_menu.py
+++ b/cfgov/mega_menu/management/commands/import_mega_menu.py
@@ -30,5 +30,7 @@ class Command(BaseCommand):
         )
 
         self.stdout.write(
-            "{} mega menu for language {}.".format("Created" if created else "Updated", language)
+            "{} mega menu for language {}.".format(
+                "Created" if created else "Updated", language
+            )
         )

--- a/cfgov/mega_menu/management/commands/import_mega_menu.py
+++ b/cfgov/mega_menu/management/commands/import_mega_menu.py
@@ -30,6 +30,5 @@ class Command(BaseCommand):
         )
 
         self.stdout.write(
-            "%s mega menu for language %s."
-            % ("Created" if created else "Updated", language)
+            "{} mega menu for language {}.".format("Created" if created else "Updated", language)
         )

--- a/cfgov/paying_for_college/apps.py
+++ b/cfgov/paying_for_college/apps.py
@@ -1,4 +1,3 @@
-
 from django.apps import AppConfig
 
 

--- a/cfgov/paying_for_college/apps.py
+++ b/cfgov/paying_for_college/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from django.apps import AppConfig
 

--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -35,10 +35,10 @@ This will create a new file in `paying_for_college/fixtures/bls_data.json`
 """
 
 BASE_DIR = "paying_for_college/data_sources"
-WE_CSVFILE = "{}/xregnw.csv".format(BASE_DIR)
-NE_CSVFILE = "{}/xregnne.csv".format(BASE_DIR)
-MW_CSVFILE = "{}/xregnmw.csv".format(BASE_DIR)
-SO_CSVFILE = "{}/xregns.csv".format(BASE_DIR)
+WE_CSVFILE = f"{BASE_DIR}/xregnw.csv"
+NE_CSVFILE = f"{BASE_DIR}/xregnne.csv"
+MW_CSVFILE = f"{BASE_DIR}/xregnmw.csv"
+SO_CSVFILE = f"{BASE_DIR}/xregns.csv"
 YEAR = 2014
 
 OUT_FILE = "paying_for_college/fixtures/bls_data.json"
@@ -83,21 +83,19 @@ def add_bls_dict_with_region(base_bls_dict, region, csvfile):
     }
 
     data = load_bls_data(csvfile)
-    print("******Processing {} file...******".format(region))
+    print(f"******Processing {region} file...******")
     for row in data:
         item = row["Item"].strip()
         if item in CATEGORIES_KEY_MAP.keys():
-            print("Current processing {}.....".format(item))
+            print(f"Current processing {item}.....")
             print(
-                "Will be adding {} to base_bls_dict...".format(
-                    CATEGORIES_KEY_MAP[item]
-                )
+                f"Will be adding {CATEGORIES_KEY_MAP[item]} to base_bls_dict..."
             )
             base_bls_dict[CATEGORIES_KEY_MAP[item]].setdefault(region, {})
             for income_key, income_json_key in INCOME_KEY_MAP.items():
-                print("adding {} ...".format(income_key))
+                print(f"adding {income_key} ...")
                 amount = int(row[income_key].replace(",", ""))
-                print("amount: {}".format(amount))
+                print(f"amount: {amount}")
                 base_bls_dict[CATEGORIES_KEY_MAP[item]][region].setdefault(
                     income_json_key, 0
                 )

--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -86,7 +86,7 @@ def add_bls_dict_with_region(base_bls_dict, region, csvfile):
     print(f"******Processing {region} file...******")
     for row in data:
         item = row["Item"].strip()
-        if item in CATEGORIES_KEY_MAP.keys():
+        if item in CATEGORIES_KEY_MAP:
             print(f"Current processing {item}.....")
             print(
                 f"Will be adding {CATEGORIES_KEY_MAP[item]} to base_bls_dict..."

--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -89,7 +89,7 @@ def add_bls_dict_with_region(base_bls_dict, region, csvfile):
         if item in CATEGORIES_KEY_MAP:
             print(f"Current processing {item}.....")
             print(
-                f"Will be adding {CATEGORIES_KEY_MAP[item]} to base_bls_dict..."
+                f"Will be adding {CATEGORIES_KEY_MAP[item]} to base_bls_dict…"
             )
             base_bls_dict[CATEGORIES_KEY_MAP[item]].setdefault(region, {})
             for income_key, income_json_key in INCOME_KEY_MAP.items():

--- a/cfgov/paying_for_college/disclosures/scripts/api_utils.py
+++ b/cfgov/paying_for_college/disclosures/scripts/api_utils.py
@@ -238,7 +238,9 @@ def build_field_string():
 def search_by_school_name(name):
     """Search api by school name, return school name, id, city, state."""
     fields = "id,school.name,school.city,school.state"
-    url = f"{SCHOOLS_ROOT}?api_key={API_KEY}&school.name={name}&fields={fields}"
+    url = (
+        f"{SCHOOLS_ROOT}?api_key={API_KEY}&school.name={name}&fields={fields}"
+    )
     data = requests.get(url).json()["results"]
     return data
 

--- a/cfgov/paying_for_college/disclosures/scripts/api_utils.py
+++ b/cfgov/paying_for_college/disclosures/scripts/api_utils.py
@@ -20,7 +20,7 @@ import requests
 
 API_KEY = os.getenv("ED_API_KEY", "")
 API_ROOT = "https://api.data.gov/ed/collegescorecard/v1"
-SCHOOLS_ROOT = "{}/schools.json".format(API_ROOT)
+SCHOOLS_ROOT = f"{API_ROOT}/schools.json"
 QUERY_URL = "{}?id={}&api_key={}&fields={}"
 PAGE_MAX = 100  # the max page size allowed as of 2015-09-14
 
@@ -229,7 +229,7 @@ def api_school_query(school_id, fields):
 def build_field_string():
     """Assemble fields for a fat API query."""
     latest_fields = [
-        "latest.{}".format(field) for field in (YEAR_FIELDS + PROGRAM_FIELDS)
+        f"latest.{field}" for field in (YEAR_FIELDS + PROGRAM_FIELDS)
     ]
     fields = BASE_FIELDS + latest_fields
     return ",".join(fields)
@@ -238,9 +238,7 @@ def build_field_string():
 def search_by_school_name(name):
     """Search api by school name, return school name, id, city, state."""
     fields = "id,school.name,school.city,school.state"
-    url = "{0}?api_key={1}&school.name={2}&fields={3}".format(
-        SCHOOLS_ROOT, API_KEY, name, fields
-    )
+    url = f"{SCHOOLS_ROOT}?api_key={API_KEY}&school.name={name}&fields={fields}"
     data = requests.get(url).json()["results"]
     return data
 

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import io
 from csv import DictReader as cdr
 
@@ -85,7 +84,7 @@ def get_school(iped):
     try:
         school = School.objects.get(school_id=int(iped))
     except Exception:
-        return ("", "ERROR: couldn't find school for ID {0}".format(iped))
+        return ("", f"ERROR: couldn't find school for ID {iped}")
     else:
         return (school, "")
 
@@ -200,7 +199,7 @@ def load(source, s3=False):
     else:
         raw_data = read_in_data(source)
     if not raw_data[0]:
-        return (["ERROR: could not read data from {0}".format(source)], "")
+        return ([f"ERROR: could not read data from {source}"], "")
 
     for row in raw_data:
         if "test" in row.keys() and row["test"].lower() == "true":
@@ -260,15 +259,11 @@ def load(source, s3=False):
 
         else:  # There is error
             for key, error_list in dict.items(serializer.errors):
-                fail_msg = "ERROR on row {}: {}: ".format(
-                    raw_data.index(row) + 1, key
-                )
+                fail_msg = f"ERROR on row {raw_data.index(row) + 1}: {key}: "
                 for e in error_list:
-                    fail_msg = "{} {},".format(fail_msg, e)
+                    fail_msg = f"{fail_msg} {e},"
                 FAILED.append(fail_msg)
 
-    endmsg = "{} programs created. " "{} programs updated.".format(
-        new_programs, updated_programs
-    )
+    endmsg = f"{new_programs} programs created. " f"{updated_programs} programs updated."
 
     return (FAILED, endmsg)

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -202,7 +202,7 @@ def load(source, s3=False):
         return ([f"ERROR: could not read data from {source}"], "")
 
     for row in raw_data:
-        if "test" in row.keys() and row["test"].lower() == "true":
+        if "test" in row and row["test"].lower() == "true":
             test_program = True
         fixed_data = clean(row)
         serializer = ProgramSerializer(data=fixed_data)

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -211,8 +211,9 @@ def load(source, s3=False):
             data = serializer.validated_data
             if not validate_pid(data["program_code"]):
                 print(
-                    "ERROR: invalid program code: "
-                    "{}".format(data["program_code"])
+                    "ERROR: invalid program code: " "{}".format(
+                        data["program_code"]
+                    )
                 )
                 continue
             (school, error) = get_school(data["ipeds_unit_id"])
@@ -264,6 +265,9 @@ def load(source, s3=False):
                     fail_msg = f"{fail_msg} {e},"
                 FAILED.append(fail_msg)
 
-    endmsg = f"{new_programs} programs created. " f"{updated_programs} programs updated."
+    endmsg = (
+        f"{new_programs} programs created. "
+        f"{updated_programs} programs updated."
+    )
 
     return (FAILED, endmsg)

--- a/cfgov/paying_for_college/disclosures/scripts/nat_stats.py
+++ b/cfgov/paying_for_college/disclosures/scripts/nat_stats.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 
 FIXTURES_DIR = Path(__file__).resolve().parents[2]
-NAT_DATA_FILE = "{0}/fixtures/national_stats.json".format(FIXTURES_DIR)
-BACKUP_FILE = "{0}/fixtures/national_stats_backup.json".format(FIXTURES_DIR)
+NAT_DATA_FILE = f"{FIXTURES_DIR}/fixtures/national_stats.json"
+BACKUP_FILE = f"{FIXTURES_DIR}/fixtures/national_stats_backup.json"
 # source for BLS_FILE: https://www.bls.gov/cex/#tables_long
-BLS_FILE = "{0}/fixtures/bls_data.json".format(FIXTURES_DIR)
+BLS_FILE = f"{FIXTURES_DIR}/fixtures/bls_data.json"
 LENGTH_MAP = {
     "earnings": {2: "median_earnings_l4", 4: "median_earnings_4"},
     "completion": {2: "completion_rate_l4", 4: "completion_rate_4"},
@@ -17,7 +17,7 @@ LENGTH_MAP = {
 def get_bls_stats():
     """Deliver BLS spending stats stored in the repo."""
     try:
-        with open(BLS_FILE, "r") as f:
+        with open(BLS_FILE) as f:
             data = json.loads(f.read())
     except FileNotFoundError:
         data = {}
@@ -26,7 +26,7 @@ def get_bls_stats():
 
 def get_national_stats():
     """return dictionary of national college statistics"""
-    with open(NAT_DATA_FILE, "r") as f:
+    with open(NAT_DATA_FILE) as f:
         return json.loads(f.read())
 
 

--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -33,10 +33,7 @@ def send_test_notifications(url=None, oid=OID, errors=ERRORS):
         "su": Contact.objects.get(name="South University").endpoint,
         "ai": Contact.objects.get(name="Art Institutes").endpoint,
     }
-    if not url:
-        urls = list(prod_endpoints.values())
-    else:
-        urls = [url]
+    urls = list(prod_endpoints.values()) if not url else [url]
     payload = {
         "oid": oid,
         "time": f"{datetime.datetime.now().isoformat()}+00:00",  # noqa

--- a/cfgov/paying_for_college/disclosures/scripts/notifications.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notifications.py
@@ -73,6 +73,6 @@ def send_stale_notifications(add_email=None):
             fail_silently=False,
         )
         return (
-            f"Found {stale_notifications.count()} stale notifications; emails sent to "
-            f"{recipients}"
+            f"Found {stale_notifications.count()} stale notifications; "
+            f"emails sent to {recipients}"
         )

--- a/cfgov/paying_for_college/disclosures/scripts/notifications.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notifications.py
@@ -12,12 +12,10 @@ INTRO = (
     "Notification delivery failed for the following offer IDs:\n\n"
 )
 NOTE_TEMPLATE = Template(
-    
-        "Offer ID $oid:\n"
-        "    timestamp: $time\n"
-        "    app errors: $errors\n"
-        "SEND LOG:\n$log\n"
-    
+    "Offer ID $oid:\n"
+    "    timestamp: $time\n"
+    "    app errors: $errors\n"
+    "SEND LOG:\n$log\n"
 )
 
 
@@ -74,4 +72,7 @@ def send_stale_notifications(add_email=None):
             recipients,
             fail_silently=False,
         )
-        return f"Found {stale_notifications.count()} stale notifications; emails sent to " f"{recipients}"
+        return (
+            f"Found {stale_notifications.count()} stale notifications; emails sent to "
+            f"{recipients}"
+        )

--- a/cfgov/paying_for_college/disclosures/scripts/notifications.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notifications.py
@@ -12,12 +12,12 @@ INTRO = (
     "Notification delivery failed for the following offer IDs:\n\n"
 )
 NOTE_TEMPLATE = Template(
-    (
+    
         "Offer ID $oid:\n"
         "    timestamp: $time\n"
         "    app errors: $errors\n"
         "SEND LOG:\n$log\n"
-    )
+    
 )
 
 
@@ -30,7 +30,7 @@ def retry_notifications(days=1):
         sent=False, timestamp__gt=days_old
     )
     for each in failed_notifications:
-        endmsg += "{}\n".format(each.notify_school())
+        endmsg += f"{each.notify_school()}\n"
     if not endmsg:
         endmsg = "No failed notifications found"
     return endmsg
@@ -74,6 +74,4 @@ def send_stale_notifications(add_email=None):
             recipients,
             fail_silently=False,
         )
-        return "Found {} stale notifications; emails sent to " "{}".format(
-            stale_notifications.count(), recipients
-        )
+        return f"Found {stale_notifications.count()} stale notifications; emails sent to " f"{recipients}"

--- a/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
+++ b/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
@@ -83,7 +83,7 @@ def run(single_school=None):
         by_control = {}
         count += 1
         if count % 500 == 0:  # pragma: no cover
-            logger.info("{} schools processed".format(count))
+            logger.info(f"{count} schools processed")
         # degree_cohort is the default, national base cohort
         # base query weeds out schools without state or degrees_highest values
         degree_cohort = DEGREE_COHORTS.get(get_grad_level(school))
@@ -131,7 +131,5 @@ def run(single_school=None):
         school.cohort_ranking_by_highest_degree = by_degree
         school.save()
     logger.info(
-        "\nCohort script took {} to process {} schools".format(
-            datetime.datetime.now() - starter, count
-        )
+        f"\nCohort script took {datetime.datetime.now() - starter} to process {count} schools"
     )

--- a/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
+++ b/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
@@ -15,7 +15,7 @@ STATES = sorted(
     + [tup[0] for tup in localflavor.us.us_states.NON_CONTIGUOUS_STATES]
     + ["PR"]
 )
-DEGREE_COHORTS = {k: [] for k in HIGHEST_DEGREES.keys()}
+DEGREE_COHORTS = {k: [] for k in HIGHEST_DEGREES}
 logger = logging.getLogger(__name__)
 
 

--- a/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
+++ b/cfgov/paying_for_college/disclosures/scripts/process_cohorts.py
@@ -131,5 +131,6 @@ def run(single_school=None):
         school.cohort_ranking_by_highest_degree = by_degree
         school.save()
     logger.info(
-        f"\nCohort script took {datetime.datetime.now() - starter} to process {count} schools"
+        f"\nCohort script took {datetime.datetime.now() - starter} to "
+        f"process {count} schools"
     )

--- a/cfgov/paying_for_college/disclosures/scripts/purge_objects.py
+++ b/cfgov/paying_for_college/disclosures/scripts/purge_objects.py
@@ -24,6 +24,6 @@ def purge(objects):
     if objects not in object_map.keys():
         return error_msg
     queryset = object_map[objects]
-    msg = "Purging {} {}".format(queryset.count(), objects)
+    msg = f"Purging {queryset.count()} {objects}"
     queryset.delete()
     return msg

--- a/cfgov/paying_for_college/disclosures/scripts/purge_objects.py
+++ b/cfgov/paying_for_college/disclosures/scripts/purge_objects.py
@@ -21,7 +21,7 @@ def purge(objects):
     objects = objects.lower()
     if not objects:
         return no_args_msg
-    if objects not in object_map.keys():
+    if objects not in object_map:
         return error_msg
     queryset = object_map[objects]
     msg = f"Purging {queryset.count()} {objects}"

--- a/cfgov/paying_for_college/disclosures/scripts/tag_settlement_schools.py
+++ b/cfgov/paying_for_college/disclosures/scripts/tag_settlement_schools.py
@@ -11,13 +11,13 @@ def tag_schools(s3_url):
     counter = 0
     csv_data = read_in_s3(s3_url)
     if not csv_data[0]:
-        return "ERROR: could not read data from {0}".format(s3_url)
+        return f"ERROR: could not read data from {s3_url}"
     headings = csv_data[0].keys()
     for heading in ["ipeds_unit_id", "flag"]:
         if heading not in headings:
             return (
                 "ERROR: CSV doesn't have required fields; "
-                "fields found were {}".format(headings)
+                f"fields found were {headings}"
             )
     initial_flag = csv_data[0]["flag"]
     for row in csv_data:
@@ -29,6 +29,4 @@ def tag_schools(s3_url):
             school.save()
             counter += 1
     intro = "school was" if counter == 1 else "schools were"
-    return "{} {} tagged as '{}' settlement schools".format(
-        counter, intro, initial_flag
-    )
+    return f"{counter} {intro} tagged as '{initial_flag}' settlement schools"

--- a/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
@@ -41,14 +41,11 @@ FIELDSTRING = api_utils.build_field_string()
 
 
 def test_for_program_data(program_data):
-    if (
+    return (
         program_data.get("earnings").get("median_earnings")
         or program_data.get("debt").get("median_debt")
         or program_data.get("debt").get("monthly_debt_payment")
-    ):
-        return True
-    else:
-        return False
+    )
 
 
 def update_programs(api_data, school):

--- a/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_colleges.py
@@ -200,9 +200,7 @@ def update(exclude_ids=None, single_school=None, store_programs=False):
         base_query = base_query.filter(pk=single_school)
         logger.info(f"Updating {base_query[0]}")
     else:
-        logger.info(
-            f"Seeking updates for {base_query.count()} schools."
-        )
+        logger.info(f"Seeking updates for {base_query.count()} schools.")
         logger.info(job_msg)
     for school in base_query:
         processed += 1

--- a/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -24,30 +24,24 @@ PFC_ROOT = Path(__file__).resolve().parents[2]
 # from the previous academic year, whose first year is two years ago.
 # In early 2020, the latest data came from the 2018-2019 academic year.
 DATA_YEAR = datetime.datetime.now().year - 2
-ipeds_directory = "{}/data_sources/ipeds".format(PFC_ROOT)
+ipeds_directory = f"{PFC_ROOT}/data_sources/ipeds"
 ipeds_data_url = "https://nces.ed.gov/ipeds/datacenter/data/"
-data_slug = "IC{}_AY".format(DATA_YEAR)
-dictionary_slug = "IC{}_AY_Dict".format(DATA_YEAR)
+data_slug = f"IC{DATA_YEAR}_AY"
+dictionary_slug = f"IC{DATA_YEAR}_AY_Dict"
 
 DATA_VARS = {
-    "universe_url": "{}/HD{}.zip".format(ipeds_data_url, DATA_YEAR),
-    "universe_zip": "{}/HD{}.zip".format(ipeds_directory, DATA_YEAR),
-    "universe_csv": "{}/hd{}.csv".format(ipeds_directory, DATA_YEAR),
-    "universe_cleaned": "{}/hd{}_cleaned.csv".format(
-        ipeds_directory, DATA_YEAR
-    ),
-    "data_url": "{}/{}.zip".format(ipeds_data_url, data_slug),
-    "data_zip": "{}/{}.zip".format(ipeds_directory, data_slug),
-    "data_csv": "{}/{}.csv".format(ipeds_directory, data_slug.lower()),
-    "data_cleaned": "{}/{}_cleaned.csv".format(
-        ipeds_directory, data_slug.lower()
-    ),
-    "services_url": "{}/IC{}.zip".format(ipeds_data_url, DATA_YEAR),
-    "services_zip": "{}/IC{}.zip".format(ipeds_directory, DATA_YEAR),
-    "services_csv": "{}/ic{}.csv".format(ipeds_directory, DATA_YEAR),
-    "services_cleaned": "{}/ic{}_cleaned.csv".format(
-        ipeds_directory, DATA_YEAR
-    ),
+    "universe_url": f"{ipeds_data_url}/HD{DATA_YEAR}.zip",
+    "universe_zip": f"{ipeds_directory}/HD{DATA_YEAR}.zip",
+    "universe_csv": f"{ipeds_directory}/hd{DATA_YEAR}.csv",
+    "universe_cleaned": f"{ipeds_directory}/hd{DATA_YEAR}_cleaned.csv",
+    "data_url": f"{ipeds_data_url}/{data_slug}.zip",
+    "data_zip": f"{ipeds_directory}/{data_slug}.zip",
+    "data_csv": f"{ipeds_directory}/{data_slug.lower()}.csv",
+    "data_cleaned": f"{ipeds_directory}/{data_slug.lower()}_cleaned.csv",
+    "services_url": f"{ipeds_data_url}/IC{DATA_YEAR}.zip",
+    "services_zip": f"{ipeds_directory}/IC{DATA_YEAR}.zip",
+    "services_csv": f"{ipeds_directory}/ic{DATA_YEAR}.csv",
+    "services_cleaned": f"{ipeds_directory}/ic{DATA_YEAR}_cleaned.csv",
 }
 
 # mapping the vars of our data_json to the IPEDS data csv
@@ -121,13 +115,13 @@ def write_clean_csv(fpath, fieldnames, clean_headings, data):
 def download_files():
     """Download the latest IPEDS Institutional Characteristics file."""
     for slug in ["universe", "data", "services"]:
-        url = DATA_VARS["{}_url".format(slug)]
-        target = DATA_VARS["{}_zip".format(slug)]
+        url = DATA_VARS[f"{slug}_url"]
+        target = DATA_VARS[f"{slug}_zip"]
         target_slug = target.split("/")[-1]
         if download_zip_file(url, target):
-            print("Downloaded {}".format(target_slug))
+            print(f"Downloaded {target_slug}")
         else:
-            print("Failed to download {}".format(target_slug))
+            print(f"Failed to download {target_slug}")
     clean_csv_headings()
 
 
@@ -151,8 +145,8 @@ def dump_csv(fpath, header, data):
 def clean_csv_headings():
     """Strip nasty leading or trailing spaces from column headings."""
     for slug in ["universe", "data", "services"]:
-        original_file = DATA_VARS["{}_csv".format(slug)]
-        cleaned_file = DATA_VARS["{}_cleaned".format(slug)]
+        original_file = DATA_VARS[f"{slug}_csv"]
+        cleaned_file = DATA_VARS[f"{slug}_cleaned"]
         fieldnames, data = read_csv(original_file, encoding="latin-1")
         clean_headings = [name.strip() for name in fieldnames]
         write_clean_csv(cleaned_file, fieldnames, clean_headings, data)
@@ -201,9 +195,7 @@ def create_school(iped, data):
 def process_missing(missing_ids):
     """Create missing school and alias objects and dump csv of additions."""
     csv_out_data = []
-    csv_slug = "{}/schools_added_on_{}.csv".format(
-        ipeds_directory, datetime.date.today()
-    )
+    csv_slug = f"{ipeds_directory}/schools_added_on_{datetime.date.today()}.csv"
     missing_data = process_datafiles(add_schools=missing_ids)
     for school_id in missing_data:
         create_school(int(school_id), missing_data[school_id])
@@ -247,22 +239,14 @@ def load_values(dry_run=True):
     if dry_run:
         msg = (
             "DRY RUN:\n"
-            "- {} would have updated {} data points for {} schools\n"
-            "- {} schools found with on-campus housing\n"
-            "- {} new school records "
-            "would have been created".format(
-                SCRIPT,
-                intcomma(points),
-                intcomma(updated),
-                intcomma(oncampus),
-                len(missing),
-            )
+            f"- {SCRIPT} would have updated {intcomma(points)} data points for {intcomma(updated)} schools\n"
+            f"- {intcomma(oncampus)} schools found with on-campus housing\n"
+            f"- {len(missing)} new school records "
+            "would have been created"
         )
         return msg
     msg = (
-        "{} updated {} data points for {} schools;\n"
-        "{} new school records were created".format(
-            SCRIPT, intcomma(points), intcomma(updated), len(missing)
-        )
+        f"{SCRIPT} updated {intcomma(points)} data points for {intcomma(updated)} schools;\n"
+        f"{len(missing)} new school records were created"
     )
     return msg

--- a/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -241,14 +241,16 @@ def load_values(dry_run=True):
     if dry_run:
         msg = (
             "DRY RUN:\n"
-            f"- {SCRIPT} would have updated {intcomma(points)} data points for {intcomma(updated)} schools\n"
+            f"- {SCRIPT} would have updated {intcomma(points)} data points "
+            f"for {intcomma(updated)} schools\n"
             f"- {intcomma(oncampus)} schools found with on-campus housing\n"
             f"- {len(missing)} new school records "
             "would have been created"
         )
         return msg
     msg = (
-        f"{SCRIPT} updated {intcomma(points)} data points for {intcomma(updated)} schools;\n"
+        f"{SCRIPT} updated {intcomma(points)} data points for "
+        f"{intcomma(updated)} schools;\n"
         f"{len(missing)} new school records were created"
     )
     return msg

--- a/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -195,7 +195,9 @@ def create_school(iped, data):
 def process_missing(missing_ids):
     """Create missing school and alias objects and dump csv of additions."""
     csv_out_data = []
-    csv_slug = f"{ipeds_directory}/schools_added_on_{datetime.date.today()}.csv"
+    csv_slug = (
+        f"{ipeds_directory}/schools_added_on_{datetime.date.today()}.csv"
+    )
     missing_data = process_datafiles(add_schools=missing_ids)
     for school_id in missing_data:
         create_school(int(school_id), missing_data[school_id])

--- a/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
+++ b/cfgov/paying_for_college/disclosures/scripts/update_ipeds.py
@@ -212,7 +212,7 @@ def load_values(dry_run=True):
     oncampus = 0
     source_dict = process_datafiles()
     current_ids = [school.pk for school in School.objects.all()]
-    missing = [pk for pk in source_dict.keys() if int(pk) not in current_ids]
+    missing = [pk for pk in source_dict if int(pk) not in current_ids]
     if missing and dry_run is False:
         process_missing(missing)
     for ID in source_dict:

--- a/cfgov/paying_for_college/management/commands/load_programs.py
+++ b/cfgov/paying_for_college/management/commands/load_programs.py
@@ -18,10 +18,7 @@ class Command(BaseCommand):
         parser.add_argument("--s3", help=S3_HELP, type=str, default="false")
 
     def handle(self, *args, **options):
-        if options["s3"].upper() == "TRUE":
-            S3 = True
-        else:
-            S3 = False
+        S3 = options["s3"].upper() == "TRUE"
         for filesource in options["source"]:
             try:
                 if S3:

--- a/cfgov/paying_for_college/management/commands/update_via_api.py
+++ b/cfgov/paying_for_college/management/commands/update_via_api.py
@@ -3,8 +3,8 @@ from django.core.management.base import BaseCommand
 from paying_for_college.disclosures.scripts import update_colleges
 
 
-COMMAND_HELP = """update_via_api gets school-level data from the Department of \
-Education's CollegeScorecard API. The script intentionally runs slowly \
+COMMAND_HELP = """update_via_api gets school-level data from the Department \
+of Education's CollegeScorecard API. The script intentionally runs slowly \
 to avoid triggering API rate limits, so allow an hour to run."""
 PARSER_HELP = """Optionally specify a single school to update \
 by passing '--school_id' and a college IPEDS ID."""

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -583,7 +583,7 @@ class Notification(models.Model):
     log = models.TextField(blank=True)
 
     def __str__(self):
-        return f"{self.oid} {self.institution.primary_alias} ({self.institution.pk})"
+        return f"{self.oid} {self.institution.primary_alias} ({self.institution.pk})"  # noqa: E501
 
     def notify_school(self):
         school = self.institution

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -597,8 +597,7 @@ class Notification(models.Model):
         }
         now = datetime.datetime.now()
         no_contact_msg = (
-            "School notification failed: "
-            f"No endpoint or email info {now}"
+            "School notification failed: " f"No endpoint or email info {now}"
         )
         # we prefer to use endpount notification, so use it first if existing
         if school.contact:
@@ -609,26 +608,19 @@ class Notification(models.Model):
                 try:
                     resp = requests.post(endpoint, data=payload, timeout=10)
                 except requests.exceptions.ConnectionError as e:
-                    exmsg = (
-                        "Error: connection error at school "
-                        f"{now} {e}\n"
-                    )
+                    exmsg = "Error: connection error at school " f"{now} {e}\n"
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg
                 except requests.exceptions.Timeout:
                     exmsg = (
-                        "Error: connection with school "
-                        f"timed out {now}\n"
+                        "Error: connection with school " f"timed out {now}\n"
                     )
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg
                 except requests.exceptions.RequestException as e:
-                    exmsg = (
-                        "Error: request error at school: "
-                        f"{now} {e}\n"
-                    )
+                    exmsg = "Error: request error at school: " f"{now} {e}\n"
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import smtplib
@@ -211,7 +210,7 @@ class ConstantRate(models.Model):
     updated = models.DateField(auto_now=True)
 
     def __str__(self):
-        return "{} ({}), updated {}".format(self.name, self.slug, self.updated)
+        return f"{self.name} ({self.slug}), updated {self.updated}"
 
     class Meta:
         ordering = ["slug"]
@@ -229,7 +228,7 @@ class ConstantCap(models.Model):
     updated = models.DateField(auto_now=True)
 
     def __str__(self):
-        return "{} ({}), updated {}".format(self.name, self.slug, self.updated)
+        return f"{self.name} ({self.slug}), updated {self.updated}"
 
     class Meta:
         ordering = ["slug"]
@@ -303,7 +302,7 @@ def format_for_null(value):
     if value is None:
         return value
     else:
-        return "{}".format(value)
+        return f"{value}"
 
 
 class School(models.Model):
@@ -492,7 +491,7 @@ class School(models.Model):
         return json.dumps(ordered_out)
 
     def __str__(self):
-        return self.primary_alias + " ({})".format(self.school_id)
+        return self.primary_alias + f" ({self.school_id})"
 
     @property
     def program_codes(self):
@@ -584,9 +583,7 @@ class Notification(models.Model):
     log = models.TextField(blank=True)
 
     def __str__(self):
-        return "{0} {1} ({2})".format(
-            self.oid, self.institution.primary_alias, self.institution.pk
-        )
+        return f"{self.oid} {self.institution.primary_alias} ({self.institution.pk})"
 
     def notify_school(self):
         school = self.institution
@@ -601,7 +598,7 @@ class Notification(models.Model):
         now = datetime.datetime.now()
         no_contact_msg = (
             "School notification failed: "
-            "No endpoint or email info {}".format(now)
+            f"No endpoint or email info {now}"
         )
         # we prefer to use endpount notification, so use it first if existing
         if school.contact:
@@ -614,7 +611,7 @@ class Notification(models.Model):
                 except requests.exceptions.ConnectionError as e:
                     exmsg = (
                         "Error: connection error at school "
-                        "{} {}\n".format(now, e)
+                        f"{now} {e}\n"
                     )
                     self.log = self.log + exmsg
                     self.save()
@@ -622,7 +619,7 @@ class Notification(models.Model):
                 except requests.exceptions.Timeout:
                     exmsg = (
                         "Error: connection with school "
-                        "timed out {}\n".format(now)
+                        f"timed out {now}\n"
                     )
                     self.log = self.log + exmsg
                     self.save()
@@ -630,7 +627,7 @@ class Notification(models.Model):
                 except requests.exceptions.RequestException as e:
                     exmsg = (
                         "Error: request error at school: "
-                        "{} {}\n".format(now, e)
+                        f"{now} {e}\n"
                     )
                     self.log = self.log + exmsg
                     self.save()
@@ -638,9 +635,7 @@ class Notification(models.Model):
                 else:
                     if resp.ok:
                         self.sent = True
-                        self.log = "School notified " "via endpoint {}".format(
-                            now
-                        )
+                        self.log = "School notified " f"via endpoint {now}"
                         self.save()
                         return self.log
                     else:
@@ -657,7 +652,7 @@ class Notification(models.Model):
                         )
                         self.log = self.log + msg
                         self.save()
-                        return "Notification failed: {}".format(msg)
+                        return f"Notification failed: {msg}"
             elif school.contact.contacts:
                 try:
                     send_mail(
@@ -672,16 +667,14 @@ class Notification(models.Model):
                     )
                     self.sent = True
                     self.emails = school.contact.contacts
-                    self.log = "School notified via email " "at {}".format(
-                        self.emails
-                    )
+                    self.log = "School notified via email " f"at {self.emails}"
                     self.save()
                     return self.log
                 except smtplib.SMTPException as e:
                     email_fail_msg = (
                         "School email notification "
-                        "failed on {}\n"
-                        "Error: {}".format(now, e)
+                        f"failed on {now}\n"
+                        f"Error: {e}"
                     )
                     self.log = self.log + email_fail_msg
                     self.save()
@@ -772,7 +765,7 @@ class Program(models.Model):
     test = models.BooleanField(default=False)
 
     def __str__(self):
-        return "{} ({})".format(self.program_name, self.institution)
+        return f"{self.program_name} ({self.institution})"
 
     def get_level(self):
         level = ""
@@ -787,10 +780,10 @@ class Program(models.Model):
             "books": self.books,
             "campus": self.campus,
             "cipCode": self.cip_code,
-            "completionRate": "{0}".format(self.completion_rate),
+            "completionRate": f"{self.completion_rate}",
             "completionCohort": self.completion_cohort,
             "completers": self.completers,
-            "defaultRate": "{0}".format(self.default_rate),
+            "defaultRate": f"{self.default_rate}",
             "fees": self.fees,
             "housing": self.housing,
             "institution": self.institution.primary_alias,
@@ -865,11 +858,11 @@ class Program(models.Model):
                     self.books,
                     self.campus,
                     self.cip_code,
-                    "{}".format(self.completion_rate),
+                    f"{self.completion_rate}",
                     self.completion_cohort,
                     self.completers,
-                    "{0}".format(self.default_rate),
-                    "{0}".format(self.job_rate),
+                    f"{self.default_rate}",
+                    f"{self.job_rate}",
                     self.job_note,
                     self.mean_student_loan_completers,
                     self.median_student_loan_completers,
@@ -891,7 +884,7 @@ class Alias(models.Model):
     is_primary = models.BooleanField(default=False)
 
     def __str__(self):
-        return "{} (alias for {})".format(self.alias, self.institution)
+        return f"{self.alias} (alias for {self.institution})"
 
     class Meta:
         verbose_name_plural = "Aliases"
@@ -907,7 +900,7 @@ class Nickname(models.Model):
     is_female = models.BooleanField(default=False)
 
     def __str__(self):
-        return "{} (nickname for {})".format(self.nickname, self.institution)
+        return f"{self.nickname} (nickname for {self.institution})"
 
     class Meta:
         ordering = ["nickname"]

--- a/cfgov/paying_for_college/tests/test_load_programs.py
+++ b/cfgov/paying_for_college/tests/test_load_programs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import mock
 from unittest.mock import mock_open, patch
 

--- a/cfgov/paying_for_college/tests/test_models.py
+++ b/cfgov/paying_for_college/tests/test_models.py
@@ -114,7 +114,7 @@ class SchoolModelsTest(TestCase):
         self.assertTrue(isinstance(a, Alias))
         self.assertIn(a.alias, a.__str__())
         self.assertEqual(s.primary_alias, a.alias)
-        self.assertEqual(s.__str__(), a.alias + " ({})".format(s.school_id))
+        self.assertEqual(s.__str__(), a.alias + f" ({s.school_id})")
         c = self.create_contact()
         self.assertTrue(isinstance(c, Contact))
         self.assertIn(c.contacts, c.__str__())

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -36,7 +36,7 @@ from paying_for_college.models import (
 )
 
 
-COLLEGE_ROOT = "{}/paying_for_college".format(settings.PROJECT_ROOT)
+COLLEGE_ROOT = f"{settings.PROJECT_ROOT}/paying_for_college"
 
 
 class ProgamDataTest(django.test.TestCase):
@@ -169,10 +169,10 @@ class PurgeTests(django.test.TestCase):
 
 class TestScripts(django.test.TestCase):
     fixtures = ["test_fixture.json", "test_contacts.json"]
-    api_fixture = "{}/fixtures/sample_4yr_api_result.json".format(COLLEGE_ROOT)
+    api_fixture = f"{COLLEGE_ROOT}/fixtures/sample_4yr_api_result.json"
 
     # a full sample API return for a 4-year school (Texas Tech 229115)
-    with open(api_fixture, "r") as f:
+    with open(api_fixture) as f:
         mock_results = json.loads(f.read())
 
     # a partial sample API return for a community college
@@ -545,7 +545,7 @@ class TestScripts(django.test.TestCase):
         self.assertEqual(mock_write.call_count, 3)
 
     def test_unzip_file(self):
-        test_zip = "{}/data_sources/ipeds/" "test.txt.zip".format(COLLEGE_ROOT)
+        test_zip = f"{COLLEGE_ROOT}/data_sources/ipeds/" "test.txt.zip"
         self.assertTrue(update_ipeds.unzip_file(test_zip))
 
     @patch("paying_for_college.disclosures.scripts.update_ipeds.requests.get")

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -403,7 +403,7 @@ class TestScripts(django.test.TestCase):
     def check_compile_net_prices(self, control):
         mock_api_data = self.mock_results.get("results")[0]
         mock_avg_net_price = mock_api_data.get(
-            "latest.cost.avg_net_price.%s" % control.lower()
+            f"latest.cost.avg_net_price.{control.lower()}"
         )
         school, _ = School.objects.get_or_create(school_id=229115)
         school.control = control

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -593,7 +593,7 @@ class TestScripts(django.test.TestCase):
         mock_read.return_value = (mock_fieldnames, [mock_return_dict])
         mock_results = update_ipeds.process_datafiles()
         self.assertTrue(mock_read.call_count == 2)
-        self.assertTrue("999999" in mock_results.keys())
+        self.assertTrue("999999" in mock_results)
         mock_fieldnames = ["UNITID"] + list(school_points.keys())
         mock_return_dict = {school_points[key]: "x" for key in school_points}
         mock_return_dict["UNITID"] = "999999"

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -83,7 +83,7 @@ class TestViews(django.test.TestCase):
     def test_get_json_file(self):
         test_json = get_json_file(EXPENSE_FILE)
         test_data = json.loads(test_json)
-        self.assertTrue("Other" in test_data.keys())
+        self.assertTrue("Other" in test_data)
         test_json2 = get_json_file("xxx")
         self.assertTrue(test_json2 == "")
 
@@ -107,7 +107,7 @@ class TestViews(django.test.TestCase):
         response = self.client.get(
             reverse("paying_for_college:disclosures:pfc-technote")
         )
-        self.assertTrue("url_root" in response.context_data.keys())
+        self.assertTrue("url_root" in response.context_data)
 
 
 class SchoolProgramTest(django.test.TestCase):

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -170,7 +170,7 @@ class ConstantsTest(django.test.TestCase):
 class OfferTest(django.test.TestCase):
     fixtures = ["test_fixture.json", "test_program.json"]
 
-    # /paying-for-college2/understanding-your-financial-aid-offer/offer/?[QUERYSTRING]
+    # /paying-for-college2/understanding-your-financial-aid-offer/offer/?[QUERYSTRING]  # noqa: E501
     def test_offer(self):
         url = reverse("paying_for_college:disclosures:offer")
         # offer_test_url = reverse("paying_for_college:disclosures:offer_test")
@@ -244,7 +244,7 @@ class APITests(django.test.TestCase):
         "test_program.json",
     ]
 
-    # /paying-for-college2/understanding-your-financial-aid-offer/api/school/155317.json
+    # /paying-for-college2/understanding-your-financial-aid-offer/api/school/155317.json  # noqa: E501
     def test_school_json(self):
         """api call for school details."""
         url = reverse(
@@ -254,7 +254,7 @@ class APITests(django.test.TestCase):
         self.assertIn(b"Kansas", resp.content)
         self.assertIn(b"155317", resp.content)
 
-    # /paying-for-college2/understanding-your-financial-aid-offer/api/constants/
+    # /paying-for-college2/understanding-your-financial-aid-offer/api/constants/  # noqa: E501
     def test_constants_json(self):
         """api call for constants."""
 
@@ -263,7 +263,7 @@ class APITests(django.test.TestCase):
         self.assertIn(b"institutionalLoanRate", resp.content)
         self.assertIn(b"apiYear", resp.content)
 
-    # /paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/
+    # /paying-for-college2/understanding-your-financial-aid-offer/api/national-stats/  # noqa: E501
     def test_national_stats_json(self):
         """api call for national statistics."""
 

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -30,7 +30,7 @@ EXPECTED_ERROR_MESSAGES = [
     "none",
     "INVALID: student indicated the offer information is wrong",
 ]
-EXPENSE_FILE = "{}/fixtures/bls_data.json".format(BASEDIR)
+EXPENSE_FILE = f"{BASEDIR}/fixtures/bls_data.json"
 IPED_ERROR = "noSchool"
 OID_ERROR = "noOffer"
 PID_ERROR = "noProgram"
@@ -38,7 +38,7 @@ PID_ERROR = "noProgram"
 
 def get_json_file(filename):
     try:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             return f.read()
     except Exception:
         return ""
@@ -277,9 +277,9 @@ class ConstantsRepresentation(View):
         for ccap in ConstantCap.objects.order_by("slug"):
             constants[ccap.slug] = ccap.value
         for crate in ConstantRate.objects.order_by("slug"):
-            constants[crate.slug] = "{0}".format(crate.value)
+            constants[crate.slug] = f"{crate.value}"
         cy = constants["constantsYear"]
-        constants["constantsYear"] = "{}-{}".format(cy, str(cy + 1)[2:])
+        constants["constantsYear"] = f"{cy}-{str(cy + 1)[2:]}"
         return json.dumps(constants)
 
     def get(self, request):

--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -55,19 +55,13 @@ def validate_oid(oid):
     if find_illegal:
         return False
     else:
-        if len(oid) >= 40 and len(oid) <= 128:
-            return True
-        else:
-            return False
+        return bool(len(oid) >= 40 and len(oid) <= 128)
 
 
 def validate_pid(pid):
     if not pid:
         return False
-    for char in [";", "<", ">", "{", "}", "_"]:
-        if char in pid:
-            return False
-    return True
+    return all(char not in pid for char in [";", "<", ">", "{", "}", "_"])
 
 
 def url_is_safe(url):

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -12,7 +12,7 @@ def remove_url_parameter(request, discards):
     """
     params = dict(request.GET.lists())
     items = {}
-    for key in params.keys():
+    for key in params:
         if key in discards:
             items[key.encode("utf-8")] = [
                 item.encode("utf-8")

--- a/cfgov/prepaid_agreements/jinja2tags.py
+++ b/cfgov/prepaid_agreements/jinja2tags.py
@@ -24,7 +24,7 @@ def remove_url_parameter(request, discards):
                 item.encode("utf-8") for item in params[key]
             ]
     querystring = urlencode(items, "utf-8")
-    return "?{}".format(querystring) if querystring else ""
+    return f"?{querystring}" if querystring else ""
 
 
 class PrepaidAgreementsExtension(Extension):

--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -40,76 +40,76 @@ def write_agreements_data(path=""):
 
     agreements_location = path + "prepaid_metadata_all_agreements.csv"
     products_location = path + "prepaid_metadata_recent_agreements.csv"
-    agreements_file = open(agreements_location, "w", encoding="utf-8")
-    products_file = open(products_location, "w", encoding="utf-8")
 
-    # Write a BOM at the top of the file so Excel knows it's UTF-8
-    agreements_file.write("\ufeff")
-    products_file.write("\ufeff")
+    with open(agreements_location, "w", encoding="utf-8") as agreements_file, open(products_location, "w", encoding="utf-8") as products_file:
 
-    agreements_writer = csv.DictWriter(
-        agreements_file, fieldnames=agreements_fieldnames
-    )
-    agreements_writer.writeheader()
+        # Write a BOM at the top of the file so Excel knows it's UTF-8
+        agreements_file.write("\ufeff")
+        products_file.write("\ufeff")
 
-    products_writer = csv.DictWriter(
-        products_file, fieldnames=products_fieldnames
-    )
-    products_writer.writeheader()
+        agreements_writer = csv.DictWriter(
+            agreements_file, fieldnames=agreements_fieldnames
+        )
+        agreements_writer.writeheader()
 
-    agreements = sorted(
-        PrepaidAgreement.objects.all(),
-        key=lambda agreement: (
-            agreement.product.issuer_name,
-            agreement.product.name,
-            agreement.product.pk,
-            agreement.created_time,
-        ),
-    )
+        products_writer = csv.DictWriter(
+            products_file, fieldnames=products_fieldnames
+        )
+        products_writer.writeheader()
 
-    for agreement in agreements:
-        product = agreement.product
-        # CSV should only includes data that has not been marked for deletion
-        if product.deleted_at is None:
-            most_recent = "Yes" if agreement.is_most_recent else "No"
-            created_time = agreement.created_time.strftime("%Y-%m-%d %H:%M:%S")
+        agreements = sorted(
+            PrepaidAgreement.objects.all(),
+            key=lambda agreement: (
+                agreement.product.issuer_name,
+                agreement.product.name,
+                agreement.product.pk,
+                agreement.created_time,
+            ),
+        )
 
-            other_relevant_parties = product.other_relevant_parties
-            if other_relevant_parties:
-                other_relevant_parties = other_relevant_parties.replace(
-                    "\n", "; "
+        for agreement in agreements:
+            product = agreement.product
+            # CSV should only includes data that has not been marked for
+            # deletion
+            if product.deleted_at is None:
+                most_recent = "Yes" if agreement.is_most_recent else "No"
+                created_time = agreement.created_time.strftime(
+                    "%Y-%m-%d %H:%M:%S"
                 )
-            else:
-                other_relevant_parties = "No information provided"
 
-            data = {
-                "issuer_name": product.issuer_name,
-                "product_name": product.name,
-                "product_id": product.pk,
-                "agreement_effective_date": agreement.effective_date,
-                "created_date": created_time,
-                "withdrawal_date": product.withdrawal_date,
-                "current_status": product.status,
-                "prepaid_product_type": product.prepaid_type,
-                "program_manager_exists": product.program_manager_exists,
-                "program_manager": product.program_manager,
-                "other_relevant_parties": other_relevant_parties,
-                "path": agreement.bulk_download_path,
-                "direct_download": agreement.compressed_files_url,
-                "agreement_id": agreement.pk,
-            }
+                other_relevant_parties = product.other_relevant_parties
+                if other_relevant_parties:
+                    other_relevant_parties = other_relevant_parties.replace(
+                        "\n", "; "
+                    )
+                else:
+                    other_relevant_parties = "No information provided"
 
-            # Product-level CSV only includes data
-            # for a product's most recent agreement,
-            # such that there is one row per product ID
-            if agreement.is_most_recent:
-                products_writer.writerow(data)
+                data = {
+                    "issuer_name": product.issuer_name,
+                    "product_name": product.name,
+                    "product_id": product.pk,
+                    "agreement_effective_date": agreement.effective_date,
+                    "created_date": created_time,
+                    "withdrawal_date": product.withdrawal_date,
+                    "current_status": product.status,
+                    "prepaid_product_type": product.prepaid_type,
+                    "program_manager_exists": product.program_manager_exists,
+                    "program_manager": product.program_manager,
+                    "other_relevant_parties": other_relevant_parties,
+                    "path": agreement.bulk_download_path,
+                    "direct_download": agreement.compressed_files_url,
+                    "agreement_id": agreement.pk,
+                }
 
-            data["most_recent_agreement"] = most_recent
-            agreements_writer.writerow(data)
+                # Product-level CSV only includes data
+                # for a product's most recent agreement,
+                # such that there is one row per product ID
+                if agreement.is_most_recent:
+                    products_writer.writerow(data)
 
-    agreements_file.close()
-    products_file.close()
+                data["most_recent_agreement"] = most_recent
+                agreements_writer.writerow(data)
 
 
 def run(*args):

--- a/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
+++ b/cfgov/prepaid_agreements/scripts/write_prepaid_agreements_data_to_csv.py
@@ -41,8 +41,11 @@ def write_agreements_data(path=""):
     agreements_location = path + "prepaid_metadata_all_agreements.csv"
     products_location = path + "prepaid_metadata_recent_agreements.csv"
 
-    with open(agreements_location, "w", encoding="utf-8") as agreements_file, open(products_location, "w", encoding="utf-8") as products_file:
-
+    with open(
+        agreements_location, "w", encoding="utf-8"
+    ) as agreements_file, open(
+        products_location, "w", encoding="utf-8"
+    ) as products_file:
         # Write a BOM at the top of the file so Excel knows it's UTF-8
         agreements_file.write("\ufeff")
         products_file.write("\ufeff")

--- a/cfgov/prepaid_agreements/tests/test_jinja2tags.py
+++ b/cfgov/prepaid_agreements/tests/test_jinja2tags.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from urllib.parse import urlencode
 
 from django.http import HttpRequest, QueryDict

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -14,8 +14,7 @@ def get_available_filters(products):
 
     for product in products.all():
         prepaid_type = product.prepaid_type
-        if prepaid_type and prepaid_type != "":
-            if prepaid_type not in available_filters["prepaid_type"]:
+        if prepaid_type and prepaid_type != "" and prepaid_type not in available_filters["prepaid_type"]:
                 available_filters["prepaid_type"].append(prepaid_type)
 
         status = product.status

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -14,8 +14,12 @@ def get_available_filters(products):
 
     for product in products.all():
         prepaid_type = product.prepaid_type
-        if prepaid_type and prepaid_type != "" and prepaid_type not in available_filters["prepaid_type"]:
-                available_filters["prepaid_type"].append(prepaid_type)
+        if (
+            prepaid_type
+            and prepaid_type != ""
+            and prepaid_type not in available_filters["prepaid_type"]
+        ):
+            available_filters["prepaid_type"].append(prepaid_type)
 
         status = product.status
         if status and status not in available_filters["status"]:

--- a/cfgov/prepaid_agreements/views.py
+++ b/cfgov/prepaid_agreements/views.py
@@ -26,7 +26,7 @@ def get_available_filters(products):
         if issuer_name and issuer_name not in available_filters["issuer_name"]:
             available_filters["issuer_name"].append(issuer_name)
 
-    for filter_type in available_filters.keys():
+    for filter_type in available_filters:
         available_filters[filter_type] = sorted(available_filters[filter_type])
 
     return available_filters

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -99,14 +99,13 @@ class PrivacyActForm(forms.Form):
     def require_address_if_mailing(self):
         data = self.cleaned_data
         msg = "Mailing address is required if requesting records by mail."
-        if data["contact_channel"] == "mail":
-            if not (
-                data["street_address"]
-                and data["city"]
-                and data["state"]
-                and data["zip_code"]
-            ):
-                self.add_error("street_address", forms.ValidationError(msg))
+        if data["contact_channel"] == "mail" and not (
+            data["street_address"]
+            and data["city"]
+            and data["state"]
+            and data["zip_code"]
+        ):
+            self.add_error("street_address", forms.ValidationError(msg))
 
     def combined_file_size(self, files):
         total = 0

--- a/cfgov/privacy/tests/test_forms.py
+++ b/cfgov/privacy/tests/test_forms.py
@@ -64,7 +64,7 @@ class RecordsAccessFormTests(TestCase):
         form.is_valid()  # so form.cleaned_data will be populated
         self.assertEqual(
             form.format_subject(),
-            "Records request from consumerfinance.gov: Rufus Xavier Sarsapa...",
+            "Records request from consumerfinance.gov: Rufus Xavier Sarsapa…",
         )
 
     def test_email_body(self):

--- a/cfgov/privacy/tests/test_views.py
+++ b/cfgov/privacy/tests/test_views.py
@@ -56,7 +56,7 @@ class TestDisclosureConsentForm(TestCase):
         response = self.client.get(reverse("privacy:disclosure_consent"))
         self.assertContains(
             response,
-            "Consent for disclosure of records protected under the Privacy Act",
+            "Consent for disclosure of records protected under the Privacy Act",  # noqa: E501
         )
 
     def test_invalid_form_post_does_not_send_email(self):

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -22,7 +22,7 @@ class CopyButtonHelper(TreeButtonHelper):
             "url": self.url_helper.get_action_url("copy", quote(pk)),
             "label": "Copy",
             "classname": cn,
-            "title": "Copy this {}".format(self.verbose_name),
+            "title": f"Copy this {self.verbose_name}",
         }
 
     def get_buttons_for_obj(

--- a/cfgov/regulations3k/copyable_modeladmin.py
+++ b/cfgov/regulations3k/copyable_modeladmin.py
@@ -73,9 +73,7 @@ class CopyableModelAdmin(TreeModelAdmin):
         )(request)
 
     def get_admin_urls_for_registration(self, parent=None):
-        urls = super(
-            CopyableModelAdmin, self
-        ).get_admin_urls_for_registration()
+        urls = super().get_admin_urls_for_registration()
 
         # Add the copy URL
         urls = urls + (

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 from datetime import date
 
@@ -210,9 +209,7 @@ class Subpart(models.Model):
             return ""
 
         sections = self.sections.all()
-        return "{}–{}".format(
-            sections[0].numeric_label, sections.reverse()[0].numeric_label
-        )
+        return f"{sections[0].numeric_label}–{sections.reverse()[0].numeric_label}"
 
     class Meta:
         ordering = ["subpart_type", "label"]
@@ -256,7 +253,7 @@ class Section(models.Model):
     def extract_graphs(self):
         """Break out and store a section's paragraphs for indexing."""
         part = self.subpart.version.part
-        section_tag = "{}-{}".format(part.part_number, self.label)
+        section_tag = f"{part.part_number}-{self.label}"
         extractor = regdown.extract_labeled_paragraph
         paragraph_ids = re.findall(r"[^{]*{(?P<label>[\w\-]+)}", self.contents)
         created = 0
@@ -269,7 +266,7 @@ class Section(models.Model):
             raw_graph = extractor(pid, self.contents, exact=True)
             markup_graph = regdown.regdown(raw_graph)
             index_graph = strip_tags(markup_graph).strip()
-            full_id = "{}-{}".format(section_tag, pid)
+            full_id = f"{section_tag}-{pid}"
             graph, cr = SectionParagraph.objects.get_or_create(
                 paragraph=index_graph, paragraph_id=pid, section=self
             )
@@ -324,7 +321,7 @@ class Section(models.Model):
     @property
     def numeric_label(self):
         if self.label.isdigit():
-            return "\xa7\xa0{}.{}".format(self.part, int(self.label))
+            return f"\xa7\xa0{self.part}.{int(self.label)}"
         else:
             return ""
 
@@ -346,9 +343,7 @@ class SectionParagraph(models.Model):
     )
 
     def __str__(self):
-        return "Section {}-{} paragraph {}".format(
-            self.section.part, self.section.label, self.paragraph_id
-        )
+        return f"Section {self.section.part}-{self.section.label} paragraph {self.paragraph_id}"
 
 
 @receiver(post_save, sender=EffectiveVersion)

--- a/cfgov/regulations3k/models/django.py
+++ b/cfgov/regulations3k/models/django.py
@@ -146,8 +146,8 @@ class EffectiveVersion(models.Model):
             raise ValidationError(
                 {
                     "effective_date": [
-                        "The part selected below already has an effective version "
-                        "with this date."
+                        "The part selected below already has an effective "
+                        "version with this date."
                     ]
                 }
             )
@@ -209,7 +209,7 @@ class Subpart(models.Model):
             return ""
 
         sections = self.sections.all()
-        return f"{sections[0].numeric_label}–{sections.reverse()[0].numeric_label}"
+        return f"{sections[0].numeric_label}–{sections.reverse()[0].numeric_label}"  # noqa: E501
 
     class Meta:
         ordering = ["subpart_type", "label"]
@@ -343,7 +343,7 @@ class SectionParagraph(models.Model):
     )
 
     def __str__(self):
-        return f"Section {self.section.part}-{self.section.label} paragraph {self.paragraph_id}"
+        return f"Section {self.section.part}-{self.section.label} paragraph {self.paragraph_id}"  # noqa: E501
 
 
 @receiver(post_save, sender=EffectiveVersion)

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -112,9 +112,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 snippet = Markup("".join(hit.meta.highlight.text[0]))
             except TypeError as e:
                 logger.warning(
-                    "Query string {} produced a TypeError: {}".format(
-                        search_query, e
-                    )
+                    f"Query string {search_query} produced a TypeError: {e}"
                 )
                 continue
             hit_payload = {
@@ -123,12 +121,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 "reg": hit.short_name,
                 "label": hit.title,
                 "snippet": snippet,
-                "url": "{}{}/{}/#{}".format(
-                    self.get_parent().specific.url,
-                    hit.part,
-                    hit.section_label.lower(),
-                    hit.paragraph_id,
-                ),
+                "url": f"{self.get_parent().specific.url}{hit.part}/{hit.section_label.lower()}/#{hit.paragraph_id}",
             }
             payload["results"].append(hit_payload)
 

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -121,7 +121,7 @@ class RegulationsSearchPage(RoutablePageMixin, CFGOVPage):
                 "reg": hit.short_name,
                 "label": hit.title,
                 "snippet": snippet,
-                "url": f"{self.get_parent().specific.url}{hit.part}/{hit.section_label.lower()}/#{hit.paragraph_id}",
+                "url": f"{self.get_parent().specific.url}{hit.part}/{hit.section_label.lower()}/#{hit.paragraph_id}",  # noqa: E501
             }
             payload["results"].append(hit_payload)
 

--- a/cfgov/regulations3k/parser/integer_conversion.py
+++ b/cfgov/regulations3k/parser/integer_conversion.py
@@ -86,7 +86,7 @@ def int_to_alpha(num):
     double_range = list(range(27, 53))
     double_map = dict(zip(double_range, double_letters))
     int_map.update(double_map)
-    return int_map.get(num, None)
+    return int_map.get(num)
 
 
 LETTER_CODES = {

--- a/cfgov/regulations3k/parser/integer_conversion.py
+++ b/cfgov/regulations3k/parser/integer_conversion.py
@@ -9,7 +9,7 @@ def roman_to_int(roman):
     unicode_literals or use explicit unicode strings, such as u'iii'.
     """
 
-    if not isinstance(roman, type("")):
+    if not isinstance(roman, str):
         return
     nums = {"m": 1000, "d": 500, "c": 100, "l": 50, "x": 10, "v": 5, "i": 1}
     total = 0
@@ -30,8 +30,8 @@ def roman_to_int(roman):
 
 def int_to_roman(num):
     """Convert an integer to a lowercase Roman numeral, as used in regs."""
-    if not isinstance(num, type(1)):
-        raise TypeError("Expected integer, got {}".format(type(num)))
+    if not isinstance(num, int):
+        raise TypeError(f"Expected integer, got {type(num)}")
     if num < 1 or num > 3999:
         raise ValueError("Argument must be between 1 and 3999")
     int_values = (1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1)
@@ -65,13 +65,13 @@ def alpha_to_int(alpha):
     which starts at 27.
     """
     letters = string.ascii_lowercase
-    if not isinstance(alpha, type("")):
+    if not isinstance(alpha, str):
         return
     if not (alpha.islower() or alpha.isupper()):
         """Handle lowercase or uppercase double letters, but not a mix."""
         return
     alpha_map = {value: i + 1 for i, value in enumerate(letters)}
-    double_letters = ["{0}{0}".format(letter) for letter in letters]
+    double_letters = [f"{letter}{letter}" for letter in letters]
     double_range = list(range(27, 53))
     double_map = dict(zip(double_letters, double_range))
     alpha_map.update(double_map)
@@ -82,7 +82,7 @@ def int_to_alpha(num):
     """Return the lowercase letter(s) at a position in the alphabet, or None"""
     letters = string.ascii_lowercase
     int_map = {i + 1: value for i, value in enumerate(letters)}
-    double_letters = ["{0}{0}".format(letter) for letter in letters]
+    double_letters = [f"{letter}{letter}" for letter in letters]
     double_range = list(range(27, 53))
     double_map = dict(zip(double_range, double_letters))
     int_map.update(double_map)
@@ -90,5 +90,5 @@ def int_to_alpha(num):
 
 
 LETTER_CODES = {
-    "{}".format(i + 1000): int_to_alpha(i).upper() for i in list(range(1, 31))
+    f"{i + 1000}": int_to_alpha(i).upper() for i in list(range(1, 31))
 }

--- a/cfgov/regulations3k/parser/paragraphs.py
+++ b/cfgov/regulations3k/parser/paragraphs.py
@@ -75,8 +75,8 @@ def pre_process_tags(paragraph_element):
     first_tag = paragraph_element.find("I")
     if first_tag:
         bold_content = first_tag.text
-        first_tag.replaceWith("**{}**".format(bold_content))
+        first_tag.replaceWith(f"**{bold_content}**")
     for element in paragraph_element.find_all("I"):
         i_content = element.text
-        element.replaceWith("*{}*".format(i_content))
+        element.replaceWith(f"*{i_content}*")
     return paragraph_element

--- a/cfgov/regulations3k/parser/patterns.py
+++ b/cfgov/regulations3k/parser/patterns.py
@@ -345,9 +345,7 @@ class IdLevelState:
             pid = self.next_appendix_id() or ""
             graph_text += "\n{" + pid + "}\n"
             graph = (
-                p_element.text.replace(
-                    f"{pid}.", f"**{pid}.**", 1
-                )
+                p_element.text.replace(f"{pid}.", f"**{pid}.**", 1)
                 .replace("  ", " ")
                 .replace("** **", " ", 1)
             )

--- a/cfgov/regulations3k/parser/patterns.py
+++ b/cfgov/regulations3k/parser/patterns.py
@@ -275,15 +275,12 @@ class IdLevelState:
 
     def token_validity_test(self, token):
         "Make sure a singleton token is some kind of valid ID."
-        if (
+        return (
             token.isdigit()
             or roman_to_int(token)
             or (token.isalpha() and len(token) == 1)
             or (token.isalpha() and len(token) == 2 and token[0] == token[1])
-        ):
-            return True
-        else:
-            return False
+        )
 
     def sniff_appendix_id_type(self, paragraphs):
         """

--- a/cfgov/regulations3k/parser/patterns.py
+++ b/cfgov/regulations3k/parser/patterns.py
@@ -349,7 +349,7 @@ class IdLevelState:
             graph_text += "\n{" + pid + "}\n"
             graph = (
                 p_element.text.replace(
-                    "{}.".format(pid), "**{}.**".format(pid), 1
+                    f"{pid}.", f"**{pid}.**", 1
                 )
                 .replace("  ", " ")
                 .replace("** **", " ", 1)

--- a/cfgov/regulations3k/parser/regtable.py
+++ b/cfgov/regulations3k/parser/regtable.py
@@ -74,4 +74,4 @@ class RegTable:
                     else:
                         td["class"] = self.cell_class
                 self.body_rows.append(clean_row(row.prettify()))
-        return "Table is set for {}!".format(self.label)
+        return f"Table is set for {self.label}!"

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -113,7 +113,7 @@ def parse_subparts(part_soup, part):
     appendix_subpart.save()
     PAYLOAD.subparts["appendix_subpart"] = appendix_subpart
     interp_subpart = Subpart(
-        title=f"Supplement I to Part {part.part_number} - Official Interpretations",
+        title=f"Supplement I to Part {part.part_number} - Official Interpretations",  # noqa: E501
         label="Interpretations",
         subpart_type=Subpart.INTERPRETATION,
         version=PAYLOAD.version,
@@ -628,7 +628,8 @@ def ecfr_to_regdown(part_number, file_path=None):
         ecfr_request = requests.get(LATEST_ECFR)
         if not ecfr_request.ok:
             logger.info(
-                f"ECFR request failed with code {ecfr_request.status_code} and reason {ecfr_request.reason}"
+                f"ECFR request failed with code {ecfr_request.status_code} "
+                f"and reason {ecfr_request.reason}"
             )
             return
         ecfr_request.encoding = "utf-8"

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -642,7 +642,10 @@ def ecfr_to_regdown(part_number, file_path=None):
     PAYLOAD.parse_version(part_soup, part)
     # parse_subparts will create and associate sections and appendices
     parse_subparts(part_soup, part)
-    msg = f"Draft version of Part {part_number} created.\n" f"Parsing took {datetime.datetime.now() - starter}"
+    msg = (
+        f"Draft version of Part {part_number} created.\n"
+        f"Parsing took {datetime.datetime.now() - starter}"
+    )
     return msg
 
 

--- a/cfgov/regulations3k/scripts/ecfr_importer.py
+++ b/cfgov/regulations3k/scripts/ecfr_importer.py
@@ -83,7 +83,7 @@ INFERRED_SECTION_IDS = ["1030"]
 # The latest eCFR version of title-12, updated every few days
 LATEST_ECFR = (
     "https://www.gpo.gov/fdsys/bulkdata/ECFR/"
-    "title-{0}/ECFR-title{0}.xml".format(CFR_TITLE)
+    f"title-{CFR_TITLE}/ECFR-title{CFR_TITLE}.xml"
 )
 HEADLINE_MAP = {
     "HD1": "\n## {}\n",
@@ -113,9 +113,7 @@ def parse_subparts(part_soup, part):
     appendix_subpart.save()
     PAYLOAD.subparts["appendix_subpart"] = appendix_subpart
     interp_subpart = Subpart(
-        title="Supplement I to Part {} - Official Interpretations".format(
-            part.part_number
-        ),
+        title=f"Supplement I to Part {part.part_number} - Official Interpretations",
         label="Interpretations",
         subpart_type=Subpart.INTERPRETATION,
         version=PAYLOAD.version,
@@ -187,7 +185,7 @@ def parse_multi_id_graph(graph, ids, label):
     id_refs = PAYLOAD.interp_refs.get(label)
     LEVEL_STATE.next_token = ids[0]
     pid1 = LEVEL_STATE.next_id()
-    split1 = graph.partition("({})".format(ids[1]))
+    split1 = graph.partition(f"({ids[1]})")
     text1 = lint_paragraph(combine_bolds(split1[0]))
     pid2_marker = split1[1]
     remainder = bold_first_italics(split1[2])
@@ -207,7 +205,7 @@ def parse_multi_id_graph(graph, ids, label):
             new_graphs += "\n" + id_refs[pid2] + "\n"
         return new_graphs
     else:
-        split2 = remainder.partition("({})".format(ids[2]))
+        split2 = remainder.partition(f"({ids[2]})")
         pid3_marker = split2[1]
         remainder2 = bold_first_italics(split2[2])
         text2 = lint_paragraph(
@@ -236,7 +234,7 @@ def parse_ids(graph, label):
     for clean_id in clean_ids:
         #  clean up edge-case bolding caused by italicized IDs, such as
         #  '(F)(<I>1</I>)' from reg 1026.7
-        graph = graph.replace("**{}**".format(clean_id), clean_id)
+        graph = graph.replace(f"**{clean_id}**", clean_id)
     valid_ids = LEVEL_STATE.multiple_id_test(clean_ids)
     if not valid_ids or LEVEL_STATE.level() == 6:
         return parse_singleton_graph(graph, label)
@@ -263,7 +261,7 @@ def parse_interp_graph(p_element):
         pid = LEVEL_STATE.next_interp_id()
         graph_text += "\n{" + pid + "}\n"
         graph = (
-            p_element.text.replace("{}.".format(pid), "**{}.**".format(pid), 1)
+            p_element.text.replace(f"{pid}.", f"**{pid}.**", 1)
             .replace("  ", " ")
             .replace("** **", " ", 1)
             .replace("\n", "")
@@ -322,14 +320,14 @@ def parse_appendix_elements(appendix_soup, label):
     paragraphs = appendix_soup.find_all("P")
     tables = appendix_soup.find_all("TABLE")
     for i, table_soup in enumerate(tables):
-        table_label = "{{table-{}-{}}}".format(label, i)
+        table_label = f"{{table-{label}-{i}}}"
         if set_table(table_soup, table_label):
-            table_soup.replaceWith("\n{}\n".format(table_label))
+            table_soup.replaceWith(f"\n{table_label}\n")
     for form_line in appendix_soup.find_all("FP-DASH"):
         form_line.string = form_line.text.replace("\n", "") + "__\n"
     for i, image in enumerate(appendix_soup.find_all("img")):
         ref = "![image-{}-{}]({})".format(label, i + 1, image.get("src"))
-        image.replaceWith("\n{}\n".format(ref))
+        image.replaceWith(f"\n{ref}\n")
     LEVEL_STATE.current_id = ""
     id_type = LEVEL_STATE.sniff_appendix_id_type(paragraphs)
     for citation in appendix_soup.find_all("CITA"):
@@ -501,7 +499,7 @@ def register_interp_reference(interp_id, section_tag):
     if section_label not in PAYLOAD.interp_refs:
         PAYLOAD.interp_refs[section_label] = {}
     PAYLOAD.interp_refs[section_label].update(
-        {graph_id: "see({}-{}-Interp)".format(section_tag, graph_id)}
+        {graph_id: f"see({section_tag}-{graph_id}-Interp)"}
     )
 
 
@@ -540,7 +538,7 @@ def parse_interps(interp_div, part, subpart):
         LEVEL_STATE.current_id = ""
         section_hed = section_heading.text.strip()
         section_label = get_interp_section_tag(section_hed)
-        interp_section_label = "Interp-{}".format(section_label)
+        interp_section_label = f"Interp-{section_label}"
         section = Section(
             subpart=subpart,
             label=interp_section_label,
@@ -553,9 +551,9 @@ def parse_interps(interp_div, part, subpart):
             divine_interp_tag_use(section_heading, part.part_number)
             == "appendix"
         ):
-            interp_id = "{}-1-Interp".format(section_label)
+            interp_id = f"{section_label}-1-Interp"
             LEVEL_STATE.current_id = interp_id
-            see = "see({}-1-Interp)".format(section_label)
+            see = f"see({section_label}-1-Interp)"
             ref = {section_label: {"1": see}}
             PAYLOAD.interp_refs.update(ref)
         for element in section_heading.findNextSiblings():
@@ -574,7 +572,7 @@ def parse_interps(interp_div, part, subpart):
                 )
                 register_interp_reference(interp_id, section_label)
                 section.contents += "\n{" + interp_id + "}\n"
-                section.contents += "### {}\n".format(_hed)
+                section.contents += f"### {_hed}\n"
             elif element.name == "P":
                 tag_use = divine_interp_tag_use(element, part.part_number)
                 if tag_use in ["graph_id", "graph_id_inferred_section"]:
@@ -585,12 +583,12 @@ def parse_interps(interp_div, part, subpart):
                     section.contents += "\n{" + interp_id + "}\n"
                     if tag_use == "graph_id_inferred_section":
                         element.insert(0, section_label)
-                    section.contents += "### {}\n".format(element.text.strip())
+                    section.contents += f"### {element.text.strip()}\n"
                 else:
                     p = pre_process_tags(element)
                     section.contents += parse_interp_graph(p)
             else:
-                section.contents += "\n{}\n".format(element.text.strip())
+                section.contents += f"\n{element.text.strip()}\n"
         section.save()
         if section not in PAYLOAD.interpretations:
             PAYLOAD.interpretations.append(section)
@@ -621,18 +619,16 @@ def ecfr_to_regdown(part_number, file_path=None):
     starter = datetime.datetime.now()
     if file_path:
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 markup = f.read()
-        except IOError:
-            logger.info("Could not open local file {}".format(file_path))
+        except OSError:
+            logger.info(f"Could not open local file {file_path}")
             return
     else:
         ecfr_request = requests.get(LATEST_ECFR)
         if not ecfr_request.ok:
             logger.info(
-                "ECFR request failed with code {} and reason {}".format(
-                    ecfr_request.status_code, ecfr_request.reason
-                )
+                f"ECFR request failed with code {ecfr_request.status_code} and reason {ecfr_request.reason}"
             )
             return
         ecfr_request.encoding = "utf-8"
@@ -646,9 +642,7 @@ def ecfr_to_regdown(part_number, file_path=None):
     PAYLOAD.parse_version(part_soup, part)
     # parse_subparts will create and associate sections and appendices
     parse_subparts(part_soup, part)
-    msg = "Draft version of Part {} created.\n" "Parsing took {}".format(
-        part_number, (datetime.datetime.now() - starter)
-    )
+    msg = f"Draft version of Part {part_number} created.\n" f"Parsing took {datetime.datetime.now() - starter}"
     return msg
 
 
@@ -664,27 +658,23 @@ def run(*args):
         if args[0] == "ALL":
             starter = datetime.datetime.now()
             for part in LEGACY_PARTS:
-                logger.info("parsing {} from the latest eCFR XML".format(part))
+                logger.info(f"parsing {part} from the latest eCFR XML")
                 logger.info(ecfr_to_regdown(part))
             logger.info(
-                "Overall, parsing took {}".format(
-                    datetime.datetime.now() - starter
-                )
+                f"Overall, parsing took {datetime.datetime.now() - starter}"
             )
         else:
-            logger.info("parsing {} from the latest eCFR XML".format(args[0]))
+            logger.info(f"parsing {args[0]} from the latest eCFR XML")
             logger.info(ecfr_to_regdown(args[0]))
     else:
         if args[0] == "ALL":
             starter = datetime.datetime.now()
             for part in LEGACY_PARTS:
-                logger.info("parsing {} from local XML file".format(part))
+                logger.info(f"parsing {part} from local XML file")
                 logger.info(ecfr_to_regdown(part, file_path=args[1]))
             logger.info(
-                "Overall, parsing took {}".format(
-                    datetime.datetime.now() - starter
-                )
+                f"Overall, parsing took {datetime.datetime.now() - starter}"
             )
         else:
-            logger.info("parsing {} from local XML file".format(args[0]))
+            logger.info(f"parsing {args[0]} from local XML file")
             logger.info(ecfr_to_regdown(args[0], file_path=args[1]))

--- a/cfgov/regulations3k/scripts/insert_section_links.py
+++ b/cfgov/regulations3k/scripts/insert_section_links.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 import logging
 import re
@@ -30,7 +29,7 @@ def get_url(section_reference):
         return section_url
     paragraph_id = "-".join(ID_RE.findall(parts.get("ids")))
     if paragraph_id:
-        return "{}#{}".format(section_url, paragraph_id)
+        return f"{section_url}#{paragraph_id}"
     else:
         return section_url
 
@@ -44,7 +43,7 @@ def insert_section_links(regdown):
     for i, ref in enumerate(section_refs):
         url = get_url(ref)
         if url:
-            link = '<a href="{}" data-linktag="{}">{}</a> '.format(url, i, ref)
+            link = f'<a href="{url}" data-linktag="{i}">{ref}</a> '
             regdown = regdown[:index_head] + regdown[index_head:].replace(
                 ref, link, 1
             )
@@ -63,16 +62,16 @@ def insert_links(reg=None):
     ).exclude(subpart__title__contains="Supplement I")
     for section in live_sections:
         if "data-linktag" in section.contents:
-            logger.info("Section {} already has links applied".format(section))
+            logger.info(f"Section {section} already has links applied")
             continue
         linked_regdown = insert_section_links(section.contents)
         if not linked_regdown:
             logger.info(
-                "No section references found in section {}".format(section)
+                f"No section references found in section {section}"
             )
             continue
         else:
-            logger.info("Links added to section {}".format(section))
+            logger.info(f"Links added to section {section}")
             section.contents = linked_regdown
             section.save()
 

--- a/cfgov/regulations3k/scripts/insert_section_links.py
+++ b/cfgov/regulations3k/scripts/insert_section_links.py
@@ -1,4 +1,3 @@
-
 import logging
 import re
 
@@ -66,9 +65,7 @@ def insert_links(reg=None):
             continue
         linked_regdown = insert_section_links(section.contents)
         if not linked_regdown:
-            logger.info(
-                f"No section references found in section {section}"
-            )
+            logger.info(f"No section references found in section {section}")
             continue
         else:
             logger.info(f"Links added to section {section}")

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 import unittest
@@ -35,15 +34,11 @@ class ImporterTestCase(DjangoTestCase):
 
     fixtures = ["test_parts.json"]
     # xml_fixture has partial XML for regs 1002 and 1005
-    xml_fixture = "{}/regulations3k/fixtures/graftest.xml".format(
-        settings.PROJECT_ROOT
-    )
-    interp_fixture = "{}/regulations3k/fixtures/interptest.xml".format(
-        settings.PROJECT_ROOT
-    )
-    with open(xml_fixture, "r") as f:
+    xml_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
+    interp_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/interptest.xml"
+    with open(xml_fixture) as f:
         test_xml = f.read()
-    with open(interp_fixture, "r") as f:
+    with open(interp_fixture) as f:
         interp_xml = f.read()
 
     def test_appendix_id_type_sniffer(self):
@@ -81,7 +76,7 @@ class ImporterTestCase(DjangoTestCase):
         PAYLOAD.parse_version(part_soup, part)
         version = PAYLOAD.version
         interp_subpart = Subpart(
-            title="Supplement I to Part {}".format(part.part_number),
+            title=f"Supplement I to Part {part.part_number}",
             label="Official Interpretations",
             version=version,
         )
@@ -140,7 +135,7 @@ class ImporterTestCase(DjangoTestCase):
         table_label = "{table-test-label}"
         regtable = RegTable(table_label)
         msg = regtable.parse_xml_table(table_soup)
-        self.assertEqual(msg, "Table is set for {}!".format(table_label))
+        self.assertEqual(msg, f"Table is set for {table_label}!")
         self.assertNotIn("<thead>", regtable.table())
 
     @mock.patch("regulations3k.scripts.ecfr_importer.requests.get")
@@ -234,7 +229,7 @@ class ImporterTestCase(DjangoTestCase):
         PAYLOAD.parse_version(part_soup, part)
         version = PAYLOAD.version
         interp_subpart = Subpart(
-            title="Supplement I to Part {}".format(part.part_number),
+            title=f"Supplement I to Part {part.part_number}",
             label="Official Interpretations",
             version=version,
         )
@@ -252,10 +247,8 @@ class AppendixCreationTestCase(DjangoTestCase):
     """Checks that parse_appendices() creates objects as expected."""
 
     fixtures = ["tree_limb.json"]
-    xml_fixture = "{}/regulations3k/fixtures/graftest.xml".format(
-        settings.PROJECT_ROOT
-    )
-    with open(xml_fixture, "r") as f:
+    xml_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
+    with open(xml_fixture) as f:
         test_xml = f.read()
 
     def test_parse_appendices_no_appendix(self):
@@ -351,12 +344,10 @@ class ImporterRunTestCase(unittest.TestCase):
 
 
 class ParagraphParsingTestCase(unittest.TestCase):
-    fixtures_dir = "{}/regulations3k/fixtures".format(settings.PROJECT_ROOT)
+    fixtures_dir = f"{settings.PROJECT_ROOT}/regulations3k/fixtures"
     # test paragraphs are from reg DD, section 1030.4
-    test_paragraph_xml_path = "{}/test_graphs_with_multi_ids.xml".format(
-        fixtures_dir
-    )
-    with open(test_paragraph_xml_path, "r") as f:
+    test_paragraph_xml_path = f"{fixtures_dir}/test_graphs_with_multi_ids.xml"
+    with open(test_paragraph_xml_path) as f:
         test_xml = f.read()
     LEVEL_STATE = IdLevelState()
 

--- a/cfgov/regulations3k/tests/test_ecfr_importer.py
+++ b/cfgov/regulations3k/tests/test_ecfr_importer.py
@@ -34,8 +34,12 @@ class ImporterTestCase(DjangoTestCase):
 
     fixtures = ["test_parts.json"]
     # xml_fixture has partial XML for regs 1002 and 1005
-    xml_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
-    interp_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/interptest.xml"
+    xml_fixture = (
+        f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
+    )
+    interp_fixture = (
+        f"{settings.PROJECT_ROOT}/regulations3k/fixtures/interptest.xml"
+    )
     with open(xml_fixture) as f:
         test_xml = f.read()
     with open(interp_fixture) as f:
@@ -247,7 +251,9 @@ class AppendixCreationTestCase(DjangoTestCase):
     """Checks that parse_appendices() creates objects as expected."""
 
     fixtures = ["tree_limb.json"]
-    xml_fixture = f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
+    xml_fixture = (
+        f"{settings.PROJECT_ROOT}/regulations3k/fixtures/graftest.xml"
+    )
     with open(xml_fixture) as f:
         test_xml = f.read()
 

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -224,7 +224,7 @@ class RegModelTests(DjangoTestCase):
         part = self.part_1002
         self.assertEqual(
             part.cfr_title,
-            f"{part.cfr_title_number} CFR Part {part.part_number} ({part.short_name})",
+            f"{part.cfr_title_number} CFR Part {part.part_number} ({part.short_name})",  # noqa: E501
         )
 
     def test_subpart_string_method(self):
@@ -420,7 +420,7 @@ class RegModelTests(DjangoTestCase):
         ]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
+        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count  # noqa: E501
         response = self.client.get(
             self.reg_search_page.url
             + self.reg_search_page.reverse_subpage("regulation_results_page"),
@@ -453,7 +453,7 @@ class RegModelTests(DjangoTestCase):
         ]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
+        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count  # noqa: E501
         response = self.client.get(
             self.reg_search_page.url
             + self.reg_search_page.reverse_subpage("regulation_results_page"),
@@ -633,7 +633,7 @@ class RegModelTests(DjangoTestCase):
     @override_settings(
         WAGTAILFRONTENDCACHE={
             "varnish": {
-                "BACKEND": "core.testutils.mock_cache_backend.MockCacheBackend",
+                "BACKEND": "core.testutils.mock_cache_backend.MockCacheBackend",  # noqa: E501
             },
         }
     )
@@ -651,7 +651,7 @@ class RegModelTests(DjangoTestCase):
     @override_settings(
         WAGTAILFRONTENDCACHE={
             "varnish": {
-                "BACKEND": "core.testutils.mock_cache_backend.MockCacheBackend",
+                "BACKEND": "core.testutils.mock_cache_backend.MockCacheBackend",  # noqa: E501
             },
         }
     )

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -420,9 +420,7 @@ class RegModelTests(DjangoTestCase):
         ]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = (
-            mock_count
-        )
+        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
         response = self.client.get(
             self.reg_search_page.url
             + self.reg_search_page.reverse_subpage("regulation_results_page"),
@@ -437,9 +435,7 @@ class RegModelTests(DjangoTestCase):
         self.assertEqual(response.status_code, 200)
 
     @mock.patch.object(SectionParagraphDocument, "search")
-    def test_routable_search_page_handles_null_highlights(
-        self, mock_search
-    ):  # noqa: E501
+    def test_routable_search_page_handles_null_highlights(self, mock_search):  # noqa: E501
         mock_hit = mock.Mock()
         mock_hit.text = (
             "i. Mortgage escrow accounts for collecting",
@@ -457,9 +453,7 @@ class RegModelTests(DjangoTestCase):
         ]
         mock_count = mock.Mock(return_value=1)
         mock_search().query().highlight().count = mock_count
-        mock_search().query().highlight().filter().sort().__getitem__().count = (
-            mock_count
-        )
+        mock_search().query().highlight().filter().sort().__getitem__().count = mock_count
         response = self.client.get(
             self.reg_search_page.url
             + self.reg_search_page.reverse_subpage("regulation_results_page"),

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -224,9 +224,7 @@ class RegModelTests(DjangoTestCase):
         part = self.part_1002
         self.assertEqual(
             part.cfr_title,
-            "{} CFR Part {} ({})".format(
-                part.cfr_title_number, part.part_number, part.short_name
-            ),
+            f"{part.cfr_title_number} CFR Part {part.part_number} ({part.short_name})",
         )
 
     def test_subpart_string_method(self):

--- a/cfgov/regulations3k/tests/test_models.py
+++ b/cfgov/regulations3k/tests/test_models.py
@@ -6,9 +6,8 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.http import Http404, HttpRequest, QueryDict
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 from django.test import TestCase as DjangoTestCase
-from django.test import override_settings
 
 from wagtail.models import Site
 

--- a/cfgov/regulations3k/tests/test_resolver.py
+++ b/cfgov/regulations3k/tests/test_resolver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 
 from django.test import TestCase, override_settings

--- a/cfgov/regulations3k/tests/test_scripts.py
+++ b/cfgov/regulations3k/tests/test_scripts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import mock
 
 from django.test import TestCase

--- a/cfgov/regulations3k/views.py
+++ b/cfgov/regulations3k/views.py
@@ -153,10 +153,7 @@ def redirect_eregs(request, **kwargs):
     if search_base:
         part = search_base.group(1)
         search_form = SearchForm(request.GET)
-        if search_form.is_valid():
-            query = search_form.cleaned_data["q"]
-        else:
-            query = ""
+        query = search_form.cleaned_data["q"] if search_form.is_valid() else ""
         return redirect(
             f"{new_base}search-regulations/results/?regs={part}&q={query}",
             permanent=True,

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -62,7 +62,7 @@ class SectionPreviewIndexView(TreeIndexView):
                 "url": preview_url,
                 "label": label,
                 "classname": "button button-small button-secondary",
-                "title": "Preview this {}".format(self.verbose_name),
+                "title": f"Preview this {self.verbose_name}",
             }
             btns.insert(-1, preview_button)
 

--- a/cfgov/regulations3k/wagtail_hooks.py
+++ b/cfgov/regulations3k/wagtail_hooks.py
@@ -49,10 +49,7 @@ class SectionPreviewIndexView(TreeIndexView):
         page = part.page.first()
 
         if page is not None:
-            if effective_version.draft:
-                label = "View draft"
-            else:
-                label = "View live"
+            label = "View draft" if effective_version.draft else "View live"
 
             preview_url = page.url + page.reverse_subpage(
                 "section",

--- a/cfgov/retirement_api/tests/test_views.py
+++ b/cfgov/retirement_api/tests/test_views.py
@@ -85,7 +85,7 @@ class ViewTests(TestCase):
         self.assertIsInstance(response.content, bytes)
         rdata = json.loads(response.content)
         for each in self.return_keys:
-            self.assertTrue(each in rdata.keys())
+            self.assertTrue(each in rdata)
 
     def test_estimator_url_data_bad_income(self):
         request = self.req_blank
@@ -104,7 +104,7 @@ class ViewTests(TestCase):
         self.assertIsInstance(response.content, bytes)
         rdata = json.loads(response.content)
         for each in self.return_keys:
-            self.assertTrue(each in rdata.keys())
+            self.assertTrue(each in rdata)
 
     def test_estimator_query_data_blank(self):
         request = self.req_blank

--- a/cfgov/retirement_api/utils/check_api.py
+++ b/cfgov/retirement_api/utils/check_api.py
@@ -69,7 +69,7 @@ def check_data(data):
 
 prefix = "https://"
 suffix = ".consumerfinance.gov/retirement"
-api_string = f"retirement-api/estimator/{dob.month}-{dob.day}-{dob.year}/{random.randrange(20000, 100000)}/"  # nosec
+api_string = f"retirement-api/estimator/{dob.month}-{dob.day}-{dob.year}/{random.randrange(20000, 100000)}/"  # nosec  # noqa: E501
 BASES = {
     "unitybox": "http://localhost:8080/retirement",
     "standalone": "http://localhost:8000/retirement",

--- a/cfgov/retirement_api/utils/check_api.py
+++ b/cfgov/retirement_api/utils/check_api.py
@@ -33,7 +33,7 @@ def handler(signum, frame):
 
 class Collector:
     data = ""
-    date = ("{0}".format(timestamp))[:16]
+    date = (f"{timestamp}")[:16]
     domain = ""
     status = ""
     error = ""
@@ -75,16 +75,16 @@ api_string = "retirement-api/estimator/{0}-{1}-{2}/{3}/".format(
 BASES = {
     "unitybox": "http://localhost:8080/retirement",
     "standalone": "http://localhost:8000/retirement",
-    default_base: "{0}{1}{2}".format(prefix, default_base, suffix),
-    "prod": "{0}www{1}".format(prefix, suffix),
+    default_base: f"{prefix}{default_base}{suffix}",
+    "prod": f"{prefix}www{suffix}",
 }
 
 
 def run(base):
     if base not in BASES:
-        collector.error = "Server '{0}' isn't recognized".format(base)
+        collector.error = f"Server '{base}' isn't recognized"
         return collector
-    url = "{0}/{1}".format(BASES[base], api_string)
+    url = f"{BASES[base]}/{api_string}"
     collector.domain = base
     signal.signal(signal.SIGALRM, handler)
     signal.alarm(timeout_seconds)
@@ -102,14 +102,12 @@ def run(base):
         end = time.time()
         signal.alarm(0)
         collector.status = "TIMEDOUT"
-        collector.error = "SSA request exceeded {0} sec".format(
-            timeout_seconds
-        )
+        collector.error = f"SSA request exceeded {timeout_seconds} sec"
     else:
         if test_request.status_code != 200:
             signal.alarm(0)
             end = time.time()
-            collector.status = "{0}".format(test_request.status_code)
+            collector.status = f"{test_request.status_code}"
             collector.error = test_request.reason.replace(",", ";")
             collector.api_fail = "FAIL"
         else:

--- a/cfgov/retirement_api/utils/check_api.py
+++ b/cfgov/retirement_api/utils/check_api.py
@@ -69,9 +69,7 @@ def check_data(data):
 
 prefix = "https://"
 suffix = ".consumerfinance.gov/retirement"
-api_string = "retirement-api/estimator/{0}-{1}-{2}/{3}/".format(
-    dob.month, dob.day, dob.year, random.randrange(20000, 100000)  # nosec
-)
+api_string = f"retirement-api/estimator/{dob.month}-{dob.day}-{dob.year}/{random.randrange(20000, 100000)}/"   # nosec
 BASES = {
     "unitybox": "http://localhost:8080/retirement",
     "standalone": "http://localhost:8000/retirement",
@@ -114,9 +112,9 @@ def run(base):
             end = time.time()
             signal.alarm(0)
             data = json.loads(test_request.text)
-            collector.status = "%s" % test_request.status_code
+            collector.status = f"{test_request.status_code}"
             collector.error = (
-                "{0}".format(data["error"])
+                "{}".format(data["error"])
                 .replace(",", ";")
                 .replace("'", "")
                 .replace('"', "")
@@ -125,7 +123,7 @@ def run(base):
             collector.data = check_data(data)
             if collector.data == "BAD DATA":
                 collector.api_fail = "FAIL"
-    collector.timer = "%s" % round(end - start, 1)
+    collector.timer = f"{round(end - start, 1)}"
     build_msg(collector)
     # print msg
     # with open('%s/tests/logs/api_check.log' % API_ROOT, 'a') as f:

--- a/cfgov/retirement_api/utils/check_api.py
+++ b/cfgov/retirement_api/utils/check_api.py
@@ -69,7 +69,7 @@ def check_data(data):
 
 prefix = "https://"
 suffix = ".consumerfinance.gov/retirement"
-api_string = f"retirement-api/estimator/{dob.month}-{dob.day}-{dob.year}/{random.randrange(20000, 100000)}/"   # nosec
+api_string = f"retirement-api/estimator/{dob.month}-{dob.day}-{dob.year}/{random.randrange(20000, 100000)}/"  # nosec
 BASES = {
     "unitybox": "http://localhost:8080/retirement",
     "standalone": "http://localhost:8000/retirement",

--- a/cfgov/retirement_api/utils/ss_calculator.py
+++ b/cfgov/retirement_api/utils/ss_calculator.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 A utility to get benefit data from SSA and handle errors.
 
@@ -79,7 +78,7 @@ def get_note(note_type, language):
 # ORIGINAL_BASE_URL = "https://www.socialsecurity.gov  # NOW REDIRECTED"
 # QUICK_URL = "{0}/OACT/quickcalc/".format(BASE_URL)  # where users go
 BASE_URL = "https://www.ssa.gov"
-RESULT_URL = "{0}/cgi-bin/benefit6.cgi".format(BASE_URL)
+RESULT_URL = f"{BASE_URL}/cgi-bin/benefit6.cgi"
 CHART_AGES = range(62, 71)
 
 comment = re.compile(r"<!--[\s\S]*?-->")  # regex for parsing indexing data
@@ -103,7 +102,7 @@ def num_test(value=""):
         try:
             int(float(value))
         except ValueError:
-            LOGGER.info("Numeric test failed for {}".format(value))
+            LOGGER.info(f"Numeric test failed for {value}")
             return False
         else:
             return True
@@ -131,8 +130,8 @@ def calculate_lifetime_benefits(results, base, fra_tuple, dob, past_fra):
     BENS = results["data"]["benefits"]
     LIFE = results["data"]["lifetime"] = {}
     for year in range(62, 71):
-        benkey = "age {0}".format(year)
-        lifekey = "age{0}".format(year)
+        benkey = f"age {year}"
+        lifekey = f"age{year}"
         if BENS[benkey] == 0:
             LIFE[lifekey] = 0
         else:
@@ -382,7 +381,7 @@ def set_up_runvars(params, language="en"):
     dob = parser.parse(dobstring).date()
     benefits = {}
     for age in CHART_AGES:
-        benefits["age {0}".format(age)] = 0
+        benefits[f"age {age}"] = 0
     results = {
         "data": {
             "months_past_birthday": get_months_past_birthday(dob),
@@ -415,16 +414,16 @@ def set_up_runvars(params, language="en"):
         ssa_params["dobday"] = 2
         if dob.month == 1:
             yob = ssa_params["yob"] - 1
-            yobstring = "{0}".format(yob)
+            yobstring = f"{yob}"
             ssa_params["dobmon"] = 12
             ssa_params["yob"] = yob
         else:
             ssa_params["dobmon"] = params["dobmon"] - 1
     fra_tuple = get_retirement_age(yobstring)  # returns tuple: (year, months)
     if fra_tuple[1]:
-        FRA = "{0} and {1} months".format(fra_tuple[0], fra_tuple[1])
+        FRA = f"{fra_tuple[0]} and {fra_tuple[1]} months"
     else:
-        FRA = "{0}".format(fra_tuple[0])
+        FRA = f"{fra_tuple[0]}"
     results["data"]["full retirement age"] = FRA
     if past_fra is True:
         ssa_params["retireyear"] = today.year
@@ -517,7 +516,7 @@ def get_retire_data(params, language):
             RESULT_URL, data=results["data"]["params"], timeout=TIMEOUT_SECONDS
         )
     except requests.exceptions.ConnectionError as e:
-        results["error"] = "connection error at SSA's website: {0}".format(e)
+        results["error"] = f"connection error at SSA's website: {e}"
         results["note"] = get_note("down", language)
         return results
     except requests.exceptions.Timeout:
@@ -525,7 +524,7 @@ def get_retire_data(params, language):
         results["note"] = get_note("down", language)
         return results
     except requests.exceptions.RequestException as e:
-        results["error"] = "request error at SSA's website: {0}".format(e)
+        results["error"] = f"request error at SSA's website: {e}"
         results["note"] = get_note("down", language)
         return results
     except Exception:
@@ -546,7 +545,7 @@ def get_retire_data(params, language):
         )
     else:
         results["data"]["benefits"][
-            "age {0}".format(fra_tuple[0])
+            f"age {fra_tuple[0]}"
         ] = base_benefit
         results = interpolate_benefits(
             results, base_benefit, fra_tuple, current_age, dob
@@ -555,6 +554,6 @@ def get_retire_data(params, language):
         results, base_benefit, fra_tuple, dob, past_fra
     )
     LOGGER.info(
-        "script took {0} to run".format((datetime.datetime.now() - starter))
+        f"script took {datetime.datetime.now() - starter} to run"
     )
     return final_results

--- a/cfgov/retirement_api/utils/ss_calculator.py
+++ b/cfgov/retirement_api/utils/ss_calculator.py
@@ -373,10 +373,10 @@ def set_up_runvars(params, language="en"):
       to match SSA's handling of edge cases
     """
     today = date.today()
-    dobstring = "{0}-{1}-{2}".format(
+    dobstring = "{}-{}-{}".format(
         params["yob"], params["dobmon"], params["dobday"]
     )
-    yobstring = "{0}".format(params["yob"])
+    yobstring = "{}".format(params["yob"])
     current_age = get_current_age(dobstring)
     dob = parser.parse(dobstring).date()
     benefits = {}
@@ -459,7 +459,7 @@ def parse_response(results, html, language):
 
 def validate_date(params):
     """Make sure delivered date is real"""
-    dobstring = "{0}-{1}-{2}".format(
+    dobstring = "{}-{}-{}".format(
         params["yob"], params["dobmon"], params["dobday"]
     )
     try:

--- a/cfgov/retirement_api/utils/ss_calculator.py
+++ b/cfgov/retirement_api/utils/ss_calculator.py
@@ -19,6 +19,7 @@ Optional inputs that SSA allows, but we're not using:
 Outputs:
 - a python dictionary of benefit data and error messages
 """
+
 import datetime
 import logging
 import re
@@ -544,16 +545,12 @@ def get_retire_data(params, language):
             results, base_benefit, current_age, dob
         )
     else:
-        results["data"]["benefits"][
-            f"age {fra_tuple[0]}"
-        ] = base_benefit
+        results["data"]["benefits"][f"age {fra_tuple[0]}"] = base_benefit
         results = interpolate_benefits(
             results, base_benefit, fra_tuple, current_age, dob
         )
     final_results = calculate_lifetime_benefits(
         results, base_benefit, fra_tuple, dob, past_fra
     )
-    LOGGER.info(
-        f"script took {datetime.datetime.now() - starter} to run"
-    )
+    LOGGER.info(f"script took {datetime.datetime.now() - starter} to run")
     return final_results

--- a/cfgov/retirement_api/utils/ss_update_stats.py
+++ b/cfgov/retirement_api/utils/ss_update_stats.py
@@ -21,12 +21,12 @@ TODAY = datetime.datetime.now().date()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.append(BASE_DIR)
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
-APP_DIR = "%s/retirement_api" % BASE_DIR
+APP_DIR = f"{BASE_DIR}/retirement_api"
 
-data_dir = "%s/data" % APP_DIR
-backup_dir = "%s/data/backups" % APP_DIR
-outcsv = "%s/early_penalty_%s.csv" % (data_dir, TODAY.year)
-outjson = "%s/early_penalty_%s.json" % (data_dir, TODAY.year)
+data_dir = f"{APP_DIR}/data"
+backup_dir = f"{APP_DIR}/data/backups"
+outcsv = f"{data_dir}/early_penalty_{TODAY.year}.csv"
+outjson = f"{data_dir}/early_penalty_{TODAY.year}.json"
 
 ss_table_urls = {
     "cola": "https://www.ssa.gov/OACT/COLA/colaseries.html",
@@ -101,7 +101,7 @@ def make_soup(url):
     req = requests.get(url)
     if req.reason != "OK":
         log.warn(
-            "request to %s failed: %s %s" % (url, req.status_code, req.reason)
+            f"request to {url} failed: {req.status_code} {req.reason}"
         )
         return ""
     else:
@@ -129,48 +129,48 @@ def update_example_reduction():
         table = soup.findAll("table")[5].find("table")
         rows = [row for row in table.findAll("tr") if row.findAll("td")]
         output_csv(outcsv, headings, rows)
-        log.info("updated %s with %s rows" % (outcsv, len(rows)))
+        log.info(f"updated {outcsv} with {len(rows)} rows")
         output_json(outjson, headings, rows)
-        log.info("updated %s with %s entries" % (outjson, len(rows)))
+        log.info(f"updated {outjson} with {len(rows)} entries")
 
 
 def update_awi_series():
     url = ss_table_urls["awi_series"]
-    outcsv = "%s/awi_series_%s.csv" % (data_dir, TODAY.year)
-    outjson = "%s/awi_series_%s.json" % (data_dir, TODAY.year)
+    outcsv = f"{data_dir}/awi_series_{TODAY.year}.csv"
+    outjson = f"{data_dir}/awi_series_{TODAY.year}.json"
     headings = ["Year", "Index"]
     soup = make_soup(url)
     if soup:
         tables = soup.findAll("table")[1].findAll("table")
         rows = []
-        log.info("found %s tables" % len(tables))
+        log.info(f"found {len(tables)} tables")
         for table in tables:
             rows.extend(
                 [row for row in table.findAll("tr") if row.findAll("td")]
             )
         output_csv(outcsv, headings, rows)
-        log.info("updated %s with %s rows" % (outcsv, len(rows)))
+        log.info(f"updated {outcsv} with {len(rows)} rows")
         output_json(outjson, headings, rows)
-        log.info("updated %s with %s entries" % (outjson, len(rows)))
+        log.info(f"updated {outjson} with {len(rows)} entries")
 
 
 def update_cola():
     url = ss_table_urls["cola"]
-    outcsv = "%s/ss_cola_%s.csv" % (data_dir, TODAY.year)
-    outjson = "%s/ss_cola_%s.json" % (data_dir, TODAY.year)
+    outcsv = f"{data_dir}/ss_cola_{TODAY.year}.csv"
+    outjson = f"{data_dir}/ss_cola_{TODAY.year}.json"
     headings = ["Year", "COLA"]
     soup = make_soup(url)
     if soup:
         [s.extract() for s in soup("small")]
         tables = soup.findAll("table")[-3:]
     rows = []
-    log.info("found %s tables" % len(tables))
+    log.info(f"found {len(tables)} tables")
     for table in tables:
         rows.extend([row for row in table.findAll("tr") if row.findAll("td")])
     output_csv(outcsv, headings, rows)
-    log.info("updated %s with %s rows" % (outcsv, len(rows)))
+    log.info(f"updated {outcsv} with {len(rows)} rows")
     output_json(outjson, headings, rows)
-    log.info("updated %s with %s entries" % (outjson, len(rows)))
+    log.info(f"updated {outjson} with {len(rows)} entries")
 
 
 def update_life():
@@ -192,12 +192,12 @@ def update_life():
     if soup:
         table = soup.find("table").find("table")
         if not table:
-            log.info("couldn't find table at %s" % url)
+            log.info(f"couldn't find table at {url}")
         else:
             rows = table.findAll("tr")[2:]
             if len(rows) > 100:
                 output_csv(outcsv, headings, rows)
-                msg += "updated %s with %s rows" % (outcsv, len(rows))
+                msg += f"updated {outcsv} with {len(rows)} rows"
                 output_json(outjson, headings, rows)
                 msg += f"updated {outjson} with {len(rows)} entries"
             else:

--- a/cfgov/retirement_api/utils/ss_update_stats.py
+++ b/cfgov/retirement_api/utils/ss_update_stats.py
@@ -215,5 +215,6 @@ if __name__ == "__main__":
     starter = datetime.datetime.now()
     harvest_all()
     log.info(
-        f"update took {datetime.datetime.now() - starter} to update four data stores"
+        f"update took {datetime.datetime.now() - starter} to update four "
+        f"data stores"
     )

--- a/cfgov/retirement_api/utils/ss_update_stats.py
+++ b/cfgov/retirement_api/utils/ss_update_stats.py
@@ -100,9 +100,7 @@ def output_json(filepath, headings, bs_rows):
 def make_soup(url):
     req = requests.get(url)
     if req.reason != "OK":
-        log.warn(
-            f"request to {url} failed: {req.status_code} {req.reason}"
-        )
+        log.warn(f"request to {url} failed: {req.status_code} {req.reason}")
         return ""
     else:
         soup = bs(req.text, "html.parser")

--- a/cfgov/retirement_api/utils/ss_update_stats.py
+++ b/cfgov/retirement_api/utils/ss_update_stats.py
@@ -199,11 +199,9 @@ def update_life():
                 output_csv(outcsv, headings, rows)
                 msg += "updated %s with %s rows" % (outcsv, len(rows))
                 output_json(outjson, headings, rows)
-                msg += "updated {0} with {1} entries".format(
-                    outjson, len(rows)
-                )
+                msg += f"updated {outjson} with {len(rows)} entries"
             else:
-                msg += "didn't find more than 100 rows at {0}".format(url)
+                msg += f"didn't find more than 100 rows at {url}"
     log.info(msg)
     return msg
 
@@ -219,7 +217,5 @@ if __name__ == "__main__":
     starter = datetime.datetime.now()
     harvest_all()
     log.info(
-        "update took {0} to update four data stores".format(
-            (datetime.datetime.now() - starter)
-        )
+        f"update took {datetime.datetime.now() - starter} to update four data stores"
     )

--- a/cfgov/retirement_api/utils/ss_utilities.py
+++ b/cfgov/retirement_api/utils/ss_utilities.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 import datetime
 import json
 import logging
@@ -63,12 +62,10 @@ def get_note(note_type, language):
 
 # this datafile specifies years that have unique retirement age values
 # since this may change, it is maintained in an external file
-datafile = "{0}\
-/retirement_api/data/unique_retirement_ages.json".format(
-    BASE_DIR
-)
+datafile = f"{BASE_DIR}\
+/retirement_api/data/unique_retirement_ages.json"
 
-with open(datafile, "r") as f:
+with open(datafile) as f:
     age_map = json.loads(f.read())
     for year in age_map:
         age_map[year] = tuple(age_map[year])

--- a/cfgov/retirement_api/utils/ss_utilities.py
+++ b/cfgov/retirement_api/utils/ss_utilities.py
@@ -204,7 +204,7 @@ def past_fra_test(dob=None, language="en"):
         return True
     elif age_tuple[0] < fra_tuple[0]:
         return False
-    elif age_tuple[0] == fra_tuple[0] and age_tuple[1] >= fra_tuple[1]:
+    elif age_tuple[0] == fra_tuple[0] and age_tuple[1] >= fra_tuple[1]:  # noqa: SIM103
         return True
     else:  # pragma: no cover -- can't currently happen, but could in future
         return False

--- a/cfgov/retirement_api/utils/ss_utilities.py
+++ b/cfgov/retirement_api/utils/ss_utilities.py
@@ -162,7 +162,7 @@ def get_retirement_age(birth_year):
     b_string = yob_test(birth_year)
     if b_string:
         yob = int(birth_year)
-        if b_string in age_map.keys():
+        if b_string in age_map:
             return age_map[b_string]
         elif yob <= 1937:
             return (65, 0)

--- a/cfgov/retirement_api/utils/ss_utilities.py
+++ b/cfgov/retirement_api/utils/ss_utilities.py
@@ -81,10 +81,10 @@ def get_current_age(dob):
         except (TypeError, ValueError):
             return None
 
-    if DOB > today:
+    if today < DOB:
         return None
 
-    if DOB == today:
+    if today == DOB:
         return 0
 
     try:
@@ -186,7 +186,7 @@ def past_fra_test(dob=None, language="en"):
         return "invalid birth date entered"
     today = datetime.date.today()
     current_age = get_current_age(dob)
-    if DOB >= today:
+    if today <= DOB:
         return get_note("too_young", language)
     # SSA has a special rule for people born on Jan. 1
     # http://www.socialsecurity.gov/OACT/ProgData/nra.html

--- a/cfgov/retirement_api/utils/tests/test_api_check.py
+++ b/cfgov/retirement_api/utils/tests/test_api_check.py
@@ -61,7 +61,7 @@ class TestApi(unittest.TestCase):
         self.assertTrue(msg == "OK")
 
     def test_build_msg(self):
-        target_text = ",{0},build,,,,".format(self.test_collector.date)
+        target_text = f",{self.test_collector.date},build,,,,"
         test_text = build_msg(self.test_collector)
         self.assertTrue(test_text == target_text)
 

--- a/cfgov/retirement_api/utils/tests/test_api_check.py
+++ b/cfgov/retirement_api/utils/tests/test_api_check.py
@@ -71,7 +71,7 @@ class TestApi(unittest.TestCase):
         mock_requests.return_value.text = json.dumps(self.test_data)
         mock_requests.return_value.status_code = 200
         mock_build_msg.return_value = (
-            ",%s,,,mock error,,," % self.test_collector.date
+            f",{self.test_collector.date},,,mock error,,,"
         )
         run("build")
         self.assertTrue(mock_build_msg.call_count == 1)

--- a/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
@@ -105,7 +105,7 @@ class UpdateSsStatsTests(TestCase):
         with open(mockpath) as f:
             data = json.loads(f.read())
         self.assertEqual(type(data), dict)
-        for key in data["0"].keys():
+        for key in data["0"]:
             self.assertTrue(key in self.life_headings)
         for age in sample_json_results:
             for key in sample_json_results[age]:

--- a/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_update_stats.py
@@ -27,14 +27,14 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 
 
 TODAY = datetime.date.today()
-mock_data_path = "{0}/retirement_api/data/mock_data".format(BASE_DIR)
+mock_data_path = f"{BASE_DIR}/retirement_api/data/mock_data"
 
 
 class UpdateSsStatsTests(TestCase):
-    cola_page = "{0}/ssa_cola.html".format(mock_data_path)
-    awi_page = "{0}/ssa_awi_series.html".format(mock_data_path)
-    life_page = "{0}/ssa_life.html".format(mock_data_path)
-    earlyretire_page = "{0}/ssa_earlyretire.html".format(mock_data_path)
+    cola_page = f"{mock_data_path}/ssa_cola.html"
+    awi_page = f"{mock_data_path}/ssa_awi_series.html"
+    life_page = f"{mock_data_path}/ssa_life.html"
+    earlyretire_page = f"{mock_data_path}/ssa_earlyretire.html"
     life_headings = [
         "exact_age",
         "male_death_probability",
@@ -61,14 +61,14 @@ class UpdateSsStatsTests(TestCase):
         """outputs csv based on inputs of
         headings and beautiful_soup rows
         """
-        mockpath = "{0}/mock_life.csv".format(self.tempdir)
-        with open(self.life_page, "r") as f:
+        mockpath = f"{self.tempdir}/mock_life.csv"
+        with open(self.life_page) as f:
             mockpage = f.read()
         table = bs(mockpage, "html.parser").find("table").find("table")
         rows = table.findAll("tr")[2:]
         output_csv(mockpath, self.life_headings, rows)
         self.assertTrue(os.path.isfile(mockpath))
-        with open(mockpath, "r") as f:
+        with open(mockpath) as f:
             reader = csv.reader(f)
             data = [row for row in reader]
         for sample in self.sample_life_results:
@@ -81,7 +81,7 @@ class UpdateSsStatsTests(TestCase):
         """outputs json to file based on inputs of
         path, headings and beautiful_soup rows
         """
-        mockpath = "{0}/mock_life.json".format(self.tempdir)
+        mockpath = f"{self.tempdir}/mock_life.json"
         sample_json_results = {
             "0": {
                 "female_life_expectancy": "80.94",
@@ -96,13 +96,13 @@ class UpdateSsStatsTests(TestCase):
                 "male_life_expectancy": "2.22",
             },
         }
-        with open(self.life_page, "r") as f:
+        with open(self.life_page) as f:
             mockpage = f.read()
         table = bs(mockpage, "html.parser").find("table").find("table")
         rows = table.findAll("tr")[2:]
         output_json(mockpath, self.life_headings, rows)
         self.assertTrue(os.path.isfile(mockpath))
-        with open(mockpath, "r") as f:
+        with open(mockpath) as f:
             data = json.loads(f.read())
         self.assertEqual(type(data), dict)
         for key in data["0"].keys():
@@ -153,7 +153,7 @@ class UpdateSsStatsTests(TestCase):
         self, mock_soup, mock_output_json, mock_output_csv
     ):
         # arrange
-        with open(self.earlyretire_page, "r") as f:
+        with open(self.earlyretire_page) as f:
             mockpage = f.read()
         mock_soup.return_value = bs(mockpage, "html.parser")
 
@@ -171,7 +171,7 @@ class UpdateSsStatsTests(TestCase):
     @mock.patch("retirement_api.utils.ss_update_stats.make_soup")
     def test_update_life(self, mock_soup, mock_output_json, mock_output_csv):
         # arrange
-        with open(self.life_page, "r") as f:
+        with open(self.life_page) as f:
             mockpage = f.read()
         mock_soup.return_value = bs(mockpage, "html.parser")
 
@@ -189,7 +189,7 @@ class UpdateSsStatsTests(TestCase):
     @mock.patch("retirement_api.utils.ss_update_stats.make_soup")
     def test_update_cola(self, mock_soup, mock_output_json, mock_output_csv):
         # arrange
-        with open(self.cola_page, "r") as f:
+        with open(self.cola_page) as f:
             mockpage = f.read()
         mock_soup.return_value = bs(mockpage, "html.parser")
 
@@ -208,7 +208,7 @@ class UpdateSsStatsTests(TestCase):
         self, mock_soup, mock_output_json, mock_output_csv
     ):
         # arrange
-        with open(self.awi_page, "r") as f:
+        with open(self.awi_page) as f:
             mockpage = f.read()
         mock_soup.return_value = bs(mockpage, "html.parser")
 

--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -241,9 +241,8 @@ class UtilitiesTests(unittest.TestCase):
         ]:
             with self.subTest(
                 birthday=birthday, today=today, expected_age=expected_age
-            ):
-                with freeze_time(today):
-                    self.assertEqual(get_current_age(birthday), expected_age)
+            ), freeze_time(today):
+                self.assertEqual(get_current_age(birthday), expected_age)
 
     def test_interpolate_benefits(self):
         mock_results = copy.deepcopy(self.sample_results)
@@ -263,7 +262,7 @@ class UtilitiesTests(unittest.TestCase):
             expected_benefits["age 62"] = 1523
         # need to pass results, base, fra_tuple, current_age, DOB
         results = interpolate_benefits(mock_results, 2176, (67, 0), 44, dob)
-        for key in results["data"]["benefits"].keys():
+        for key in results["data"]["benefits"]:
             self.assertTrue(
                 results["data"]["benefits"][key] == expected_benefits[key]
             )
@@ -557,9 +556,9 @@ class UtilitiesTests(unittest.TestCase):
         data = self._get_retire_data()["data"]
         self.assertEqual(data["params"]["yob"], self.sample_year)
 
-        for each in data.keys():
+        for each in data:
             self.assertTrue(each in self.data_keys)
-        for each in data["benefits"].keys():
+        for each in data["benefits"]:
             self.assertTrue(each in self.benefit_keys)
 
     def test_get_retire_data_too_young(self):

--- a/cfgov/retirement_api/utils/tests/test_ss_utilities.py
+++ b/cfgov/retirement_api/utils/tests/test_ss_utilities.py
@@ -439,14 +439,12 @@ class UtilitiesTests(unittest.TestCase):
             self.assertEqual(get_retirement_age(year), sample_inputs[year])
 
     def test_past_fra_test(self):
-        one_one = "{0}".format(
-            date(1980, 1, 1).replace(year=self.today.year - 25)
-        )
-        way_old = "{0}".format(self.today - timedelta(days=80 * 365))
-        too_old = "{0}".format(self.today - timedelta(days=68 * 365))
-        ok = "{0}".format(self.today - timedelta(days=57 * 365))
-        too_young = "{0}".format(self.today - timedelta(days=21 * 365))
-        future = "{0}".format(self.today + timedelta(days=365))
+        one_one = f"{date(1980, 1, 1).replace(year=self.today.year - 25)}"
+        way_old = f"{self.today - timedelta(days=80 * 365)}"
+        too_old = f"{self.today - timedelta(days=68 * 365)}"
+        ok = f"{self.today - timedelta(days=57 * 365)}"
+        too_young = f"{self.today - timedelta(days=21 * 365)}"
+        future = f"{self.today + timedelta(days=365)}"
         # edge = "{0}".format(self.today - timedelta(days=67 * 365))
         invalid = "xx/xx/xxxx"
         self.assertFalse(past_fra_test(one_one, language="en"))

--- a/cfgov/retirement_api/views.py
+++ b/cfgov/retirement_api/views.py
@@ -75,7 +75,7 @@ def estimator(request, dob=None, income=None, language="en"):
 def get_full_retirement_age(request, birth_year):
     data_tuple = get_retirement_age(birth_year)
     if not data_tuple:
-        return HttpResponseBadRequest("bad birth year (%s)" % birth_year)
+        return HttpResponseBadRequest(f"bad birth year ({birth_year})")
     else:
         data = json.dumps(data_tuple)
         return HttpResponse(data, content_type="application/json")

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -210,7 +210,8 @@ def check_urls(base, url_list=None):
             failures.append((url, e))
     timer = int(time.time() - starter)
     logger.info(
-        f"\n{sys.argv[0]} took {timer} seconds to check {count} URLs at {base}\n  "
+        f"\n{sys.argv[0]} took {timer} seconds to check {count} "
+        f"URLs at {base}\n  "
         f"{len(failures)} failed\n  "
         f"{len(timeouts)} timed out"
     )

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -188,39 +188,37 @@ def check_urls(base, url_list=None):
     for url_suffix in url_list:
         logger.info(url_suffix)
         count += 1
-        url = "{}{}".format(base, url_suffix)
+        url = f"{base}{url_suffix}"
         try:
             response = requests.get(url, timeout=TIMEOUT, headers=HEADERS)
             code = response.status_code
             if code == 200:
                 pass
             else:
-                logger.info("{} failed with status code {}".format(url, code))
+                logger.info(f"{url} failed with status code {code}")
                 failures.append((url, code))
         except requests.exceptions.Timeout:
-            logger.info("{} timed out".format(url))
+            logger.info(f"{url} timed out")
             timeouts.append(url)
         except requests.exceptions.ConnectionError as e:
-            logger.info("{} returned a connection error".format(url))
+            logger.info(f"{url} returned a connection error")
             failures.append((url, e))
         except requests.exceptions.RequestException as e:
-            logger.info("{} failed for '{}'".format(url, e))
+            logger.info(f"{url} failed for '{e}'")
             failures.append((url, e))
     timer = int(time.time() - starter)
     logger.info(
-        "\n{} took {} seconds to check {} URLs at {}\n  "
-        "{} failed\n  "
-        "{} timed out".format(
-            sys.argv[0], timer, count, base, len(failures), len(timeouts)
-        )
+        f"\n{sys.argv[0]} took {timer} seconds to check {count} URLs at {base}\n  "
+        f"{len(failures)} failed\n  "
+        f"{len(timeouts)} timed out"
     )
 
     if failures:
-        logger.error("These URLs failed: {}".format(failures))
+        logger.error(f"These URLs failed: {failures}")
     if len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error(
-            "These URLs timed out after {} seconds: "
-            "{}".format(TIMEOUT, timeouts)
+            f"These URLs timed out after {TIMEOUT} seconds: "
+            f"{timeouts}"
         )
     elif timeouts:
         logger.info(

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -61,7 +61,9 @@ HEADERS = {}
 ALLOWED_TIMEOUTS = 1
 FULL = False
 BASE = "https://www.consumerfinance.gov"
-S3_URI = "https://files.consumerfinance.gov/build/smoketests/smoketest_urls.json"  # noqa: E501
+S3_URI = (
+    "https://files.consumerfinance.gov/build/smoketests/smoketest_urls.json"  # noqa: E501
+)
 
 # Fall-back list of top 25 URLs, as of May 2024
 # All URLs in the list should be canonical locations of the given pages,
@@ -217,20 +219,20 @@ def check_urls(base, url_list=None):
         logger.error(f"These URLs failed: {failures}")
     if len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error(
-            f"These URLs timed out after {TIMEOUT} seconds: "
-            f"{timeouts}"
+            f"These URLs timed out after {TIMEOUT} seconds: " f"{timeouts}"
         )
     elif timeouts:
         logger.info(
-            "{} allowed timeouts occurred:\n"
-            "{}".format(len(timeouts), "\n".join(timeouts))
+            "{} allowed timeouts occurred:\n" "{}".format(
+                len(timeouts), "\n".join(timeouts)
+            )
         )
 
     if failures or len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error("FAIL")
         return False
 
-    logger.info("\x1B[32mAll URLs return 200. No smoke!\x1B[0m")
+    logger.info("\x1b[32mAll URLs return 200. No smoke!\x1b[0m")
     return True
 
 

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -29,7 +29,7 @@ def run():
     # If specified in the environment, create or activate superuser.
     if admin_username and admin_password:
         logger.info(
-            "Configuring superuser, username: {}".format(admin_username)
+            f"Configuring superuser, username: {admin_username}"
         )
 
         User.objects.update_or_create(
@@ -75,7 +75,7 @@ def run():
         default_site.root_page_id = home_page.id
         default_site.port = http_port
         default_site.save()
-        logger.info("Configured default Wagtail Site: {}".format(default_site))
+        logger.info(f"Configured default Wagtail Site: {default_site}")
 
     # Setup a sharing site for the default Wagtail site if a sharing hostname
     # has been configured in the environment.
@@ -87,4 +87,4 @@ def run():
                 "port": http_port,
             },
         )
-        logger.info("Configured wagtail-sharing site: {}".format(sharing_site))
+        logger.info(f"Configured wagtail-sharing site: {sharing_site}")

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -28,9 +28,7 @@ def run():
 
     # If specified in the environment, create or activate superuser.
     if admin_username and admin_password:
-        logger.info(
-            f"Configuring superuser, username: {admin_username}"
-        )
+        logger.info(f"Configuring superuser, username: {admin_username}")
 
         User.objects.update_or_create(
             username=admin_username,

--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -74,42 +74,34 @@ def check_static(url):
     failures = []
     response = requests.get(url)
     if not response.ok:
-        return "\x1B[91mFAIL! Request to {} failed ({})".format(
-            url, response.reason
-        )
+        return f"\x1B[91mFAIL! Request to {url} failed ({response.reason})"
     static_links = extract_static_links(response.content)
     for link in static_links:
         count += 1
         if link.startswith("/"):
-            final_url = "{}{}".format(CFPB_BASE, link)
+            final_url = f"{CFPB_BASE}{link}"
         else:
-            final_url = "{}{}".format(url, link)
+            final_url = f"{url}{link}"
         code = requests.get(
             final_url, headers={"referer": CFPB_BASE}
         ).status_code
         if code == 200:
-            logger.info("checked {}".format(final_url))
+            logger.info(f"checked {final_url}")
         else:
             failures.append((link, code))
     if failures:
         if len(failures) > 2:  # allow for font failures when testing locally
             return (
-                "\x1B[91mFAIL! {} static links out of {} failed "
-                "for {}: {}\x1B[0m\n".format(
-                    len(failures), count, url, failures
-                )
+                f"\x1B[91mFAIL! {len(failures)} static links out of {count} failed "
+                f"for {url}: {failures}\x1B[0m\n"
             )
         else:
             return (
-                "\x1B[91mPartial failure: {} static links out of {} failed"
-                " for {}: {}\x1B[0m\n".format(
-                    len(failures), count, url, failures
-                )
+                f"\x1B[91mPartial failure: {len(failures)} static links out of {count} failed"
+                f" for {url}: {failures}\x1B[0m\n"
             )
     else:
-        return "\x1B[32m{} static links passed " "for {}\x1B[0m\n".format(
-            count, url
-        )
+        return f"\x1B[32m{count} static links passed " f"for {url}\x1B[0m\n"
 
 
 if __name__ == "__main__":  # pragma: nocover
@@ -128,16 +120,14 @@ if __name__ == "__main__":  # pragma: nocover
         logger.info(base_msg)
     if args.sub_urls:
         for arg in args.sub_urls:
-            sub_msg = check_static("{}{}".format(CFPB_BASE, arg))
+            sub_msg = check_static(f"{CFPB_BASE}{arg}")
             if "FAIL!" in sub_msg:
                 fail = True
                 logger.warning(sub_msg)
             else:
                 logger.info(sub_msg)
     logger.info(
-        "{} took {} seconds to check {}\n".format(
-            sys.argv[0], int(time.time() - start), CFPB_BASE
-        )
+        f"{sys.argv[0]} took {int(time.time() - start)} seconds to check {CFPB_BASE}\n"
     )
     if fail:
         logger.warning(

--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Check that static assets are available on consumerfinance.gov."""
+
 import argparse
 import logging
 import sys
@@ -74,7 +75,7 @@ def check_static(url):
     failures = []
     response = requests.get(url)
     if not response.ok:
-        return f"\x1B[91mFAIL! Request to {url} failed ({response.reason})"
+        return f"\x1b[91mFAIL! Request to {url} failed ({response.reason})"
     static_links = extract_static_links(response.content)
     for link in static_links:
         count += 1
@@ -92,16 +93,16 @@ def check_static(url):
     if failures:
         if len(failures) > 2:  # allow for font failures when testing locally
             return (
-                f"\x1B[91mFAIL! {len(failures)} static links out of {count} failed "
-                f"for {url}: {failures}\x1B[0m\n"
+                f"\x1b[91mFAIL! {len(failures)} static links out of {count} failed "
+                f"for {url}: {failures}\x1b[0m\n"
             )
         else:
             return (
-                f"\x1B[91mPartial failure: {len(failures)} static links out of {count} failed"
-                f" for {url}: {failures}\x1B[0m\n"
+                f"\x1b[91mPartial failure: {len(failures)} static links out of {count} failed"
+                f" for {url}: {failures}\x1b[0m\n"
             )
     else:
-        return f"\x1B[32m{count} static links passed " f"for {url}\x1B[0m\n"
+        return f"\x1b[32m{count} static links passed " f"for {url}\x1b[0m\n"
 
 
 if __name__ == "__main__":  # pragma: nocover
@@ -131,7 +132,7 @@ if __name__ == "__main__":  # pragma: nocover
     )
     if fail:
         logger.warning(
-            "\x1B[91mFAIL. Too many static links " "didn't return 200.\x1B[0m"
+            "\x1b[91mFAIL. Too many static links " "didn't return 200.\x1b[0m"
         )
     else:
-        logger.info("\x1B[32mSUCCESS! Static links return 200.\x1B[0m")
+        logger.info("\x1b[32mSUCCESS! Static links return 200.\x1b[0m")

--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -93,13 +93,13 @@ def check_static(url):
     if failures:
         if len(failures) > 2:  # allow for font failures when testing locally
             return (
-                f"\x1b[91mFAIL! {len(failures)} static links out of {count} failed "
-                f"for {url}: {failures}\x1b[0m\n"
+                f"\x1b[91mFAIL! {len(failures)} static links out of {count} "
+                f"failed for {url}: {failures}\x1b[0m\n"
             )
         else:
             return (
-                f"\x1b[91mPartial failure: {len(failures)} static links out of {count} failed"
-                f" for {url}: {failures}\x1b[0m\n"
+                f"\x1b[91mPartial failure: {len(failures)} static links out "
+                f"of {count} failed for {url}: {failures}\x1b[0m\n"
             )
     else:
         return f"\x1b[32m{count} static links passed " f"for {url}\x1b[0m\n"
@@ -128,7 +128,8 @@ if __name__ == "__main__":  # pragma: nocover
             else:
                 logger.info(sub_msg)
     logger.info(
-        f"{sys.argv[0]} took {int(time.time() - start)} seconds to check {CFPB_BASE}\n"
+        f"{sys.argv[0]} took {int(time.time() - start)} seconds to check "
+        f"{CFPB_BASE}\n"
     )
     if fail:
         logger.warning(

--- a/cfgov/scripts/tests/test_smoke_tests.py
+++ b/cfgov/scripts/tests/test_smoke_tests.py
@@ -12,8 +12,10 @@ from scripts.http_smoke_test import ALLOWED_TIMEOUTS, URLS, check_urls
 class StaticAssetTests(unittest.TestCase):
     """Tests for the static assets smoke tests."""
 
-    mock_links = '<script src="/static/js/atomic/header.97504b419ce4.js"></script>\n\
-                  <script src="static/js/atomic/header.97504b419ce4.js"></script>'  # noqa: E501
+    mock_links = (
+        '<script src="/static/js/atomic/header.97504b419ce4.js"></script>\n'
+        '<script src="static/js/atomic/header.97504b419ce4.js"></script>'
+    )
 
     @mock.patch("scripts.static_asset_smoke_test.requests.get")
     def test_home_page_test_success(self, mock_get):

--- a/cfgov/scripts/tests/test_unpublish_closed_jobs.py
+++ b/cfgov/scripts/tests/test_unpublish_closed_jobs.py
@@ -17,7 +17,7 @@ def create_job_link(control_number, applicant_type, page):
     job_link = USAJobsApplicationLink(
         announcement_number=control_number,
         applicant_type=applicant_type,
-        url="http://www.test.com/{}".format(control_number),
+        url=f"http://www.test.com/{control_number}",
         job_listing=page,
     )
     job_link.save()
@@ -198,7 +198,7 @@ class UnpublishClosedJobsTestCase(TestCase):
 
         self.page.refresh_from_db()
         logger_mock.assert_called_with(
-            'API check for job "{}" failed'.format(job_link.url)
+            f'API check for job "{job_link.url}" failed'
         )
         self.assertTrue(self.page.live)
 
@@ -213,6 +213,6 @@ class UnpublishClosedJobsTestCase(TestCase):
 
         self.page.refresh_from_db()
         logger_mock.assert_called_with(
-            'Check of USAJobs page "{}" failed'.format(job_link.url)
+            f'Check of USAJobs page "{job_link.url}" failed'
         )
         self.assertTrue(self.page.live)

--- a/cfgov/scripts/unpublish_closed_jobs.py
+++ b/cfgov/scripts/unpublish_closed_jobs.py
@@ -66,9 +66,7 @@ def run():
     job_pages = JobListingPage.objects.filter(live=True)
     if job_pages:
         for page in job_pages:
-            logger.info(
-                f'Checking status of job posting "{page.title}"...'
-            )
+            logger.info(f'Checking status of job posting "{page.title}"...')
             if page.usajobs_application_links:
                 closed_count = 0
                 links = page.usajobs_application_links.all()
@@ -77,8 +75,6 @@ def run():
                         closed_count += 1
                 if closed_count == links.count():
                     page.unpublish(set_expired=True)
-                    logger.info(
-                        f"Job posting {page.title} has closed."
-                    )
+                    logger.info(f"Job posting {page.title} has closed.")
     else:
         logger.info("No live job posting pages found...")

--- a/cfgov/scripts/unpublish_closed_jobs.py
+++ b/cfgov/scripts/unpublish_closed_jobs.py
@@ -27,7 +27,7 @@ def job_page_closed(link):
         closed_div = soup.find("div", attrs={"class": "usajobs-joa-closed"})
         return closed_div and CLOSED_TEXT in closed_div.contents
     except Exception:
-        logger.exception('Check of USAJobs page "{}" failed'.format(link))
+        logger.exception(f'Check of USAJobs page "{link}" failed')
         sys.exit(1)
 
 
@@ -45,7 +45,7 @@ def job_archived(link):
             item = results["SearchResultItems"][0]
             return item["MatchedObjectId"] == job
     except Exception:
-        logger.exception('API check for job "{}" failed'.format(link))
+        logger.exception(f'API check for job "{link}" failed')
         sys.exit(1)
 
 
@@ -67,7 +67,7 @@ def run():
     if job_pages:
         for page in job_pages:
             logger.info(
-                'Checking status of job posting "{}"...'.format(page.title)
+                f'Checking status of job posting "{page.title}"...'
             )
             if page.usajobs_application_links:
                 closed_count = 0
@@ -78,7 +78,7 @@ def run():
                 if closed_count == links.count():
                     page.unpublish(set_expired=True)
                     logger.info(
-                        "Job posting {} has closed.".format(page.title)
+                        f"Job posting {page.title} has closed."
                     )
     else:
         logger.info("No live job posting pages found...")

--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -120,7 +120,8 @@ class ElasticsearchTestsMixin:
             raise SkipTest("Cannot connect to local Elasticsearch") from e
 
         # Patch the Elasticsearch bulk API call to ensure that reindexes and
-        # individual document updates are immediately available in search results.
+        # individual document updates are immediately available in search
+        # results.
         #
         # See the Elasticsearch documentation on refresh:
         # https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-refresh.html

--- a/cfgov/search/management/commands/load_synonyms.py
+++ b/cfgov/search/management/commands/load_synonyms.py
@@ -13,11 +13,11 @@ class Command(BaseCommand):
         synonyms_saved = 0
         for file in options["file"]:
             try:
-                synonym_file = open(file)
-                for line in synonym_file:
-                    synonym = Synonym(synonym=line.rstrip("\n"))
-                    synonym.save()
-                    synonyms_saved += 1
+                with open(file) as synonym_file:
+                    for line in synonym_file:
+                        synonym = Synonym(synonym=line.rstrip("\n"))
+                        synonym.save()
+                        synonyms_saved += 1
             except Exception as err:
                 raise CommandError(
                     "Failed to load synonym file %s", file

--- a/cfgov/tccp/enums.py
+++ b/cfgov/tccp/enums.py
@@ -16,8 +16,8 @@ BalanceTransferFeeTypeChoices = make_choices(
     "2. If fee is percentage of transaction amount, what is it?",
     "3. If there's a minimum dollar amount, what is it?",
     (
-        "4. If the fee is not a percentage, or a percentage subject to a minimum "
-        "dollar amount, how do you calculate the fee?"
+        "4. If the fee is not a percentage, or a percentage subject to a "
+        "minimum dollar amount, how do you calculate the fee?"
     ),
 )
 
@@ -27,8 +27,8 @@ CashAdvanceFeeTypeChoices = make_choices(
     "2. If the fee is a percentage of transaction amount, what is it?",
     "3. If there's a minimum dollar amount, what is it?",
     (
-        "4. If the fee is not a percentage, or a percentage subject to a minimum "
-        "dollar amount, how do you calculate the fee?"
+        "4. If the fee is not a percentage, or a percentage subject to a "
+        "minimum dollar amount, how do you calculate the fee?"
     ),
 )
 
@@ -79,8 +79,8 @@ ForeignTransactionFeeTypeChoices = make_choices(
     "2. If fee is percentage of transaction amount, what is it?",
     "3. If there's a minimum dollar amount, what is it?",
     (
-        "4. If the fee is not a percentage, or a percentage subject to a minimum "
-        "dollar amount, how do you calculate the fee?"
+        "4. If the fee is not a percentage, or a percentage subject to a "
+        "minimum dollar amount, how do you calculate the fee?"
     ),
 )
 
@@ -114,12 +114,12 @@ InstitutionTypeChoices = make_choices("Bank", "CU")
 LateFeeTypeChoices = make_choices(
     "1. What is the amount of the first late fee on the account?",
     (
-        "2. What is the amount of late fees charged within six billing cycles of a "
-        "previous late fee (repeat late fee)?"
+        "2. What is the amount of late fees charged within six billing cycles "
+        "of a previous late fee (repeat late fee)?"
     ),
     (
-        "3. If you charge late fees that are not fixed dollar amounts, please explain "
-        "your late fee policy here."
+        "3. If you charge late fees that are not fixed dollar amounts, please "
+        "explain your late fee policy here."
     ),
 )
 
@@ -127,8 +127,8 @@ LateFeeTypeChoices = make_choices(
 OverlimitFeeTypeChoices = make_choices(
     "1. What is the amount of the overlimit fee when charged?",
     (
-        "2. If you charge overlimit fees that are not fixed dollar amounts, please "
-        "explain what overlimit fees you charge here:"
+        "2. If you charge overlimit fees that are not fixed dollar amounts, "
+        "please explain what overlimit fees you charge here:"
     ),
 )
 
@@ -144,15 +144,18 @@ PurchaseAPRRatings = [
 
 
 PurchaseTransactionFeeTypeChoices = make_choices(
-    "1. If you have such a charge, enter the amount of the charge in dollars here:",
     (
-        "2. or if the charge is a percentage of the transaction amount, enter that "
-        "percentage here"
+        "1. If you have such a charge, enter the amount of the charge in "
+        "dollars here:"
+    ),
+    (
+        "2. or if the charge is a percentage of the transaction amount, enter "
+        "that percentage here"
     ),
     "3. If there's a minimum dollar amount, what is it?",
     (
-        "4. If the fee is not a percentage, or a percentage subject to a minimum "
-        "dollar amount, how do you calculate the fee?"
+        "4. If the fee is not a percentage, or a percentage subject to a "
+        "minimum dollar amount, how do you calculate the fee?"
     ),
 )
 

--- a/cfgov/tccp/management/commands/import_tccp.py
+++ b/cfgov/tccp/management/commands/import_tccp.py
@@ -35,7 +35,8 @@ class Command(BaseCommand):
                     card.full_clean()
                 except ValidationError:
                     self.stderr.write(
-                        f"Validation failed for card survey data: {survey_data}"
+                        "Validation failed for card survey data: "
+                        f"{survey_data}"
                     )
                     raise
 

--- a/cfgov/tccp/models.py
+++ b/cfgov/tccp/models.py
@@ -78,9 +78,9 @@ class CardSurveyDataQuerySet(models.QuerySet):
 
         # These are the statistics we want to compute:
         # (
-        #   stat name,
-        #   computation function,
-        #   whether to include min/max-only cards in the computation (see below)
+        #  stat name,
+        #  computation function,
+        #  whether to include min/max-only cards in the computation (see below)
         # )
         stats = [
             ("count", Count, True),
@@ -371,7 +371,7 @@ class CardSurveyDataQuerySet(models.QuerySet):
                 f"purchase_apr_{tier_suffix}_rating": Case(
                     When(
                         **{
-                            f"purchase_apr_{tier_suffix}_max__lt": summary_stats[
+                            f"purchase_apr_{tier_suffix}_max__lt": summary_stats[  # noqa: E501
                                 f"purchase_apr_{tier_suffix}_pct25"
                             ]
                             or 0
@@ -380,7 +380,7 @@ class CardSurveyDataQuerySet(models.QuerySet):
                     ),
                     When(
                         **{
-                            f"purchase_apr_{tier_suffix}_max__lt": summary_stats[
+                            f"purchase_apr_{tier_suffix}_max__lt": summary_stats[  # noqa: E501
                                 f"purchase_apr_{tier_suffix}_pct75"
                             ]
                             or 0

--- a/cfgov/tccp/serializers.py
+++ b/cfgov/tccp/serializers.py
@@ -36,7 +36,7 @@ class CardSurveyDataSerializer(serializers.HyperlinkedModelSerializer):
         # django-rest-framework. This code is needed to ensure that
         # JSONListFields are serialized properly as JSON.
         if isinstance(model_field, JSONListField):
-            field_kwargs.pop("encoder"),
+            field_kwargs.pop("encoder")
             field_kwargs.pop("decoder")
 
         return field_class, field_kwargs

--- a/cfgov/tccp/situations.py
+++ b/cfgov/tccp/situations.py
@@ -116,8 +116,8 @@ SITUATIONS = [
             },
             {
                 "content": (
-                    "If a card has an introductory interest rate offer, ensure "
-                    "you're on track to pay off the balance within the "
+                    "If a card has an introductory interest rate offer, "
+                    "ensure you're on track to pay off the balance within the "
                     "promotional period, or you could end up owing more "
                     "interest than the original purchase amount."
                 ),
@@ -141,8 +141,13 @@ SITUATIONS = [
                     "for necessary purchases and pay your credit card balance "
                     "in full every month."
                 ),
-                "link": "Learn about ways to build credit and your credit score.",
-                "url": "/ask-cfpb/how-do-i-get-and-keep-a-good-credit-score-en-318/",
+                "link": (
+                    "Learn about ways to build credit and your credit score."
+                ),
+                "url": (
+                    "/ask-cfpb/"
+                    "how-do-i-get-and-keep-a-good-credit-score-en-318/"
+                ),
             }
         ],
     ),
@@ -158,7 +163,9 @@ SITUATIONS = [
                     "If you carry a balance on your credit card, interest and "
                     "fees typically exceed the value of any rewards earned."
                 ),
-                "link": "Learn why rewards may not be as beneficial as they seem.",
+                "link": (
+                    "Learn why rewards may not be as beneficial as they seem.",
+                ),
                 "url": (
                     "/about-us/newsroom/"
                     "cfpb-report-highlights-consumer-frustrations-with-credit-card-"

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -106,7 +106,10 @@ class CardListViewTests(TestCase):
             json.loads(response.content),
             {
                 "credit_tier": [
-                    "Select a valid choice. foo is not one of the available choices."
+                    (
+                        "Select a valid choice. "
+                        "foo is not one of the available choices."
+                    )
                 ]
             },
         )

--- a/cfgov/tccp/widgets.py
+++ b/cfgov/tccp/widgets.py
@@ -29,7 +29,6 @@ class Select(forms.Select):
 
 
 class OrderingSelect(Select):
-
     def __init__(self, attrs=None, **kwargs):
         attrs = attrs or {}
         attrs.setdefault("form", "tccp-filters")

--- a/cfgov/teachers_digital_platform/documents.py
+++ b/cfgov/teachers_digital_platform/documents.py
@@ -65,11 +65,7 @@ class ActivityPageDocument(Document):
 
     def get_queryset(self, *args, **kwargs):
         """Prevent non-live pages from being indexed."""
-        return (
-            super()
-            .get_queryset(*args, **kwargs)
-            .filter(live=True)
-        )
+        return super().get_queryset(*args, **kwargs).filter(live=True)
 
     def prepare_activity_duration(self, instance):
         if instance.activity_duration:

--- a/cfgov/teachers_digital_platform/documents.py
+++ b/cfgov/teachers_digital_platform/documents.py
@@ -66,7 +66,7 @@ class ActivityPageDocument(Document):
     def get_queryset(self, *args, **kwargs):
         """Prevent non-live pages from being indexed."""
         return (
-            super(ActivityPageDocument, self)
+            super()
             .get_queryset(*args, **kwargs)
             .filter(live=True)
         )

--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -48,9 +48,7 @@ FACET_MAP = (
 FACET_LIST = [tup[0] for tup in FACET_MAP]
 FACET_DICT = {"aggs": {}}
 for facet in FACET_LIST:
-    FACET_DICT["aggs"].update(
-        {f"{facet}_terms": {"terms": {"field": facet}}}
-    )
+    FACET_DICT["aggs"].update({f"{facet}_terms": {"terms": {"field": facet}}})
 ALWAYS_EXPANDED = {"topic", "school_subject"}
 SEARCH_FIELDS = [
     "text",

--- a/cfgov/teachers_digital_platform/models/activity_index_page.py
+++ b/cfgov/teachers_digital_platform/models/activity_index_page.py
@@ -49,7 +49,7 @@ FACET_LIST = [tup[0] for tup in FACET_MAP]
 FACET_DICT = {"aggs": {}}
 for facet in FACET_LIST:
     FACET_DICT["aggs"].update(
-        {"{}_terms".format(facet): {"terms": {"field": facet}}}
+        {f"{facet}_terms": {"terms": {"field": facet}}}
     )
 ALWAYS_EXPANDED = {"topic", "school_subject"}
 SEARCH_FIELDS = [

--- a/cfgov/teachers_digital_platform/models/django.py
+++ b/cfgov/teachers_digital_platform/models/django.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import models
 
 from wagtail.admin.panels import FieldPanel

--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -65,9 +65,7 @@ class ActivityPage(CFGOVPage):
     big_idea = RichTextField("Big idea", blank=False)
     essential_questions = RichTextField("Essential questions", blank=False)
     objectives = RichTextField("Objectives", blank=False)
-    what_students_will_do = RichTextField(
-        "What students will do", blank=False
-    )  # noqa: E501
+    what_students_will_do = RichTextField("What students will do", blank=False)  # noqa: E501
     search_tags = models.TextField(
         "Activity search tags",
         blank=True,
@@ -186,9 +184,7 @@ class ActivityPage(CFGOVPage):
         FieldPanel("school_subject", widget=forms.CheckboxSelectMultiple),
         MultiFieldPanel(
             [
-                FieldPanel(
-                    "grade_level", widget=forms.CheckboxSelectMultiple
-                ),  # noqa: E501
+                FieldPanel("grade_level", widget=forms.CheckboxSelectMultiple),  # noqa: E501
                 FieldPanel("age_range", widget=forms.CheckboxSelectMultiple),
                 FieldPanel(
                     "student_characteristics",

--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django import forms
 from django.db import models
 from django.utils import timezone

--- a/cfgov/v1/admin_views.py
+++ b/cfgov/v1/admin_views.py
@@ -42,7 +42,7 @@ def purge(url=None):
             logger.info(f'Purging {url} from "akamai" cache')
             batch.purge(backends=["akamai"])
 
-        return "Submitted invalidation for %s" % url
+        return f"Submitted invalidation for {url}"
 
     else:
         # purge_all only exists on our AkamaiBackend
@@ -91,7 +91,7 @@ def manage_cdn(request):
         else:
             for field, error_list in form.errors.items():
                 for error in error_list:
-                    messages.error(request, "Error in %s: %s" % (field, error))
+                    messages.error(request, f"Error in {field}: {error}")
 
     history = CDNHistory.objects.all().order_by("-created")[:20]
     return render(

--- a/cfgov/v1/admin_views.py
+++ b/cfgov/v1/admin_views.py
@@ -34,12 +34,12 @@ def purge(url=None):
         if any(
             k for k in cloudfront_config.get("DISTRIBUTION_ID", {}) if k in url
         ):
-            logger.info('Purging {} from "files" cache'.format(url))
+            logger.info(f'Purging {url} from "files" cache')
             batch.purge(backends=["files"])
 
         # Otherwise invalidate with our default backend
         else:
-            logger.info('Purging {} from "akamai" cache'.format(url))
+            logger.info(f'Purging {url} from "akamai" cache')
             batch.purge(backends=["akamai"])
 
         return "Submitted invalidation for %s" % url

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -201,7 +201,9 @@ class Notification(blocks.StructBlock):
     )
     explanation = blocks.TextBlock(
         required=False,
-        help_text="Explanation text appears below the message in smaller type.",
+        help_text=(
+            "Explanation text appears below the message in smaller type."
+        ),
     )
     links = blocks.ListBlock(
         atoms.Hyperlink(required=False),
@@ -292,7 +294,10 @@ class ContactPhone(blocks.StructBlock):
                     "number",
                     blocks.CharBlock(
                         max_length=15,
-                        help_text="Do not include spaces or dashes. Ex. 8554112372",
+                        help_text=(
+                            "Do not include spaces or dashes. "
+                            "Ex. 8554112372"
+                        ),
                         validators=[phone_number_format_validator()],
                     ),
                 ),
@@ -312,7 +317,10 @@ class ContactPhone(blocks.StructBlock):
                         max_length=15,
                         required=False,
                         label="TTY",
-                        help_text="Do not include spaces or dashes. Ex. 8554112372",
+                        help_text=(
+                            "Do not include spaces or dashes. "
+                            "Ex. 8554112372"
+                        ),
                         validators=[phone_number_format_validator()],
                     ),
                 ),

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -16,7 +16,7 @@ from wagtailmedia.blocks import AbstractMediaChooserBlock
 from v1 import blocks as v1_blocks
 from v1.atomic_elements import atoms, molecules
 
-# Bring tables into this module to maintain import structure across the project.
+# Bring tables into this module to maintain import structure across the project
 from v1.atomic_elements.tables import (  # noqa: F401
     CaseDocketTable,
     ConsumerReportingCompanyTable,
@@ -106,9 +106,9 @@ class InfoUnitGroup(blocks.StructBlock):
                     raise StructBlockValidationError(
                         block_errors={
                             "format": ValidationError(
-                                "Info units must include images when using the "
-                                '25/75 format. Search for an "FPO" image if you '
-                                "need a temporary placeholder."
+                                "Info units must include images when using "
+                                'the 25/75 format. Search for an "FPO" image '
+                                "if you need a temporary placeholder."
                             )
                         }
                     )
@@ -653,7 +653,9 @@ class FilterableList(BaseExpandable):
     )
     filter_by_topics = blocks.BooleanBlock(
         required=False,
-        help_text='Whether to include a "Topics" filter in the filter controls',
+        help_text=(
+            'Whether to include a "Topics" filter in the filter controls'
+        ),
     )
     filter_by_enforcement_statuses = blocks.BooleanBlock(
         default=False,
@@ -744,7 +746,8 @@ class VideoPlayer(blocks.StructBlock):
                 errors["video_id"] = ValidationError("This field is required.")
             elif cleaned["thumbnail_image"]:
                 errors["thumbnail_image"] = ValidationError(
-                    "This field should not be used if YouTube video ID is not set."
+                    "This field should not be used if YouTube video ID is "
+                    "not set."
                 )
 
         if errors:
@@ -806,8 +809,8 @@ class FeaturedContentStructValue(blocks.StructValue):
         if post and self.get("show_post_link"):
             links.append(
                 {
-                    # Unfortunately, we don't have access to the request context
-                    # here, so we can't do post.get_url(request).
+                    # Unfortunately, we don't have access to the request
+                    # context here, so we can't do post.get_url(request).
                     "url": post.url,
                     "text": self.get("post_link_text") or post.title,
                 }
@@ -1040,7 +1043,7 @@ class DataSnapshot(blocks.StructBlock):
     tightness_year_over_year_change_text = blocks.CharBlock(
         required=False,
         max_length=100,
-        help_text="Descriptive sentence, e.g. In year-over-year credit tightness",  # noqa
+        help_text="Descriptive sentence, e.g. In year-over-year credit tightness",  # noqa: E501
     )
 
     # Select an image

--- a/cfgov/v1/feeds.py
+++ b/cfgov/v1/feeds.py
@@ -33,7 +33,7 @@ class FilterableFeed(Feed):
         return self.page.full_url
 
     def title(self):
-        return "%s | Consumer Financial Protection Bureau" % self.page.title
+        return f"{self.page.title} | Consumer Financial Protection Bureau"
 
     def items(self):
         return self.context["results_page"]
@@ -56,7 +56,7 @@ class FilterableFeed(Feed):
         return categories + tags
 
     def item_guid(self, item):
-        return "%s<>consumerfinance.gov" % item.page_ptr_id
+        return f"{item.page_ptr_id}<>consumerfinance.gov"
 
 
 def get_appropriate_rss_feed_url_for_page(page, request=None):

--- a/cfgov/v1/management/commands/_sync_storage_base.py
+++ b/cfgov/v1/management/commands/_sync_storage_base.py
@@ -41,7 +41,7 @@ class SyncStorageCommandMixin:
         url = self.base_url + path
         filename = self.dest_dir + path
 
-        self.stdout.write("Saving %s to %s\n" % (url, filename))
+        self.stdout.write(f"Saving {url} to {filename}\n")
 
         response = requests.get(url, stream=True)
 

--- a/cfgov/v1/management/commands/add_images.py
+++ b/cfgov/v1/management/commands/add_images.py
@@ -47,7 +47,7 @@ class Command(WagtailClient, BaseCommand):
             },
         )
 
-        if 302 != response.status_code:
+        if response.status_code != 302:
             raise RuntimeError(f"something went wrong: {response}")
 
         image_model = get_image_model()

--- a/cfgov/v1/management/commands/add_images.py
+++ b/cfgov/v1/management/commands/add_images.py
@@ -26,12 +26,12 @@ class Command(WagtailClient, BaseCommand):
             try:
                 self.add_image(filename)
             except Exception as e:
-                self.stderr.write("failed to add image {}".format(filename))
+                self.stderr.write(f"failed to add image {filename}")
                 self.stderr.write(str(e))
                 failures.append(filename)
 
         if failures:
-            raise CommandError("failed to add images: {}".format(filenames))
+            raise CommandError(f"failed to add images: {filenames}")
 
     def add_image(self, filename):
         filename_only = os.path.split(filename)[-1]
@@ -48,9 +48,9 @@ class Command(WagtailClient, BaseCommand):
         )
 
         if 302 != response.status_code:
-            raise RuntimeError("something went wrong: {}".format(response))
+            raise RuntimeError(f"something went wrong: {response}")
 
         image_model = get_image_model()
         image = image_model.objects.filter(title=filename_only).latest("pk")
 
-        self.stdout.write("added image {}: {}".format(image.pk, image))
+        self.stdout.write(f"added image {image.pk}: {image}")

--- a/cfgov/v1/management/commands/archive_events.py
+++ b/cfgov/v1/management/commands/archive_events.py
@@ -38,23 +38,19 @@ class Command(BaseCommand):
             for event in live_event_pages:
                 event = event.specific
 
-                if event.end_dt:
-                    end_dt = event.end_dt
-                else:
-                    end_dt = event.start_dt
+                end_dt = event.end_dt if event.end_dt else event.start_dt
 
-                if end_dt < timezone.now():
-                    if event.can_move_to(archive):
-                        try:
-                            event.move(archive, pos="last-child")
-                        except ValidationError:
-                            iso_date = event.start_dt.date().isoformat()
-                            event.slug = event.slug + "-" + iso_date
-                            event.save()
-                            event.move(archive, pos="last-child")
-                        # Not logging here because event.move writes its
-                        # own log to stdout.
-                        events_archived = True
+                if end_dt < timezone.now() and event.can_move_to(archive):
+                    try:
+                        event.move(archive, pos="last-child")
+                    except ValidationError:
+                        iso_date = event.start_dt.date().isoformat()
+                        event.slug = event.slug + "-" + iso_date
+                        event.save()
+                        event.move(archive, pos="last-child")
+                    # Not logging here because event.move writes its
+                    # own log to stdout.
+                    events_archived = True
 
             if not events_archived:
                 self.stdout.write("No past events found to be archived.")

--- a/cfgov/v1/management/commands/makemessages.py
+++ b/cfgov/v1/management/commands/makemessages.py
@@ -22,9 +22,11 @@ class Command(makemessages.Command):
         django_block_re = translate_tag.block_re
         django_endblock_re = translate_tag.endblock_re
 
-        # This monkey-patches support for Jinja2's {% translate %}{% endtrans %}
+        # This monkey-patches support for Jinja2's:
+        # {% translate %}{% endtrans %}
         # blocks into trans_real's block/endblock-matching regular expressions.
-        # These differ from Django's {% blocktranslate %}{% endblocktranslate %}
+        # These differ from Django's
+        # {% blocktranslate %}{% endblocktranslate %}
         # blocks.
         #
         # trans_real's other regular expressions, context_re, inline_re,

--- a/cfgov/v1/management/commands/makemessages.py
+++ b/cfgov/v1/management/commands/makemessages.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This command overrides the built-in Django makemessages command to extract
 # messages from both Django templates and Jinja2 templates.
 #

--- a/cfgov/v1/management/commands/update_chart_block_dates.py
+++ b/cfgov/v1/management/commands/update_chart_block_dates.py
@@ -58,13 +58,13 @@ class Command(BaseCommand):
                     last_updated_inquiry = get_inquiry_month(
                         markets, chart_options["data_source"]
                     )
-                    chart["value"][
-                        "last_updated_projected_data"
-                    ] = last_updated_inquiry
+                    chart["value"]["last_updated_projected_data"] = (
+                        last_updated_inquiry
+                    )
                 else:
-                    chart["value"][
-                        "last_updated_projected_data"
-                    ] = last_updated
+                    chart["value"]["last_updated_projected_data"] = (
+                        last_updated
+                    )
             publish_changes(page.specific)
 
     def handle(self, *args, **options):

--- a/cfgov/v1/management/commands/update_data_snapshot_values.py
+++ b/cfgov/v1/management/commands/update_data_snapshot_values.py
@@ -64,7 +64,7 @@ class Command(BaseCommand):
             if (
                 not snapshot_data
             ):  # Market may not have been added to Wagtail yet  # noqa
-                logger.warning("Market key {} not found".format(key))
+                logger.warning(f"Market key {key} not found")
                 continue
 
             # Update snapshot fields with the provided values

--- a/cfgov/v1/management/commands/validate_page_html.py
+++ b/cfgov/v1/management/commands/validate_page_html.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         ]
 
         for mapping in http_image_url_mappings:
-            if 2 != len(mapping):
+            if len(mapping) != 2:
                 raise CommandError(
                     "HTTP image URL mappings must be comma-separated pairs"
                 )

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -371,7 +371,7 @@ class CFGOVPage(Page):
 
     @property
     def post_preview_cache_key(self):
-        return "post_preview_{}".format(self.id)
+        return f"post_preview_{self.id}"
 
     def get_translations(self, inclusive=True, live=True):
         if self.language == "en" and self.pk:

--- a/cfgov/v1/models/caching.py
+++ b/cfgov/v1/models/caching.py
@@ -68,10 +68,8 @@ class AkamaiBackend(BaseBackend):
             auth=self.auth,
         )
         logger.info(
-            "Attempted to {action} content provider {obj}, "
-            "got back response {message}".format(
-                action=action, obj=obj, message=resp.text
-            )
+            f"Attempted to {action} content provider {obj}, "
+            f"got back response {resp.text}"
         )
         resp.raise_for_status()
 
@@ -83,10 +81,8 @@ class AkamaiBackend(BaseBackend):
             auth=self.auth,
         )
         logger.info(
-            "Attempted to {action} cache for page {url}, "
-            "got back response {message}".format(
-                action=action, url=url, message=resp.text
-            )
+            f"Attempted to {action} cache for page {url}, "
+            f"got back response {resp.text}"
         )
         resp.raise_for_status()
 
@@ -147,7 +143,7 @@ def cloudfront_cache_invalidation(sender, instance, **kwargs):
 
     url = instance.file.url
 
-    logger.info('Purging {} from "files" cache'.format(url))
+    logger.info(f'Purging {url} from "files" cache')
 
     batch = PurgeBatch()
     batch.add_url(url)

--- a/cfgov/v1/models/images.py
+++ b/cfgov/v1/models/images.py
@@ -73,7 +73,7 @@ class CFGOVImage(PlaceholderRenditionMixin, AbstractImage):
 
     @staticmethod
     def apply_size_operation(operation, width, height):
-        class MockResizableImage(object):
+        class MockResizableImage:
             def __init__(self, width, height):
                 self.width = width
                 self.height = height

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -383,13 +383,7 @@ class EventPage(AbstractFilterPage):
                 self.venue_city, self.venue_state
             )
         api_url = "https://api.mapbox.com/styles/v1/mapbox/streets-v11/static"
-        static_map_image_url = "{}/{},{}/{}?access_token={}".format(
-            api_url,
-            self.venue_coords,
-            zoom,
-            size,
-            settings.MAPBOX_ACCESS_TOKEN,
-        )
+        static_map_image_url = f"{api_url}/{self.venue_coords},{zoom}/{size}?access_token={settings.MAPBOX_ACCESS_TOKEN}"
 
         return static_map_image_url
 

--- a/cfgov/v1/models/learn_page.py
+++ b/cfgov/v1/models/learn_page.py
@@ -383,7 +383,10 @@ class EventPage(AbstractFilterPage):
                 self.venue_city, self.venue_state
             )
         api_url = "https://api.mapbox.com/styles/v1/mapbox/streets-v11/static"
-        static_map_image_url = f"{api_url}/{self.venue_coords},{zoom}/{size}?access_token={settings.MAPBOX_ACCESS_TOKEN}"
+        static_map_image_url = (
+            f"{api_url}/{self.venue_coords},{zoom}/{size}"
+            f"?access_token={settings.MAPBOX_ACCESS_TOKEN}"
+        )
 
         return static_map_image_url
 
@@ -396,8 +399,9 @@ class EventPage(AbstractFilterPage):
         if self.post_event_image_type == "image" and not self.post_event_image:
             raise ValidationError(
                 {
-                    "post_event_image": 'Required if "Post-event image type" is '
-                    '"Image".'
+                    "post_event_image": (
+                        'Required if "Post-event image type" is "Image".'
+                    )
                 }
             )
         if self.live_stream_availability:

--- a/cfgov/v1/models/portal_topics.py
+++ b/cfgov/v1/models/portal_topics.py
@@ -1,4 +1,3 @@
-
 from django.db import models
 
 from modelcluster.fields import ParentalKey

--- a/cfgov/v1/models/portal_topics.py
+++ b/cfgov/v1/models/portal_topics.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 from django.db import models
 

--- a/cfgov/v1/page_validation.py
+++ b/cfgov/v1/page_validation.py
@@ -34,9 +34,7 @@ def convert_http_image_match(match, url_mappings):
         if http_image_url.startswith(from_prefix):
             return re.sub(from_prefix, to_prefix, match.group(0))
 
-    raise ValueError(
-        f"cannot convert HTTP image link {http_image_url}"
-    )
+    raise ValueError(f"cannot convert HTTP image link {http_image_url}")
 
 
 class PageValidator:

--- a/cfgov/v1/page_validation.py
+++ b/cfgov/v1/page_validation.py
@@ -35,7 +35,7 @@ def convert_http_image_match(match, url_mappings):
             return re.sub(from_prefix, to_prefix, match.group(0))
 
     raise ValueError(
-        "cannot convert HTTP image link {}".format(http_image_url)
+        f"cannot convert HTTP image link {http_image_url}"
     )
 
 

--- a/cfgov/v1/template_debug/__init__.py
+++ b/cfgov/v1/template_debug/__init__.py
@@ -9,9 +9,11 @@ from .featured_content import featured_content_test_cases  # noqa 401
 from .heading import heading_test_cases  # noqa 401
 from .notification import notification_test_cases  # noqa 401
 from .related_posts import related_posts_test_cases  # noqa 401
-from .tables import contact_us_table_test_cases  # noqa 401
-from .tables import crc_table_test_cases  # noqa 401
-from .tables import table_test_cases  # noqa 401
+from .tables import (
+    contact_us_table_test_cases,  # noqa 401
+    crc_table_test_cases,  # noqa 401
+    table_test_cases,  # noqa 401
+)
 from .translation_links import translation_links_test_cases  # noqa 401
 from .video_player import video_player_test_cases  # noqa 401
 

--- a/cfgov/v1/template_debug/featured_content.py
+++ b/cfgov/v1/template_debug/featured_content.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 featured_content_defaults = {
     "heading": "Featured content",
     "body": (

--- a/cfgov/v1/tests/atomic_elements/test_molecules.py
+++ b/cfgov/v1/tests/atomic_elements/test_molecules.py
@@ -256,7 +256,7 @@ class RSSFeedTests(TestCase):
 
     def assertHTMLContainsLinkToPageFeed(self, html, page):
         feed = page.url + "feed/"
-        self.assertIn('<a class="a-btn" href="{}">'.format(feed), html)
+        self.assertIn(f'<a class="a-btn" href="{feed}">', html)
 
     def test_render_no_page_in_context_renders_nothing(self):
         html = self.render(context={})

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -49,10 +49,7 @@ class TestFragmentCacheJinjaTag(TestCase):
         cache_key = "test-cache-key"
 
         """Render a template with a single cached value."""
-        s = '{%% cache "%s", "%s" %%}{{ value }}{%% endcache %%}' % (
-            cache_key,
-            cache_name,
-        )
+        s = f'{{% cache "{cache_key}", "{cache_name}" %}}{{{{ value }}}}{{% endcache %}}'
 
         template = self.jinja_engine.from_string(s)
         return template.render({"value": value})

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -49,7 +49,10 @@ class TestFragmentCacheJinjaTag(TestCase):
         cache_key = "test-cache-key"
 
         """Render a template with a single cached value."""
-        s = f'{{% cache "{cache_key}", "{cache_name}" %}}{{{{ value }}}}{{% endcache %}}'
+        s = (
+            f'{{% cache "{cache_key}", "{cache_name}" %}}'
+            f"{{{{ value }}}}{{% endcache %}}"
+        )
 
         template = self.jinja_engine.from_string(s)
         return template.render({"value": value})

--- a/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
+++ b/cfgov/v1/tests/jinja2tags/test_fragment_cache.py
@@ -75,7 +75,7 @@ class TestFragmentCacheJinjaTag(TestCase):
     )
     def test_if_caching_is_disabled_value_always_has_right_value(self):
         value = "foo"
-        self._render_tag(value, cache_name="default"),
+        self._render_tag(value, cache_name="default")
         value = "bar"
         self.assertEqual(self._render_tag(value, cache_name="default"), "bar")
 
@@ -91,7 +91,7 @@ class TestFragmentCacheJinjaTag(TestCase):
         value = "foo"
 
         # Rendering this value will store False in the cache.
-        self._render_tag(value, cache_name="default"),
+        self._render_tag(value, cache_name="default")
 
         value = "bar"
 
@@ -115,7 +115,7 @@ class TestFragmentCacheJinjaTag(TestCase):
         value = "foo"
 
         # Rendering this value will store 'foo' in the 'default' cache.
-        self._render_tag(value, cache_name="default"),
+        self._render_tag(value, cache_name="default")
 
         value = "bar"
 

--- a/cfgov/v1/tests/management/commands/test_archive_events.py
+++ b/cfgov/v1/tests/management/commands/test_archive_events.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import json
 from io import StringIO

--- a/cfgov/v1/tests/management/commands/test_makemessages.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages.py
@@ -64,7 +64,7 @@ class TestCustomMakeMessages(SimpleTestCase):
     def test_extraction_works_as_expected_including_jinja2_block(self):
         call_command("makemessages", locale=[self.LOCALE], verbosity=0)
 
-        with open(self.PO_FILE, "r") as f:
+        with open(self.PO_FILE) as f:
             contents = f.read()
 
         self.assertIn('msgid "Test string from Python file."', contents)

--- a/cfgov/v1/tests/management/commands/test_makemessages.py
+++ b/cfgov/v1/tests/management/commands/test_makemessages.py
@@ -18,7 +18,7 @@ class TestCustomMakeMessages(SimpleTestCase):
 
     LOCALE = "de"
 
-    PO_FILE = "locale/%s/LC_MESSAGES/django.po" % LOCALE
+    PO_FILE = f"locale/{LOCALE}/LC_MESSAGES/django.po"
 
     def setUp(self):
         # https://github.com/django/django/blob/1.11.18/tests/i18n/utils.py#L33

--- a/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
+++ b/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
@@ -61,7 +61,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
         call_command(
-            "update_chart_block_dates", "--snapshot_file={}".format(filename)
+            "update_chart_block_dates", f"--snapshot_file={filename}"
         )
         response = self.client.get("/browse/")
 
@@ -97,7 +97,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
         call_command(
-            "update_chart_block_dates", "--snapshot_file={}".format(filename)
+            "update_chart_block_dates", f"--snapshot_file={filename}"
         )
         response = self.client.get("/browse/")
 
@@ -133,7 +133,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
         call_command(
-            "update_chart_block_dates", "--snapshot_file={}".format(filename)
+            "update_chart_block_dates", f"--snapshot_file={filename}"
         )
         response = self.client.get("/browse/")
 

--- a/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
+++ b/cfgov/v1/tests/management/commands/test_update_chart_block_dates.py
@@ -60,9 +60,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
         filename = os.path.join(
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
-        call_command(
-            "update_chart_block_dates", f"--snapshot_file={filename}"
-        )
+        call_command("update_chart_block_dates", f"--snapshot_file={filename}")
         response = self.client.get("/browse/")
 
         # Tests last_updated_projected_data is correct
@@ -96,9 +94,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
         filename = os.path.join(
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
-        call_command(
-            "update_chart_block_dates", f"--snapshot_file={filename}"
-        )
+        call_command("update_chart_block_dates", f"--snapshot_file={filename}")
         response = self.client.get("/browse/")
 
         # Tests last_updated_projected_data is correct
@@ -132,9 +128,7 @@ class UpdateChartBlockDatesTestCase(TestCase):
         filename = os.path.join(
             settings.PROJECT_ROOT, "v1/tests/fixtures/data_snapshot.json"
         )
-        call_command(
-            "update_chart_block_dates", f"--snapshot_file={filename}"
-        )
+        call_command("update_chart_block_dates", f"--snapshot_file={filename}")
         response = self.client.get("/browse/")
 
         # Tests last_updated_projected_data is correct

--- a/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
+++ b/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
@@ -28,7 +28,7 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
         )
         call_command(
             "update_data_snapshot_values",
-            "--snapshot_file={}".format(filename),
+            f"--snapshot_file={filename}",
         )
         response = self.client.get("/browse/")
 
@@ -69,7 +69,7 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
         )
         call_command(
             "update_data_snapshot_values",
-            "--snapshot_file={}".format(filename),
+            f"--snapshot_file={filename}",
         )
         # July 2018
         response = self.client.get("/browse/")

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -120,9 +120,9 @@ class TestCFGOVPageContext(TestCase):
         result = test_context["meta_description"]
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_from_header_text_introduction_intro(
+    def test_get_context_sets_meta_description_from_header_text_introduction_intro(  # noqa: E501
         self,
-    ):  # noqa
+    ):
         expected = "Correct Meta Description"
         self.page = LandingPage(
             title="test",
@@ -151,9 +151,9 @@ class TestCFGOVPageContext(TestCase):
         result = test_context["meta_description"]
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_from_content_text_introduction_intro(
+    def test_get_context_sets_meta_description_from_content_text_introduction_intro(  # noqa: E501
         self,
-    ):  # noqa
+    ):
         expected = "Correct Meta Description"
         self.page = SublandingPage(
             title="test",
@@ -192,9 +192,9 @@ class TestCFGOVPageContext(TestCase):
         result = test_context["meta_description"]
         self.assertEqual(expected, result)
 
-    def test_get_context_sets_meta_description_to_blank_if_no_other_data_to_set(
+    def test_get_context_sets_meta_description_to_blank_if_no_other_data_to_set(  # noqa: E501
         self,
-    ):  # noqa
+    ):
         expected = ""
         self.page = SublandingPage(
             title="test",

--- a/cfgov/v1/tests/models/test_snippets.py
+++ b/cfgov/v1/tests/models/test_snippets.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 from django.test import TestCase
@@ -72,7 +71,7 @@ class TestReusableTextRendering(TestCase):
         default_site = Site.objects.get(is_default_site=True)
         default_site.root_page.add_child(instance=page)
 
-        html = '<a linktype="page" id="{}">Link</a>'.format(page.pk)
+        html = f'<a linktype="page" id="{page.pk}">Link</a>'
         block = ReusableTextChooserBlock(ReusableText)
         self.assertIn('<a href="/foo/">', block.render({"text": html}))
 

--- a/cfgov/v1/tests/templatetags/test_app_urls.py
+++ b/cfgov/v1/tests/templatetags/test_app_urls.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 

--- a/cfgov/v1/tests/test_meta_image.py
+++ b/cfgov/v1/tests/test_meta_image.py
@@ -63,7 +63,7 @@ class TestMetaImage(TestCase):
             response,
             (
                 '<meta property="og:image" content='
-                '"{}{}">'.format(expected_root, rendition_url)
+                f'"{expected_root}{rendition_url}">'
             ),
             html=True,
         )

--- a/cfgov/v1/util/events.py
+++ b/cfgov/v1/util/events.py
@@ -10,7 +10,7 @@ def get_venue_coords(city=None, state=None):
     if not city or not state or not settings.MAPBOX_ACCESS_TOKEN:
         return venue_coords
 
-    location = "{} {}".format(city, state)
+    location = f"{city} {state}"
     api = "https://api.mapbox.com/geocoding/v5/mapbox.places-permanent/"
     location_api_url = api + location + ".json"
 

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -33,10 +33,7 @@ def process_tags(queryset):
 
 
 def process_related_item(related_item, key):
-    if related_item:
-        value = getattr(related_item, key)
-    else:
-        value = ""
+    value = getattr(related_item, key) if related_item else ""
     return str(value)
 
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -84,16 +84,10 @@ def raise_bulk_delete_error(
 @hooks.register("after_delete_page")
 def log_page_deletion(request, page):
     logger.warning(
-        (
-            "User {user} with ID {user_id} deleted page {title} "
-            "with ID {page_id} at URL {url}"
-        ).format(
-            user=request.user,
-            user_id=request.user.id,
-            title=page.title,
-            page_id=page.id,
-            url=page.url_path,
-        )
+        
+            f"User {request.user} with ID {request.user.id} deleted page {page.title} "
+            f"with ID {page.id} at URL {page.url_path}"
+        
     )
 
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -84,8 +84,8 @@ def raise_bulk_delete_error(
 @hooks.register("after_delete_page")
 def log_page_deletion(request, page):
     logger.warning(
-        f"User {request.user} with ID {request.user.id} deleted page {page.title} "
-        f"with ID {page.id} at URL {page.url_path}"
+        f"User {request.user} with ID {request.user.id} deleted page "
+        f"{page.title} with ID {page.id} at URL {page.url_path}"
     )
 
 

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -84,10 +84,8 @@ def raise_bulk_delete_error(
 @hooks.register("after_delete_page")
 def log_page_deletion(request, page):
     logger.warning(
-        
-            f"User {request.user} with ID {request.user.id} deleted page {page.title} "
-            f"with ID {page.id} at URL {page.url_path}"
-        
+        f"User {request.user} with ID {request.user.id} deleted page {page.title} "
+        f"with ID {page.id} at URL {page.url_path}"
     )
 
 

--- a/cfgov/wellbeing/forms.py
+++ b/cfgov/wellbeing/forms.py
@@ -246,7 +246,7 @@ class ResultsForm(forms.Form):
         answer_values = 0
 
         for i in range(1, 11):
-            q = "question_%s" % i
+            q = f"question_{i}"
             answers.append(int(cleaned_data.get(q)))
             answer_values += int(cleaned_data.get(q))
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,7 +134,7 @@ as the formatter for Python files.
 ### Install pre-commit
 
 We use `pre-commit` to automatically run our linting tools before a commit
-takes place. These tools consist of `black`, `ruff`, `isort`, and `bandit`.
+takes place. These tools consist of `ruff` and `bandit`.
 To install `pre-commit`, running the following commands from within the
 `consumerfinance.gov` directory:
 

--- a/docs/python-unit-tests.md
+++ b/docs/python-unit-tests.md
@@ -117,18 +117,22 @@ If you would like to skip running Django migrations when testing, set the
 
 ### Formatting
 
-We use `black` to autoformat our Python code. `black` is invoked by Tox using
-the `lint` environment (this will also run `ruff` and `isort`):
+We use `ruff` to do `black`-compatible formatting of our Python code. `ruff` is invoked by Tox using the `lint` environment (this will also run `bandit` to do Python-specific static security analysis).
 
 ```sh
 tox -e lint
 ```
 
-**It is highly recommended to only invoke black via tox**
+This will run `ruff` in check-only mode. To automatically fix any formatting issues it flags, run:
+
+
+```sh
+ruff format
+```
 
 ### Linting
 
-We use the `ruff` and `isort` tools to ensure compliance with
+We also use `ruff` to ensure compliance with
 [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/),
 [Django coding style guidelines](https://docs.djangoproject.com/en/stable/internals/contributing/writing-code/coding-style/),
 and the
@@ -137,18 +141,16 @@ and the
 We also use [Bandit](https://bandit.readthedocs.io/) to find any common
 security issues in our Python code.
 
-`ruff`, `isort`, and `bandit` can all be run using the Tox `lint` environment
-(this will also run `black`):
+`ruff` and `bandit` can all be run using the Tox `lint` environment:
 
 ```sh
 tox -e lint
 ```
 
-This will run `isort` in check-only mode and it will print diffs for imports
-that need to be fixed. To automatically fix import sort issues, run:
+This will run `ruff` in check-only mode. To automatically (try to) fix any linting issues it flags, run:
 
 ```sh
-isort --recursive cfgov/
+ruff check --fix
 ```
 
 From the root of `consumerfinance.gov`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,3 @@
-[tool.black]
-line-length = 79
-target-version = ['py38']
-include = '\.pyi?$'
-extend-exclude = '''
-(
-  /(
-      migrations
-  )/
-)
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 79
-lines_after_imports = 2
-skip = ["f", ".tox", "migrations", ".venv", "venv"]
-known_django = ["django"]
-known_wagtail = ["wagtail"]
-src_paths = ["cfgov"]
-# Necessary due to the conflicting cfgov/jinja2 top-level template directory.
-known_third_party = ["jinja2"]
-sections = [
-    "STDLIB",
-    "DJANGO",
-    "WAGTAIL",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER"
-]
-
 [tool.bandit]
 exclude_dirs = [
     "*/tests/*",
@@ -45,6 +14,11 @@ skips = [
 ]
 
 [tool.ruff]
+# Use PEP8 line-length
+line-length = 79
+# Target Python 3.8
+target-version = "py38"
+# Exclude common paths
 exclude = [
     # These are directories that it's a waste of time to traverse
     ".git",
@@ -75,6 +49,8 @@ exclude = [
     # standards
     "cfgov/cfgov/settings",
 ]
+src = ["cfgov/"]
+
 
 [tool.ruff.lint]
 ignore = [
@@ -86,8 +62,33 @@ ignore = [
     "B905"
 ]
 select = [
+    # pycodestyle
     "E",
+    # pyflakes
     "F",
-    "W",
+    # flake8-bugbear
     "B",
+    # pyupgrade
+    "UP",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+
+[tool.ruff.lint.isort.sections]
+"django" = ["django"]
+"wagtail" = ["wagtail"]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+known-third-party = ["jinja2"]
+section-order = [
+    "future",
+    "standard-library",
+    "django",
+    "wagtail",
+    "third-party",
+    "first-party",
+    "local-folder",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -55,14 +55,11 @@ commands=
 #
 # To run Python linting.
 deps=
-    black
     ruff
-    isort
     bandit[toml]
 commands=
-    black cfgov --check
+    ruff format --check
     ruff check cfgov
-    isort --check-only --diff cfgov
     bandit -c "pyproject.toml" -r cfgov
 
 


### PR DESCRIPTION
Proposal: Switch to ruff for all our Python linting and formatting needs.

This replaces Black and isort with ruff, and enables ruff's support for pyupgrade and flake8-simplify checks, and then makes all the necessary formatting changes to comply with those changes.

Anecdotally, pre-commit's hooks are a lot faster locally than they were with black and isort, as is `tox -e lint`

## How to test this PR

1. Test pre-commit (with changes that should break and without): `pre-commit run`
1. Test tox listing (with changes that should break and without): `tox -e lint`
1. Test `ruff format` and `ruff check` with changes that should break and without

## How to review this PR

I tried to split the commits up so that all of the configuration is in the first PR; commits that are automatic changes by `ruff format`, `ruff check --fix`, and `ruff check --fix --unsafe-fixes` include the command used in the extended commit message, and changes I've manually made are described in manual commits. 

For the most part though, the changes that have to be made to formatting to pass linting checks are necessary. Some things (like when to use `noqa` and when not to) are within our control.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Visually tested in the following supported browsers:
- [ ] Firefox
- [ ] Chrome
- [ ] Safari
- [ ] Edge 18 (the last Edge prior to it switching to Chromium)
- [ ] Internet Explorer 11 and 8 (via emulation in 11's dev tools)
- [ ] Safari on iOS
- [ ] Chrome on Android

<!--
Further guidance on browser support can be found at:
https://github.com/cfpb/development/blob/main/guides/browser-support.md
-->

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
