### PR TITLE
BAH/OAH: Move borderless notification to standard notification

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -549,33 +549,26 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
             </section>
             <!-- /.next-steps -->
-            <div class="block
-                        block--border-top
-                        block--flush-top
-                        block--padded-top
-                        credit-note-ctr">
-                {# TODO: Look into using the default notification macro #}
-                <div class="m-notification
-                            m-notification--borderless
-                            m-notification--warning
-                            m-notification--visible"
-                        role="alert">
-                    {{ svg_icon('warning-round') }}
-                    <div class="m-notification__content">
-                        <div class="m-notification__message">Check your credit</div>
-                        <p class="m-notification__explanation">
-                            If you haven’t checked your credit report recently,
-                            <a class="external-link"
-                                href="https://annualcreditreport.com"
-                                target="_blank"
-                                rel="noopener noreferrer">do so now</a>. If you find errors,
-                            <a href="/ask-cfpb/how-do-i-dispute-an-error-on-my-credit-report-en-314/"
-                                target="_blank"
-                                rel="noopener noreferrer">get them corrected
-                            </a> before you apply for a mortgage.
-                        </p>
-                    </div>
-                </div>
+            <div class="block">
+                {% import 'v1/includes/molecules/notification.html' as notification %}
+                {{- notification.render(
+                    'warning',
+                    true,
+                    'Check your credit',
+                    'If you haven’t checked your credit report recently, do so now. ' ~
+                    'If you find errors, get them corrected before you apply for a mortgage.',
+                    [
+                       {
+                        'text': 'Check your credit report now',
+                        'url': 'https://annualcreditreport.com',
+                        'open_link_in_new_window': True
+                       },
+                       {
+                        'text': 'How do I dispute an error on my credit report?',
+                        'url': '/ask-cfpb/how-do-i-dispute-an-error-on-my-credit-report-en-314/'
+                       },
+                    ] ) }}
+
             </div>
             <section id="about" class="content-l">
                 <div class="content-l__col content-l__col-1">

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -500,17 +500,6 @@
     margin-top: 2em;
   }
 
-  .credit-note-ctr {
-    border-top: 1px solid var(--gray-10);
-  }
-
-  .m-notification--borderless {
-    padding-top: 0;
-    padding-bottom: 0;
-    border: none;
-    background: none;
-  }
-
   /*
         Media queries
         --------------------------- */
@@ -566,13 +555,6 @@
       margin-bottom: 0.5em;
       font-weight: 600;
       color: var(--gray-60);
-    }
-  });
-
-  .respond-to-min(@bp-sm-max, {
-
-    .m-notification--borderless {
-      .grid__column( 8 );
     }
   });
 

--- a/cfgov/v1/jinja2/v1/includes/molecules/notification.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/notification.html
@@ -23,9 +23,10 @@
                 Defaults to none.
 
    links:       Array of link objects, which each contain:
-                - text (required):      text of link.
-                - url:                  link url.
-                - is_link_boldface:     sets bold formatting.
+                - text (required):         text of link.
+                - url:                     link url.
+                - is_link_boldface:        sets bold formatting.
+                - open_link_in_new_window: opens the link in a new window
                 Defaults to an empty array.
 
    ========================================================================== #}
@@ -61,7 +62,12 @@
               {% if link.text %}
                   {% if loop.first %}<ul class="m-list m-list--links">{% endif %}
                       <li class="m-list__item">
-                          <a class="m-list__link" href="{{ link.url }}">
+                          <a class="m-list__link"
+                             href="{{ link.url }}"
+                             {% if link.open_link_in_new_window %}
+                             target="_blank"
+                             rel="noopener noreferrer"
+                             {% endif %}>
                             {% if link.is_link_boldface %}<strong>{% endif %}
                             {{ link.text }}
                             {% if link.is_link_boldface %}</strong>{% endif %}


### PR DESCRIPTION
BAH/OAH has this borderless notification that is not used anywhere else. This requires a custom notification block and uses the custom `credit-note-ctr` class to add a divider. This PR moves the whole block to a standard `block` and a standard warning notification. It also adds the ability to open links in a new window to the standard notification.

cc @csebianlander for content changes.

## Changes

- BAH/OAH: Move borderless notification to standard notification.
- BAH/OAH: remove custom `credit-note-ctr` class.
- Adds the ability to open links in a new window to the standard notification.


## How to test this PR

1. `yarn build` and visit http://localhost:8000/owning-a-home/explore-rates/ and scroll down till you see the notification.


## Screenshots

Before:

<img width="261" alt="Screenshot 2024-05-28 at 5 48 58 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/12fd3a88-c8c9-4275-bfbb-73e4e9305a28">


---

<img width="738" alt="Screenshot 2024-05-28 at 5 39 03 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8001c5c9-9f93-4609-86ce-8288549d75a6">

---

After:

<img width="277" alt="Screenshot 2024-05-28 at 5 49 05 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/d51d96fb-f25b-49bf-8b2b-9cf57ca2457f">


---

<img width="738" alt="Screenshot 2024-05-28 at 5 38 48 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/5698bbc9-9eeb-475d-a184-cac5800df811">



