### PR TITLE
BAH/OAH: Cleanup page-intro | remove unused classes

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -39,11 +39,11 @@ home price, down payment, and more can affect mortgage interest rates.
                     <h1>Explore interest rates</h1>
                     <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  Check back often -- the rates in the tool are updated every Wednesday and Friday.</p>
                     <div class="page-intro__cols">
-                        <p class="page-intro__col-left u-mb30">
+                        <p class="page-intro__cols-first">
                             Keep in mind that the interest rate is important,
                             but not the only cost of a mortgage.  Fees, <a href="/ask-cfpb/what-are-discount-points-and-lender-credits-and-how-do-they-work-en-136/">points</a>, <a href="/ask-cfpb/what-is-mortgage-insurance-and-how-does-it-work-en-1953/">mortgage insurance</a>, and <a href="/ask-cfpb/what-fees-or-charges-are-paid-when-closing-on-a-mortgage-and-who-pays-them-en-1845/">closing costs</a> all add up.  Compare <a href="/ask-cfpb/what-is-a-loan-estimate-en-1995/">Loan Estimates</a> to get the best deal.
                         </p>
-                        <div class="page-intro__col-right u-right-on-desktop">
+                        <div>
                             {{ social_media.render( {
                                 "twitter_text": "Use the @CFPB\'s interest rates tool to explore the range of mortgage interest rates you can expect.",
                                 "email_title": "Wondering what interest rate you can expect on a mortgage?",
@@ -588,7 +588,7 @@ home price, down payment, and more can affect mortgage interest rates.
         <!-- END .rate-checker -->
     </div>
 
-    <div class="rate-checker__links u-js-only">
+    <div class="u-js-only">
         {% import "_templates/brand-footer.html" as brand_footer %}
         {% set footer_links = [ {
             "img": static("apps/owning-a-home/img/footer_calculator.png"),

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -12,14 +12,31 @@
 .rate-checker {
   position: relative;
 
-  /* lead paragraphs are typically the first paragraph in a content area */
+  // lead paragraphs are typically the first paragraph in a content area.
   .lead {
     margin-bottom: unit(30px / @base-font-size-px, em);
     font-size: 1.125em;
   }
 
+  // Page intros are content areas that are in place of a hero.
   .page-intro {
     border-bottom: 1px solid var(--gray-10);
+    padding-bottom: unit(36px / @base-font-size-px, rem);
+
+    &__cols {
+      display: flex;
+      gap: unit(15px / @base-font-size-px, rem);
+      flex-direction: column;
+
+      // Desktop and above.
+      .respond-to-min(@bp-med-min, {
+        flex-direction: row;
+      });
+    }
+
+    &__cols-first {
+      flex-basis: fit-content;
+    }
   }
 
   .rc-illu-inner {
@@ -556,19 +573,6 @@
 
     .m-notification--borderless {
       .grid__column( 8 );
-    }
-
-    .page-intro__cols {
-      display: table;
-      .page-intro__col-left,
-      .page-intro__col-right {
-        display: table-cell;
-      }
-
-      .page-intro__col-right {
-        padding-left: unit( ( @grid_gutter-width / 2 ) / @base-font-size-px, em );
-        white-space: nowrap;
-      }
     }
   });
 

--- a/cfgov/unprocessed/apps/owning-a-home/css/main.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/main.less
@@ -13,8 +13,3 @@
 @import (less) './helpers.less';
 @import (less) './tab.less';
 @import (less) './a-range.less';
-
-// Page intros are content areas that are in place of a hero.
-.page-intro {
-  padding-bottom: 36px;
-}


### PR DESCRIPTION


## Removals

- Remove unused `rate-checker__links` class.
- Remove `u-right-on-desktop` utility.


## Changes

- BAH/OAH: Consolidate and simplify `page-intro__cols` class by using flexbox.


## How to test this PR

1. `yarn build` and visit http://localhost:8000/owning-a-home/explore-rates/ and compare the page intro area (with the social media icons) to production. Resize and compare across screen sizes. It should be essentially unchanged.


## Screenshots
<img width="785" alt="Screenshot 2024-05-28 at 6 32 51 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f75beede-db9d-4272-a4f6-78fd6d15572a">

