### PR TITLE
BAH/OAH: Remove `sans` and `u-pb0` classes

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -465,7 +465,7 @@ home price, down payment, and more can affect mortgage interest rates.
             <section class="next-steps tabs-layout">
                 <h2><strong>Next steps:</strong> How to get the best interest rate on your mortgage</h2>
                 <!-- put into a container to prevent long line length -->
-                <p class="sans">
+                <p>
                     When you’re ready to get serious about buying, the best thing you can do to get a better interest rate on your mortgage is <strong>shop around</strong>. But if you don’t plan to buy for a few months, there are more things you can do to ensure you get a great rate on your mortgage.
                 </p>
                 <ul class="tabs">

--- a/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/helpers.less
@@ -40,17 +40,6 @@
   text-align: center;
 }
 
-/* use sans-serif typeface */
-.sans {
-  strong {
-    font-weight: 600;
-  }
-}
-
-.u-pb0 {
-  padding-bottom: 0 !important;
-}
-
 .u-right-on-desktop {
   .respond-to-min(801px, {
     text-align: right;


### PR DESCRIPTION
I couldn't find a use of rate checkers' `u-pb0` utility class.

The `sans` class only sets the bolding on `<strong>` text, but we already set the same weight via our base styling, so this was redundant.

## Removals

- BAH/OAH: Remove `sans` and `u-pb0` classes

## How to test this PR

1. There should be no changes to rate checker.
You can inspect https://www.consumerfinance.gov/owning-a-home/explore-rates/ and search for `sans` and then remove that class and see there is no change to the paragraph of text.