### PR TITLE
BEM fix to BAH header

### DIFF
--- a/cfgov/jinja2/owning-a-home/_templates/brand-header.html
+++ b/cfgov/jinja2/owning-a-home/_templates/brand-header.html
@@ -1,6 +1,6 @@
 <header aria-label="Buying a House header" class="brand-header">
   <div class="content__wrapper">
-    <div class="brand-header__1-2-container brand-header__1-2-container-with-icon">
+    <div class="brand-header__1-2-container brand-header__1-2-container--with-icon">
       <div class="brand-header__headline">
         <span class="brand-header__icon" aria-hidden="true">{{ svg_icon('house') }}</span>
         This page is part of <a href="/owning-a-home/">Buying a House</a>, the CFPB’s


### PR DESCRIPTION
Before:
<img width="596" alt="Screenshot 2024-05-29 at 11 19 19 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/478610bf-6eda-47c3-ad93-e1d9dfd365fe">

After:
<img width="615" alt="Screenshot 2024-05-29 at 11 19 13 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/f8ff2c23-046d-48bd-91b6-6985905dbce6">

The above appears on localhost:8000/owning-a-home/explore-rates/