### PR TITLE
Fix notification link markup

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/notification.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/notification.html
@@ -68,9 +68,9 @@
                              target="_blank"
                              rel="noopener noreferrer"
                              {% endif %}>
-                            {% if link.is_link_boldface %}<strong>{% endif %}
+                            {%- if link.is_link_boldface %}<strong>{% endif -%}
                             {{ link.text }}
-                            {% if link.is_link_boldface %}</strong>{% endif %}
+                            {%- if link.is_link_boldface %}</strong>{% endif -%}
                           </a>
                       </li>
                   {% if loop.last %}</ul>{% endif %}


### PR DESCRIPTION
Notification links with icons are getting incorrect markup because of whitespace in the HTML template. This commit fixes that.

## How to test this PR

Run a local server and visit http://localhost:8000/owning-a-home/explore-rates/. Check the links in the notification towards the bottom of the page.

## Screenshots

|Before|After|
|-|-|
|<img width="254" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/27c0553f-7e5d-4f27-a453-6f90a9fa9d82">|<img width="256" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/ddfc403e-7ad3-413b-a70b-de5c26cffa70">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)