### PR TITLE
Ask: Apply `m-list__item--last` only at tablet and above

### DIFF
--- a/cfgov/unprocessed/apps/ask-cfpb/css/main.less
+++ b/cfgov/unprocessed/apps/ask-cfpb/css/main.less
@@ -170,10 +170,6 @@
     font-weight: 500;
   }
 
-  .m-list__item--last {
-    padding-top: unit(7px / @base-font-size-px, em);
-  }
-
   .lead-paragraph {
     // This makes for line lengths between 85-95 characters
     max-width: 41.875rem;
@@ -184,6 +180,13 @@
     display: block;
     color: var(--gray-90);
   }
+
+  // Tablet and above.
+  .respond-to-min(@bp-sm-min, {
+    .m-list__item--last {
+      padding-top: unit(7px / @base-font-size-px, em);
+    }
+  });
 }
 
 /* Landing page */


### PR DESCRIPTION
Ask adds padding above its last link list item. However, when these take on the jump link appearance at mobile, the last link looks lop-sided. Also, when the hover on list links is fixed to above highlight the top line, this will be broken.

## Changes

- Ask: Apply `m-list__item--last` only at tablet and above


## How to test this PR

1. Visit an ask answer, like http://localhost:8000/ask-cfpb/a-box-on-my-credit-card-bill-says-that-i-will-pay-off-the-balance-in-three-years-if-i-pay-a-certain-amount-what-does-that-mean-do-i-have-to-pay-that-much-if-i-pay-that-much-and-make-new-purchases-will-i-still-owe-nothing-after-three-years-en-36/ and check the link list at the bottom of the page across screen sizes.


## Screenshots

Before:
<img width="488" alt="Screenshot 2024-05-30 at 4 26 58 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/0bceb91d-87e0-4178-aef6-05403299ee32">
<img width="550" alt="Screenshot 2024-05-30 at 4 27 15 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/e1288f22-e6b2-4aa9-9fd0-ebf0be98f6d6">


After:
<img width="414" alt="Screenshot 2024-05-30 at 4 25 45 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/c78ca001-2261-496d-9010-b289d0fb7a22">

