### PR TITLE
Fix extra whitespace in some link markup cases

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -261,3 +261,19 @@ class LinkUtilsTests(SimpleTestCase):
         expected_tag = BeautifulSoup(expected_html, "html.parser")
 
         self.assertEqual(add_link_markup(tag, path), str(expected_tag))
+
+    def test_link_with_whitespace_in_text(self):
+        url = "https://example.com"
+        tag = f'<a href="{url}">\nClick <strong>here</strong> now! </a>'
+        path = "/about-us/blog/"
+
+        expected_html = (
+            f'<a class="a-link a-link--icon" href="{url}">'
+            '<span class="a-link__text">'
+            "Click <strong>here</strong> now!</span> "
+            f"{self.external_link_icon}"
+            "</a>"
+        )
+
+        expected_tag = BeautifulSoup(expected_html, "html.parser")
+        self.assertEqual(add_link_markup(tag, path), str(expected_tag))


### PR DESCRIPTION
Our link icon markup incorrectly leaves behind whitespace in certain cases. For example, given a link like this:

```html
<a href="https://example.com"> text </a>
```

the markup will generate:

```html
<a href="https://example.com" class="a-link a-link--icon">
  <span class="a-link__text"> text </span>
  <svg class="cf-icon-svg cf-icon-svg--external-link">...</svg>
</a>
```

The extra whitespace in the `<span>` gets underlined incorrectly.

See "View a webinar on the rule" on https://www.consumerfinance.gov/know-before-you-owe/ for an example where this happens on the live site.

This fix attempts to strip surrounding whitespace from the link text to prevent this happening.

## How to test this PR

Run a local server and visit http://localhost:8000/know-before-you-owe/, and compare the link above to the live site.

## Screenshots

|Before|After|
|-|-|
|<img width="233" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/fa24bb8e-4ca9-4307-ade0-fe786b7adb1b">|<img width="243" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/416305a7-d17d-4d09-b6eb-037e797f05e3">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)