### PR TITLE
Remove reference to deprecated comments_close_date

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/post-preview.html
@@ -25,8 +25,6 @@
    post.title:                    A string with the title of the post.
    post.seo_title:                A string with an alternate title for the post
                                   (overrides post.title).
-   post.comments_close_date:      A datetime object marking the deadline of the
-                                  comment period.
    post.search_description:      A string with content of post summary.
    post.get_authors():            An array with authors of the post.
    post.tags:                     An array with the post tags for the post.
@@ -139,11 +137,6 @@
                     {{ time.render(event.start_dt) }}
                     </div>
                 {% endif %}
-            {% endif %}
-            {% if post.comments_close_date %}
-                <div class="o-post-preview__subtitle">
-                    Comments close {{ time.render(post.comments_close_date, {'date':true}) }}
-                </div>
             {% endif %}
             {% if post.search_description %}
                 <div class="o-post-preview__description">


### PR DESCRIPTION
Commit 54ccbf85838e08744a3b766e24213d721c206b0b removed the `comments_close_by` field from AbstractFilterPage. A reference to `comments_close_date` was left behind in the post preview template, but that is never set anywhere. This commit cleans that up.

[There are no other references to this field in the codebase.](https://github.com/search?q=repo%3Acfpb%2Fconsumerfinance.gov%20comments_close_date&type=code)

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)