### PR TITLE
Migrate iRegs notifications to standard notification

### DIFF
--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -4,6 +4,26 @@
 {% import 'v1/includes/templates/render_block.html' as render_block with context %}
 {% import 'v1/includes/templates/streamfield-sidefoot.html' as streamfield_sidefoot with context %}
 
+{% if requested_version and current_version %}
+    {% import 'v1/includes/molecules/notification.html' as notification %}
+
+    {% set is_past_reg = requested_version.effective_date < current_version.effective_date %}
+    {% set is_future_reg = requested_version.effective_date > current_version.effective_date %}
+
+    {% set notification_explanation_first = namespace(
+        past='You are viewing a previous version of this regulation with amendments that went into effect on',
+        future='You are viewing a future version of this regulation with amendments that will go into effect on' ) %}
+    {% set notification_explanation_last = ap_date(requested_version.effective_date) %}
+
+    {% set notification_message = 'This version is not the current regulation.' %}
+
+    {% if is_past_reg %}
+        {% set notification_explanation = notification_explanation_first.past ~ ' ' ~ notification_explanation_last ~ '.' %}
+    {% elif is_future_reg %}
+        {% set notification_explanation = notification_explanation_first.future ~ ' ' ~ notification_explanation_last ~ '.' %}
+    {% endif %}
+{% endif %}
+
 {# HEAD items #}
 
 {% block title -%}
@@ -35,11 +55,11 @@
         {% else -%}
             § {{ regulation.part_number }}.{{ section.label }}
         {% endif -%}
-        {% if requested_version.effective_date < current_version.effective_date -%}
+        {% if is_past_reg -%}
             is part of a previous version of {{ page.regulation }} with
             amendments that went into effect on
             {{ ap_date(requested_version.effective_date) }}.
-        {% elif requested_version.effective_date > current_version.effective_date -%}
+        {% elif is_future_reg -%}
             is part of a future version of {{ page.regulation }} with
             amendments that will go into effect on
             {{ ap_date(requested_version.effective_date) }}.
@@ -110,24 +130,16 @@
                     </li>
                 </ul>
             {% else %}
-                <div class="m-full-width-text
-                            m-notification
-                            m-notification--visible
-                            m-notification--warning">
-                    {{ svg_icon('warning-round') }}
-                    <div class="m-notification__content">
-                        <div class="m-notification__message">This version is not the current regulation.</div>
-                        <p class="m-notification__explanation">
-                        {% if requested_version.effective_date < current_version.effective_date %}
-                            You are viewing a previous version of this regulation with amendments that went into effect on
-                        {% endif %}
-                        {% if requested_version.effective_date > current_version.effective_date %}
-                            You are viewing a future version of this regulation with amendments that will go into effect on
-                        {% endif %}
-                        {{ ap_date(requested_version.effective_date) }}. <a class="m-list__link" href="{{ routablepageurl(page, 'versions', section_label=section.url_path) }}">View all versions of this regulation</a>
-                        </p>
-                    </div>
-                </div>
+                {{- notification.render(
+                    'warning',
+                    true,
+                    notification_message,
+                    notification_explanation,
+                    [{
+                        'text': 'View all versions of this regulation',
+                        'url': routablepageurl(page, 'versions', section_label=section.url_path)
+                    }]
+                )}}
             {% endif %}
         </div>
 
@@ -148,12 +160,11 @@
                             <span class="o-regulations-wayfinder__section-title"></span><span class="o-regulations-wayfinder__marker"></span>
                         </a>
                         <div class="o-regulations-wayfinder__version">
-                            {% if requested_version.effective_date < current_version.effective_date %}
+                            {% if is_past_reg %}
                                 Previous version (effective
                                 {{ ap_date(requested_version.effective_date) }} to
                                 {{ ap_date(next_version.effective_date) }})
-                            {% endif %}
-                            {% if requested_version.effective_date > current_version.effective_date %}
+                            {% elif is_future_reg %}
                                 Future version (effective
                                 {{ ap_date(requested_version.effective_date) }})
                             {% endif %}
@@ -210,23 +221,12 @@
         <div class="block block--flush-bottom block--flush-regs3k">
             {% if requested_version != current_version %}
             <div class="block block--sub">
-                <div class="m-full-width-text
-                            m-notification
-                            m-notification--visible
-                            m-notification--warning">
-                    {{ svg_icon('warning-round') }}
-                    <div class="m-notification__content">
-                        <div class="m-notification__message">This version is not the current regulation.</div>
-                        <p class="m-notification__explanation">
-                            {% if requested_version.effective_date < current_version.effective_date %}
-                                You are viewing a previous version of this regulation with amendments that went into effect on {{ ap_date(requested_version.effective_date) }}.
-                            {% endif %}
-                            {% if requested_version.effective_date > current_version.effective_date %}
-                                You are viewing a future version of this regulation with amendments that will go into effect on {{ ap_date(requested_version.effective_date) }}.
-                            {% endif %}
-                        </p>
-                    </div>
-                </div>
+                {{- notification.render(
+                    'warning',
+                    true,
+                    notification_message,
+                    notification_explanation
+                )}}
             </div>
             {% endif %}
 


### PR DESCRIPTION

## Changes

- Migrate iRegs notifications to standard notification


## How to test this PR

1. Visit a regulation, like http://localhost:8000/rules-policy/regulations/1005/, and click "View all versions of this regulation"
2. Click on a prior date for the regulation and note that there's a notification that says the regulation is not current. Compare to production and it should be the same (*almost—see notes below)
3. Click into a section of the regulation and see that there's a notification with a link. Compare to production and it have the same content.
4. To view a future regulation, you'll need to go into Wagtail and edit a regulation to have a future publish date, and then follow steps 1-3 to see the future notifications.


## Screenshots

Before/after across past/future and screensizes

<img width="448" alt="Screenshot 2024-05-31 at 2 42 15 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/8785433e-9516-4bbb-ae2b-af8d6a176240">
<img width="883" alt="Screenshot 2024-05-31 at 2 42 27 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/a30c51f6-d7a0-44e7-ac7f-840fb1957243">
<img width="872" alt="Screenshot 2024-05-31 at 2 45 37 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/067f3918-6eb7-4dd2-b968-33e8129801da">
<img width="490" alt="Screenshot 2024-05-31 at 2 45 45 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/26092d24-a2b1-4dc4-912a-030c2c310cf1">
<img width="877" alt="Screenshot 2024-05-31 at 2 48 27 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f7104d2a-d71c-4a6a-8cfa-56de7f73b379">
<img width="388" alt="Screenshot 2024-05-31 at 2 48 35 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/3e8b20ea-8d4a-41b8-8c17-a197995a3447">



## Notes and todos

- The hardcoded notifications used paragraph tags for their content, which gets our standard max-width paragraph length set. Using our standard notification template does not use a paragraph, so it loses the max-width. I think this is fine (and actually looks better I think as the date fits on the same line). If we want to constrain the max-width on notification content, we should probably add it to the standard notification so that it is consistent.
- The standard notification puts the link below the notification explanation as a jump link.
