### PR TITLE
Remove weird aria-labels on links and fixup alt text for images

### DIFF
--- a/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
@@ -86,8 +86,7 @@
 
 <a class="a-link
           a-link--jump"
-   href="{{ link.url }}"
-   aria-label="{{ link.label }}">
+   href="{{ link.url }}">
     {{ link.text | safe }}
 </a>
 {% endmacro %}

--- a/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
@@ -76,8 +76,8 @@
 
 {% macro render_link( link ) %}
 <div class="brand-footer__img">
-    <a href="{{ link.url }}">
-        <img src="{{ link.img }}" alt="{{ link.label }}">
+  <a href="{{ link.url }}" aria-label="{{link.label}}">
+        <img src="{{ link.img }}">
     </a>
 </div>
 {% if link.intro %}

--- a/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
+++ b/cfgov/jinja2/owning-a-home/_templates/brand-footer.html
@@ -77,7 +77,7 @@
 {% macro render_link( link ) %}
 <div class="brand-footer__img">
   <a href="{{ link.url }}" aria-label="{{link.label}}">
-        <img src="{{ link.img }}">
+        <img src="{{ link.img }}" alt="">
     </a>
 </div>
 {% if link.intro %}

--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -586,7 +586,7 @@ home price, down payment, and more can affect mortgage interest rates.
         {% set footer_links = [ {
             "img": static("apps/owning-a-home/img/footer_calculator.png"),
             "text": "Ready to begin the homebuying process?",
-            "label": "Get started now",
+            "label": "Prepare for the homebuying process",
             "url": "/owning-a-home/process/prepare/"
         }, {
             "img": static("apps/owning-a-home/img/footer_house.png"),
@@ -596,7 +596,7 @@ home price, down payment, and more can affect mortgage interest rates.
         }, {
             "img": static("apps/owning-a-home/img/footer_loan-estimate.png"),
             "text": "Have a Loan Estimate?",
-            "label": "Review it with our tool",
+            "label": "Review loan estimate",
             "url": "/owning-a-home/loan-estimate/"
         } ] %}
         {{ brand_footer.render(footer_links) }}


### PR DESCRIPTION
As reported by @anselmbradford.

On http://localhost:8000/owning-a-home/explore-rates/, the footer images should have more sensible alt-text while the strange aria-labels on the links have been removed.