### PR TITLE
Ask: Change `innerHTML` to `innerText` in Ask Search

### DIFF
--- a/cfgov/unprocessed/apps/ask-cfpb/js/ask-autocomplete.js
+++ b/cfgov/unprocessed/apps/ask-cfpb/js/ask-autocomplete.js
@@ -49,7 +49,7 @@ function handleMaxCharacters(event) {
 }
 
 if (autocompleteContainer) {
-  const language = document.documentElement.getAttribute('lang')
+  const language = document.documentElement.getAttribute('lang');
   const autocomplete = new Autocomplete(autocompleteContainer, {
     url: language === 'es' ? URLS.es : URLS.en,
     onSubmit: function (event, selected) {
@@ -64,7 +64,7 @@ if (autocompleteContainer) {
       li.setAttribute('data-val', item.question);
       const link = document.createElement('a');
       link.setAttribute('href', item.url);
-      link.innerHTML = item.question;
+      link.innerText = item.question;
       li.appendChild(link);
       return li;
     },


### PR DESCRIPTION

## Changes

- Ask: Change `innerHTML` to `innerText` in Ask Search.


## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/ and type some text into the Ask autocomplete and it should still work as before.
