### PR TITLE
Add margins to m-full-width-text 'content' blocks that match h2s

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -28,12 +28,23 @@
     }
   }
 
+  .m-full-width-text {
+    margin-top: unit(30px / @base-font-size-px, em);
+    margin-bottom: unit(30px / @base-font-size-px, em);
+  }
+
   .m-full-width-text + .m-call-to-action {
     margin-top: unit(30px / @base-font-size-px, em);
   }
 
   // Tablet and above.
   .respond-to-min(@bp-sm-min, {
+
+    .m-full-width-text {
+      margin-top: unit(45px / @base-font-size-px, em);
+      margin-bottom: unit(45px / @base-font-size-px, em);
+    }
+
     .m-inset {
       margin-left: unit( @grid_gutter-width / @base-font-size-px, em );
 


### PR DESCRIPTION
My proposal for https://github.local/Design-Development/Design-and-Content-Team/issues/379

## Testing
 - http://localhost:8000/about-us/blog/los-pasos-que-debe-tomar-para-cerrar-el-trato-de-su-vivienda-con-confianza/ should have consistent spacing between sections at mobile and desktop
 - The MANY pages with full width text components should appear unchanged. Use this querystring with the crawler for examples: `?q=m-full-width-text&search_type=components`

There MAY be pages where this breaks the existing spacing and the use of `h2`s as the heading level in "full width text" content sections is not universal (eg, http://localhost:8000/about-us/careers/application-process/ is `h3`s). But this seems like a decent enough compromise. Happy to hear other theories of what the ideal spacing should be. I'd say decisively that it's not 0, though (current behavior).