### PR TITLE
FIG: Don't swallow clicks to field links on mobile

### DIFF
--- a/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/js/fig-sidenav.js
@@ -44,7 +44,7 @@ const handleMobileNav = (event) => {
     setTimeout(() => {
       defaultScrollOffset(event.target);
     }, 300);
-  } else if (event.target.matches('.o-fig__heading > a')) {
+  } else if (event.target.matches('.o-fig__section--sub a')) {
     defaultScrollOffset(event.target);
   }
 };


### PR DESCRIPTION
@anselmbradford

## Testing
- Go to http://localhost:8000/data-research/small-business-lending/filing-instructions-guide/2024-guide/#pricing-information
- Make sure you're in the mobile view
- Click on one of the fields and note that it scrolls down as expected