### PR TITLE
Make homepage editable in Wagtail

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -10,23 +10,6 @@
     "is_jumbo": true
 } -%}
 
-{%- set inkwell = {
-    "infounits": [
-        {
-            "heading": "We enforce",
-            "content": "We’ve taken action against predatory companies and practices, returning billions of dollars to harmed consumers.",
-        },
-        {
-            "heading": "We educate",
-            "content": "We help consumers build the skills they need to take control of their finances and plan for the future.",
-        },
-        {
-            "heading": "We empower",
-            "content": "Our tools and resources help consumers make informed decisions through every step of their financial journey.",
-        },
-    ],
-} -%}
-
 {%- set answers_heading = "Find answers to your money questions" -%}
 
 {%- set topics = {
@@ -58,8 +41,6 @@
         }
     ],
 } -%}
-
-<!-- {%- set highlights_heading = "Bureau highlights" -%} -->
 
 {%- set highlights = [
     {

--- a/cfgov/v1/models/home_page.py
+++ b/cfgov/v1/models/home_page.py
@@ -1,15 +1,99 @@
-from wagtail.admin.panels import ObjectList, TabbedInterface
-from wagtail.models import Page
+from django.db import models
+
+from wagtail.admin.panels import (
+    FieldPanel,
+    MultiFieldPanel,
+    ObjectList,
+    TabbedInterface,
+)
+from wagtail.blocks import ListBlock, StructBlock, TextBlock
 
 from v1.models.base import CFGOVPage
 
 
+class home_card(StructBlock):
+    icon = TextBlock()
+    text = TextBlock()
+    url = TextBlock()
+
+
+class home_highlight(StructBlock):
+    card_type = "highlight"
+    img_src = TextBlock()
+    heading = TextBlock()
+    link_text = TextBlock()
+    link_url = TextBlock()
+
+
+class home_breakout(StructBlock):
+    card_type = "breakout"
+    link_text = TextBlock()
+    link_url = TextBlock()
+    img_src = TextBlock()
+
+
+class HomeTopics(StructBlock):
+    topics = ListBlock("home_card", default=list())
+
+
+class HomeHighlights(StructBlock):
+    highlights = ListBlock("home_highlight", default=list())
+
+
+class HomeBreakouts(StructBlock):
+    breakouts = ListBlock("home_breakout", default=list())
+
+
 class HomePage(CFGOVPage):
+    hero_heading = models.TextField(
+        default="On your side",
+        help_text=("Will be formatted in bold"),
+    )
+
+    hero_heading_continued = models.TextField(
+        default="through life's financial moments."
+    )
+
+    hero_image = models.TextField()
+
+    answers_heading = models.TextField(
+        default="Find answers to your money questions",
+    )
+
+    breakout_cards_heading = models.TextField(
+        default="Get help planning for future goals"
+    )
+
+    content_panels = CFGOVPage.content_panels + [
+        MultiFieldPanel(
+            [
+                FieldPanel("hero_heading"),
+                FieldPanel("hero_heading_continued"),
+                FieldPanel("hero_image"),
+            ],
+            heading="Hero",
+        ),
+        FieldPanel("highlights"),
+        MultiFieldPanel(
+            [
+                FieldPanel("answers_heading"),
+                FieldPanel("home_topics", HomeTopics()),
+            ],
+            heading="Topics",
+        ),
+        # 50/50 goes here when we un-hardcode it
+        MultiFieldPanel(
+            [
+                FieldPanel("breakout_cards_heading"),
+                FieldPanel("breakout_cards"),
+            ],
+            heading="Breakout cards",
+        ),
+    ]
+
     edit_handler = TabbedInterface(
         [
-            # This is required to support editing of the page's title field.
-            # HomePages have no other Wagtail-editable content fields.
-            ObjectList(Page.content_panels, heading="General Content"),
+            ObjectList(content_panels, heading="General Content"),
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR reworks our homepage, currently hard-coded, into editable fields in Wagtail

It is currently incomplete and in _very_ draft form as I start hacking at the existing code and trying to build some bespoke field panels for use on the home page.

---

## How to test this PR

1.

## Notes and todos

- This will probably need to be a multi-phase rollout to ensure we don't have a period of displaying a broken/empty homepage. I'm thinking one PR with all the back-end changes but which preserves the current hard-coded html pages, and then a second PR which swaps those out for the correct template files.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Check the current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
