### PR TITLE
Remove broken and deprecated CFGOVPage unit test

### DIFF
--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -28,12 +27,6 @@ class TestCFGOVPage(TestCase):
         save_new_page(self.page)
         key = self.page.post_preview_cache_key
         self.assertIn(str(self.page.id), key)
-
-    @mock.patch("builtins.super")
-    def test_serve_calls_super_on_non_ajax_request(self, mock_super):
-        self.page.serve(self.request)
-        mock_super.assert_called_once()
-        mock_super().serve.assert_called_with(self.request)
 
 
 class TestCFGOVPageContext(TestCase):


### PR DESCRIPTION
This unit test was failing for me with certain invocations of Python unit tests, for example:

```
tox -e unittest -- v1.tests.models.test_base
```

This fails due to a RecursionError in Django's settings code, whereas running those tests in reverse passed:

```
tox -e unittest -- --reverse v1.tests.models.test_base
```

Digging into this, the problem is that this test patches the Python `super()` call which has all sorts of potential side effects. In this case, it was breaking something about how Django settings are cached the first time they are accessed.

As it turns out, this test can be removed - it was created at a time when our `CFGOVPage.serve()` method was sometimes invoked via AJAX, which is no longer the case.

## Notes and todos

We have [a few other tests](https://github.com/search?q=repo%3Acfpb%2Fconsumerfinance.gov%20%22builtins.super%22&type=code) that also patch `builtins.super()` in this way. These should also be changed to avoid this approach, as it's a very broad brush with all sorts of unpredictable side effects.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)