### PR TITLE
Modify Python tests to avoid patching super()

### DIFF
--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -306,17 +306,6 @@ class FilterableListForm(forms.Form):
 
         return cleaned_data
 
-    # Sets the html name by replacing the render method to use the given name.
-    def set_field_html_name(self, field, new_name):
-        """
-        This creates wrapper around the normal widget rendering,
-        allowing for a custom field name (new_name).
-        """
-        old_render = field.widget.render
-        field.widget.render = lambda name, value, **kwargs: old_render(
-            new_name, value, **kwargs
-        )
-
 
 class EnforcementActionsFilterForm(FilterableListForm):
     statuses = forms.MultipleChoiceField(

--- a/cfgov/v1/tests/test_forms.py
+++ b/cfgov/v1/tests/test_forms.py
@@ -1,8 +1,8 @@
-import datetime
-from unittest import mock
+from datetime import date
+from unittest.mock import MagicMock, patch
 
 from django import forms
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from wagtail.images.forms import get_image_form
 
@@ -12,137 +12,72 @@ from v1.forms import FilterableDateField, FilterableListForm
 from v1.models import CFGOVImage
 
 
-class TestFilterableListForm(TestCase):
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    def test_clean_returns_cleaned_data_if_in_future(
-        self, mock_super, mock_init
-    ):
-        mock_init.return_value = None
-        from_date = datetime.date(2048, 1, 23)
-        to_date = from_date + datetime.timedelta(weeks=52)
-        form_data = {"from_date": from_date, "to_date": to_date}
+class TestFilterableListFormDateFields(SimpleTestCase):
+    def check_date_fields(self, data, expected_from_date, expected_to_date):
+        form = FilterableListForm(filterable_search=MagicMock(), data=data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["from_date"], expected_from_date)
+        self.assertEqual(form.cleaned_data["to_date"], expected_to_date)
 
-        form = FilterableListForm()
-        mock_super().clean.return_value = form_data
-        form.cleaned_data = form_data
-        form.data = {"from_date": "1/23/2048", "to_date": "1/23/2049"}
-        form._errors = {}
+    @freeze_time("2020-01-01")
+    def test_clean_returns_cleaned_data_if_in_future(self):
+        self.check_date_fields(
+            data={
+                "from_date": "2048-01-23",
+                "to_date": "2049-01-23",
+            },
+            expected_from_date=date(2048, 1, 23),
+            expected_to_date=date(2049, 1, 23),
+        )
 
-        result = form.clean()
-        assert result["from_date"] == from_date
-        assert result["to_date"] == to_date
+    def test_clean_returns_cleaned_data_if_valid(self):
+        self.check_date_fields(
+            data={
+                "from_date": "2017-07-04",
+                "to_date": "2017-07-05",
+            },
+            expected_from_date=date(2017, 7, 4),
+            expected_to_date=date(2017, 7, 5),
+        )
 
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    @freeze_time("2017-07-04")
-    def test_clean_returns_cleaned_data_if_valid(self, mock_super, mock_init):
-        mock_init.return_value = None
-        from_date = datetime.date(2017, 7, 4)
-        to_date = from_date + datetime.timedelta(days=1)
-        form_data = {"from_date": from_date, "to_date": to_date}
+    @patch(
+        "v1.forms.FilterableListForm.first_page_date",
+        return_value=date(1995, 1, 1),
+    )
+    def test_clean_uses_earliest_result_if_fromdate_field_is_empty(self, _):
+        self.check_date_fields(
+            data={"to_date": "2017-01-15"},
+            expected_from_date=date(1995, 1, 1),
+            expected_to_date=date(2017, 1, 15),
+        )
 
-        form = FilterableListForm()
-        mock_super().clean.return_value = form_data
-        form.cleaned_data = form_data
-        form.data = {"from_date": "7/4/2017", "to_date": "7/5/2017"}
-        form._errors = {}
+    @freeze_time("2020-01-01")
+    def test_clean_uses_today_if_todate_field_is_empty(self):
+        self.check_date_fields(
+            data={"from_date": "2016-05-15"},
+            expected_from_date=date(2016, 5, 15),
+            expected_to_date=date(2020, 1, 1),
+        )
 
-        result = form.clean()
-        assert result["from_date"] == from_date
-        assert result["to_date"] == to_date
+    def test_clean_returns_cleaned_data_if_both_date_fields_are_empty(self):
+        self.check_date_fields(
+            data={},
+            expected_from_date=None,
+            expected_to_date=None,
+        )
 
-    @mock.patch("v1.forms.FilterableListForm.first_page_date")
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    @freeze_time("2017-01-15")
-    def test_clean_uses_earliest_result_if_fromdate_field_is_empty(
-        self, mock_super, mock_init, mock_pub_date
-    ):
-        mock_init.return_value = None
-        from_date = None
-        to_date = datetime.date(2017, 1, 15)
-        form_data = {"from_date": from_date, "to_date": to_date}
-
-        form = FilterableListForm()
-        mock_super().clean.return_value = form_data
-        form.cleaned_data = form_data
-        form.data = {"to_date": "1-15-2017"}
-        form._errors = {}
-        mock_pub_date.return_value = datetime.date(1995, 1, 1)
-
-        result = form.clean()
-        assert result["from_date"] == datetime.date(1995, 1, 1)
-        assert result["to_date"] == to_date
-
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    @freeze_time("2016-05-15")
-    def test_clean_uses_today_if_todate_field_is_empty(
-        self, mock_super, mock_init
-    ):
-        mock_init.return_value = None
-        from_date = datetime.date(2016, 5, 15)
-        to_date = None
-        form_data = {"from_date": from_date, "to_date": to_date}
-
-        form = FilterableListForm()
-        mock_super().clean.return_value = form_data
-        form.cleaned_data = form_data
-        form.data = {"from_date": "5-15-2016"}
-        form._errors = {}
-
-        result = form.clean()
-        assert result["from_date"] == from_date
-        assert result["to_date"] == datetime.date.today()
-
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    def test_clean_returns_cleaned_data_if_both_date_fields_are_empty(
-        self, mock_super, mock_init
-    ):
-        mock_init.return_value = None
-        from_date = None
-        to_date = None
-
-        form = FilterableListForm()
-        mock_super().clean.return_value = {
-            "from_date": from_date,
-            "to_date": to_date,
-        }
-        form.cleaned_data = {"from_date": from_date, "to_date": to_date}
-        form.data = {}
-        form._errors = {}
-
-        result = form.clean()
-        assert result["from_date"] == from_date
-        assert result["to_date"] == to_date
-
-    @mock.patch("v1.forms.FilterableListForm.__init__")
-    @mock.patch("builtins.super")
-    @freeze_time("2000-03-15")
-    def test_clean_switches_date_fields_if_todate_is_less_than_fromdate(
-        self, mock_super, mock_init
-    ):
-        mock_init.return_value = None
-        to_date = datetime.date(2000, 3, 15)
-        from_date = to_date + datetime.timedelta(days=1)
-
-        form = FilterableListForm()
-        mock_super().clean.return_value = {
-            "from_date": from_date,
-            "to_date": to_date,
-        }
-        form.cleaned_data = {"from_date": from_date, "to_date": to_date}
-        form.data = {"from_date": "3/16/2000", "to_date": "3/15/2000"}
-        form._errors = {}
-
-        result = form.clean()
-        assert result["from_date"] == to_date
-        assert result["to_date"] == from_date
+    def test_clean_switches_date_fields_if_todate_is_less_than_fromdate(self):
+        self.check_date_fields(
+            data={
+                "from_date": "2017-07-05",
+                "to_date": "2017-07-04",
+            },
+            expected_from_date=date(2017, 7, 4),
+            expected_to_date=date(2017, 7, 5),
+        )
 
 
-class TestFilterableDateField(TestCase):
+class TestFilterableDateField(SimpleTestCase):
     def test_default_required(self):
         field = FilterableDateField()
         self.assertFalse(field.required)


### PR DESCRIPTION
The Python unit tests for FilterableListForm currently patch the `builtins.super` function which can break unit tests when run in a reverse or unpredictable order.

This PR updates those tests to avoid the need to patch super while still continuing to test the same functionality. I also removed an unused `set_field_html_name` method whose only use was removed in 2019 in 934a39791d10041e8142517ef3cb6feb787d541e.

## How to test this PR

All tests continue to pass with the same coverage (actually slightly increased due to removal of unused code). 

## Notes and todos

This is a followup to #8461 which removed the only other patching of `builtins.super` in the codebase.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)