### PR TITLE
Remove broken highlight from homepage

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -10,23 +10,6 @@
     "is_jumbo": true
 } -%}
 
-{%- set inkwell = {
-    "infounits": [
-        {
-            "heading": "We enforce",
-            "content": "We’ve taken action against predatory companies and practices, returning billions of dollars to harmed consumers.",
-        },
-        {
-            "heading": "We educate",
-            "content": "We help consumers build the skills they need to take control of their finances and plan for the future.",
-        },
-        {
-            "heading": "We empower",
-            "content": "Our tools and resources help consumers make informed decisions through every step of their financial journey.",
-        },
-    ],
-} -%}
-
 {%- set answers_heading = "Find answers to your money questions" -%}
 
 {%- set topics = {
@@ -62,13 +45,6 @@
 <!-- {%- set highlights_heading = "Bureau highlights" -%} -->
 
 {%- set highlights = [
-    {
-        "img_src": static( "apps/homepage/img/putting-green_finances-covid.png" ),
-        "card_type": "highlight",
-        "heading": "Help with finances during the COVID-19 pandemic",
-        "link_text": "Get help",
-        "link_url": "/coronavirus/"
-    },
     {
         "img_src": static( "apps/homepage/img/putting-green_housing-counselor.png" ),
         "card_type": "highlight",

--- a/cfgov/v1/jinja2/v1/home_page/home_page.html
+++ b/cfgov/v1/jinja2/v1/home_page/home_page.html
@@ -27,7 +27,7 @@ content__main--flush-inner
             <div class="o-info-unit-group">
                 <div class="content-l">
                     {% for highlight in hardcoded.highlights %}
-                    <div class="content-l__col content-l__col-1-3">
+                    <div class="content-l__col content-l__col-1-2">
                         <div class="m-info-unit">
                             <div style="padding-bottom:.25em;">
                                 <img style="max-height:2.5em;" src="{{ highlight.img_src }}" alt="" width="60" height="40">

--- a/cfgov/v1/jinja2/v1/home_page/home_page_legacy.html
+++ b/cfgov/v1/jinja2/v1/home_page/home_page_legacy.html
@@ -26,18 +26,6 @@
         {% include "v1/includes/molecules/hero.html" with context %}
     {% endwith %}
 
-    {% with value = hardcoded.features %}
-        <section class="wrapper
-                        wrapper--match-content
-                        block
-                        block--bg
-                        block--border
-                        block--flush-top
-                        u-mb0"
-        >
-            {% include "v1/includes/organisms/info-unit-group.html" with context %}
-        </section>
-    {% endwith %}
 {% endblock %}
 
 {% block content_main %}


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
Right now one of the three highlights under the hero on the homepage links to page that no longer exists. This PR removes that highlight entirely and modifies the template HTML so that the two remaining items are spaced properly.

For similar reasons (broken/outdated links), this PR removes both "feature" items on the Spanish homepage.

---


## How to test this PR

1. localhost
2. view `/`
3. view `/es`


## Screenshots
| Before | After |
| - | - |
| <img width="1279" alt="Screenshot 2024-06-11 at 11 50 42 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/d4c38b45-1321-4787-8302-1dd883bd5faa"> | <img width="1243" alt="Screenshot 2024-06-11 at 11 50 49 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/3605a884-5a60-4d06-9794-4ec1436aa477"> |

## Notes and todos

- A replacement for that highlight page is in development; once it's live, we'll have a follow-up to this PR restoring the three-column layout and adding that third highlight back.
