### PR TITLE
Fix incorrect use of HttpRequest in Ask CFPB tests

### DIFF
--- a/cfgov/ask_cfpb/tests/test_hooks.py
+++ b/cfgov/ask_cfpb/tests/test_hooks.py
@@ -32,7 +32,7 @@ class TestAskHooks(TestCase):
 
     def test_create_answer_id_english(self):
         """Test that English page creation generates an Ask ID and pages."""
-        request = HttpRequest
+        request = HttpRequest()
         request.user = self.user
         test_page = AnswerPage(slug="test-page", title="Test page")
         self.english_landing_page.add_child(instance=test_page)
@@ -48,7 +48,7 @@ class TestAskHooks(TestCase):
 
     def test_create_answer_id_spanish(self):
         """Test that Spanish page creation generates an Ask ID and pages."""
-        request = HttpRequest
+        request = HttpRequest()
         request.user = self.user
         test_page = AnswerPage(
             slug="spanish-page-1", title="Spanish page 1", language="es"


### PR DESCRIPTION
These Ask CFPB tests are trying to create an HttpRequest for a specific user, but instead of creating a new instance and modifying it, they modify the HttpRequest class itself.

This has side effects for other Python unit tests that need to use HttpRequest objects, because they always get the user that was assigned here.

## How to test this PR

All tests continue to pass.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)