### PR TITLE
Fix search index updates for AbstractFilterPages

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -181,22 +181,28 @@ class WagtailSignalProcessor(BaseSignalProcessor):
     Wagtail events and calls the appropriate signals to update the search
     index.
 
-    It also translates the `instance` object that gets passed by Wagtail
-    signal handlers into its `instance.specific` equivalent for any
-    downstream logic that depends on the specific page type.
+    It also translates the `instance` Page object that gets passed by Wagtail
+    signal handlers into its AbstractFilterPage equivalent (if it so inherits)
+    to ensure that the filterable page search index is properly updated.
     """
 
-    def handle_delete(self, sender, instance, **kwargs):
-        if isinstance(instance, Page):
-            instance = instance.specific
+    def check_afp(self, instance):
+        # If the provided instance is a Wagtail page instance that inherits
+        # from AbstractFilterPage, convert it to an AFP instance.
+        from v1.models import AbstractFilterPage
 
-        super().handle_delete(sender, instance, **kwargs)
+        if isinstance(instance, Page) and issubclass(
+            instance.specific_class, AbstractFilterPage
+        ):
+            instance = AbstractFilterPage.objects.get(pk=instance.pk)
+
+        return instance
+
+    def handle_delete(self, sender, instance, **kwargs):
+        super().handle_delete(sender, self.check_afp(instance), **kwargs)
 
     def handle_save(self, sender, instance, **kwargs):
-        if isinstance(instance, Page):
-            instance = instance.specific
-
-        super().handle_save(sender, instance, **kwargs)
+        super().handle_save(sender, self.check_afp(instance), **kwargs)
 
     def setup(self):
         page_published.connect(self.handle_save)

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -38,6 +38,12 @@ class FilterablePagesDocument(Document):
     products = fields.KeywordField()
     content = fields.TextField()
 
+    def update(self, thing, *args, **kwargs):
+        if isinstance(thing, AbstractFilterPage):
+            thing = thing.specific
+
+        return super().update(thing, *args, **kwargs)
+
     def get_queryset(self, *args, **kwargs):
         return AbstractFilterPage.objects.live().public().specific()
 


### PR DESCRIPTION
We have a bug whereby AbstractFilterPage deletes (and, presumably, updates) don't get reflected in the filterable list search index. This happens because of some logic around Wagtail specific page types; see internal
https://github.local/Design-Development/Design-and-Content-Team/issues/471 for details.

Our current code hooks up Wagtail Page save/delete events to django-opensearch-dsl save/delete handlers but, before passing along the events, casts AbstractFilterPage instances to their specific page type. This prevents the d-o-d logic from actually updating the search index because it can't associate a specific page model type with any particular document/index.

With this change, we do two things:

1. Ensure that pages are cast to their AbstractFilterPage versions, thus ensuring that d-o-d knows how to index them.
2. Modify FilterablePagesDocument.update() so that, at the moment we are trying to update the search index, we ensure that we are using the most specific version of the page.

## Notes and todos

This approach does have one drawback which is that it prevents us from, theoretically, having some other d-o-d search index for a more specific page type. It would definitely be nicer if d-o-d supported inherited model types and thus knew to update the AbstractFilterPage index when a BlogPage is updated. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)