### PR TITLE
Video Player: Remove `grid__wrapper`

### DIFF
--- a/cfgov/unprocessed/css/organisms/video-player.less
+++ b/cfgov/unprocessed/css/organisms/video-player.less
@@ -219,10 +219,7 @@ button.o-video-player__play-btn,
   right: 0;
   left: auto;
 
-  .grid__wrapper();
-
-  padding-top: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
-  padding-bottom: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
+  padding: unit(@grid_gutter-width / 2 / @base-font-size-px, em);
   color: var(--white);
 
   .m-social-media__heading {


### PR DESCRIPTION
The `grid__wrapper` mixin has these rules:

```css
  max-width: (@grid_wrapper-width - @grid_gutter-width);
  padding-right: (@grid_gutter-width / 2);
  padding-left: (@grid_gutter-width / 2);
  margin: 0 auto;
  clear: both;
```


Where `@grid_wrapper-width` is 1230px and  `@grid_gutter-width` is 30px;
https://github.com/cfpb/design-system/blob/6b566bdb7ae2ce4c80a1cd05404bf3ea2e8fe6fa/packages/cfpb-grid/src/cfpb-grid.less#L20

It appears the only aspect of these rules that the video player actually uses is the left and right padding, which is the same as the top and bottom padding. This PR replaces the `grid__wrapper()` with padding.

## Changes

- Video Player: replace the `grid__wrapper()` mixin with padding.


## How to test this PR

1. Check that when playing, across screen sizes, that our various video layouts are unchanged, such as:

http://localhost:8000/about-us/blog/hidden-cost-junk-fees-zh/
http://localhost:8000/about-us/blog/the-cfpb-is-here-to-help-consumers-facing-housing-insecurity/
http://localhost:8000/consumer-tools/educator-tools/your-money-your-goals/videos/paying-bills-and-saving/
http://localhost:8000/language/zh/
http://localhost:8000/rules-policy/tenant-background-checks/

Some videos open the video in a new window, but still have the controls in the markup (though they aren't shown)"
http://localhost:8000/about-us/events/archive-past-events/special-populations-presentation/
http://localhost:8000/know-before-you-owe/
