### PR TITLE
Remove `.m-inset__test` class

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.less
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.less
@@ -63,10 +63,5 @@
     .m-full-width-text + .m-inset__image + .m-full-width-text {
       margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
     }
-
-    .m-full-width-text + .m-inset__test,
-    .m-full-width-text + .m-inset__test + .m-full-width-text {
-      margin-top: unit( @grid_gutter-width / 2 / @base-font-size-px, em );
-    }
   });
 }


### PR DESCRIPTION
This was added in https://github.com/cfpb/consumerfinance.gov/pull/2810 and should have been removed in https://github.com/cfpb/consumerfinance.gov/pull/7606

## Removals

- Remove `.m-inset__test` class


## How to test this PR

1. PR checks should pass.
