### PR TITLE
Properly BEMify `m-inset--email`

### DIFF
--- a/cfgov/unprocessed/css/molecules/inset.less
+++ b/cfgov/unprocessed/css/molecules/inset.less
@@ -78,12 +78,18 @@
   }
 
   &--email {
+    // This originally was a block,
+    // so we override the 30px margin added by .full-width-text-group .m-inset.
+    margin-bottom: unit(
+      @grid_gutter-width * 2 / @base-font-size-px,
+      em
+    ) !important;
+
     // Tablet and above.
     .respond-to-min(@bp-sm-min, {
       box-sizing: border-box;
       width: 50%;
       padding-left: unit( @grid_gutter-width / @base-font-size-px, em );
-      float: right;
     });
   }
 }

--- a/cfgov/unprocessed/css/organisms/prefooter.less
+++ b/cfgov/unprocessed/css/organisms/prefooter.less
@@ -3,6 +3,9 @@
 //       our atomic rules.
 
 .o-prefooter {
+  // Clear any floating m-inset that may be above this.
+  clear: both;
+
   margin-top: unit(((@grid_gutter-width * 2) / @base-font-size-px), em);
   margin-bottom: 0;
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/full-width-text.html
@@ -36,7 +36,7 @@
                 {{ block | safe }}
             </div>
         {% elif block_type in ['email_signup'] %}
-            <div class="block{{ " block--flush-top" if loop.first }} m-inset--email">
+            <div class="m-inset m-inset--email">
                 <div class="o-well">
                     {% include_block block %}
                 </div>


### PR DESCRIPTION
## Changes

- Add `m-inset` to accompany orphan `m-inset--email`
- Add bottom margin to `m-inset--email` to mimic block spacing.
- Remove `float: right` on `m-inset--email`, since that's already set on `m-inset`.
- Add clear float to `o-prefooter`, to clear any floats above the prefooter.



## How to test this PR

1. Crawler search for pages is `?q=m-inset--email&search_type=html`. For example:
http://localhost:8000/compliance/compliance-resources/mortgage-resources/loan-origination-rule/
http://localhost:8000/compliance/compliance-resources/signup/
http://localhost:8000/compliance/compliance-resources/consumer-cards-resources/credit-card-penalty-fees/

In some cases, the inset is below the heading because of the top margin of the block that was there, so in this PR the inset moves up to be in line with the heading. This seems acceptable, since some of the pages have insets that are already aligned with their associated section heading, so this makes it more consistent.


## Screenshots
 Before:
 
<img width="1118" alt="Screenshot 2024-06-13 at 5 58 28 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/5193971d-1485-4e14-bb45-a799ba171761">

After:

<img width="1111" alt="Screenshot 2024-06-13 at 5 58 37 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/1eed2f41-bff7-432e-9307-be672254b0dd">

---


 Before:
  
<img width="948" alt="Screenshot 2024-06-13 at 5 50 05 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/f894dfbf-05ca-4874-9562-1571611dbecb">

After:
<img width="972" alt="Screenshot 2024-06-13 at 5 50 20 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/4ab1ceac-7994-4ce5-bae9-56a0b8884fbb">

---

Before:
<img width="978" alt="Screenshot 2024-06-13 at 5 56 13 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/9b91befc-2f53-47b1-9bba-67f492a19386">

After **(this one gets kind of a gap now. The page should probably be edited in Wagtail to move the inset up)**:
https://www.consumerfinance.gov/compliance/compliance-resources/other-applicable-requirements/annual-percentage-rate-tables/
<img width="993" alt="Screenshot 2024-06-13 at 5 56 27 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/704760/2eec76c3-562c-465e-8b73-4a5ff601ec6e">


