### PR TITLE
Fix PostPreviewSnapshot rendering

### DIFF
--- a/cfgov/v1/models/sublanding_page.py
+++ b/cfgov/v1/models/sublanding_page.py
@@ -5,10 +5,13 @@ from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.fields import StreamField
 from wagtail.images.blocks import ImageChooserBlock
 
+from jinja2 import pass_context
+
 from jobmanager.blocks import JobListingList
 from v1.atomic_elements import molecules, organisms
 from v1.models.base import CFGOVPage
 from v1.models.learn_page import AbstractFilterPage
+from v1.serializers import FilterPageSerializer
 
 
 class SublandingPage(CFGOVPage):
@@ -107,7 +110,8 @@ class SublandingPage(CFGOVPage):
 
     template = "v1/sublanding-page/index.html"
 
-    def get_browsefilterable_posts(self, limit):
+    @pass_context
+    def get_browsefilterable_posts(self, context, limit):
         filter_pages = [
             p.specific
             for p in self.get_appropriate_descendants()
@@ -122,9 +126,12 @@ class SublandingPage(CFGOVPage):
                 )
             )
 
-        return sorted(
+        pages = sorted(
             posts_list, key=lambda p: p.date_published, reverse=True
         )[:limit]
+
+        serializer = FilterPageSerializer(pages, many=True, context=context)
+        return serializer.data
 
     @property
     def has_hero(self):


### PR DESCRIPTION
Commit 942be7067d9a0d6009d7328244a5ce6ecb4dddbf broke rendering of PostPreviewSnapshots because the post preview template now expects a serialized version of pages, not the page objects themselves.

I've updated the relevant code and added a new regression test that actually renders the PPS template, something we lacked before.

## How to test this PR

To test, run a local server and visit

http://localhost:8000/compliance/amicus/
http://localhost:8000/rules-policy/notice-opportunities-comment/

These pages now once again render properly.

## Notes and todos

It's strange and suboptimal that SublandingPages with PostPreviewSnapshots don't use the same page search approach that regular FilterableLists do. For example, [this page](https://www.consumerfinance.gov/compliance/amicus/) looks like a FilterableList but under the hood it's using [this](https://github.com/cfpb/consumerfinance.gov/blob/942be7067d9a0d6009d7328244a5ce6ecb4dddbf/cfgov/v1/models/sublanding_page.py#L110) `get_browsefilterable_posts` method that does a direct database query (with some smelly logic) instead of querying the page search index. Is there any reason why we shouldn't try to unify this code? Ping @csebianlander for any thoughts.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)