### PR TITLE
BAH/OAH: Move rate explorer to content--2-1 layout

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -33,7 +33,7 @@ home price, down payment, and more can affect mortgage interest rates.
     </div>
 
     <div class="block block--flush-top u-js-only">
-        <div class="rate-checker content">
+        <div class="rate-checker content content--2-1">
             <section class="page-intro content-l">
                 <div class="content-l__col content-l__col-2-3">
                     <h1>Explore interest rates</h1>
@@ -64,7 +64,157 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
                 <!-- /.content-l__col-1-3 -->
             </section>
-            <div class="calculator content-l" aria-controls="rate-results">
+
+            <div class="rc-results content__main" id="rate-results" aria-live="polite">
+                <h2 id="rc-summary" class="rate-checker-heading data-enabled clear">In <strong class="location"></strong>, most lenders in our data are offering rates at or below <strong class="rate" id="median-rate"></strong>.</h2>
+                <div id="accessible-data-results" class="u-visually-hidden">
+                    <h3>Data table</h3>
+                    <p>The following table will populate with our data results</p>
+                    <table id="accessible-data">
+                        <tr class="table-head">
+                            <th>Loan Rates</th>
+                        </tr>
+                        <tr class="table-body">
+                            <td>number of corresponding rates</td>
+                        </tr>
+                    </table>
+                </div>
+                <section id="chart-section" class="chart">
+                    <div class="chart-menu">
+                        <button class="chart-menu__btn">
+                            Download chart
+                            {{ svg_icon('download') }}
+                        </button>
+                        <ul class="chart-menu__options">
+                            <li>PNG</li>
+                            <li>SVG</li>
+                            <li>JPEG</li>
+                            <li>Print chart</li>
+                        </ul>
+                    </div>
+                    <figure class="data-enabled loading">
+                        <div id="chart" class="chart-area"></div>
+                        <figcaption class="chart-caption">
+                            <div class="caption-title">
+                                Interest rates for your situation
+                            </div>
+                            <div class="rc-data-link">
+                                <a href="#about" class="u-link-underline">Read about our data source</a>
+                            </div>
+                        </figcaption>
+                    </figure>
+
+                    {# Alert Shown when there are no results. #}
+                    {# TODO: Look into using the default notification macro #}
+                    <div id="chart-result-alert"
+                            class="result-alert
+                                m-notification
+                                m-notification--error"
+                            role="alert">
+                        {{ svg_icon('error-round') }}
+                        <div class="m-notification__content">
+                            <div class="m-notification__message">We're sorry!</div>
+                            <p class="m-notification__explanation">
+                                Based on the information you entered,
+                                we don't have enough data to display results.
+                                Change your settings or
+                                <a id="reload-link" class="defaults-link" href="">
+                                    revert to our default values.
+                                </a>
+                            </p>
+                        </div>
+                    </div>
+                    {# Alert Shown when there was an API failure. #}
+                    <div id="chart-fail-alert"
+                            class="result-alert
+                                m-notification
+                                m-notification--error"
+                            role="alert">
+                        {{ svg_icon('error-round') }}
+                        <div class="m-notification__content">
+                            <div class="m-notification__message">We're sorry!</div>
+                            <p class="m-notification__explanation">
+                                <strong>We're sorry!</strong>
+                                We're having trouble connecting to our data.<br>
+                                Try again another time.
+                            </p>
+                        </div>
+                    </div>
+                </section>
+                <p id="timestamp-p" class="data-enabled timestamp-message clear">These rates are current as of <strong id="timestamp">…</strong>.</p>
+                <section class="compare data-enabled loading">
+                    <h3>
+                    Explore what a lower interest rate means for your wallet</h2>
+                    <div id="rate-selects">
+                        <label for="rate-compare-1">Rate 1</label>
+                        <div class="rc-comp-3">
+                            <div class="a-select">
+                                <select name="rate-compare-1"
+                                        id="rate-compare-1"
+                                        class="rate-compare">
+                                    <option value="1">1%</option>
+                                </select>
+                            </div>
+                        </div>
+                        <!-- /.select-content-->
+                        <div class="rc-comp-1 vs">
+                            vs.
+                        </div>
+                        <label for="rate-compare-2">Rate 2</label>
+                        <div class="rc-comp-3">
+                            <div class="a-select">
+                                <select name="rate-compare-2" id="rate-compare-2" class="rate-compare">
+                                    <option value="1">1%</option>
+                                </select>
+                            </div>
+                        </div>
+                        <!-- /.select-content-->
+                        <div class="rc-comp-5 mobi-no">
+                            <p>Interest is only one of many costs associated with getting a mortgage. <a href="/ask-cfpb/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan-en-153/" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
+                        </div>
+                    </div>
+                    <!-- /.rate-selects -->
+                    <div class="rc-comparison-section rc-comparison-short">
+                        <h4 class="rc-comparison-subhead">Interest costs over the first <span class="loan-years">5</span> years</h4>
+                        <div class="rc-comparison-subsection">
+                            <div class="interest-cost interest-cost-primary rc-comp-3">
+                                <span class="new-cost">$150,000</span>
+                            </div>
+                            <div class="interest-cost interest-cost-secondary rc-comp-3-push">
+                                <span class="new-cost">$150,000</span>
+                            </div>
+                            <div class="interest-summary rc-comp-5" id="rc-comparison-summary-short">
+                                <p>Over the first <span class="comparison-term">5</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
+                            </div>
+                        </div>
+                        <!-- /.rc-comparison-subsection -->
+                    </div>
+                    <!-- /.rc-comparison-section -->
+                    <div class="rc-comparison-section rc-comparison-long">
+                        <h4 class="rc-comparison-subhead">
+                        Interest costs over <span class="loan-years">30</span> years</h5>
+                        <div class="rc-comparison-subsection">
+                            <div class="interest-cost interest-cost-primary rc-comp-3">
+                                <span class="new-cost no-arm">$150,000</span>
+                                <span class="arm-info u-hidden">Can change</span>
+                            </div>
+                            <div class="interest-cost interest-cost-secondary rc-comp-3-push">
+                                <span class="new-cost no-arm">$150,000</span>
+                                <span class="arm-info u-hidden">Can change</span>
+                            </div>
+                            <div class="interest-summary rc-comp-5" id="rc-comparison-summary-long">
+                                <p class="no-arm">Over <span class="comparison-term">30</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
+                                <p class="arm-info u-hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
+                            </div>
+                        </div>
+                        <!-- /.rc-comparison-subsection -->
+                        <p class="mobi-yes u-mt30">Interest is only one of many costs associated with getting a mortgage. <a href="/ask-cfpb/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan-en-153/" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
+                    </div>
+                    <!-- /.rc-comparison-section -->
+                </section>
+            </div>
+            <!-- END .result -->
+            <div class="calculator content__sidebar" aria-controls="rate-results">
                 <section class="form-intro">
                     <h4>Explore rate options</h4>
                 </section>
@@ -313,155 +463,6 @@ home price, down payment, and more can affect mortgage interest rates.
                 </section>
             </div>
             <!-- END .calculator -->
-            <div class="rc-results" id="rate-results" aria-live="polite">
-                <h2 id="rc-summary" class="rate-checker-heading data-enabled clear">In <strong class="location"></strong>, most lenders in our data are offering rates at or below <strong class="rate" id="median-rate"></strong>.</h2>
-                <div id="accessible-data-results" class="u-visually-hidden">
-                    <h3>Data table</h3>
-                    <p>The following table will populate with our data results</p>
-                    <table id="accessible-data">
-                        <tr class="table-head">
-                            <th>Loan Rates</th>
-                        </tr>
-                        <tr class="table-body">
-                            <td>number of corresponding rates</td>
-                        </tr>
-                    </table>
-                </div>
-                <section id="chart-section" class="chart">
-                    <div class="chart-menu">
-                        <button class="chart-menu__btn">
-                            Download chart
-                            {{ svg_icon('download') }}
-                        </button>
-                        <ul class="chart-menu__options">
-                            <li>PNG</li>
-                            <li>SVG</li>
-                            <li>JPEG</li>
-                            <li>Print chart</li>
-                        </ul>
-                    </div>
-                    <figure class="data-enabled loading">
-                        <div id="chart" class="chart-area"></div>
-                        <figcaption class="chart-caption">
-                            <div class="caption-title">
-                                Interest rates for your situation
-                            </div>
-                            <div class="rc-data-link">
-                                <a href="#about" class="u-link-underline">Read about our data source</a>
-                            </div>
-                        </figcaption>
-                    </figure>
-
-                    {# Alert Shown when there are no results. #}
-                    {# TODO: Look into using the default notification macro #}
-                    <div id="chart-result-alert"
-                            class="result-alert
-                                m-notification
-                                m-notification--error"
-                            role="alert">
-                        {{ svg_icon('error-round') }}
-                        <div class="m-notification__content">
-                            <div class="m-notification__message">We're sorry!</div>
-                            <p class="m-notification__explanation">
-                                Based on the information you entered,
-                                we don't have enough data to display results.
-                                Change your settings or
-                                <a id="reload-link" class="defaults-link" href="">
-                                    revert to our default values.
-                                </a>
-                            </p>
-                        </div>
-                    </div>
-                    {# Alert Shown when there was an API failure. #}
-                    <div id="chart-fail-alert"
-                            class="result-alert
-                                m-notification
-                                m-notification--error"
-                            role="alert">
-                        {{ svg_icon('error-round') }}
-                        <div class="m-notification__content">
-                            <div class="m-notification__message">We're sorry!</div>
-                            <p class="m-notification__explanation">
-                                <strong>We're sorry!</strong>
-                                We're having trouble connecting to our data.<br>
-                                Try again another time.
-                            </p>
-                        </div>
-                    </div>
-                </section>
-                <p id="timestamp-p" class="data-enabled timestamp-message clear">These rates are current as of <strong id="timestamp">…</strong>.</p>
-                <section class="compare data-enabled loading">
-                    <h3>
-                    Explore what a lower interest rate means for your wallet</h2>
-                    <div id="rate-selects">
-                        <label for="rate-compare-1">Rate 1</label>
-                        <div class="rc-comp-3">
-                            <div class="a-select">
-                                <select name="rate-compare-1"
-                                        id="rate-compare-1"
-                                        class="rate-compare">
-                                    <option value="1">1%</option>
-                                </select>
-                            </div>
-                        </div>
-                        <!-- /.select-content-->
-                        <div class="rc-comp-1 vs">
-                            vs.
-                        </div>
-                        <label for="rate-compare-2">Rate 2</label>
-                        <div class="rc-comp-3">
-                            <div class="a-select">
-                                <select name="rate-compare-2" id="rate-compare-2" class="rate-compare">
-                                    <option value="1">1%</option>
-                                </select>
-                            </div>
-                        </div>
-                        <!-- /.select-content-->
-                        <div class="rc-comp-5 mobi-no">
-                            <p>Interest is only one of many costs associated with getting a mortgage. <a href="/ask-cfpb/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan-en-153/" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
-                        </div>
-                    </div>
-                    <!-- /.rate-selects -->
-                    <div class="rc-comparison-section rc-comparison-short">
-                        <h4 class="rc-comparison-subhead">Interest costs over the first <span class="loan-years">5</span> years</h4>
-                        <div class="rc-comparison-subsection">
-                            <div class="interest-cost interest-cost-primary rc-comp-3">
-                                <span class="new-cost">$150,000</span>
-                            </div>
-                            <div class="interest-cost interest-cost-secondary rc-comp-3-push">
-                                <span class="new-cost">$150,000</span>
-                            </div>
-                            <div class="interest-summary rc-comp-5" id="rc-comparison-summary-short">
-                                <p>Over the first <span class="comparison-term">5</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
-                            </div>
-                        </div>
-                        <!-- /.rc-comparison-subsection -->
-                    </div>
-                    <!-- /.rc-comparison-section -->
-                    <div class="rc-comparison-section rc-comparison-long">
-                        <h4 class="rc-comparison-subhead">
-                        Interest costs over <span class="loan-years">30</span> years</h5>
-                        <div class="rc-comparison-subsection">
-                            <div class="interest-cost interest-cost-primary rc-comp-3">
-                                <span class="new-cost no-arm">$150,000</span>
-                                <span class="arm-info u-hidden">Can change</span>
-                            </div>
-                            <div class="interest-cost interest-cost-secondary rc-comp-3-push">
-                                <span class="new-cost no-arm">$150,000</span>
-                                <span class="arm-info u-hidden">Can change</span>
-                            </div>
-                            <div class="interest-summary rc-comp-5" id="rc-comparison-summary-long">
-                                <p class="no-arm">Over <span class="comparison-term">30</span> years, an interest rate of <span class="higher-rate">1%</span> costs <strong class="rate-diff">$0</strong> more than an interest rate of <span class="lower-rate">1%</span>.</p>
-                                <p class="arm-info u-hidden">With the <strong>adjustable-rate mortgage</strong> you've chosen, the rate is only fixed for the <strong>first <span class="arm-comparison-term">5</span> years.</strong> Your interest costs in the future can change.</p>
-                            </div>
-                        </div>
-                        <!-- /.rc-comparison-subsection -->
-                        <p class="mobi-yes u-mt30">Interest is only one of many costs associated with getting a mortgage. <a href="/ask-cfpb/what-costs-will-i-have-to-pay-as-part-of-taking-out-a-mortgage-loan-en-153/" class="go-link" target="_blank" rel="noopener noreferrer">Learn more</a></p>
-                    </div>
-                    <!-- /.rc-comparison-section -->
-                </section>
-            </div>
-            <!-- END .result -->
             <section class="next-steps tabs-layout">
                 <h2><strong>Next steps:</strong> How to get the best interest rate on your mortgage</h2>
                 <!-- put into a container to prevent long line length -->

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -52,11 +52,6 @@
   /*
         layout
         --------------------------- */
-  .rc-results {
-    .grid__column( 8 );
-    .grid__pull( 4 );
-  }
-
   #credit-score-container,
   .loan-amt-total,
   .state-col,
@@ -68,9 +63,6 @@
         Sidebar with all the user input
        --------------------------- */
   .calculator {
-    .grid__column( 4 );
-    .grid__push( 8 );
-
     background: var(--gray-5);
 
     p:last-child,
@@ -503,13 +495,28 @@
   /*
         Media queries
         --------------------------- */
-  .respond-to-max(720px, {
+  // Tablet and below.
+  .respond-to-max(@bp-sm-max, {
+    display: grid;
+    grid-template-areas:
+      'page-intro'
+      'calculator'
+      'rc-results';
 
-    .calculator,
-    .rc-results {
-      .grid__column( 12 );
-      .grid__push( 0 );
+    .page-intro {
+      grid-area: page-intro
     }
+
+    .rc-results {
+      grid-area: rc-results;
+    }
+
+    .calculator {
+      grid-area: calculator;
+    }
+  });
+
+  .respond-to-max(720px, {
 
     .rc-home-illu {
       display: none;
@@ -578,12 +585,6 @@
   @media print {
     .rc-illu-inner {
       display: none;
-    }
-
-    .calculator,
-    .rc-results {
-      .grid__column( 12 );
-      .grid__push( 0 );
     }
 
     .calculator section {

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.less
@@ -63,6 +63,7 @@
         Sidebar with all the user input
        --------------------------- */
   .calculator {
+    padding-left: unit(10px / @base-font-size-px, rem);
     background: var(--gray-5);
 
     p:last-child,
@@ -93,7 +94,7 @@
     }
 
     section:first-child {
-      padding: unit(30px / @base-font-size-px, em) 0 0;
+      padding: 0;
     }
 
     .calc-footer {
@@ -160,7 +161,7 @@
         Main section with output
         --------------------------- */
   .rate-checker-heading {
-    margin-top: unit(20px / @base-font-size-px, em);
+    margin-right: unit(10px / @base-font-size-px, em);
     margin-bottom: unit(16px / @base-font-size-px, em);
     font-size: 1.375em;
   }
@@ -169,11 +170,22 @@
         Middle section with chart
         --------------------------- */
 
-  // this is shameful, but this is needed to force
-  // highcharts to display overflowing tooltips
+  // This is shameful, but this is needed to force
+  // highcharts to display overflowing tooltips.
   .chart-area,
   .highcharts-container {
     overflow: visible !important;
+  }
+
+  .chart-area {
+    // This matches the height of the highcharts chart.
+    min-height: 400px;
+  }
+
+  // This ensures the chart resizes when the page is resized.
+  .highcharts-container {
+    position: absolute !important;
+    width: 100% !important;
   }
 
   .highcharts-tooltip > span {


### PR DESCRIPTION
Remove use of `grid__pull` from the codebase, and `grid__push` from rate explorer (this is still used in PfC disclosures). 

The DOM changes are just swapping the DOM order and adding `content__main` and `content__sidebar` classes.


## Changes

- BAH/OAH: Move rate explorer to content--2-1 layout


## How to test this PR

1. `yarn build` and rate explorer should be (generally) unchanged in its layout. The calculator is slightly closer to the right-hand edge, but this is more correct as it aligns with the header items now.
