### PR TITLE
Fix index bug in author sorting method and display bug in item introduction

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/item-introduction.html
@@ -14,7 +14,7 @@
    value.show_category:    Whether to show the category or not.
    value.heading:          Heading text.
    value.paragraph.source: Body introduction text.
-   value.authors:          Array of author names and associated URLs.
+   value.authors:          Array of author names
 
    value.date:             A datetime for the post.
    value.has_social:       Whether to show the share icons or not.
@@ -59,7 +59,7 @@
             <span class="byline">
             {%- for author in page.get_authors() -%}
                 {% if loop.first %}By {% elif loop.last %}and {% endif %}
-                {{ author.name }}
+                {{ author }}
                 {%- if loop.length > 2 and loop.index < loop.length %}, {% endif %}
             {% endfor %}
                 &ndash;

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -198,7 +198,7 @@ class CFGOVPage(Page):
 
         def sorting(name):
             parts = name.rsplit(" ", 1)
-            return parts[1], parts[0]
+            return parts[0] if len(parts) == 1 else parts[1], parts[0]
 
         return sorted(
             [author.name for author in self.authors.all()], key=sorting

--- a/cfgov/v1/tests/models/test_author_names.py
+++ b/cfgov/v1/tests/models/test_author_names.py
@@ -9,6 +9,11 @@ class TestAuthorNames(TestCase):
         page.authors.add(*authors)
         self.assertEqual(page.get_authors(), expected)
 
+    def test_author_names_with_no_space(self):
+        self.check_authors(
+            ["Wyatt Pearsall", "CFPB"], ["CFPB", "Wyatt Pearsall"]
+        )
+
     def test_alphabetize_authors_by_last_name(self):
         self.check_authors(
             ["Ross Karchner", "Richa Agarwal", "Andy Chosak", "Will Barton"],


### PR DESCRIPTION
This crept in via https://github.com/cfpb/consumerfinance.gov/pull/8450 and is currently throwing 500s in prod

The visual bug:
<img width="818" alt="Screenshot 2024-06-15 at 11 09 49 AM" src="https://github.com/cfpb/consumerfinance.gov/assets/1558033/60295fc6-9e82-49ae-a35f-f46035f7d3cb">

And the 500 error is on any page with an author name without a space (usually `CFPB`)