### PR TITLE
TCCP: Design iteration

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -43,24 +43,26 @@
 
 <h1 class="u-mb45">{{ heading }}</h1>
 
-<div id="o-filterable-list-controls" class="o-filterable-list-controls u-cap-width">
-    {% call() expandable({
-        "label": "Customize card features",
-        "is_bordered": true,
-        "is_expanded": not situations or not cards,
-        "is_midtone": true
-    }) %}
-        {{ filter_form(form) }}
-    {% endcall %}
-</div>
-
-{% if not situations %}
 <div class="block block--sub">
     <p>
-        <a href="{{ url('tccp:landing_page') }}">Choose what you're looking for in a card</a>
+        <a href="{{ url('tccp:landing_page') }}">
+            Change what you're looking for in a card
+        </a>
     </p>
 </div>
-{% endif %}
+
+<div class="block block--sub">
+    <div id="o-filterable-list-controls" class="o-filterable-list-controls u-cap-width">
+        {% call() expandable({
+            "label": "Customize card features",
+            "is_bordered": true,
+            "is_expanded": not situations or not cards,
+            "is_midtone": true
+        }) %}
+            {{ filter_form(form) }}
+        {% endcall %}
+    </div>
+</div>
 
 <div class="block block--flush-top">
     <div class="o-filterable-list-results o-filterable-list-results--partial" id="htmx-results" aria-live="polite" aria-busy="false">

--- a/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
@@ -16,7 +16,7 @@
             Pay {{ label }} interest
 
             {% if apr_min is not none and apr_max is not none -%}
-                ({{- apr_range(apr_min, apr_max) -}})
+                ({{- apr_range(apr_min, apr_max, spaceless=true) -}})
             {%- endif %}
         </dd>
     </div>

--- a/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
+++ b/cfgov/tccp/jinja2/tccp/includes/apr_rating.html
@@ -1,4 +1,6 @@
-{%- macro apr_rating(rating, count=none) -%}
+{% from 'tccp/includes/fields.html' import apr_range %}
+
+{%- macro apr_rating(rating, apr_min=none, apr_max=none) -%}
     {%- set label = apr_rating_lookup[rating] -%}
 
     <div class="m-apr-rating m-apr-rating--{{ label }}">
@@ -12,15 +14,10 @@
         </dt>
         <dd>
             Pay {{ label }} interest
-            {{-
-                (
-                    ' ('
-                    ~ count
-                    ~ ' card'
-                    ~ count | pluralize()
-                    ~ ')'
-                ) if count is not none
-            }}
+
+            {% if apr_min is not none and apr_max is not none -%}
+                ({{- apr_range(apr_min, apr_max) -}})
+            {%- endif %}
         </dd>
     </div>
 {%- endmacro -%}

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -41,8 +41,8 @@
         Use the ratings to compare your results:
     </p>
     <dl>
-        {% for rating, rating_count in purchase_apr_rating_counts.items() %}
-            {{ apr_rating(rating, count=rating_count) }}
+        {% for rating, (apr_min, apr_max) in purchase_apr_rating_ranges.items() %}
+            {{ apr_rating(rating, apr_min=apr_min, apr_max=apr_max) }}
         {% endfor %}
     </dl>
 </div>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -4,22 +4,6 @@
 {% from 'tccp/includes/speed_bump.html' import speed_bump %}
 {% import 'v1/includes/molecules/notification.html' as notification %}
 
-{% if situation_features -%}
-<div class="block block--sub">
-    <h2>Cards you're looking for have these features:</h2>
-
-    <ul>
-        {% for feature in situation_features -%}
-        <li>{{ feature.results_html }}</li>
-        {%- endfor %}
-    </ul>
-
-    <p>
-        <a href="{{ url('tccp:landing_page') }}">Change what you're looking for in a card</a>
-    </p>
-</div>
-{%- endif %}
-
 <div class="u-cap-width">
 {% if count -%}
 {{- notification.render(
@@ -70,7 +54,7 @@
         <article class="m-card m-card--tabular{% if show_more %} u-show-more{% endif %}">
             <a href="{{ card.url }}">
                 <div class="m-card__heading-group">
-                    <h3 class="m-card__heading">{{ card.institution_name }}</h3>
+                    <h2 class="h3 m-card__heading">{{ card.institution_name }}</h2>
                     <p class="m-card__subtitle">{{ card.product_name }}</p>
                 </div>
                 <dl>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -1,6 +1,6 @@
 {% from 'tccp/includes/apr_rating.html' import apr_rating with context %}
 {% from 'tccp/includes/data_published.html' import data_published %}
-{% from 'tccp/includes/fields.html' import apr, apr_range, currency %}
+{% from 'tccp/includes/fields.html' import apr, apr_range, currency, date %}
 {% from 'tccp/includes/speed_bump.html' import speed_bump %}
 {% import 'v1/includes/molecules/notification.html' as notification %}
 
@@ -62,11 +62,17 @@
                 </dl>
                 <dl class="m-data-specs">
                     <div class="m-data-spec m-data-spec--apr">
-                        <dt><strong>Purchase APR</strong></dt>
+                        <dt>
+                            <strong>Purchase APR</strong>
+                            <div class="m-data-spec--apr-disclaimer">
+                                *As of {{ date(stats_all.first_report_date) }}
+                            </div>
+                        </dt>
                         <dd>
                             <strong>{{ apr_range(
                                 card.purchase_apr_for_tier_min,
-                                card.purchase_apr_for_tier_max
+                                card.purchase_apr_for_tier_max,
+                                asterisk=true
                             ) }}</strong>
                         </dd>
                     </div>
@@ -86,7 +92,8 @@
                             {%- if ordering_by == 'transfer_apr' -%}<strong>{%- endif -%}
                             {{- apr_range(
                                 card.transfer_apr_for_tier_min,
-                                card.transfer_apr_for_tier_max
+                                card.transfer_apr_for_tier_max,
+                                asterisk=true
                             ) -}}
                             {%- if ordering_by == 'transfer_apr' -%}</strong>{%- endif -%}
                         </dd>

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -1,12 +1,9 @@
-{%- import 'v1/includes/macros/time.html' as time -%}
+{% from 'tccp/includes/fields.html' import date %}
 
-{%- macro data_published(date, verbose=false) -%}
+{%- macro data_published(value, verbose=false) -%}
 
 <p class="u-small-text u-small-text--subtle">
-    Data as of
-    {{ time.render(
-        ensure_date(date), {"date": true}, text_format=true
-    ) }}
+    Data as of {{ date(value) }}
     ({{- 'credit card terms may have changed since then, double-check with the company
           for the most current terms or ' if verbose -}}
     <a href="{{ url('tccp:about') }}">{{ 'l' if verbose else 'L' }}earn about the data</a>)

--- a/cfgov/tccp/jinja2/tccp/includes/data_published.html
+++ b/cfgov/tccp/jinja2/tccp/includes/data_published.html
@@ -3,9 +3,8 @@
 {%- macro data_published(date, verbose=false) -%}
 
 <p class="u-small-text u-small-text--subtle">
-    Data reported
-    {{- ' directly by the company ' if verbose else ' ' -}}
-    on {{ time.render(
+    Data as of
+    {{ time.render(
         ensure_date(date), {"date": true}, text_format=true
     ) }}
     ({{- 'credit card terms may have changed since then, double-check with the company

--- a/cfgov/tccp/jinja2/tccp/includes/fields.html
+++ b/cfgov/tccp/jinja2/tccp/includes/fields.html
@@ -4,7 +4,7 @@
     {%- elif value == 0 -%}
         0%
     {%- else -%}
-        {{ ('%.2f%%' | format(value * 100)) }}
+        {{ ('%g%%' | format(value * 100)) }}
     {%- endif %}
 {%- endmacro -%}
 

--- a/cfgov/tccp/jinja2/tccp/includes/fields.html
+++ b/cfgov/tccp/jinja2/tccp/includes/fields.html
@@ -1,4 +1,4 @@
-{%- macro apr(value) -%}
+{%- macro apr(value, asterisk=asterisk) -%}
     {% if value is none -%}
         N/A
     {%- elif value == 0 -%}
@@ -6,17 +6,18 @@
     {%- else -%}
         {{ ('%g%%' | format(value * 100)) }}
     {%- endif %}
+    {%- if asterisk and value is not none %}*{% endif %}
 {%- endmacro -%}
 
-{%- macro apr_range(min, max, spaceless=false) -%}
+{%- macro apr_range(min, max, spaceless=false, asterisk=false) -%}
     {% if min == max -%}
-        {{ apr(min) }}
+        {{ apr(min, asterisk=asterisk) }}
     {%- else -%}
         {{ apr(min) }}
         {{- ' ' if not spaceless -}}
         &ndash;
         {{- ' ' if not spaceless }}
-        {{- apr(max) }}
+        {{- apr(max, asterisk=asterisk) }}
     {%- endif %}
 {%- endmacro -%}
 
@@ -26,6 +27,13 @@
         if value is not none and (value or not boolean)
         else (default if default is not none else "None")
     }}
+{%- endmacro -%}
+
+{%- macro date(value) -%}
+{%- import 'v1/includes/macros/time.html' as time -%}
+    {{ time.render(
+        ensure_date(value), {"date": true}, text_format=true
+    ) }}
 {%- endmacro -%}
 
 {%- macro lower_first_letter(s) -%}

--- a/cfgov/tccp/jinja2/tccp/includes/fields.html
+++ b/cfgov/tccp/jinja2/tccp/includes/fields.html
@@ -8,11 +8,15 @@
     {%- endif %}
 {%- endmacro -%}
 
-{%- macro apr_range(min, max) -%}
+{%- macro apr_range(min, max, spaceless=false) -%}
     {% if min == max -%}
         {{ apr(min) }}
     {%- else -%}
-        {{ apr(min) }} - {{ apr(max) }}
+        {{ apr(min) }}
+        {{- ' ' if not spaceless -}}
+        &ndash;
+        {{- ' ' if not spaceless }}
+        {{- apr(max) }}
     {%- endif %}
 {%- endmacro -%}
 

--- a/cfgov/tccp/jinja2/tccp/situations/results/avoid-fees.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/avoid-fees.html
@@ -1,1 +1,0 @@
-No annual, monthly, or weekly account fees.

--- a/cfgov/tccp/jinja2/tccp/situations/results/build-credit.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/build-credit.html
@@ -1,4 +1,0 @@
-Targeted for your credit score range.
-<a
-    href="/ask-cfpb/how-do-i-get-and-keep-a-good-credit-score-en-318/"
->Learn about ways to build credit and your credit score.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/earn-rewards.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/earn-rewards.html
@@ -1,1 +1,0 @@
-Offers rewards.

--- a/cfgov/tccp/jinja2/tccp/situations/results/make-a-big-purchase.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/make-a-big-purchase.html
@@ -1,4 +1,0 @@
-Lower than average interest rates.
-<a
-    href="/about-us/newsroom/cfpb-warns-credit-card-companies-against-deceptively-marketing-promotional-offers/"
->Learn about the risks of 0% offers.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest-make-a-big-purchase.html
@@ -1,8 +1,0 @@
-Lower than average interest rates.
-<a
-    href="/ask-cfpb/how-does-my-credit-card-company-calculate-the-amount-of-interest-i-owe-en-51/"
->Learn how APRs affect your monthly bill</a>
-and
-<a
-    href="/ask-cfpb/i-got-a-credit-card-promising-no-interest-for-a-purchase-if-i-pay-in-full-within-12-months-how-does-this-work-en-40/"
->about the risks of 0% offers</a>.

--- a/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/pay-less-interest.html
@@ -1,4 +1,0 @@
-Lower than average interest rates.
-<a
-    href="/ask-cfpb/how-does-my-credit-card-company-calculate-the-amount-of-interest-i-owe-en-51/"
->Learn how APRs affect your monthly bill.</a>

--- a/cfgov/tccp/jinja2/tccp/situations/results/transfer-a-balance.html
+++ b/cfgov/tccp/jinja2/tccp/situations/results/transfer-a-balance.html
@@ -1,3 +1,0 @@
-Low balance transfer interest rates.
-Cards designed to transfer a balance are generally available to
-consumers with good or great credit scores.

--- a/cfgov/tccp/management/commands/validate_tccp.py
+++ b/cfgov/tccp/management/commands/validate_tccp.py
@@ -10,9 +10,14 @@ from tccp.views import CardListView
 
 
 def fmt(value):
-    return (
-        ("%.2f%%" % (100 * value)) if isinstance(value, float) else str(value)
-    )
+    return ("%g%%" % (100 * value)) if isinstance(value, float) else str(value)
+
+
+def fmt_range(min, max):
+    if min == max:
+        return fmt(min)
+    else:
+        return f"{fmt(min)} - {fmt(max)}"
 
 
 class Command(BaseCommand):
@@ -70,19 +75,23 @@ class Command(BaseCommand):
 
             cards_for_tier = cards.for_credit_tier(tier_name)
 
-            purchase_apr_rating_counts = (
-                CardListView.get_purchase_apr_rating_counts(
-                    cards_for_tier.values("purchase_apr_for_tier_rating")
+            purchase_apr_rating_ranges = (
+                CardListView.get_purchase_apr_rating_ranges(
+                    cards_for_tier.values(
+                        "purchase_apr_for_tier_max",
+                        "purchase_apr_for_tier_rating",
+                    )
                 )
             )
 
-            # Write out counts for each rating label.
+            # Write out ranges for each rating label.
             for (
                 rating,
-                rating_count,
-            ) in purchase_apr_rating_counts.items():
+                (rating_apr_min, rating_apr_max),
+            ) in purchase_apr_rating_ranges.items():
                 self.stdout.write(
-                    f"{apr_rating_lookup[rating]}: {rating_count}"
+                    f"{apr_rating_lookup[rating]}: "
+                    + fmt_range(rating_apr_min, rating_apr_max)
                 )
 
             self.stdout.write()

--- a/cfgov/tccp/situations.py
+++ b/cfgov/tccp/situations.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass, field
 from itertools import chain
-from operator import attrgetter
 
 from django.template import loader
 from django.utils.safestring import mark_safe
@@ -29,10 +28,6 @@ class Situation:
     @property
     def select_html(self):
         return self.render("select")
-
-    @property
-    def results_html(self):
-        return self.render("results")
 
     @classmethod
     def get_nonconflicting_params(cls, situations):
@@ -182,31 +177,6 @@ SituationChoices = [(situation, situation.title) for situation in SITUATIONS]
 
 def get_situation_by_title(title):
     return {v: k for k, v in SituationChoices}[title]
-
-
-class SituationFeatures:
-    def __init__(self, situations):
-        # Each selected situation normally displays one feature to the user,
-        # but if multiple are selected we may want to combine them.
-        combos = [("Pay less interest", "Make a big purchase")]
-
-        for combo in combos:
-            if set(combo).issubset(set(map(attrgetter("title"), situations))):
-                situations = [
-                    # Create a fake situation identified by the concatenation
-                    # of the titles of the situations being combined.
-                    Situation(title=" ".join(combo)),
-                    # Remove the situations that were combined.
-                    *(s for s in situations if s.title not in combo),
-                ]
-
-        self.situations = situations
-
-    def __bool__(self):
-        return bool(self.situations)
-
-    def __iter__(self):
-        return self.situations.__iter__()
 
 
 class SituationSpeedBumps:

--- a/cfgov/tccp/tests/test_situations.py
+++ b/cfgov/tccp/tests/test_situations.py
@@ -1,5 +1,3 @@
-from itertools import product
-
 from django.test import SimpleTestCase
 
 from tccp.situations import (

--- a/cfgov/tccp/tests/test_situations.py
+++ b/cfgov/tccp/tests/test_situations.py
@@ -5,7 +5,6 @@ from django.test import SimpleTestCase
 from tccp.situations import (
     SITUATIONS,
     Situation,
-    SituationFeatures,
     SituationSpeedBumps,
     get_situation_by_title,
 )
@@ -49,34 +48,9 @@ class SituationTests(SimpleTestCase):
 
 class SituationContentTests(SimpleTestCase):
     def test_situation_content(self):
-        for situation, content in product(SITUATIONS, ["select", "results"]):
-            with self.subTest(title=situation.title, content=content):
-                self.assertTrue(getattr(situation, f"{content}_html"))
-
-
-class SituationFeatureTests(SimpleTestCase):
-    def test_no_combinations(self):
-        features = SituationFeatures(
-            [
-                Situation("Pay less interest"),
-                Situation("Foo"),
-            ]
-        )
-        self.assertSequenceEqual(
-            [s.title for s in features], ["Pay less interest", "Foo"]
-        )
-
-    def test_combination(self):
-        features = SituationFeatures(
-            [
-                Situation("Pay less interest"),
-                Situation("Make a big purchase"),
-            ]
-        )
-        self.assertSequenceEqual(
-            [s.title for s in features],
-            ["Pay less interest Make a big purchase"],
-        )
+        for situation in SITUATIONS:
+            with self.subTest(title=situation.title):
+                self.assertTrue(situation.select_html)
 
 
 class SituationSpeedBumpTests(SimpleTestCase):

--- a/cfgov/tccp/tests/test_validate.py
+++ b/cfgov/tccp/tests/test_validate.py
@@ -4,12 +4,21 @@ import tempfile
 from io import StringIO
 
 from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from tccp.enums import CreditTierColumns
+from tccp.management.commands.validate_tccp import fmt_range
 from tccp.models import CardSurveyData
 
 from .baker import baker
+
+
+class TestValidationFormatting(SimpleTestCase):
+    def test_fmt_single_value(self):
+        self.assertEqual(fmt_range(0.1235, 0.1235), "12.35%")
+
+    def test_fmt_range(self):
+        self.assertEqual(fmt_range(0.1235, 0.5), "12.35% - 50%")
 
 
 class TestValidation(TestCase):
@@ -75,14 +84,14 @@ class TestValidation(TestCase):
 CREDIT SCORE 619 OR LESS
 ------------------------
 Count: 1
-Minimum: 10.00%
-Maximum: 10.00%
-25th percentile: 10.00%
-75th percentile: 10.00%
+Minimum: 10%
+Maximum: 10%
+25th percentile: 10%
+75th percentile: 10%
 
-less: 0
-average: 0
-more: 1
+less: None
+average: None
+more: 10%
 
 Pay less interest: 1
 Transfer a balance: 1
@@ -94,14 +103,14 @@ Earn rewards: 1
 CREDIT SCORES FROM 620 TO 719
 -----------------------------
 Count: 3
-Minimum: 10.00%
-Maximum: 30.00%
-25th percentile: 15.00%
-75th percentile: 25.00%
+Minimum: 10%
+Maximum: 30%
+25th percentile: 15%
+75th percentile: 25%
 
-less: 1
-average: 1
-more: 1
+less: 10%
+average: 20%
+more: 30%
 
 Pay less interest: 3
 Transfer a balance: 3
@@ -113,14 +122,14 @@ Earn rewards: 3
 CREDIT SCORE OF 720 OR GREATER
 ------------------------------
 Count: 3
-Minimum: 10.00%
-Maximum: 30.00%
-25th percentile: 15.00%
-75th percentile: 25.00%
+Minimum: 10%
+Maximum: 30%
+25th percentile: 15%
+75th percentile: 25%
 
-less: 1
-average: 1
-more: 1
+less: 10%
+average: 20%
+more: 30%
 
 Pay less interest: 3
 Transfer a balance: 3

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -1,4 +1,4 @@
-from operator import attrgetter, itemgetter
+from operator import attrgetter
 from urllib.parse import urlencode
 
 from django.shortcuts import redirect, reverse
@@ -19,7 +19,7 @@ from .forms import LandingPageForm
 from .jinja2tags import render_contact_info
 from .models import CardSurveyData
 from .serializers import CardSurveyDataListSerializer, CardSurveyDataSerializer
-from .situations import Situation, SituationFeatures, SituationSpeedBumps
+from .situations import Situation, SituationSpeedBumps
 
 
 class LandingPageView(FlaggedTemplateView):
@@ -157,7 +157,6 @@ class CardListView(FlaggedViewMixin, ListAPIView):
                     "breadcrumb_items": self.breadcrumb_items,
                     "form": form,
                     "situations": situations,
-                    "situation_features": SituationFeatures(situations),
                     "speed_bumps": SituationSpeedBumps(situations),
                     "purchase_apr_rating_ranges": purchase_apr_rating_ranges,
                     "apr_rating_lookup": dict(enums.PurchaseAPRRatings),

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -280,6 +280,15 @@
     grid-area: apr;
   }
 
+  &--apr-disclaimer {
+    font-size: unit((14px / @base-font-size-px), rem);
+
+    .respond-to-min(@bp-sm-min, {
+      font-size: unit((16px / @base-font-size-px), rem);
+      line-height: unit((22px / @base-font-size-px), rem);
+    });
+  }
+
   &--fee {
     grid-area: fee;
   }


### PR DESCRIPTION
This commit modifies the TCCP landing view in these ways:

- Remove "Cards your looking for have these features" and dynamic bullets
  - Keep link "Change what you're looking for in a card" above filter
- Add APR ranges to key
- Update content of "Data reported on Dec. 31, 2023..." to "Data as of Dec. 31, 2023. Learn about the data"
- Add asterisk to purchase APR and balance transfer APR
- Add disclaimer under "Purchase APR" label that displays date of reporting that says "*As of Month, XX, XXXX"

See internal https://github.local/Design-Development/Design-Thinking-and-User-Research/issues/334 for context.

## How to test this PR

To test, run a local server and visit http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/.

## Screenshots

<img width="354" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/9b3b84c8-8d0d-4a15-997f-c66c3ff79141">

<img width="477" alt="image" src="https://github.com/cfpb/consumerfinance.gov/assets/654645/990fd991-a2d4-426b-a9e5-dcd653c9d1a6">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)