### PR TITLE
Cache SVG icons in memory

### DIFF
--- a/cfgov/core/templatetags/svg_icon.py
+++ b/cfgov/core/templatetags/svg_icon.py
@@ -23,7 +23,7 @@ SVG_REGEX = re.compile(
 )
 
 
-def load_svg(name: str) -> str:
+def load_svg_from_file(name: str) -> str:
     relative_path = f"icons/{name}.svg"
     if not (static_filename := finders.find(relative_path)):
         raise FileNotFoundError(f"{relative_path} not found in staticfiles.")
@@ -32,7 +32,22 @@ def load_svg(name: str) -> str:
         content = f.read()
         if not SVG_REGEX.match(content):
             raise ValueError(f"{static_filename} not a valid SVG.")
+
     return content
+
+
+_SVG_ICON_CACHE = {}
+
+
+def load_svg(name: str) -> str:
+    try:
+        return _SVG_ICON_CACHE[name]
+    except KeyError:
+        pass
+
+    svg = load_svg_from_file(name)
+    _SVG_ICON_CACHE[name] = svg
+    return svg
 
 
 @register.simple_tag()

--- a/cfgov/core/tests/templatetags/test_svg_icon.py
+++ b/cfgov/core/tests/templatetags/test_svg_icon.py
@@ -68,6 +68,11 @@ class SvgIconTests(TestCase):
         template = Template('{% load svg_icon %}{% svg_icon "test" %}')
         self.assertEqual(template.render(Context()), VALID_SVG)
 
+    @patch("core.templatetags.svg_icon._SVG_ICON_CACHE", {"test": "cached"})
+    def test_caching(self):
+        template = Template('{% load svg_icon %}{% svg_icon "test" %}')
+        self.assertEqual(template.render(Context()), "cached")
+
     @patch("core.templatetags.svg_icon.FALLBACK_ICON_NAME", "test")
     def test_template_tag_fallback(self):
         """


### PR DESCRIPTION
Currently any use of the `{% svg_icon %}` template tag loads the SVG contents from disk. This commit modifies that behavior so that SVG icons are cached in memory, to avoid the need to load from file each time.

In [our icon library](https://github.com/cfpb/design-system/tree/6b566bdb7ae2ce4c80a1cd05404bf3ea2e8fe6fa/packages/cfpb-icons/src/icons) icon files range from 220 bytes to 2.6 KB in size. The total size of all icons is 2.8 MB.

Closes internal https://github.local/CFGOV/platform/issues/3667.

## How to test this PR

Everything should work the same, just slightly faster at the expense of slightly greater memory usage.

Locally, `SKIP_DJANGO_MIGRATIONS=1 tox -e unittest` takes 285s vs 291s for me on main, as an example of code that does a whole bunch of icon loads. On our production instances, [we don't limit memory usage for mod_wsgi](https://github.com/cfpb/consumerfinance.gov/blob/7cebc54f09f8510f4b8ce8836c7b5f609677b712/cfgov/apache/conf.d/wsgi.conf#L6). Our prod servers are [t3.2xlarge](https://aws.amazon.com/ec2/instance-types/t3/) which have 32GB of RAM. By inspection each of our running Apache processes can consume ~1GB so an extra 2.8MB isn't significant.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)