### PR TITLE
Optimize JobListingTable DB queries

### DIFF
--- a/cfgov/jobmanager/blocks.py
+++ b/cfgov/jobmanager/blocks.py
@@ -40,7 +40,9 @@ class JobListingTable(blocks.StaticBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
 
-        jobs = JobListingPage.objects.open().prefetch_related("grades__grade")
+        jobs = JobListingPage.objects.open().prefetch_related(
+            "grades__grade", "offices", "regions"
+        )
 
         request = context.get("request")
 

--- a/cfgov/jobmanager/tests/test_blocks.py
+++ b/cfgov/jobmanager/tests/test_blocks.py
@@ -119,19 +119,13 @@ class JobListingTableTestCase(JobListingBlockTestUtils, TestCase):
         for i in range(5):
             self.make_job(f"live{i}")
 
-        # We expect 13 database queries:
+        # We expect 5 database queries:
         #
         # 1. Wagtail has to look up the site root paths, which get cached on
         #    the request object.
         # 2. One query to retrieve all of the job listing pages.
         # 3. One query to prefetch all of the job grades.
-        # 5x2. Two additional queries per job to retrieve offices and
-        #      regions.
-        #
-        # This could be greatly optimized (reducing to only 2 additional
-        # location queries total) if django-modelcluster adds prefetch_related
-        # support to ParentalManyToManyField:
-        #
-        # https://github.com/wagtail/django-modelcluster/issues/101
-        with self.assertNumQueries(13):
+        # 4. One query to prefetch all of the job offices.
+        # 5. One query to prefetch all of the job regions.
+        with self.assertNumQueries(5):
             self.render_block()


### PR DESCRIPTION
This commit optimizes rendering of the JobListingTable organism found on https://www.consumerfinance.gov/about-us/careers/current-openings/ so that it takes 5 database queries instead of 13.

When this code was last touched in April 2020, django-modelcluster didn't properly support prefetching of ParentalManyToManyFields (see https://github.com/wagtail/django-modelcluster/issues/101). In May 2020 I opened a PR to remedy this (see https://github.com/wagtail/django-modelcluster/issues/122), and this was released in September 2020, but I neglected to revisit this code to add the optimization. This commit does so.

All existing tests continue to pass properly.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)