### PR TITLE
Improve TCCP tooltip handling and visuals

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -73,6 +73,7 @@
                                         name='apr-disclaimer',
                                         heading=(
                                             'Published rates are from '
+                                            ~ '<span class="u-nowrap">' | safe
                                             ~ (
                                                 stats_all.report_period_start
                                                 | date('%B')
@@ -82,6 +83,7 @@
                                                 stats_all.first_report_date
                                                 | date('%B %Y')
                                             )
+                                            ~ '</span>' | safe
                                         ),
                                         body=(
                                             'APRs change over time and are '

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -4,6 +4,8 @@ import { attach } from '@cfpb/cfpb-atomic-component';
 import orderingDropdown from './ordering';
 import webStorageProxy from '../../../js/modules/util/web-storage-proxy';
 
+let tooltips;
+
 /**
  * Initialize some things.
  */
@@ -31,9 +33,9 @@ function init() {
  * See https://kabbouchi.github.io/tippyjs-v4-docs/html-content/
  */
 function initializeTooltips() {
-  tippy('[data-tooltip]', {
+  tooltips = tippy('[data-tooltip]', {
     theme: 'cfpb',
-    maxWidth: 500,
+    maxWidth: 450,
     content: function (reference) {
       const template = reference.nextElementSibling;
       const container = document.createElement('div');
@@ -46,14 +48,16 @@ function initializeTooltips() {
 
 /**
  * Handle links that shouldn't be followed when
- * specified children elements are targeted.
+ * specified children elements are targeted
+ * or a tooltip is open.
  * @param {Event} event - Touch/click event.
  */
 function handleIgnoreLinkTargets(event) {
   const ignoredTargets = event.currentTarget?.getAttribute(
     'data-ignore-link-targets',
   );
-  if (event.target.closest(ignoredTargets)) {
+  const tooltipIsOpen = tooltips.some((tip) => tip.state.isMounted);
+  if (event.target.closest(ignoredTargets) || tooltipIsOpen) {
     event.preventDefault();
   }
 }

--- a/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
+++ b/test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js
@@ -42,7 +42,7 @@ describe('Explore credit cards results page', () => {
       });
     });
   });
-  it.only('should not follow card links when tooltips are clicked', () => {
+  it('should not follow card links when tooltips are clicked', () => {
     exploreCards.openResultsPage();
 
     cy.get('.m-card--tabular [data-tooltip]').first().click();
@@ -51,6 +51,27 @@ describe('Explore credit cards results page', () => {
     cy.get('h2')
       .contains('Purchase interest rate and fees')
       .should('not.exist');
+  });
+  it('should not follow card links when tooltips are open', () => {
+    exploreCards.openResultsPage();
+
+    // Open a tooltip
+    cy.get('.m-card--tabular [data-tooltip]').first().click();
+    // Click away to close the tooltip
+    cy.get('.m-card--tabular .m-card__heading-group').first().click();
+
+    // The link should not have been followed
+    cy.get('h1').contains('Explore credit cards').should('exist');
+    cy.get('h2')
+      .contains('Purchase interest rate and fees')
+      .should('not.exist');
+
+    cy.wait(1000);
+    // Click a second time now that the tooltip is closed
+    cy.get('.m-card--tabular .m-card__heading-group').first().click();
+    // The link should now have been followed
+    cy.get('h1').contains('Explore credit cards').should('not.exist');
+    cy.get('h2').contains('Purchase interest rate and fees').should('exist');
   });
   it('should show additional results when "Show more" button is clicked', () => {
     exploreCards.openResultsPage();


### PR DESCRIPTION
Wraps the date range in TCCP tooltips in a `nowrap` element to prevent it from line breaking. Also prevents TCCP card links from being mistakenly followed when a user clicks away to close a tooltip.

## How to test this PR

1. PR tests should pass.
1. `yarn cypress run --spec test/cypress/integration/consumer-tools/credit-cards/explore-cards.cy.js`
1. http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ is the same ol' thang.

## Screenshots


| mobile | desktop |
|--------|---------|
|![Screenshot 2024-06-26 at 9 41 19 AM](https://github.com/cfpb/consumerfinance.gov/assets/1060248/26f1554f-64a8-4bae-b6d7-3aa0014aee4a)|![Screenshot 2024-06-26 at 9 40 48 AM](https://github.com/cfpb/consumerfinance.gov/assets/1060248/e6ea432c-80c0-4fda-aac5-6c23eaccb7da)|
|![Screenshot 2024-06-26 at 9 41 23 AM](https://github.com/cfpb/consumerfinance.gov/assets/1060248/fe7add08-ea91-492a-8cd4-743f9f25eb83)|![Screenshot 2024-06-26 at 9 40 51 AM](https://github.com/cfpb/consumerfinance.gov/assets/1060248/cab08e68-d22f-4726-9dfa-3608def075f4)|






