### PR TITLE
Fix new ruff warnings

### DIFF
--- a/cfgov/paying_for_college/views.py
+++ b/cfgov/paying_for_college/views.py
@@ -67,9 +67,7 @@ def validate_pid(pid):
 def url_is_safe(url):
     """Only save disclosure URLs with expected values."""
     find_illegal = re.search("[^0-9a-zA-Z-/?&=:.#]+", url)
-    if find_illegal:
-        return False
-    return True
+    return find_illegal is None
 
 
 def get_program_length(program, school):

--- a/cfgov/regulations3k/models/pages.py
+++ b/cfgov/regulations3k/models/pages.py
@@ -270,13 +270,11 @@ class RegulationPage(ShareableRoutablePageMixin, CFGOVPage):
 
     def can_serve_draft_versions(self, request):
         perms = request.user.get_all_permissions()
-        if (
+        return (
             request.user.is_superuser
             or getattr(request, "served_by_wagtail_sharing", False)
             or "regulations3k.change_section" in perms
-        ):
-            return True
-        return False
+        )
 
     def get_versions_query(self, request):
         versions = self.regulation.versions


### PR DESCRIPTION
These two files triggered ruff's `SIM103: Return the condition directly` warning, which wants you to return a boolean directly rather than testing it then returning `True` or `False` literals.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
