### PR TITLE
Sort spanish key terms pages to match english page results

### DIFF
--- a/cfgov/ask_cfpb/models/pages.py
+++ b/cfgov/ask_cfpb/models/pages.py
@@ -294,10 +294,7 @@ class PortalSearchPage(RoutablePageMixin, CFGOVPage):
         return TemplateResponse(request, "ask-cfpb/see-all.html", context)
 
     def get_glossary_terms(self):
-        if self.language == "es":
-            terms = self.portal_topic.glossary_terms.order_by("name_es")
-        else:
-            terms = self.portal_topic.glossary_terms.order_by("name_en")
+        terms = self.portal_topic.glossary_terms.order_by("name_en")
         for term in terms:
             if term.name(self.language) and term.definition(self.language):
                 yield term


### PR DESCRIPTION
Similar to https://github.com/cfpb/consumerfinance.gov/pull/8360, this sorts spanish key terms pages such that the results are ordered by the english results (so they're stable when switching between english and spanish).