### PR TITLE
Improve helper text for SVG picker

### DIFF
--- a/cfgov/draftail_icons/static/draftail_icons/js/draftail_icons.js
+++ b/cfgov/draftail_icons/static/draftail_icons/js/draftail_icons.js
@@ -1,7 +1,9 @@
 class EntityIconSource extends window.React.Component {
   componentDidMount() {
     const { editorState, entityType, onComplete } = this.props;
-    const icon_name = window.prompt("Icon identifier:");
+    const icon_name = window.prompt(
+      'Canonical icon name (refer to the Iconography page in the CFPB Design System):',
+    );
 
     if (icon_name) {
       const content = editorState.getCurrentContent();
@@ -9,12 +11,12 @@ class EntityIconSource extends window.React.Component {
 
       const contentWithEntity = content.createEntity(
         entityType.type,
-        "SEGMENTED",
+        'SEGMENTED',
         {
-          "icon-name": icon_name,
-        }
+          'icon-name': icon_name,
+        },
       );
-      const entityKey = contentWithEntity.getLastCreatedEntityKey()
+      const entityKey = contentWithEntity.getLastCreatedEntityKey();
 
       // Attach the new entity to a space, since it has to have a range of
       // some length > 0. This will get rendered out in the decorator below
@@ -22,14 +24,14 @@ class EntityIconSource extends window.React.Component {
       const newContent = window.DraftJS.Modifier.replaceText(
         content,
         selection,
-        " ",
+        ' ',
         null,
-        entityKey
+        entityKey,
       );
       const nextState = window.DraftJS.EditorState.push(
         editorState,
         newContent,
-        "insert-characters"
+        'insert-characters',
       );
 
       onComplete(nextState);
@@ -50,19 +52,16 @@ const Icon = (props) => {
   // Get the icon name, then add an img tag that loads the icon from our
   // static files path. This will render the ICON "entity" with the svg in
   // the editor.
-  var icon_name = data["icon-name"];
+  var icon_name = data['icon-name'];
   var icon_url = `/static/icons/${icon_name}.svg`;
-  return window.React.createElement(
-    'img',
-    {
-      "src": icon_url,
-      "data-icon-name": icon_name,
-    },
-  );
+  return window.React.createElement('img', {
+    src: icon_url,
+    'data-icon-name': icon_name,
+  });
 };
 
 window.draftail.registerPlugin({
-  type: "ICON",
+  type: 'ICON',
   source: EntityIconSource,
-  decorator: Icon
+  decorator: Icon,
 });


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR modifies the helper text shown in the `window.prompt` when selecting an SVG in Draftail, to point users to the relevant Design System name where appropriate icon names can be found.

My VSCode linter appears to have enforced some other formatting opinions across the .js file; feel free to revert if any of those don't seem right.

---


## How to test this PR

1. localhost
2. Edit any page with a rich text editor
3. Click the "Icon" button to see the prompt


## Screenshots
| Before | After |
| - | - |
| <img width="446" alt="Screenshot 2024-07-03 at 12 48 35 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/985edff2-8d4a-4482-8f94-873d8932e35a"> | <img width="450" alt="Screenshot 2024-07-03 at 12 47 42 PM" src="https://github.com/cfpb/consumerfinance.gov/assets/29648039/0c00308d-1961-474d-a5ff-a7bbdd2399c1"> |


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
