### PR TITLE
Remove Chrome blank first print page hack

### DIFF
--- a/cfgov/unprocessed/css/print.less
+++ b/cfgov/unprocessed/css/print.less
@@ -217,16 +217,4 @@
       display: block !important;
     }
   }
-
-  // Prevent Chrome from adding in a blank first page
-  @media (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
-    .content__main {
-      margin: 0;
-      display: block !important;
-    }
-
-    .content__sidebar {
-      display: block !important;
-    }
-  }
 });


### PR DESCRIPTION
Printing seems fine without this, and also `-webkit-min-device-pixel-ratio` is deprecated. 

## Removals

- Remove Chrome blank first print page hack


## How to test this PR

1. Try printing a few pages from Chrome and seeing that there is no blank first page in the preview or when saved to a PDF.
