### PR TITLE
Form explainers: Remove redundant CSS

### DIFF
--- a/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
+++ b/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less
@@ -130,12 +130,6 @@
             background-color: @@med;
           }
         }
-
-        &.has-attention {
-          .o-expandable__header {
-            background-color: @@med;
-          }
-        }
       }
     });
 


### PR DESCRIPTION
## Removals

- Form explainers: Remove redundant CSS


## How to test this PR

1. Check the code block immediately above the one being deleted and see that it is the same https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/apps/form-explainer/css/form-explainer.less#L128-L138
