### PR TITLE
Retirement: remove redundant CSS

### DIFF
--- a/cfgov/unprocessed/apps/retirement/css/claiming.less
+++ b/cfgov/unprocessed/apps/retirement/css/claiming.less
@@ -415,10 +415,6 @@
 
   // Tablet only.
   .respond-to-range(@bp-sm-min, @bp-sm-max, {
-    p.y-axis-label {
-      top: 310px;
-    }
-
     .step-one {
       padding-top: 30px;
     }


### PR DESCRIPTION

## Removals

- Retirement: remove redundant CSS


## How to test this PR

1. See that this CSS is set the same further down
https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/apps/retirement/css/claiming.less#L418-L420
https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/apps/retirement/css/claiming.less#L439-L441
