### PR TITLE
Mega Menu: remove redundant CSS

### DIFF
--- a/cfgov/unprocessed/css/organisms/mega-menu.less
+++ b/cfgov/unprocessed/css/organisms/mega-menu.less
@@ -232,13 +232,6 @@ body {
       font-weight: normal;
     }
 
-    // …however, show the icons in featured links.
-    &-item--has-icon {
-      .cf-icon-svg {
-        display: inline-block;
-      }
-    }
-
     // Ensure desktop up/down arrow link icons don't appear at mobile.
     &-link {
       width: 100%;
@@ -846,39 +839,6 @@ body {
         .u-focus-link-desktop();
       }
 
-      // Featured item has a highlight box around it.
-      &-list--featured ul {
-        // Style the featured item box.
-        padding-right: unit( 13px / @base-font-size-px, em );
-        padding-top: unit( 30px / @base-font-size-px, em );
-        padding-bottom: unit( 30px / @base-font-size-px, em );
-        margin-bottom: unit( 30px / @base-font-size-px, em );
-        border: 1px solid var(--gray-40);
-        border-top: 6px solid var(--gold);
-        box-sizing: border-box;
-      }
-
-      &-list--featured &-link {
-        display: flex;
-        padding: 0;
-        left: 0;
-        border: none;
-
-        & .cf-icon-svg {
-          color: var(--gold);
-          width: 100%;
-          max-width: unit( 16px / @base-font-size-px, rem );
-        }
-      }
-
-      &-list--featured &-item {
-        margin-bottom: unit( 15px / @base-font-size-px, em );
-
-        &:last-child {
-          margin-bottom: 0;
-        }
-      }
-
       &-item--has-icon {
         // Pad in featured items from their icons.
         padding-left: unit( 13px / @base-font-size-px, em );
@@ -894,10 +854,41 @@ body {
         }
       }
 
-      // Remove hover bar for featured item link.
+      // Featured item has a highlight box around it.
+      &-list--featured ul {
+        // Style the featured item box.
+        padding-right: unit( 13px / @base-font-size-px, em );
+        padding-top: unit( 30px / @base-font-size-px, em );
+        padding-bottom: unit( 30px / @base-font-size-px, em );
+        margin-bottom: unit( 30px / @base-font-size-px, em );
+        border: 1px solid var(--gray-40);
+        border-top: 6px solid var(--gold);
+        box-sizing: border-box;
+      }
+
+      &-list--featured &-item {
+        margin-bottom: unit( 15px / @base-font-size-px, em );
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
       &-list--featured &-link {
+        // Remove hover bar for featured item link.
         .u-hover-link-featured-desktop();
         .u-focus-link-featured-desktop();
+
+        display: flex;
+        padding: 0;
+        left: 0;
+        border: none;
+
+        & .cf-icon-svg {
+          color: var(--gold);
+          width: 100%;
+          max-width: unit( 16px / @base-font-size-px, rem );
+        }
       }
     }
 


### PR DESCRIPTION
## Changes

- Remove `&-item--has-icon .cf-icon-svg` `display: inline-block` rule, which is overridden with `display: inline` by the same selector further down. 

- Rearrange `&-list--featured &-link` so that redundant definition is removed.


## How to test this PR

1. See that `&-item--has-icon .cf-icon-svg` display rule appears twice.

https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/mega-menu.less#L238
https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/mega-menu.less#L263

2. See that `&-list--featured &-link` appeared twice. 

https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/mega-menu.less#L861
https://github.com/cfpb/consumerfinance.gov/blob/main/cfgov/unprocessed/css/organisms/mega-menu.less#L898

3. Pull branch, run `yarn build` and check desktop megamenu featured items hover and padding. It should be the same as prod.
