### PR TITLE
TCCP: Fix phone number parsing

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/contact_info.html
+++ b/cfgov/tccp/jinja2/tccp/includes/contact_info.html
@@ -1,13 +1,13 @@
-{% if urls or phone_numbers -%}
+{% if urls or phone_number -%}
 <div class="o-contact-info">
     {% for value in urls %}
         {%- include "v1/includes/molecules/contact-hyperlink.html" -%}
     {% endfor %}
 
-    {% for phone_number in phone_numbers %}
+    {% if phone_number %}
         {% with value = {"phones": [{"number": phone_number}]} %}
             {%- include "v1/includes/molecules/contact-phone.html" -%}
         {% endwith %}
-    {%- endfor %}
+    {%- endif %}
 </div>
 {%- endif %}

--- a/cfgov/tccp/jinja2tags.py
+++ b/cfgov/tccp/jinja2tags.py
@@ -45,9 +45,8 @@ def _format_contact_info(card):
         "urls": fmt_list(
             _format_contact_website, card["website_for_consumer"]
         ),
-        "phone_numbers": fmt_list(
-            _format_contact_phone_number,
-            card["telephone_number_for_consumers"],
+        "phone_number": _format_contact_phone_number(
+            card["telephone_number_for_consumers"] or ""
         ),
     }
 

--- a/cfgov/tccp/tests/test_jinja2tags.py
+++ b/cfgov/tccp/tests/test_jinja2tags.py
@@ -75,7 +75,7 @@ class TestRenderContactInfo(SimpleTestCase):
         html = render_contact_info(
             {
                 "website_for_consumer": "https://example.com foo.com",
-                "telephone_number_for_consumers": "212-555-1234",
+                "telephone_number_for_consumers": "1 212-555-1234",
             }
         )
 
@@ -83,3 +83,4 @@ class TestRenderContactInfo(SimpleTestCase):
         self.assertIn('<a href="https://example.com">', html)
         self.assertNotIn('<a href="foo.com">', html)
         self.assertEqual(len(re.findall("m-contact-phone", html)), 1)
+        self.assertIn("2125551234", html)


### PR DESCRIPTION
This commit modifies how phone numbers are rendered on the frontend of the "Explore credit cards" tool. It fixes an issue with parsing phone numbers that have spaces in them in the TCCP dataset. The TCCP dataset contains cards that only provide a single phone number, but sometimes this can include spaces, for example:

1 (800) 555-1234

Instead of parsing this like multiple phone numbers separated by spaces, we need to parse this as a single phone number.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)