### PR TITLE
Charts: Remove `@font-size` variable that is used on the next line

### DIFF
--- a/cfgov/unprocessed/css/on-demand/chart.less
+++ b/cfgov/unprocessed/css/on-demand/chart.less
@@ -6,6 +6,5 @@
   padding-top: unit(15px / @base-font-size-px, em);
   margin-top: unit(30px / @base-font-size-px, em);
   color: var(--black);
-  @font-size: 12px;
-  font-size: unit(@font-size / @base-font-size-px, em);
+  font-size: unit(12px / @base-font-size-px, em);
 }


### PR DESCRIPTION
This CSS defines a simple variable and then uses it on the very next line and nowhere else (that I can see). It seems simpler to use the direct value.

I'm sure @contolini remembers with crystal clarity why he added this 7.5 years ago in https://github.com/cfpb/consumerfinance.gov/pull/2688, and will stop me if this is breaking something.

## Removals

- `@font-size` variable from `chart.less`


## How to test this PR

1. Pages with `m-chart-footnote` (see crawler) should still have small text for their footnotes.
