### PR TITLE
Mortgage Performance Trends: Remove redundant margin bottom

### DIFF
--- a/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
@@ -156,10 +156,6 @@
   // Highcharts auto resizes the charts, causing odd overflow issues
   overflow: inherit;
 
-  .a-label h4 {
-    .u-mb15();
-  }
-
   // Fieldsets have silly default values. We should remove them at the CF level
   // but for now I'm removing them only within our app.
   fieldset {


### PR DESCRIPTION
Mortgage Performance Trends sets the margin bottom of its `a-label h4` to 15px. However, an h4 already has its styles setting a 15px bottom margin https://github.com/cfpb/design-system/blob/main/packages/cfpb-core/src/base.less#L76

I think what happened is this was added as a 10px margin override, and then it was updated to 15px in https://github.com/cfpb/consumerfinance.gov/commit/92e17a3a5b863820426db164fb074b38b7ae4de4, when it could have been removed entirely. 


## Removals

- Remove redundant `a-label h4` bottom margin utility.

## How to test this PR

1. `yarn build` and http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/ should have unchanged spacing under "Select map view", for example.
