### PR TITLE
TDP: Remove unused CSS | Update BEM names in markup

### DIFF
--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_page.html
@@ -12,7 +12,7 @@
         <span class="a-date">
             Updated
             <span class="datetime">
-                <time class="datetime_date" datetime="{{ page.date.strftime("%Y-%m-%d") }}">
+                <time datetime="{{ page.date.strftime("%Y-%m-%d") }}">
                     {{ page.date.strftime("%b %d, %Y") }}
                 </time>
             </span>

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_facets_and_results.html
@@ -51,7 +51,7 @@
     {% endfor %}
 {% endmacro %}
 
-<a class="skip-filters u-visually-hidden{% if not activities %} skip-filters__hidden{% endif %}" href="#tdp-search-results">Skip to search results</a>
+<a class="skip-filters u-visually-hidden{% if not activities %} skip-filters--hidden{% endif %}" href="#tdp-search-results">Skip to search results</a>
 
 <div class="results__count block--padded-bottom u-hide-on-med u-hide-on-lg u-hide-on-xl" data-results-count="{{ page.results.total_results }}">
     {% if page.results.total_results %}

--- a/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_result.html
+++ b/cfgov/teachers_digital_platform/jinja2/teachers_digital_platform/activity_search_result.html
@@ -1,10 +1,10 @@
 <div class="activity">
-    <h3><a class="activity_title-link" href="{{ result.url }}">{{ result.title }}</a></h3>
+    <h3><a href="{{ result.url }}">{{ result.title }}</a></h3>
     <p class="meta">
         <span class="a-date">
             Updated
             <span class="datetime">
-                <time class="datetime_date" datetime="{{ result.date_attr }}">
+                <time datetime="{{ result.date_attr }}">
                     {{ result.date }}
                 </time>
             </span>
@@ -14,10 +14,10 @@
         <span class="a-icon a-icon--large a-icon--gold a-icon--space-after">
             {{ svg_icon('favorite-round') }}
         </span>
-        <span class="activity_for">Ideal for: {{ result.grade_level | join(', ') }}</span>
+        <span class="activity__for">Ideal for: {{ result.grade_level | join(', ') }}</span>
     </p>
     <p class="lead-paragraph u-mb30">{{ result.summary }}</p>
-    <div class="activity_meta-wrapper">
+    <div class="activity__meta-wrapper">
         <div>
             <h4 class="h5">Key information</h4>
             <div class="layout-row u-mb15">
@@ -25,7 +25,7 @@
                 {{ result.topic }}
             </div>
             <div class="layout-row">
-                <h5 class="activity_meta-key">Activity duration:</h5>
+                <h5 class="activity__meta-key">Activity duration:</h5>
                 {{ result.activity_duration }}
             </div>
             {% if result.available_in_spanish %}

--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/pages/activity-search.less
@@ -230,7 +230,7 @@
   }
 
   .activity__meta-key {
-    font-size: unit(@base-font-size-px / 16 * 100, %);
+    font-size: 100%;
     margin: 0;
     text-transform: none;
   }


### PR DESCRIPTION
`datetime_date` was removed in https://github.com/cfpb/design-system/pull/1966

`activity_title-link` does not have any associated styles that I can find.


## Changes

- TDP: Remove unused CSS 
- Update BEM names in markup that were still on old BEM styles.
- Simplify font-size calculation.


## How to test this PR

1. `yarn build` and visit localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/


## Screenshots

Before:
<img width="567" alt="Screenshot 2024-07-11 at 5 03 28 PM" src="https://github.com/user-attachments/assets/d2ee555b-0751-41e6-a552-4d138c3e9c9b">

After:
<img width="567" alt="Screenshot 2024-07-11 at 5 03 17 PM" src="https://github.com/user-attachments/assets/54254f7c-43ab-48f3-81df-a58df902a936">


