### PR TITLE
Fix ruff E721 comparison errors

### DIFF
--- a/cfgov/data_research/models.py
+++ b/cfgov/data_research/models.py
@@ -230,7 +230,7 @@ class MortgageBase(models.Model):
             for field in count_fields:
                 setattr(self, field, count_fields[field])
             self.save()
-        elif type(self) == NonMSAMortgageData:
+        elif type(self) is NonMSAMortgageData:
             for field in count_fields:
                 setattr(self, field, count_fields[field])
             self.save()

--- a/cfgov/regulations3k/jinja2tags.py
+++ b/cfgov/regulations3k/jinja2tags.py
@@ -15,7 +15,7 @@ def ap_date(date):
     """Convert a date object or date string into an AP-styled date string."""
     if date is None:
         return None
-    if type(date) != datetime.date:
+    if type(date) is not datetime.date:
         try:
             date = parser.parse(date).date()
         except ValueError:

--- a/cfgov/retirement_api/utils/ss_utilities.py
+++ b/cfgov/retirement_api/utils/ss_utilities.py
@@ -73,7 +73,7 @@ with open(datafile) as f:
 
 def get_current_age(dob):
     today = datetime.date.today()
-    if type(dob) == datetime.date:
+    if type(dob) is datetime.date:
         DOB = dob
     else:
         try:


### PR DESCRIPTION
Ruff is complaining about our comparison operators and wants us to "use `is` and `is not` for type comparisons".

See failed job at https://github.com/cfpb/consumerfinance.gov/actions/runs/9942217435/job/27463160690?pr=8506#step:8:20