### PR TITLE
TCCP: Move deprecated keyCode to key

### DIFF
--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -49,8 +49,12 @@ function initializeTooltips() {
         name: 'hideOnEsc',
         defaultValue: true,
         fn({ hide }) {
+          /**
+           * Hide when the escape key is pressed.
+           * @param {KeyboardEvent} event - Key down event.
+           */
           function onKeyDown(event) {
-            if (event.keyCode === 27) {
+            if (event.key === 'Escape') {
               hide();
             }
           }


### PR DESCRIPTION
`keyCode` is deprecated https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

Follow-on to https://github.com/cfpb/consumerfinance.gov/pull/8506

## Changes

- TCCP: Move deprecated keyCode to key


## How to test this PR

1. Hover over a tooltip and click `esc` to close it.
