### PR TITLE
Upgrade Wagtail to 6.1

### DIFF
--- a/cfgov/jobmanager/models/django.py
+++ b/cfgov/jobmanager/models/django.py
@@ -92,6 +92,12 @@ class Region(ClusterableModel):
         InlinePanel("major_cities", label="Major cities"),
     ]
 
+    def states_in_region(self):
+        return ", ".join(str(state) for state in self.states.all())
+
+    def major_city_names(self):
+        return "; ".join(str(city) for city in self.major_cities.all())
+
 
 class State(models.Model):
     name = models.CharField(max_length=255)

--- a/cfgov/jobmanager/views.py
+++ b/cfgov/jobmanager/views.py
@@ -48,13 +48,12 @@ class RegionViewSet(SnippetViewSet):
     icon = "site"
     menu_label = "Regions"
 
-    def states_in_region(self):
-        return ", ".join(str(state) for state in self.states.all())
-
-    def major_cities(self):
-        return "; ".join(str(city) for city in self.major_cities.all())
-
-    list_display = ["abbreviation", "name", states_in_region, major_cities]
+    list_display = [
+        "abbreviation",
+        "name",
+        "states_in_region",
+        "major_city_names",
+    ]
 
 
 class ServiceTypeViewSet(SnippetViewSet):

--- a/cfgov/permissions_viewer/wagtail_hooks.py
+++ b/cfgov/permissions_viewer/wagtail_hooks.py
@@ -36,7 +36,7 @@ def register_settings_menu_item():
 
 
 @hooks.register("register_user_listing_buttons")
-def user_listing_buttons(context, user):
+def user_listing_buttons(user, request_user):
     yield UserListingButton(
         "View Permissions",
         reverse("permissions:user", args=[user.pk]),

--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==6.0.5
+wagtail==6.1.3

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -38,8 +38,8 @@ export class AdminPage {
     return cy.get('#listing-results').find('li');
   }
 
-  tags() {
-    return cy.get('.tagfilter');
+  filters() {
+    return cy.get('.w-filter-button');
   }
 
   openDocumentsLibrary() {
@@ -119,7 +119,7 @@ export class AdminPage {
   }
 
   cleanUpRegulations() {
-    cy.get('table tr').last().contains('Delete').click({ force: true });
+    cy.get('table.listing tr').last().contains('Delete').click({ force: true });
     this.submitForm();
   }
 

--- a/test/cypress/integration/admin/admin.cy.js
+++ b/test/cypress/integration/admin/admin.cy.js
@@ -19,7 +19,7 @@ describe('Admin', () => {
   it('should be able to open the Images library', () => {
     admin.openImageGallery();
     admin.getImages().should('be.visible');
-    admin.tags().should('be.visible');
+    admin.filters().should('be.visible');
   });
 
   it('should be able to open the Documents library', () => {


### PR DESCRIPTION
This PR upgrades us to Wagtail 6.1. The required changes are minor.


One thing to note, we still have a `RemovedInWagtail70Warning: The usage of `WidgetWithScript` hook is deprecated. Use external scripts instead.` warning that will be fixed by https://github.com/wagtail/wagtail-autocomplete/pull/180 when (if?) it gets merged.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)