### PR TITLE
Add open script to invoke cypress

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "watch": "yarn build watch",
     "build": "node ./esbuild/build.js",
     "cypress": "./node_modules/.bin/cypress run --config-file cypress.template.mjs",
+    "open": "./node_modules/.bin/cypress open --config-file cypress.template.mjs",
     "fast-cypress": "./test/cypress/run-specs.sh && ./node_modules/.bin/cypress run"
   },
   "prettier": {


### PR DESCRIPTION
This is much nicer than having to invoke it from .bin

## Testing

`yarn run open` opens cypress as expected