### PR TITLE
Update some of our Python dependencies

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -2,19 +2,19 @@
 base36==0.1.1
 backports.zoneinfo==0.2.1
 beautifulsoup4==4.11.2
-boto3==1.34.54
+boto3==1.34.144
 django-autocomplete-light==3.11.0
-django-cors-headers==4.3.1
+django-cors-headers==4.4.0
 django-csp==3.8
-django-opensearch-dsl==0.5.2
+django-opensearch-dsl==0.6.2
 django-extensions==3.2.3
 django-flags==5.0.13
 django-formtools==2.5.1
-django-health-check==3.18.1
-django-htmx==1.17.3
+django-health-check==3.18.3
+django-htmx==1.18.0
 django-localflavor==4.0
 django-mptt==0.14.0
-django-storages==1.14.2
+django-storages==1.14.4
 django-treebeard==4.7.1
 edgegrid-python==1.3.1
 elasticsearch<7.11  # Keep pinned to the deployed ES version
@@ -23,14 +23,14 @@ Jinja2==3.1.4
 lxml==5.1.0
 matplotlib==3.7.5
 mozilla-django-oidc==4.0.1
-opensearch-py==2.4.2
-psycopg2-binary==2.9.6
+opensearch-py==2.6.0
+psycopg2-binary==2.9.9
 python-dateutil==2.9.0
 regdown==1.0.7
 requests-aws4auth==1.2.3
-s3transfer==0.10.0
+s3transfer==0.10.2
 setuptools>=65.5.1
-tailslide==0.1.1
+tailslide==0.2.0
 wagtail-autocomplete==0.11.0
 wagtail-content-audit==0.1
 wagtail_draftail_anchors==0.6.0
@@ -40,7 +40,7 @@ wagtail-inventory==2.6
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.12.1
 wagtail-treemodeladmin==1.9.2
-wagtailmedia==0.15.1
+wagtailmedia==0.15.2
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.18.2/owning_a_home_api-0.18.2-py3-none-any.whl

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,6 @@
 -r base.txt
 django-cprofile-middleware==1.0.5
-django-debug-toolbar==4.3.0
+django-debug-toolbar==4.4.6
 django-sslserver==0.22
 pre-commit==3.5.0
-tox==4.13.0
+tox==4.16.0


### PR DESCRIPTION
This PR bumps some of our Python dependency versions. 

One notable one is django-opensearch-dsl, which in its 0.6 version made the `BaseSignalProcessor` we subclass into an abstract base class, and changed the delete-related method name. Instead of `BaseSignalProcessor`, we now subclass `RealTimeSignalProcessor `.


## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
