### PR TITLE
Correct jumplinks underlining

### DIFF
--- a/cfgov/v1/jinja2/v1/newsroom/newsroom-page.html
+++ b/cfgov/v1/jinja2/v1/newsroom/newsroom-page.html
@@ -14,7 +14,9 @@
         </p>
         <a class="a-link a-link--jump"
            href="/about-us/newsroom/press-resources/">
-            Go to press resources page
+           <span class="a-link__text">
+                Go to press resources page
+           </span>
         </a>
     </aside>
 {% endblock %}

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -138,9 +138,11 @@
                     {{ svg_icon('external-link') -}}
                 </a>.
             </p>
-            <a class="a-link--jump"
+            <a class="a-link a-link--jump"
             href="/data-research/research-reports/financial-well-being-scale/">
-                Download printable versions of the questionnaire in English and Spanish
+                <span class="a-link__text">
+                    Download printable versions of the questionnaire in English and Spanish
+                </span>
             </a>
         </div>
     {% else %}


### PR DESCRIPTION
The newsroom and financial well-being apps contained jumplinks that weren't properly marked up, leading to missing underlines.

## Changes

- Add correct classes for jump links.


## How to test this PR

1. `yarn build` and compare the sidebar link http://localhost:8000/consumer-tools/financial-well-being/about/ on to production. Also, the press resources link on a newsroom page.


## Screenshots

Before:
<img width="432" alt="Screenshot 2024-07-30 at 1 16 49 PM" src="https://github.com/user-attachments/assets/dc1b64d9-9ae1-4220-8493-17b9756baa6d">

After:
<img width="333" alt="Screenshot 2024-07-30 at 1 18 55 PM" src="https://github.com/user-attachments/assets/257edfc4-2a93-422b-8f89-3528013acaee">

