### PR TITLE
TCCP: minor markup and breakpoint adjustments

### DIFF
--- a/cfgov/tccp/jinja2/tccp/about.html
+++ b/cfgov/tccp/jinja2/tccp/about.html
@@ -99,7 +99,11 @@
         <a
             class="a-link a-link--jump"
             href="/data-research/credit-card-data/terms-credit-card-plans-survey/"
-        >View data downloads and resources</a>
+        >
+            <span class="a-link__text">
+                View data downloads and resources
+            </span>
+        </a>
     </p>
 </div>
 {% endblock %}

--- a/cfgov/unprocessed/apps/tccp/css/main.less
+++ b/cfgov/unprocessed/apps/tccp/css/main.less
@@ -461,13 +461,15 @@ html.js .o-filterable-list-results--partial {
     margin-bottom: unit((10px / @base-font-size-px), rem);
     border-bottom: 1px solid var(--gray-40);
 
-    .respond-to-max(@bp-sm-min, {
+    // Mobile only.
+    .respond-to-max(@bp-xs-max, {
       margin-top: unit((30px / @base-font-size-px), rem);
     });
   }
 
   &:not(.o-card-details-section--introduction) > h2 {
-    .respond-to-max(@bp-sm-min, {
+    // Mobile only.
+    .respond-to-max(@bp-xs-max, {
       font-weight: 600;
     });
   }


### PR DESCRIPTION
We rarely use `.respond-to-max(@bp-sm-min, {…});`, which is 601px, and instead use `.respond-to-max(@bp-xs-max, {…});` for mobile only, which is 600px.

## Changes

- Fix issue where jump link didn't have underlining class.
- Change breakpoint to be 600px instead of 601px.


## How to test this PR

1. Check TCCP
