### PR TITLE
Update topic tag related metadata pattern to use jump links

### DIFF
--- a/cfgov/unprocessed/css/molecules/related-metadata.less
+++ b/cfgov/unprocessed/css/molecules/related-metadata.less
@@ -1,6 +1,36 @@
-@margin-half-em: unit(15px / @base-font-size-px, em);
+// Modifier for jump links to give them topic-tags style gold/gray styling.
+.a-link--jump-gold {
+  font-size: unit(12px / @base-font-size-px, rem);
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--gold-80);
+  border-color: var(--gold-80);
+  letter-spacing: 1px;
 
-@bullet-font-size__em: unit(15px / @base-font-size-px, em);
+  .u-link--colors(var(--gold-80));
+
+  .a-link__text {
+    color: var(--gray-90);
+    border-bottom-color: var(--gold-80);
+  }
+
+  a&:hover .a-link__text {
+    color: var(--black);
+  }
+
+  a&:hover:before {
+    border-color: var(--gold-80);
+    color: var(--gold-80);
+  }
+
+  // If it's not a link, don't add a border.
+  // TODO: Make it so topic tag related metadata items are ALWAYS links.
+  span&:hover:before {
+    border-top-color: transparent !important;
+  }
+}
+
+@margin-half-em: unit(15px / @base-font-size-px, em);
 
 .m-related-metadata {
   .m-list__link {
@@ -37,34 +67,4 @@
 
 .m-related-metadata__topics {
   line-height: 1em;
-
-  .m-list__link {
-    .h6();
-    position: relative;
-    margin: 0 0 0 @bullet-font-size__em;
-    text-transform: uppercase;
-
-    .u-link--colors(var(--gray), var(--gray), var(--gray), var(--gray), var(--gray),
-    var(--gold-80), var(--gold-80), var(--gold-80), var(--gold-80), var(--gold-80));
-
-    &::before {
-      position: absolute;
-      left: -@bullet-font-size__em;
-      width: @bullet-font-size__em;
-
-      // Adding bullet.
-      content: '\2022';
-      color: var(--gold-80);
-    }
-  }
-
-  .respond-to-max(@bp-sm-min, {
-    .m-list__link {
-      margin-left: 0;
-
-      &:before {
-        position: static;
-      }
-    }
-  });
 }

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-metadata-enforcement-action.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-metadata-enforcement-action.html
@@ -151,7 +151,10 @@
            m-related-metadata__topics">
     {% for item in list %}
     <li class="m-list__item">
-        <span class="m-list__link">{{item}}</span>
+        <span class="a-link a-link--jump a-link--jump-gold">
+          •
+          <span class="a-link__text">{{item}}</span>
+        </span>
     </li>
     {% endfor %}
 </ul>

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-metadata.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-metadata.html
@@ -88,11 +88,15 @@
     {% for link in list.links %}
     <li class="m-list__item">
         {% if link.url %}
-            <a href="{{ link.url }}" class="m-list__link">
-                {{ link.text }}
+            <a href="{{ link.url }}" class="a-link a-link--jump a-link--jump-gold">
+                •
+                <span class="a-link__text">{{ link.text }}</span>
             </a>
         {% else %}
-            <span class="m-list__link">{{ link.text }}</span>
+            <span class="a-link a-link--jump a-link--jump-gold">
+                •
+                <span class="a-link__text">{{ link.text }}</span>
+            </span>
         {% endif %}
     </li>
     {% endfor %}


### PR DESCRIPTION
## Changes

- Update topic tag related metadata pattern to use jump links.
- Adds `a-link--jump-gold` modifier to handle related metadata appearance.
- Darken topic tag gray to be color contrast accessible.
- Add a black text hover state.


## How to test this PR

1. `yarn build` and visit http://localhost:8000/data-research/research-reports/no-fear-act-annual-report-fiscal-year-2015/ and compare the topic tags across screensizes to production.
2. Visit http://localhost:8000/enforcement/actions/1st-alliance-lending-llc-et-al/ and compare the topic tags across screensizes to production.


## Screenshots

Before:
<img width="307" alt="Screenshot 2024-07-31 at 10 23 13 AM" src="https://github.com/user-attachments/assets/af855baa-e131-4bac-9263-ed8867d20e52">

After:
<img width="301" alt="Screenshot 2024-07-31 at 10 31 45 AM" src="https://github.com/user-attachments/assets/ff56c4bb-69a6-4fcc-adb5-924d7742bbdc">

<img width="309" alt="Screenshot 2024-07-31 at 10 23 05 AM" src="https://github.com/user-attachments/assets/0459ff03-53d7-4fe1-b835-2d680fccfbf5">


Before:
<img width="311" alt="Screenshot 2024-07-31 at 10 23 54 AM" src="https://github.com/user-attachments/assets/04cd7e11-8301-48e1-96a6-2d14f3a40919">

After:
<img width="304" alt="Screenshot 2024-07-31 at 10 23 41 AM" src="https://github.com/user-attachments/assets/3461b78b-1b5b-4433-9689-3318bb04af09">

## Todo

- Topic tags use jump links and should therefore always be links. They are currently only sometimes links.