### PR TITLE
[Paying for College] Fix bug in Parent PLUS loan field

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/05-customize-estimate.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/05-customize-estimate.html
@@ -340,8 +340,7 @@
                             'label': 'Loan amount',
                             'id': 'plan__parentPlus',
                             'value': '0',
-                            'data_attr
-                            ibute': 'data-financial-item="plusLoan_parentPlus"',
+                            'data_attribute': 'data-financial-item="plusLoan_parentPlus"',
                             'note': ''
                         })
                     }}


### PR DESCRIPTION
This is a fast-follow to [yesterday's PR](https://github.com/cfpb/consumerfinance.gov/pull/8407) that fixes a bug caused by a typo in the template file.

## Changes
- A new line in `05-customize-estimate.html` was breaking the code for this PLUS loan. Removing the newline fixes it.

## How to test this PR
1. On localhost, the "Parent PLUS loan" amount field (only visible for undergraduate students) should function as expected.

## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
