### PR TITLE
MPT: Remove @font-size variable that is used on the next line

### DIFF
--- a/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
+++ b/cfgov/unprocessed/css/on-demand/mortgage-performance-trends.less
@@ -170,8 +170,7 @@
   // Helper text under some filter or zoom options
   .m-field-helper-text {
     color: var(--gray-80);
-    @font-size: 12px;
-    font-size: unit(@font-size / @base-font-size-px, em);
+    font-size: unit(12px / @base-font-size-px, em);
   }
 }
 
@@ -187,6 +186,5 @@
 
 #mp-map-month-container label,
 #mp-map-year-container label {
-  @font-size: 14px;
-  font-size: unit(@font-size / @base-font-size-px, em);
+  font-size: unit(14px / @base-font-size-px, em);
 }


### PR DESCRIPTION
Analogous PR to https://github.com/cfpb/consumerfinance.gov/pull/8507

## Changes

- `@font-size` variable from mortage-performance-trends.less


## How to test this PR

1. PR checks should pass. MPT page, such as http://localhost:8000/data-research/mortgage-performance-trends/mortgages-30-89-days-delinquent/, should have unchanged label size for the month/year drop-down on the map.