### PR TITLE
Replace `a-legend` with `h4`

### DIFF
--- a/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
+++ b/cfgov/hmda/jinja2/hmda/hmda-explorer-controls.html
@@ -25,7 +25,7 @@
                 content-l__col-1">
         <div class="o-form__group">
             <fieldset class="o-form__fieldset">
-                <legend class="a-legend">
+                <legend class="h4">
                     Records included
                 </legend>
                {% for radio in form.records %}
@@ -49,7 +49,7 @@
         </div>
         <div class="o-form__group">
             <fieldset class="o-form__fieldset">
-                <legend class="a-legend">
+                <legend class="h4">
                     Variable descriptions
                 </legend>
                {% for radio in form.field_descriptions %}

--- a/cfgov/tccp/jinja2/tccp/includes/filter_form.html
+++ b/cfgov/tccp/jinja2/tccp/includes/filter_form.html
@@ -37,7 +37,7 @@
 
     <div class="o-form__group">
         <fieldset class="o-form__fieldset">
-            <legend class="a-legend">Features</legend>
+            <legend class="h4">Features</legend>
 
             {{ render_field(form.small_institution, "checkbox") }}
 
@@ -47,7 +47,7 @@
 
     <div class="o-form__group">
         <fieldset class="o-form__fieldset">
-            <legend class="a-legend">Rewards</legend>
+            <legend class="h4">Rewards</legend>
 
             {{ form.rewards }}
         </fieldset>

--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -127,7 +127,7 @@
 
             <div class="o-form__group">
                 <fieldset class="o-form__fieldset o-form__fieldset--helpers">
-                    <legend class="a-legend">
+                    <legend class="h4">
                         I’m looking for a card that will help me...
                     </legend>
                     {{ form.situations }}

--- a/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/filterable-list-controls.html
@@ -123,7 +123,7 @@
                             content-l__col-2-3">
                     <div class="o-form__group">
                         <fieldset class="o-form__fieldset">
-                            <legend class="a-legend">
+                            <legend class="h4">
                                 Date range
                             </legend>
                             <div class="content-l">

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -118,7 +118,7 @@
                 <h2>{{ _('Part 1: How well does this statement describe you or your situation?') }}</h2>
                 <div class="o-well">
                     <fieldset class="o-form__fieldset o-scale" id="question_1">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I could handle a major unexpected expense') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }}</div>
@@ -191,7 +191,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_2">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I am securing my financial future') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }} </div>
@@ -264,7 +264,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_3">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('Because of my money situation, I feel like I will never have the things I want in life') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }} </div>
@@ -337,7 +337,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_4">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I can enjoy life because of the way I’m managing my money') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }} </div>
@@ -410,7 +410,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_5">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I am just getting by financially') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }} </div>
@@ -483,7 +483,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_6">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I am concerned that the money I have or will save won’t last') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement describes me') }} </div>
@@ -561,7 +561,7 @@
                 <h2>{{ _('Part 2: How often does this statement apply to you?') }}</h2>
                 <div class="o-well">
                     <fieldset class="o-form__fieldset o-scale" id="question_7">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('Giving a gift for a wedding, birthday or other occasion would put a strain on my finances for the month') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement applies to me') }}</div>
@@ -634,7 +634,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_8">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I have money left over at the end of the month') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement applies to me') }}</div>
@@ -706,7 +706,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_9">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('I am behind with my finances') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement applies to me') }}</div>
@@ -779,7 +779,7 @@
                         </div>
                     </fieldset>
                     <fieldset class="o-form__fieldset o-scale" id="question_10">
-                        <h3 class="a-legend">
+                        <h3 class="h4">
                             {{ _('My finances control my life') }}
                         </h3>
                         <div class="o-scale_answer-prefix">{{ _('This statement applies to me') }}</div>
@@ -858,7 +858,7 @@
                 <div class="o-well">
                     <div class="o-form__group">
                         <fieldset class="o-form__fieldset" id="age">
-                            <h3 class="a-legend">
+                            <h3 class="h4">
                                 {{ _('Select your age group. This changes the scoring calculation.') }}
                             </h3>
                             <ul class="m-list m-list--unstyled content-l">
@@ -897,7 +897,7 @@
                     </div>
                     <div>
                         <fieldset class="o-form__fieldset" id="method">
-                            <h3 class="a-legend">
+                            <h3 class="h4">
                                 {{ _('Select how you completed the questionnaire. This changes the scoring calculation.') }}
                             </h3>
                             <ul class="m-list m-list--unstyled content-l">

--- a/test/unit_tests/js/organisms/FilterableListControls-spec.js
+++ b/test/unit_tests/js/organisms/FilterableListControls-spec.js
@@ -50,7 +50,7 @@ const HTML_SNIPPET = `
                     content-l__col-1-3">
             <div class="o-form__group">
                 <fieldset class="o-form__fieldset">
-                    <legend class="a-legend">
+                    <legend class="h4">
                         Category
                     </legend>
                     <ul class="m-list m-list--unstyled">
@@ -119,7 +119,7 @@ const HTML_SNIPPET = `
                                 content-l__col-1">
                         <div class="o-form__group">
                             <fieldset class="o-form__fieldset">
-                                <legend class="a-legend">
+                                <legend class="h4">
                                     Date range
                                 </legend>
                                 <div class="content-l">


### PR DESCRIPTION
The `a-legend` class was just an h4 with additional IE legacy CSS. With the legacy CSS removed it just becomes an h4, so best to just set `<legend class="h4">` instead.

See https://github.com/cfpb/design-system/pull/2009

## Changes

- Replace `a-legend` with `h4`


## How to test this PR

1. PR checks should pass.
