### PR TITLE
Change H2 for footnotes to "Endnotes"

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/footnotes.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/footnotes.html
@@ -14,7 +14,7 @@
 
 {% macro render( footnotes ) %}
   <div class="block m-footnotes">
-      <h2 id="footnotes">Footnotes</h2>
+      <h2 id="footnotes">Endnotes</h2>
       <ol>
           {% for footnote in footnotes %}
               <li id="footnote-{{ loop.index }}">


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR changes the automatic H2 for a generated footnotes section from "Footnotes" to "Endnotes", per ongoing discussion about best-practices and labeling for this kind of web content. This is not meant to be the final word on how this section is labeled or set up, but instead an improvement/iteration on existing work that will be checked and reinforced (or altered) by forthcoming user research and testing.

## How to test this PR

1. localhost
2. Preview or view any page with a footnotes section


## Notes and todos

- This does conflict with the use of "footnotes" everywhere in the code; we can revisit that as needed down the road when we do proper, wider-scale reassessment and improvement of the functionality.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance
