### PR TITLE
Add layout classes to intro segment in grad path

### DIFF
--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/0-intro.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-cost-blocks/0-intro.html
@@ -1,7 +1,7 @@
-<div class="college-costs__intro-segment u-js-only">
+<div class="college-costs__intro-segment u-layout-grid u-js-only">
     {% if return_user %}
-        <div class="content__wrapper">
-            <div class="content__main">
+        <div class="u-layout-grid__wrapper">
+            <div class="u-layout-grid__main">
                 <div class="m-notification
                             m-notification--visible">
                     {{ svg_icon('updating') }}
@@ -17,8 +17,8 @@
                 {% include_block block %}
             {% endif %}
         {%- endfor %}
-        <div class="content__wrapper">
-            <div class="content__main">
+        <div class="u-layout-grid__wrapper">
+            <div class="u-layout-grid__main">
                {% for block in page.header -%}
                     {% if block.block_type != 'hero' %}
                         {{ render_block.render(block, loop.index) }}


### PR DESCRIPTION
Somehow the gradpath intro section layout got exploded, as follows: 
<img width="1617" alt="Screenshot 2024-08-16 at 12 09 12 PM" src="https://github.com/user-attachments/assets/af3c957f-be11-4574-99c1-1aeba5c65532">

This PR
<img width="1213" alt="Screenshot 2024-08-16 at 12 25 29 PM" src="https://github.com/user-attachments/assets/2ff44bf7-ad36-4c2f-9a05-2e1fba261cd8">
 fixes it:
