### PR TITLE
Reinitialize tooltips after htmx ajax calls

### DIFF
--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -26,6 +26,8 @@ function init() {
   orderingDropdown.move();
   // Initialize any tooltips on the page
   initializeTooltips();
+  //Reinitialize tooltips after an htmx request replaces DOM nodes
+  document.addEventListener('htmx:afterRequest', initializeTooltips);
 }
 
 /**

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -26,8 +26,8 @@ function init() {
   orderingDropdown.move();
   // Initialize any tooltips on the page
   initializeTooltips();
-  //Reinitialize tooltips after an htmx request replaces DOM nodes
-  document.addEventListener('htmx:afterRequest', initializeTooltips);
+  // Reinitialize tooltips after an htmx request replaces DOM nodes
+  attach(document, 'htmx:afterSwap', initializeTooltips);
 }
 
 /**


### PR DESCRIPTION
Closes https://github.local/Design-Development/External-Products/issues/398

## Testing
- Pull and build
- Go to http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards
- Hover over some tooltip triggers -> :)
- Check some boxes and/or sort the cards
- Hover over some tooltip triggers again -> :)