### PR TITLE
Pin psycopg to 2.9.6

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -24,7 +24,9 @@ lxml==5.1.0
 matplotlib==3.7.5
 mozilla-django-oidc==4.0.1
 opensearch-py==2.6.0
-psycopg2-binary==2.9.9
+# psycopg2 > 2.9.6 causes cf.gov to hang locally for people with on-network
+# Macs, so we'll pin to 2.9.6 for now. See PR 8203 for details.
+psycopg2-binary==2.9.6
 python-dateutil==2.9.0
 regdown==1.0.7
 requests-aws4auth==1.2.3


### PR DESCRIPTION
`psycopg2` > 2.9.6 causes cf.gov to hang locally for people with on-network Macs, so we'll pin to 2.9.6 for now. See #8203 for more details.

---

## Changes

- Pin `psycopg` to `2.9.6`

## How to test this PR

If you happen to be on an on-network Mac:

1. Build cf.gov with this PR, `./runserver.sh`, and note the server starts up as normal
2. `pip install psycopg2-binary==2.9.9`, `./runserver.sh`, and note the server hangs when starting up

If you're not on an on-network Mac, build cf.gov and make sure everything works as expected.

## Notes and todos

- It's not clear when, if, or by whom this bug will ever be fixed (sounds like it's a misconfiguration of GSSAPI), but if it ever is, we can unpin `psycopg` from 2.9.6

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets