### PR TITLE
Import footnotes CSS file to main

### DIFF
--- a/cfgov/unprocessed/css/main.scss
+++ b/cfgov/unprocessed/css/main.scss
@@ -83,6 +83,7 @@
 
 @use 'skip-nav' as *;
 @use 'breadcrumbs' as *;
+@use 'footnotes' as *;
 
 /* Print styles
    ========================================================================== */


### PR DESCRIPTION
This import got wiped out in the Less to Sass conversion (added in https://github.com/cfpb/consumerfinance.gov/pull/8466 and wiped out in https://github.com/cfpb/consumerfinance.gov/pull/8514)

## Additions

- Import footnotes CSS file to main

## How to test this PR

1. A page like http://localhost:8000/compliance/circulars/consumer-financial-protection-circular-2023-02-reopening-deposit-accounts-that-consumers-previously-closed/ should have inline footnote links.
