### PR TITLE
Reduce deprecation warnings

### DIFF
--- a/cfgov/unprocessed/apps/ask-cfpb/css/main.scss
+++ b/cfgov/unprocessed/apps/ask-cfpb/css/main.scss
@@ -28,9 +28,9 @@
     }
 
     .term__name {
-      @include h2;
-
       display: block;
+
+      @include h2;
     }
 
     .term__definition {
@@ -190,9 +190,10 @@
   }
 
   .answer-edited-date {
-    @include h5;
     display: block;
     color: var(--gray-90);
+
+    @include h5;
   }
 
   // Tablet and above.

--- a/cfgov/unprocessed/apps/cfpb-chart-builder/css/cfpb-chart-builder.scss
+++ b/cfgov/unprocessed/apps/cfpb-chart-builder/css/cfpb-chart-builder.scss
@@ -92,9 +92,10 @@ x/y positioning on the SVG elements.
     // Center "Select time range" label.
     .cfpb-chart__small {
       .highcharts-range-selector-label {
-        @include h6;
         transform: translateY(370px);
         left: calc(50% - 64px) !important;
+
+        @include h6;
       }
 
       .highcharts-axis-title {

--- a/cfgov/unprocessed/apps/filing-instruction-guide/css/main.scss
+++ b/cfgov/unprocessed/apps/filing-instruction-guide/css/main.scss
@@ -10,11 +10,13 @@
 
   h2 {
     @include h1;
+    // Override for h1 margin.
     margin-top: 60px;
   }
 
   h3 {
     @include h2;
+    // Override for h2 margin.
     margin-top: 45px;
   }
 
@@ -25,6 +27,7 @@
 
   h5 {
     @include h4;
+    // Override for h4 margin.
     margin-top: 30px;
   }
 

--- a/cfgov/unprocessed/apps/paying-for-college/css/disclosures.scss
+++ b/cfgov/unprocessed/apps/paying-for-college/css/disclosures.scss
@@ -399,9 +399,9 @@ $bp-graph-cols-min: 740px;
   &__summary,
   &__summary.column-well__content {
     padding-top: math.div(20px, $base-font-size-px) + em;
-    padding-right: ($grid_gutter-width / 2);
+    padding-right: math.div($grid_gutter-width, 2);
     padding-bottom: math.div(20px, $base-font-size-px) + em;
-    padding-left: ($grid_gutter-width / 2);
+    padding-left: math.div($grid_gutter-width, 2);
     margin-top: math.div(30px, $base-font-size-px) + em;
     margin-right: -1 * math.div($grid_gutter-width, 2);
     margin-left: -1 * math.div($grid_gutter-width, 2);
@@ -1232,7 +1232,9 @@ $bp-graph-cols-min: 740px;
 
   &__top-label {
     width: $bar-graph-top-label-width;
-    margin-left: -($bar-graph-top-label-width - $bar-graph-width) / 2 - $bar-graph-line-overhang;
+    margin-left: (
+        -1 * math.div(($bar-graph-top-label-width - $bar-graph-width), 2)
+      ) - $bar-graph-line-overhang;
     position: absolute;
     top: math.div(-$bar-graph-top-label-height, $small-font-size-px) + em;
     left: 50%;

--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -230,9 +230,10 @@
   }
 
   .m-apr-rating {
-    @include u-heading-4-size-only;
-    margin-bottom: math.div(20px, $base-font-size-px) + rem;
     font-weight: 600;
+    margin-bottom: math.div(20px, $base-font-size-px) + rem;
+
+    @include u-heading-4-size-only;
 
     // Mobile only.
     @include respond-to-max($bp-xs-max) {
@@ -543,10 +544,6 @@ html.js .o-filterable-list-results--partial {
 .htmx-progress {
   display: none;
 
-  .htmx-request & {
-    display: inline;
-  }
-
   position: fixed;
   top: 0;
   z-index: 1000;
@@ -573,6 +570,10 @@ html.js .o-filterable-list-results--partial {
       animation-delay: 1s;
     }
   }
+}
+
+.htmx-request .htmx-progress {
+  display: inline;
 }
 
 // Dim search results while inflight

--- a/cfgov/unprocessed/css/enhancements/typography.scss
+++ b/cfgov/unprocessed/css/enhancements/typography.scss
@@ -1,9 +1,10 @@
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
 
 dt {
-  @include h5;
   display: inline-block;
 
+  @include h5;
+  // Override h5 margin.
   margin-bottom: 0.5em;
 
   &:last-of-type {

--- a/cfgov/unprocessed/css/molecules/global-header-cta.scss
+++ b/cfgov/unprocessed/css/molecules/global-header-cta.scss
@@ -10,6 +10,8 @@
   padding-bottom: 11px;
 
   a {
+    font-weight: 500;
+
     // Colors for :link, :visited, :hover, :focus, :active.
     @include u-link-colors(
       var(--pacific),
@@ -18,6 +20,5 @@
       var(--pacific),
       var(--navy-dark)
     );
-    font-weight: 500;
   }
 }

--- a/cfgov/unprocessed/css/molecules/global-search.scss
+++ b/cfgov/unprocessed/css/molecules/global-search.scss
@@ -12,11 +12,6 @@ $mobile-trigger-ht-px: 54px;
 
 .m-global-search {
   &__trigger {
-    // Hide search unless we have JavaScript (JS).
-    html.no-js & {
-      display: none;
-    }
-
     font-weight: 500;
 
     // Resets for default button styles.
@@ -106,8 +101,6 @@ $mobile-trigger-ht-px: 54px;
       width: 100%;
 
       &-form {
-        @include u-drop-shadow-after;
-
         box-sizing: border-box;
         width: 100%;
         padding: $margin-em $margin-half-em $margin-half-em;
@@ -118,6 +111,8 @@ $mobile-trigger-ht-px: 54px;
         background-color: var(--gray-5);
         border-top: 1px solid var(--gray-40);
         border-bottom: 1px solid var(--gray-40);
+
+        @include u-drop-shadow-after;
       }
     }
   }
@@ -186,4 +181,9 @@ $mobile-trigger-ht-px: 54px;
       display: block;
     }
   }
+}
+
+// Hide search unless we have JavaScript (JS).
+html.no-js .m-global-search__trigger {
+  display: none;
 }

--- a/cfgov/unprocessed/css/molecules/tags.scss
+++ b/cfgov/unprocessed/css/molecules/tags.scss
@@ -7,9 +7,10 @@ $bullet-font-size: 17px;
 .m-tags {
   // Mobile.
   &__heading {
-    @include h4;
     display: block;
     color: var(--black);
+
+    @include h4;
   }
 
   &__list {
@@ -22,15 +23,16 @@ $bullet-font-size: 17px;
   }
 
   &__tag {
-    @include h6;
-
-    // Override h6 margin.
-    margin: 0;
     box-sizing: border-box;
     display: inline-block;
     position: relative;
-    line-height: $bullet-font-size;
     color: var(--gray);
+
+    @include h6;
+
+    // Override h6 margin and line-height.
+    margin: 0;
+    line-height: $bullet-font-size;
   }
 
   &__item {
@@ -46,7 +48,7 @@ $bullet-font-size: 17px;
     margin-left: $bullet-font-size;
   }
 
-  a.m-tags--tag {
+  a.m-tags__tag {
     @include u-link-colors(
       var(--gray),
       var(--gray),
@@ -63,7 +65,7 @@ $bullet-font-size: 17px;
 
   // Negate the border of the sibling when hovering.
   &__item:hover + &__item {
-    a.m-tags--tag {
+    a.m-tags__tag {
       border-top: none;
     }
   }

--- a/cfgov/unprocessed/css/on-demand/job-listing-list.scss
+++ b/cfgov/unprocessed/css/on-demand/job-listing-list.scss
@@ -12,9 +12,10 @@
   }
 
   .a-link__subtext {
-    @include u-link-colors(var(--black));
     display: block;
     margin-top: math.div(2px, $base-font-size-px) + em;
     font-weight: normal;
+
+    @include u-link-colors(var(--black));
   }
 }


### PR DESCRIPTION
This PR moves some mixins to remove some deprecation warnings we get on `yarn build`.

Sass says 

> Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version

This mostly comes from our heading mixins—which include nested CSS—so, those mixins need to appear after declarations.  The remaining warnings are mostly margin overrides that are applied to the heading mixins, which need to appear after the mixin in order to perform the override.

## Changes

- Move some mixin calls to after declarations within a block.
- Fix misnamed tag BEM.
- Fix some deprecated division syntax.


## How to test this PR

1. `yarn build` on this branch should have less deprecation warnings than `yarn build` on `main`.


## Notes and todos

- There's a deprecation warning originating from the grid mixins that will be fixed in a future patch release to the DS. 