### PR TITLE
Freeze before-you-claim tests in 2024

### DIFF
--- a/test/cypress/integration/consumer-tools/before-you-claim/before-you-claim-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/before-you-claim/before-you-claim-helpers.cy.js
@@ -18,8 +18,8 @@ export class BeforeYouClaim {
   }
 
   enterAge(age) {
-    const year = new Date().getFullYear();
-    this.setBirthDate('1', '1', String(year - age));
+    const year = 2024;
+    this.setBirthDate('4', '1', String(year - age));
     this.setHighestAnnualSalary('115000');
     this.getEstimate();
   }

--- a/test/cypress/integration/consumer-tools/before-you-claim/before-you-claim-helpers.cy.js
+++ b/test/cypress/integration/consumer-tools/before-you-claim/before-you-claim-helpers.cy.js
@@ -19,7 +19,7 @@ export class BeforeYouClaim {
 
   enterAge(age) {
     const year = 2024;
-    this.setBirthDate('4', '1', String(year - age));
+    this.setBirthDate('5', '1', String(year - age));
     this.setHighestAnnualSalary('115000');
     this.getEstimate();
   }


### PR DESCRIPTION
We mock the responses from the retirement API, however the starting year was relative t the current year. This change freezes the starting year to 2024 and adjusts the month to ensure the tests pass against the fixture data.

Hopefully this avoids any future failures due to the continued march of time.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
