### PR TITLE
Remove `a-text-input__full`

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
@@ -41,7 +41,7 @@
                id="{{ value.input_id }}"
                name="{{ value.input_name }}"
                value="{{ value.input_value or '' }}"
-               class="a-text-input a-text-input__full"
+               class="a-text-input"
                placeholder="{{ value.placeholder }}"
                title="{{ value.placeholder }}"
                autocomplete="off"


### PR DESCRIPTION
This class should be `a-text-input--full`, however, it only has an effect inside an `m-form-field` (see https://github.com/cfpb/design-system/blob/main/packages/cfpb-design-system/src/components/cfpb-forms/form-field.scss#L6). The global search separately makes its text field 100% width. We could either leave `a-text-input--full` to show the intent is that it is full width, or remove it. I opted to remove it, since it doesn't actually apply any styling.

## Removals

- Remove `a-text-input__full`

## How to test this PR

1. Global search should be unchanged.