### PR TITLE
Update reg table BEM names

### DIFF
--- a/cfgov/regulations3k/parser/regtable.py
+++ b/cfgov/regulations3k/parser/regtable.py
@@ -16,9 +16,9 @@ class RegTable:
         self.label = label
         self.header_rows = []
         self.body_rows = []
-        self.table_class = "o-table o-table-wrapper__scrolling"
-        self.cell_class = "o-table_cell__right-align"
-        self.cell_class_left = "o-table_cell__left-align"
+        self.table_class = "o-table o-table-wrapper--scrolling"
+        self.cell_class = "o-table__cell--right-align"
+        self.cell_class_left = "o-table__cell--left-align"
 
     def table(self):
         return self.SHELL.format(


### PR DESCRIPTION
These are old-style BEM names that should be updated.

## Changes

- Update reg table BEM names


## How to test this PR

1. I'm not sure how this file is run, but an example page that uses these classes is http://localhost:8000/rules-policy/regulations/1010/2016-06-10/a/

## Notes and todos

- Can this not use a template that it populates with content? The classes here seem very buried.