### PR TITLE
Ask: Fix card BEM

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/card.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/card.html
@@ -33,7 +33,7 @@
                 {% if value.card_type == 'topic-action' %} m-card--topic m-card--topic-action {% endif %}
                 {% if value.card_type  == 'highlight' %} m-card__highlight {% endif %}
                 {% if value.card_type  == 'breakout' %} m-card--breakout {% endif %}
-                {% if value.card_type  == 'featured' %} m-card__featured {% endif %}">
+                {% if value.card_type  == 'featured' %} m-card--featured {% endif %}">
     <a href="{{ value.link_url }}">
         {% if value.heading or value.icon %}
         <h3 class="{% if value.card_type != 'highlight' %}m-card__heading{% endif %}{% if value.card_type == 'featured' %} h2{% endif %}">

--- a/cfgov/v1/jinja2/v1/includes/molecules/feature-card.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/feature-card.html
@@ -74,7 +74,7 @@
         {%- endfor %}
     </ul>
 
-    <div class="m-card_footer">
+    <div class="m-card__footer">
         <a href="{{ value.category.url }}">
             {{ value.footer_label }}
         </a>


### PR DESCRIPTION

## Changes

- Ask: Fix card BEM `m-card_footer` should be `m-card__footer`
- `m-card__featured` should be `m-card--featured`. Fixed for consistency—this class isn't in use.


## How to test this PR

1. Visit http://localhost:8000/ask-cfpb/ and see that the footer links in the cards are at the card bottom.


## Screenshots

Before:
<img width="789" alt="Screenshot 2024-09-04 at 6 07 48 PM" src="https://github.com/user-attachments/assets/c6b3c5a0-4da7-4fd3-a772-78aad8d5a693">

After:
<img width="804" alt="Screenshot 2024-09-04 at 6 07 43 PM" src="https://github.com/user-attachments/assets/dea87ad6-09eb-4883-8a0b-68eaa6857922">
