### PR TITLE
Remove deprecated `a-link__external-link` class

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_page.html
@@ -206,7 +206,7 @@
             we do and new opportunities to be a part of it.
         </p>
         <a href="https://www.linkedin.com/company/consumer-financial-protection-bureau"
-           class="a-link a-link--jump a-link__external-link">
+           class="a-link a-link--jump">
             Follow us on LinkedIn
         </a>
     </div>


### PR DESCRIPTION
The `a-link__external-link` class shouldn't be specified here. External link markup is added by the cf.gov middleware. See CFPB Design System documentation at https://cfpb.github.io/design-system/components/links#link-with-icon.

## How to test this PR

To test, run a local server and confirm that the external link markup still appears correctly at any job listing under http://localhost:8000/about-us/careers/current-openings/.

## Screenshots

External link icon still appears after this change:

<img width="407" alt="image" src="https://github.com/user-attachments/assets/d3bf8088-ac18-4fc8-b2c2-6936b804c4f2">

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)