### PR TITLE
Fix Akamai frontend cache backend

### DIFF
--- a/cfgov/cdntools/backends.py
+++ b/cfgov/cdntools/backends.py
@@ -15,6 +15,7 @@ class AkamaiBackend(BaseBackend):
     """Akamai backend that performs an 'invalidate' purge"""
 
     def __init__(self, params):
+        super().__init__(params)
         self.client_token = params.get("CLIENT_TOKEN")
         self.client_secret = params.get("CLIENT_SECRET")
         self.access_token = params.get("ACCESS_TOKEN")


### PR DESCRIPTION
Wagtail 6.2 introduced new initialization and configuration in frontend cache backends. This ensures that gets run in the Akamai backend.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
