### PR TITLE
Update itemscope usage and jinja multi-attributes-in-conditionals

### DIFF
--- a/cfgov/ask_cfpb/tests/test_blocks.py
+++ b/cfgov/ask_cfpb/tests/test_blocks.py
@@ -94,15 +94,15 @@ class SchemaBlocksTestCase(TestCase):
             ],
         }
         expected_html = (
-            '<div itemscope="" itemtype="https://schema.org/FAQPage" '
+            '<div itemscope itemtype="https://schema.org/FAQPage" '
             'class="schema-block schema-block--faq">'
             '<div itemprop="description" class="schema-block_description">'
             "test description"
             "</div>"
-            '<div itemscope="" itemprop="mainEntity" '
+            '<div itemscope itemprop="mainEntity" '
             'itemtype="https://schema.org/Question" class="schema-block_item">'  # noqa
             '<h2 itemprop="name">Question one</h2>'
-            '<div itemprop="acceptedAnswer" itemscope="" '
+            '<div itemprop="acceptedAnswer" itemscope '
             'itemtype="https://schema.org/Answer">'
             '<div itemprop="text">Answer content</div>'
             "</div>"

--- a/cfgov/v1/jinja2/v1/includes/blocks/schema/faq-group.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/schema/faq-group.html
@@ -35,7 +35,7 @@
 
 <div>
     {% for item in value.faq_items %}
-    <div itemscope=""
+    <div itemscope
          itemprop="mainEntity"
          itemtype="https://schema.org/Question"
          class="block
@@ -47,7 +47,7 @@
             {{- item.question -}}
         </{{ value.question_tag }}>
         <div itemprop="acceptedAnswer"
-             itemscope=""
+             itemscope
              itemtype="https://schema.org/Answer">
             <div itemprop="text">
                 {% for block in item.answer -%}

--- a/cfgov/v1/jinja2/v1/includes/blocks/schema/faq.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/schema/faq.html
@@ -24,7 +24,7 @@
    ========================================================================== #}
 
 
-<div itemscope=""
+<div itemscope
      itemtype="https://schema.org/FAQPage"
      class="schema-block schema-block--faq">
     {% if value.description %}
@@ -33,14 +33,14 @@
   	</div>
     {% endif %}
   	{% for question in value.questions %}
-  		  <div itemscope=""
+  		  <div itemscope
              itemprop="mainEntity"
              itemtype="https://schema.org/Question"
              class="schema-block_item"
              {% if question.anchor_tag %}id="{{ question.anchor_tag }}"{% endif %}>
     		    <h2 itemprop="name">{{ question.question }}</h2>
     		    <div itemprop="acceptedAnswer"
-                 itemscope=""
+                 itemscope
                  itemtype="https://schema.org/Answer">
                 <div itemprop="text">
                   {% include_block question.answer_content %}

--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -39,7 +39,7 @@
             {{ 'o-expandable--border' if value.is_bordered else '' }}
             {{ 'o-expandable--onload-open' if value.is_expanded else '' }}"
      id="{{ value.group_index_slug if value.group_index_slug else value.label | slugify_unique }}"
-     {{ 'itemscope="" itemprop="mainEntity" itemtype="https://schema.org/Question"'
+     {{ 'itemscope itemprop=mainEntity itemtype=https://schema.org/Question'
         if value.is_faq else '' }} >
     <button class="o-expandable__header" type="button">
         {% if value.icon %}
@@ -60,7 +60,7 @@
     </button>
 
     <div class="o-expandable__content"
-          {{ 'itemprop="acceptedAnswer" itemscope="" itemtype="https://schema.org/Answer"'
+          {{ 'itemprop=acceptedAnswer itemscope itemtype=https://schema.org/Answer'
         if value.is_faq else '' }}>
         {% if value.is_faq %}<div itemprop='text'>{% endif %}
             {% if caller is defined %}

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -23,7 +23,7 @@
 {% endif %}
 <html lang="{{ language }}" class="no-js"
 {%- if is_faq_page %}
-itemscope="" itemtype="https://schema.org/FAQPage"
+itemscope itemtype="https://schema.org/FAQPage"
 {% endif -%}>
 
 <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# {% block og_article_prefix %}{% endblock %}">


### PR DESCRIPTION
itemscope is just a boolean attribute, so the `=""` is unnecessary.

Also, removing the quotes in the multi-attribute conditionals in jinja prevents weird double quoting