### PR TITLE
Alphabetize topic tags in sidebar

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/related-metadata-enforcement-action.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-metadata-enforcement-action.html
@@ -147,7 +147,7 @@
       {% do tags_list.append({'text': item}) %}
     {% endfor %}
     {% import "v1/includes/molecules/tags.html" as tags with context %}
-    {{ tags.render(tags_list, false, true) }}
+    {{ tags.render(tags_list | sort(attribute='text'), false, true) }}
 {% endmacro %}
 
 {# ==========================================================================

--- a/cfgov/v1/jinja2/v1/includes/molecules/related-metadata.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/related-metadata.html
@@ -79,7 +79,7 @@
 
 {% macro _list(list) %}
     {% import "v1/includes/molecules/tags.html" as tags with context %}
-    {{ tags.render(list.links, false, true) }}
+    {{ tags.render(list.links | sort(attribute='text'), false, true) }}
 {% endmacro %}
 
 {# ==========================================================================
@@ -98,7 +98,7 @@
 
  {% macro _topics(list) %}
     {% import "v1/includes/molecules/tags.html" as tags with context %}
-    {{ tags.render(page.related_metadata_tags().links, false, true) }}
+    {{ tags.render(page.related_metadata_tags().links | sort(attribute='text'), false, true) }}
  {% endmacro %}
 
 {# ==========================================================================


### PR DESCRIPTION
We alphabetize the topic tags in the filterable search results, but not necessarily in the sidebar of individual posts. This PR alphabetizes them.

## Changes

- Alphabetize topic tags in sidebar


## How to test this PR

1. Visit http://localhost:8000/rules-policy/final-rules/prepaid-accounts-under-electronic-fund-transfer-act-regulation-e-and-truth-lending-act-regulation-z/ and see sidebar tags are alphabetized.
2. Visit http://localhost:8000/enforcement/actions/colony-ridge/ and see sidebar tags are alphabetized.


## Screenshots

Before:
<img width="285" alt="Screenshot 2024-09-11 at 2 42 03 PM" src="https://github.com/user-attachments/assets/d35db88a-e7ee-42b5-83b4-1d1ba8c12b42">

After:
<img width="265" alt="Screenshot 2024-09-11 at 2 41 33 PM" src="https://github.com/user-attachments/assets/9e133115-908f-4270-91e9-aa62241fe100">
