### PR TITLE
Swap out heading mixin

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.scss
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-navigation.scss
@@ -108,10 +108,9 @@
   }
 
   &--parent {
-    @include heading-4;
+    margin-bottom: 0;
     font-size: 1em;
     font-weight: 300;
-    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
This code includes the heading-4 mixin, but then overwrites the font-size, font-weight, and margin-bottom, which is most of the heading-4 mixin. The remaining values of `letter-spacing`, `line-height`, `text-transform` come from the base secondary nav.


## Changes

- Swap out heading mixin


## How to test this PR

1. `o-secondary-nav__link--parent` on a regs page, like http://localhost:8000/rules-policy/regulations/1092/204/, should be visually unchanged.
