### PR TITLE
Events - Organize overrides

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.scss
+++ b/cfgov/unprocessed/css/on-demand/event.scss
@@ -125,7 +125,6 @@
 
   .datetime {
     @include h5;
-    text-transform: uppercase;
   }
 
   .event-meta__address {
@@ -158,10 +157,12 @@
 }
 
 .modification-date {
-  @include h6;
   background: var(--green-20);
   color: var(--black);
-  letter-spacing: 0;
   padding: math.div(9px, $base-font-size-px) + rem;
   text-align: center;
+
+  @include h6;
+  // Override for h6 letter-spacing
+  letter-spacing: 0;
 }


### PR DESCRIPTION
`h5` includes `text-transform: uppercase`, so it doesn't seem like we need to declare it again.


## Changes

- Remove redundant `text-transform`
- Move h6 mixin below declarations and note letter-spacing override.


## How to test this PR

1. An event like http://localhost:8000/about-us/events/archive-past-events/2016-academic-research-council-meeting/ should be unchanged in its datetime appearances.

