### PR TITLE
Update itemprop quoting in jinja template 

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -46,7 +46,7 @@
             <span class="o-expandable__icon">{{ svg_icon( value.icon ) }}</span>
         {% endif %}
         <span class="o-expandable__label"
-              {{'itemprop="name"' if value.is_faq else ''}}>
+              {{'itemprop=name' if value.is_faq else ''}}>
             {{ value.label }}
         </span>
         <span class="o-expandable__cues">


### PR DESCRIPTION
Follow-up to https://github.com/cfpb/consumerfinance.gov/pull/8565. There's another itemprop that was getting double-quoted.

