### PR TITLE
Remove h6 letter-spacing override

### DIFF
--- a/cfgov/unprocessed/css/on-demand/event.scss
+++ b/cfgov/unprocessed/css/on-demand/event.scss
@@ -163,6 +163,4 @@
   text-align: center;
 
   @include h6;
-  // Override for h6 letter-spacing
-  letter-spacing: 0;
 }


### PR DESCRIPTION
On event pages like https://www.consumerfinance.gov/about-us/events/archive-past-events/2016-academic-research-council-meeting/ we make the "modification date" have a tighter letter spacing.
It would be easier if we didn't have to override our standard h6 letter spacing. This seems like a non-standard pattern that we should probably remove, particularly since there's another date on the same page without the same spacing.

## Removals

- Remove h6 letter-spacing override

## How to test this PR

1. http://localhost:8000/about-us/events/archive-past-events/2016-academic-research-council-meeting/ shouldn't have such tightly spaced modification date compared to production.


## Screenshots

Before:
<img width="460" alt="Screenshot 2024-09-12 at 3 18 01 PM" src="https://github.com/user-attachments/assets/6ff9fdcf-53e6-4c37-98ee-9376c5ce9e4a">

After:
<img width="435" alt="Screenshot 2024-09-12 at 3 18 08 PM" src="https://github.com/user-attachments/assets/57e7818c-5452-49c2-9fed-a614d74f6797">

