### PR TITLE
Bugfix: Footer missing margin clearing at mobile

### DIFF
--- a/cfgov/unprocessed/css/organisms/footer.scss
+++ b/cfgov/unprocessed/css/organisms/footer.scss
@@ -107,6 +107,15 @@
     }
   }
 
+  // Mobile only.
+  @include respond-to-max($bp-xs-max) {
+    // This is essentially .m-list--links.
+    &__nav-list .m-list__item,
+    &__list .m-list__item {
+      margin-bottom: 0;
+    }
+  }
+
   &__pre {
     position: relative;
     margin-bottom: math.div(45px, $base-font-size-px) + em;


### PR DESCRIPTION
In the Less to Sass work this override for the default `li` margin was overlooked.


## Changes

- Bugfix: Footer missing margin clearing at mobile


## How to test this PR

1. `yarn build` and visit any page and resize to mobile and hover over the footer links. The line above and below the link should go solid.


## Screenshots

Before:
<img width="581" alt="Screenshot 2024-09-12 at 4 00 30 PM" src="https://github.com/user-attachments/assets/c2d19fe9-cc3a-4fef-b457-9bc4aa181abd">

After:
<img width="587" alt="Screenshot 2024-09-12 at 4 00 19 PM" src="https://github.com/user-attachments/assets/2c2335a8-07f3-4454-874f-e1fe95767037">



## Notes and todos

- The footer links should be re-written to be groups of jump links.