### PR TITLE
Remove `short-desc` CSS class

### DIFF
--- a/cfgov/jobmanager/jinja2/jobmanager/job_listing_list.html
+++ b/cfgov/jobmanager/jinja2/jobmanager/job_listing_list.html
@@ -45,6 +45,6 @@
        View all job openings
     </a>
     {% else %}
-    <h3 class='short-desc'>There are no current openings at this time.</h3>
+    <h3>There are no current openings at this time.</h3>
     {% endif %}
 </div>

--- a/cfgov/retirement_api/jinja2/retirement_api/about.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/about.html
@@ -99,7 +99,7 @@
         <h2>
             my Social Security
         </h2>
-        <p class="short-desc">
+        <p>
             {{ _("Create a <em>my</em> Social Security account to review your expected benefits based on your actual Social Security record.") }}
         </p>
         <a href="https://www.ssa.gov/myaccount/" class="a-btn a-btn--full">
@@ -110,7 +110,7 @@
         <h2>
             {{ _("Get in touch") }}
         </h2>
-        <p class="short-desc">
+        <p>
             {{ _("You can send feedback or questions to") }} <a href="mailto:olderamericans@cfpb.gov">olderamericans@cfpb.gov</a>.
         </p>
     </div>

--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.scss
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.scss
@@ -84,11 +84,6 @@
     @include h4;
     // Override for h4 margin.
     margin: 0;
-
-    .short-desc {
-      display: block;
-      font-size: $base-font-size-px;
-    }
   }
 }
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/chart.html
@@ -35,7 +35,7 @@
          {% if value.description %}{{ value.description }}{% endif %}
     </div>
 
-    <p class="m-chart-footnote block--sub block--border-top block short-desc">
+    <p class="m-chart-footnote block--sub block--border-top block">
         <strong>Source:</strong> CFPB Consumer Credit Panel<br>
         <strong>Date published:</strong> {{ value.date_published.strftime('%B %Y') }}<br>
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-chart.html
@@ -168,7 +168,7 @@
          id="mp-line-chart">
         {{ value.description }}
     </div>
-    <p class="m-chart-footnote block block--sub block--border-top short-desc">
+    <p class="m-chart-footnote block block--sub block--border-top">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a href="{{ state_meta['url'] }}">state</a> ({{ state_meta['size'] }}), <a href="{{ metro_meta['url'] }}">metro and non-metro areas</a> ({{ metro_meta['size'] }}), or <a href="{{ county_meta['url'] }}">county</a> ({{ county_meta['size'] }}).<br>

--- a/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/mortgage-map.html
@@ -207,7 +207,7 @@
             </g>
         </svg>
     </div>
-    <p class="m-chart-footnote block block--sub short-desc">
+    <p class="m-chart-footnote block block--sub">
     <strong>Source:</strong> National Mortgage Database<br>
     <strong>Date published:</strong> {{ pub_date_formatted }}<br>
     <strong>Downloads:</strong> CSV files with data by <a href="{{ state_meta['url'] }}">state</a> ({{ state_meta['size'] }}), <a href="{{ metro_meta['url'] }}">metro and non-metro areas</a> ({{ metro_meta['size'] }}), or <a href="{{ county_meta['url'] }}">county</a> ({{ county_meta['size'] }}).<br>

--- a/cfgov/v1/jinja2/v1/includes/organisms/simple-chart.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/simple-chart.html
@@ -59,7 +59,7 @@
          >
     </div>
     <div class="o-simple-chart__tilemap-legend"></div>
-    <p class="m-chart-footnote block block--sub block--border-top short-desc">
+    <p class="m-chart-footnote block block--sub block--border-top">
         {% if value.source_credits %}<strong>Source:</strong> {{value.source_credits}}<br>{% endif %}
         {% if value.date_published %}<strong>Date Published:</strong> {{value.date_published}}<br>{% endif %}
         {% if value.download_text %}


### PR DESCRIPTION
`short-desc` only has styles in `cf-notification`, which is a deprecated notification used on PfC disclosures, which actually doesn't include `short-desc` in its markup.

## Removals

- Remove `short-desc`

## How to test this PR

1. PR checks should pass.
