### PR TITLE
Remove regs label margin

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.scss
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.scss
@@ -37,6 +37,25 @@
     border: 1px solid var(--gray-40);
     background-color: var(--gray-5);
 
+    .reg-checkbox {
+      display: inline-block;
+    }
+    .num-results {
+      float: right;
+    }
+    .o-form__group {
+      margin-bottom: 0;
+    }
+
+    // TODO: Create sidebar filter pattern and remove expandable customizations.
+    .o-expandable {
+      padding-bottom: 15px;
+      border-bottom: 1px solid var(--gray-40);
+      margin-bottom: 15px;
+      &:last-child() {
+        border-bottom: none;
+      }
+    }
     .o-expandable__content,
     .o-expandable__header {
       border: 0;
@@ -46,29 +65,6 @@
         border: 0;
         padding: 0;
       }
-    }
-
-    .reg-checkbox {
-      display: inline-block;
-    }
-    .num-results {
-      float: right;
-    }
-    .o-expandable {
-      padding-bottom: 15px;
-      border-bottom: 1px solid var(--gray-40);
-      margin-bottom: 15px;
-      &:nth-child(3n) {
-        border-bottom: none;
-      }
-      &__label {
-        @include h4;
-        // Override for h4 margin.
-        margin-bottom: 0;
-      }
-    }
-    .o-form__group {
-      margin-bottom: 0;
     }
   }
   .content__main {


### PR DESCRIPTION
Expandables already format labels as h4s, so the `@include h4;` was redundant, other than it added margin at mobile. However, with the margin added it was misaligning the label text and the cue, since the margin was only added to the label. Probably best to just strip out this customization and make the label slightly closer to its content, which matches the desktop appearance.

## Changes

- Moves all expandable overriding code together and adds a TODO.
- Change `nth-child(3n)` to `last-child()` to remove last border of filters.
- Removes expandable label h4 customization.


## How to test this PR

1.  `yarn build`
2. Visit http://localhost:8000/rules-policy/regulations/search-regulations/results/?regs=1002&q=mortgage 
3. Resize to mobile and compare the filters labels position to production. It should be slightly closer to the content.


## Screenshots

Before:

<img width="235" alt="Screenshot 2024-09-13 at 1 05 55 PM" src="https://github.com/user-attachments/assets/59391c2f-4b07-483f-aabb-7fc841adc781">
 
After:
<img width="226" alt="Screenshot 2024-09-13 at 1 06 09 PM" src="https://github.com/user-attachments/assets/cb09a95c-4d8d-456e-9605-cb377d2a0b78">

