### PR TITLE
Remove h2s from prepaid agreements

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -30,23 +30,23 @@
     <div class="content-l">
             <div class="content-l__col content-l__col-1-2">
                 <dl>
-                    <dt><h2>Issuer name</h2></dt>
+                    <dt>Issuer name</dt>
                     <dd>{{ product.issuer_name }}</dd>
-                    <dt><h2>Prepaid product type</h2></dt>
+                    <dt>Prepaid product type</dt>
                     <dd>{{ product.prepaid_type if product.prepaid_type else default_text }}</dd>
                 </dl>
             </div>
             <div class="content-l__col content-l__col-1-2">
                 <dl>
-                    <dt><h2>Program manager</h2></dt>
+                    <dt>Program manager</dt>
                     <dd>{{ product.program_manager if product.program_manager else default_text }}</dd>
-                    <dt><h2>Current status</h2></dt>
+                    <dt>Current status</dt>
                     <dd>{{ product.status if product.status else default_text }}</dd>
                 </dl>
             </div>
         </div>
             <dl>
-                <dt><h2>Other relevant parties</h2></dt>
+                <dt>Other relevant parties</dt>
                 <dd>
                 {% if product.other_relevant_parties %}
                     {% if product.other_relevant_parties | length > 500 %}

--- a/cfgov/unprocessed/apps/prepaid-agreements/css/main.scss
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/main.scss
@@ -30,13 +30,6 @@
     // Override for h4 margin.
     margin-bottom: math.div(math.div($grid-gutter-width, 6), $base-font-size-px) +
       em;
-
-    &:last-of-type {
-      margin-bottom: math.div(
-          math.div($grid-gutter-width, 6),
-          $base-font-size-px
-        ) + em;
-    }
   }
 
   dd + dt {
@@ -104,13 +97,6 @@
 }
 
 .prepaid-agreements-detail {
-  dt h2 {
-    @include h4;
-    // Override for h4 margin.
-    margin-bottom: math.div(math.div($grid-gutter-width, 6), $base-font-size-px) +
-      em;
-  }
-
   dd {
     margin-bottom: math.div(
         math.div($grid-gutter-width, 1.5),


### PR DESCRIPTION
The prepaid agreements have definition lists for each company. The detail pages set these definition terms (dt) as h2s, which includes them in the heading structure. On the search results list they are not h2s, so are not included in the heading structure.

On the details page, the dts are h2s that are set as h4s via CSS, which steps down at mobile. The search result page set these dts as heading-4s, which don't step down at mobile.

I could be wrong, but it doesn't seem like the dts should be heading elements, but instead their parent should be the heading element, which it is (the company name). 

## Changes

- Remove h2 from definition terms.
- Remove unneeded heading CSS.


## How to test this PR

1.  `yarn build` and visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and compare to production. Resize to mobile.


## Screenshots

Before:
<img width="802" alt="Screenshot 2024-09-13 at 3 40 55 PM" src="https://github.com/user-attachments/assets/78b9e380-0a3f-458a-af38-4f317e0f87cb">

After:
<img width="786" alt="Screenshot 2024-09-13 at 3 41 03 PM" src="https://github.com/user-attachments/assets/9cec4319-5e2c-4b02-9096-a4f182f5fbd2">

## Todo

- The definition lists should be a continuous list (instead of two) and laid out using CSS grid into two columns.