### PR TITLE
PfC: Remove `.estimated-expenses .aid-form__summary-heading`

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/disclosures.scss
+++ b/cfgov/unprocessed/apps/paying-for-college/css/disclosures.scss
@@ -1415,13 +1415,6 @@ $bp-graph-cols-min: 740px;
         padding-left: math.div(40px, $base-font-size-px) + em;
       }
     }
-
-    &__summary-heading {
-      @include heading-4;
-      // Override for h4 margin and text-transform.
-      margin-bottom: math.div(10px, $size-iv) + em;
-      text-transform: none;
-    }
   }
 
   .line-item {


### PR DESCRIPTION
I couldn't find that `.estimated-expenses .aid-form__summary-heading` matched any element.

## Changes

- PfC: Remove `.estimated-expenses .aid-form__summary-heading`


## How to test this PR

1. Check [the disclosures tool](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=154022&pid=BAHCA&totl=70950&tuit=14160&hous=7109&book=1150&tran=500&othr=4743&pelg=0&schg=&stag=&othg=&mta=&gib=&wkst=0&ppl=&parl=&perl=&subl=3500&unsl=6000&gpl=&prvl=&prvi=&prvf=&insl=&insi=&inst=&oid=4D0B9265B45716DF4B81EEB4BE117E1DF69871AF) and try to find an element that matches `.estimated-expenses .aid-form__summary-heading`. 
