### PR TITLE
Tiny fix to remove parentheses

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/reg-search.scss
+++ b/cfgov/unprocessed/apps/regulations3k/css/reg-search.scss
@@ -52,7 +52,7 @@
       padding-bottom: 15px;
       border-bottom: 1px solid var(--gray-40);
       margin-bottom: 15px;
-      &:last-child() {
+      &:last-child {
         border-bottom: none;
       }
     }


### PR DESCRIPTION
Tiny follow-on to https://github.com/cfpb/consumerfinance.gov/pull/8577/ to remove unnecessary parentheses.