### PR TITLE
Remove matplotlib and dependent code

### DIFF
--- a/cfgov/tccp/management/commands/validate_tccp.py
+++ b/cfgov/tccp/management/commands/validate_tccp.py
@@ -1,7 +1,5 @@
 from django.core.management.base import BaseCommand, CommandError
 
-import matplotlib.pyplot as plt
-
 from tccp.enums import CreditTierColumns, PurchaseAPRRatings
 from tccp.filterset import CardSurveyDataFilterSet
 from tccp.models import CardSurveyData
@@ -23,16 +21,7 @@ def fmt_range(min, max):
 class Command(BaseCommand):
     help = "Validate TCCP dataset"
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--save-charts",
-            help="Save charts of card purchase APRs (requires matplotlib)",
-            action="store_true",
-        )
-
     def handle(self, **options):
-        save_charts = options["save_charts"]
-
         summary_stats = CardSurveyData.objects.get_summary_statistics()
 
         if not summary_stats["count"]:
@@ -114,108 +103,4 @@ class Command(BaseCommand):
             if not all(situation_counts.values()):
                 raise CommandError("Situation with no results!")
 
-            # Dump out purchase APR charts, if specified.
-            if save_charts:
-                self.save_tier_specific_purchase_apr_chart(
-                    tier_name,
-                    tier_column,
-                    cards_for_tier,
-                    summary_stats,
-                )
-
             self.stdout.write()
-
-    def save_tier_specific_purchase_apr_chart(
-        self, tier_name, tier_column, cards_for_tier, summary_stats
-    ):
-        plt.figure(figsize=(10, 6))
-
-        cards = list(
-            cards_for_tier.order_by("purchase_apr_for_tier_max").values(
-                "purchase_apr_min",
-                "purchase_apr_max",
-                "purchase_apr_median",
-                f"purchase_apr_{tier_column}",
-                f"purchase_apr_{tier_column}_rating",
-            )
-        )
-
-        # Plot min-max.
-        min_maxes = {
-            i: (100 * card["purchase_apr_min"], 100 * card["purchase_apr_max"])
-            for i, card in enumerate(cards)
-            if card["purchase_apr_min"] and card["purchase_apr_max"]
-        }
-        plt.vlines(
-            list(min_maxes.keys()),
-            ymin=[v[0] for v in min_maxes.values()],
-            ymax=[v[1] for v in min_maxes.values()],
-            color="lightgray",
-            label="Global minimum - maximum",
-        )
-
-        # Plot global medians.
-        global_medians = {
-            i: 100 * card["purchase_apr_median"]
-            for i, card in enumerate(cards)
-            if card["purchase_apr_median"]
-        }
-        plt.plot(
-            list(global_medians.keys()),
-            list(global_medians.values()),
-            label="Global median",
-            linestyle="",
-            marker="o",
-        )
-
-        # Plot tier-specific medians.
-        tier_medians = {
-            i: 100 * card[f"purchase_apr_{tier_column}"]
-            for i, card in enumerate(cards)
-            if card[f"purchase_apr_{tier_column}"]
-        }
-        plt.plot(
-            list(tier_medians.keys()),
-            list(tier_medians.values()),
-            label="Tier-specific median",
-            linestyle="",
-            marker=".",
-        )
-
-        for rating, (percentile, color) in enumerate(
-            [(25, "darkgreen"), (75, "gold")]
-        ):
-            pct_cards = [
-                i
-                for i, card in enumerate(cards)
-                if card[f"purchase_apr_{tier_column}_rating"] == rating
-            ]
-
-            if not pct_cards:
-                continue
-
-            pct_index = max(pct_cards)
-
-            pct_value = (
-                100
-                * summary_stats[f"purchase_apr_{tier_column}_pct{percentile}"]
-            )
-
-            plt.axvline(
-                pct_index,
-                label=(
-                    f"{percentile}th Percentile (Index: {pct_index}): "
-                    f"{pct_value:.2f}%"
-                ),
-                color=color,
-            )
-
-        plt.xlabel(f"Cards ({len(cards)}, sorted by purchase APR)")
-        plt.ylabel("Purchase APR (%)")
-        plt.title(f"Purchase APRs for tier: {tier_name}")
-        plt.legend()
-        plt.grid(True)
-
-        filename = f"tccp-purchase-aprs-{tier_column}.png"
-        self.stdout.write(f"Saving chart to {filename}.")
-        plt.savefig(filename, bbox_inches="tight")

--- a/cfgov/tccp/tests/test_validate.py
+++ b/cfgov/tccp/tests/test_validate.py
@@ -140,10 +140,3 @@ Earn rewards: 3
 """.strip()
             + "\n\n",
         )
-
-    def test_charts(self):
-        self.make_test_data()
-
-        self.assertFalse(len(os.listdir(self.tempdir)))
-        self.call_validate(save_charts=True)
-        self.assertEqual(len(os.listdir(self.tempdir)), 3)

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -21,7 +21,6 @@ elasticsearch<7.11  # Keep pinned to the deployed ES version
 govdelivery==1.4.0
 Jinja2==3.1.4
 lxml==5.2.2
-matplotlib==3.7.5
 mozilla-django-oidc==4.0.1
 opensearch-py==2.6.0
 # psycopg2 > 2.9.6 causes cf.gov to hang locally for people with on-network


### PR DESCRIPTION
This change removes our matplotlib dependency and chart-generation code and option in the TCCP validation management command.

This should fix our dev docker container build for folks while we're still on Python 3.8.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
