### PR TITLE
Bump wagtail-inventory

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -37,7 +37,7 @@ wagtail-content-audit==0.1
 wagtail_draftail_anchors==0.6.0
 wagtail-flags==5.3.1
 wagtail-footnotes==0.12
-wagtail-inventory==2.6
+wagtail-inventory==3.0
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.12.1
 wagtail-treemodeladmin==1.9.2


### PR DESCRIPTION
This change updates wagtail-inventory to 3.0, which adds support for Wagtail 6.2's universal listings in the report view.

This unbreaks the block inventory report.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
