### PR TITLE
TCCP: Change "N/A" to "Not available"

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/fields.html
+++ b/cfgov/tccp/jinja2/tccp/includes/fields.html
@@ -1,6 +1,6 @@
 {%- macro apr(value, asterisk=asterisk) -%}
     {% if value is none -%}
-        N/A
+        Not available
     {%- elif value == 0 -%}
         0%
     {%- else -%}


### PR DESCRIPTION
Changes "N/A" to "Not available" when APRs are blank in the data.

See GHE/Design-Development/External-Products/issues/399 for full details. The upshot is when people saw "N/A balance transfer APR" on cards in the card list in usability testing, they thought the card had no APR on balance transfers instead of what it actually means: the card doesn't offer balance transfers. This change is our attempt to make it clearer.

Note that the `apr` macro is used in lots of places and, in theory, "N/A" (as in "not applicable") might make more sense in some spots. Practically, though, in the current datasets the only place "N/A" will show up is in the card list for cards that don't offer a balance transfer, so this change seems better than something more complex like making both "N/A" and "Not available" possible outputs of the `apr` macro.

---

## Changes

- "N/A" now reads "Not available"

## How to test this PR

1. Go to http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/ and make sure any cards that don't offer a balance transfer show "Not available" instead of "N/A" in that field.

## Screenshots

Before | This PR
---- | ----
<img width="1197" alt="old" src="https://github.com/user-attachments/assets/bd265974-aeca-4876-bfb6-8cc80347ee3e"> | <img width="1197" alt="new" src="https://github.com/user-attachments/assets/20164c6d-543a-4e71-b2ab-46b90cdb7e17">

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)