### PR TITLE
Use nonce-based Content Security Policy

### DIFF
--- a/cfgov/agreements/jinja2/agreements/base_agreements.html
+++ b/cfgov/agreements/jinja2/agreements/base_agreements.html
@@ -9,7 +9,7 @@
 {{ super() }}
 <script src="{{ static( 'agreements/js/jquery-3.5.1.min.js' ) }}"></script>
 <script src="{{ static( 'agreements/js/chosen.jquery.js' ) }}"></script>
-<script>
+<script nonce="{{request.csp_nonce}}">
     $(document).ready(function () {
         $("#issuer_select").chosen();
         $("#issuer_select").chosen().change( function(e){

--- a/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
+++ b/cfgov/ask_cfpb/jinja2/ask-cfpb/landing-page.html
@@ -48,5 +48,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script src="{{ static('apps/ask-cfpb/js/main.js') }}"></script>
+    <script nonce="{{request.csp_nonce}}">
+      jsl(["{{ static('apps/ask-cfpb/js/main.js') }}"])
+    </script>
 {% endblock javascript %}

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -463,117 +463,28 @@ if ENABLE_CLOUDFRONT_CACHE_PURGE:
         "HOSTNAMES": environment_json("CLOUDFRONT_PURGE_HOSTNAMES")
     }
 
-# CSP Allowlists
+# CSP
 #
-# Please note: Changing these lists will change the value of the
-# Content-Security-Policy header Django returns. Django does NOT include
-# header values when calculating the response hash returned in the ETag
-# header.
-# Our Akamai cache uses the ETag header to know whether a cached copy of a
-# page has been updated after it expires or after an invalidation purge.
-#
-# Together, this means that any changes to these CSP values WILL NOT BE
-# RETURNED by Akamai until a page's non-header content changes, or a
-# delete-purge is performed.
+# See https://web.dev/articles/strict-csp
 
-# These specify what is allowed in <script> tags
 CSP_SCRIPT_SRC = (
-    "'self'",
+    "'strict-dynamic'",
+    "https:",
     "'unsafe-inline'",
-    "'unsafe-eval'",
-    "*.consumerfinance.gov",
-    "dap.digitalgov.gov",
-    "*.googleanalytics.com",
-    "*.google-analytics.com",
-    "*.googletagmanager.com",
-    "*.googleoptimize.com",
-    "optimize.google.com",
-    "api.mapbox.com",
-    "js-agent.newrelic.com",
-    "bam.nr-data.net",
-    "gov-bam.nr-data.net",
-    "*.youtube.com",
-    "*.ytimg.com",
-    "*.mouseflow.com",
-    "*.geo.census.gov",
-    "about:",
-    "www.federalregister.gov",
-    "*.qualtrics.com",
-    "www.ssa.gov/accessibility/andi/",
-    "ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js", # needed for ANDI accessibility tool
 )
-
-# These specify valid sources of CSS code
 CSP_STYLE_SRC = (
     "'self'",
     "'unsafe-inline'",
-    "*.consumerfinance.gov",
-    "*.googletagmanager.com",
-    "optimize.google.com",
-    "fonts.googleapis.com",
-    "api.mapbox.com",
-    "www.ssa.gov/accessibility/andi/",
+    "https:",
 )
-
-# These specify valid image sources
 CSP_IMG_SRC = (
-    "'self'",
-    "*.consumerfinance.gov",
-    "www.ecfr.gov",
-    "s3.amazonaws.com",
-    "img.youtube.com",
-    "*.google-analytics.com",
-    "*.googletagmanager.com",
-    "optimize.google.com",
-    "api.mapbox.com",
-    "*.tiles.mapbox.com",
-    "blob:",
+    "*",
     "data:",
-    "www.gravatar.com",
-    "*.qualtrics.com",
-    "*.mouseflow.com",
-    "i.ytimg.com",
-    "www.ssa.gov/accessibility/andi/",
+    "blob:",
 )
-
-# These specify what URL's we allow to appear in frames/iframes
-CSP_FRAME_SRC = (
-    "'self'",
-    "*.consumerfinance.gov",
-    "*.googletagmanager.com",
-    "*.google-analytics.com",
-    "*.googleoptimize.com",
-    "optimize.google.com",
-    "www.youtube.com",
-    "*.qualtrics.com",
-    "mailto:",
-)
-
-# These specify where we allow fonts to come from
-CSP_FONT_SRC = ("'self'", "fonts.gstatic.com")
-
-# These specify hosts we can make (potentially) cross-domain AJAX requests to
-CSP_CONNECT_SRC = (
-    "'self'",
-    "*.consumerfinance.gov",
-    "*.google-analytics.com",
-    "*.googleoptimize.com",
-    "*.tiles.mapbox.com",
-    "api.mapbox.com",
-    "bam.nr-data.net",
-    "gov-bam.nr-data.net",
-    "s3.amazonaws.com",
-    "public.govdelivery.com",
-    "n2.mouseflow.com",
-    "*.qualtrics.com",
-    "raw.githubusercontent.com",
-)
-
-# These specify valid media sources (e.g., MP3 files)
-CSP_MEDIA_SRC = (
-    "'self'",
-    "*.consumerfinance.gov",
-)
+CSP_OBJECT_SRC = ("'none'")
+CSP_BASE_URI = ("'none'")
+CSP_INCLUDE_NONCE_IN = ["script-src"]
 
 # FEATURE FLAGS
 # Flags can be declared here with an empty list, which will evaluate as false

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -485,6 +485,7 @@ CSP_IMG_SRC = (
 CSP_OBJECT_SRC = ("'none'")
 CSP_BASE_URI = ("'none'")
 CSP_INCLUDE_NONCE_IN = ["script-src"]
+CSP_EXCLUDE_URL_PREFIXES = ("/admin")
 
 # FEATURE FLAGS
 # Flags can be declared here with an empty list, which will evaluate as false

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -94,8 +94,6 @@ WAGTAIL_PLACEHOLDERIMAGES_SOURCE = (
     f"//{_placeholder_domain}/{{width}}x{{height}}/addc91/1fa040"
 )
 
-CSP_IMG_SRC += (_placeholder_domain,)
-
 # Add django-cprofile-middleware to enable lightweight local profiling.
 # The middleware's profiling is only available if DEBUG=True
 MIDDLEWARE += ("django_cprofile_middleware.middleware.ProfilerMiddleware",)

--- a/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
+++ b/cfgov/filing_instruction_guide/jinja2/filing_instruction_guide/index.html
@@ -38,7 +38,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
         jsl(['{{ static("apps/filing-instruction-guide/js/fig-init.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -315,7 +315,7 @@
 {% block javascript %}
     {{ super() }}
 
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       // Store backend settings to pass to front-end scripts.
       window.cfpbHudSettings = {};
       window.cfpbHudSettings.hud_data = {};
@@ -325,7 +325,7 @@
       window.cfpbHudSettings.mapbox_access_token = "{{ mapbox_access_token }}";
     </script>
 
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("apps/find-a-housing-counselor/js/common.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/jinja2/ccdb-complaint/ccdb-search.html
+++ b/cfgov/jinja2/ccdb-complaint/ccdb-search.html
@@ -38,7 +38,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl([
         'https://files.consumerfinance.gov/ccdb/metadata.js',
         '{{ static("apps/ccdb-search/js/main.js") }}'

--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -606,7 +606,7 @@ home price, down payment, and more can affect mortgage interest rates.
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl([
         '{{ static("apps/owning-a-home/js/common.js") }}',
         '{{ static("apps/owning-a-home/js/explore-rates/index.js") }}'

--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -19,7 +19,7 @@ home price, down payment, and more can affect mortgage interest rates.
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       window.cfpbMapboxAccessToken = '{{ mapbox_access_token }}';
       jsl(['{{ static("apps/rural-or-underserved-tool/js/common.js") }}']);
     </script>

--- a/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/college-costs.html
@@ -77,7 +77,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("apps/paying-for-college/js/college-costs.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
+++ b/cfgov/paying_for_college/jinja2/paying-for-college/disclosure.html
@@ -3332,7 +3332,7 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script>
+<script nonce="{{request.csp_nonce}}">
   jsl(['{{ static("apps/paying-for-college/js/disclosures/index.js") }}']);
 </script>
 {% endblock javascript %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/detail.html
@@ -137,7 +137,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("js/routes/data-research/prepaid-accounts/search-agreements/index.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
@@ -89,7 +89,7 @@
 
 {% block javascript %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("apps/prepaid-agreements/js/common.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
+++ b/cfgov/privacy/jinja2/privacy/disclosure-consent-form.html
@@ -304,7 +304,7 @@
 
 {% block javascript %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("js/routes/on-demand/privacy-forms.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/privacy/jinja2/privacy/records-access-form.html
+++ b/cfgov/privacy/jinja2/privacy/records-access-form.html
@@ -277,7 +277,7 @@
 
 {% block javascript %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("js/routes/on-demand/privacy-forms.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/browse-regulation.html
@@ -312,7 +312,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl([
         '{{ static("apps/regulations3k/js/index.js") }}',
         '{{ static("apps/regulations3k/js/permalinks.js") }}'

--- a/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/landing-page.html
@@ -43,7 +43,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl([
         '{{ static("apps/regulations3k/js/index.js") }}',
         '{{ static("apps/regulations3k/js/recent-notices.js") }}'

--- a/cfgov/regulations3k/jinja2/regulations3k/regulations3k-side-nav.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/regulations3k-side-nav.html
@@ -32,7 +32,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("js/routes/on-demand/secondary-nav.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
+++ b/cfgov/regulations3k/jinja2/regulations3k/search-regulations.html
@@ -194,7 +194,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl([
         '{{ static("apps/regulations3k/js/index.js") }}'
         {%- if page.results.search_query -%}

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -988,7 +988,7 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script>
+<script nonce="{{request.csp_nonce}}">
   jsl(['{{ static("apps/retirement/js/index.js") }}']);
 </script>
 {% endblock javascript %}

--- a/cfgov/v1/jinja2/v1/layouts/404.html
+++ b/cfgov/v1/jinja2/v1/layouts/404.html
@@ -53,8 +53,3 @@
         </p>
     </div>
 {% endblock %}
-
-{% block javascript %}
-{# Include site-wide JavaScript. #}
-<script type='text/javascript' src="{{ static('js/routes/common.js') }}"></script>
-{% endblock javascript %}

--- a/cfgov/v1/jinja2/v1/layouts/500.html
+++ b/cfgov/v1/jinja2/v1/layouts/500.html
@@ -53,8 +53,3 @@
         </p>
     </div>
 {% endblock %}
-
-{% block javascript %}
-{# Include site-wide JavaScript. #}
-<script type='text/javascript' src="{{ static('js/routes/common.js') }}"></script>
-{% endblock javascript %}

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -150,7 +150,7 @@ itemscope itemtype="https://schema.org/FAQPage"
           href="{{ static('fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2') }}"
           as="font"
           type="font/woff2" crossorigin>
-    <link rel="preload" href="{{ static('js/routes/common.js') }}" as="script">
+    <link rel="preload" nonce="{{request.csp_nonce}}" href="{{ static('js/routes/common.js') }}" as="script">
 
     {# Preconnecting comes from the 3rd best practice in
        https://developer.mozilla.org/en-US/docs/Web/Performance/dns-prefetch#best_practices #}
@@ -184,7 +184,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     {# Begin Google Optimize #}
     {# Optimize anti-flicker snippet. #}
     <style>.async-hide { opacity: 0 !important} </style>
-    <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+    <script nonce="{{request.csp_nonce}}">(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
     h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
     (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
     })(window,document.documentElement,'async-hide','dataLayer',4000,
@@ -197,7 +197,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     {% endif %}
 
     {# Begin Google Tag Manager #}
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    <script nonce="{{request.csp_nonce}}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;
@@ -209,7 +209,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     {% endif -%}
 
     {% block javascript_loader %}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       {# Minified dynamic JavaScript loader that injects a script tag in the head of the page. #}
       function jsl(a){
         if(window.fetch){
@@ -219,7 +219,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     </script>
     {% endblock javascript_loader %}
 
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       if(window.fetch){
         document.documentElement.className = document.documentElement.className.replace('no-js', 'js')
       }
@@ -308,7 +308,7 @@ itemscope itemtype="https://schema.org/FAQPage"
 
     {% block javascript scoped %}
 
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       if ( window.fetch ) {
         !function(){
           {# Include site-wide JavaScript. #}
@@ -361,7 +361,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     </script>
 
     {% if flag_enabled('PATH_MATCHES_FOR_QUALTRICS') %}
-        <script type='text/javascript'>
+        <script nonce="{{request.csp_nonce}}" type='text/javascript'>
         (function(){var g=function(e,h,f,g){
         this.get=function(a){for(var a=a+"=",c=document.cookie.split(";"),b=0,e=c.length;b<e;b++){for(var d=c[b];" "==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return d.substring(a.length,d.length)}return null};
         this.set=function(a,c){var b="",b=new Date;b.setTime(b.getTime()+6048E5);b="; expires="+b.toGMTString();document.cookie=a+"="+c+b+"; path=/; "};

--- a/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
@@ -35,7 +35,7 @@
 
 {% block javascript scoped %}
     {{ super() }}
-    <script>
+    <script nonce="{{request.csp_nonce}}">
       jsl(['{{ static("js/routes/on-demand/secondary-nav.js") }}']);
     </script>
 {% endblock javascript %}

--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/userbar/base.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/userbar/base.html
@@ -1,0 +1,41 @@
+{% load wagtailadmin_tags i18n %}
+<!-- Wagtail user bar embed code -->
+<template id="wagtail-userbar-template">
+    {# In preview panels, we still render the userbar UI, but hidden by default. #}
+    <aside {% if request.in_preview_panel %}hidden{% endif %}>
+        <div class="w-userbar w-userbar--{{ position|default:'bottom-right' }} {% admin_theme_classname %}" data-wagtail-userbar part="userbar">
+            <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/core.css' %}">
+            {% hook_output 'insert_global_admin_css' %}
+            <div class="w-userbar-nav">
+
+                <svg class="w-hidden">
+                    <defs>
+                        {% include "wagtailadmin/icons/wagtail.svg" %}
+                        {% include "wagtailadmin/icons/key.svg" %}
+                        {% include "wagtailadmin/icons/folder-open-inverse.svg" %}
+                        {% include "wagtailadmin/icons/edit.svg" %}
+                        {% include "wagtailadmin/icons/plus.svg" %}
+                        {% include "wagtailadmin/icons/check.svg" %}
+                        {% include "wagtailadmin/icons/cross.svg" %}
+                        {% include "wagtailadmin/icons/crosshairs.svg" %}
+                    </defs>
+                </svg>
+
+                <button aria-controls="wagtail-userbar-items" aria-haspopup="true" class="w-userbar-trigger" id="wagtail-userbar-trigger" data-wagtail-userbar-trigger>
+                    {% block branding_logo %}{% include "wagtailadmin/logo.html" with classname="w-userbar-icon" %}{% endblock %}
+                    <span class="w-sr-only">{% trans 'View Wagtail quick actions' %}</span>
+                </button>
+                <ul aria-labelledby="wagtail-userbar-trigger" class="w-userbar-items" id="wagtail-userbar-items" role="menu">
+                    {% for item in items %}
+                        {{ item|safe }}
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+        <div data-a11y-result-outline-container></div>
+    </aside>
+</template>
+<wagtail-userbar></wagtail-userbar>
+<script nonce="{{request.csp_nonce}}" src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
+<script nonce="{{request.csp_nonce}}" src="{% versioned_static 'wagtailadmin/js/userbar.js' %}"></script>
+<!-- end Wagtail user bar embed code -->

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -984,7 +984,7 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script>
+<script nonce="{{request.csp_nonce}}">
   jsl(['{{ static("apps/financial-well-being/js/home.js") }}']);
 </script>
 {% endblock %}

--- a/cfgov/wellbeing/jinja2/wellbeing/results.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/results.html
@@ -517,7 +517,7 @@
 
 {% block javascript scoped %}
 {{ super() }}
-<script>
+<script nonce="{{request.csp_nonce}}">
   jsl(['{{ static("apps/financial-well-being/js/results.js") }}']);
 </script>
 {% endblock %}


### PR DESCRIPTION
This updates our CSP to use nonces, provided by Django-csp. This shrinks the size of the CSP header by ~7x while increasing its security. The main mechanism of CSP enforcement is `strict-dynamic` mode, which requires a nonce (or hash) for any script element included in the html, but allows the creation of further script elements from trusted scripts (so we don't have to specifically allow a bunch of random third-party domains if we're already trusting their initiators).

Note: the `unsafe-inline` and `https:` bits are only for backwards compatibility with browsers that support CSP but not `strict-dynamic`. Modern browsers ignore these entries when `strict-dynamic` is set. Removing `unsafe-eval` and `unsafe-inline` from our CSP will increase its efficacy incredibly :)

Because we're much more secure-by-default, I've also removed a bunch of the other IMG/STYLE/etc CSP settings which are now less important (because XSS to then include bad domains/styles is harder).

Another important note: due to limitations in how Wagtail includes scripts *in the admin*, I've made admin pages exclude the CSP. This isn't actually a problem because these pages are excluded from the public website. The only other solution of this was to override several base wagtail templates, which seemed like a big maintenance headache (for no real benefit). One exception to this was this the wagtail userbar, which I needed to override so to get working.