### PR TITLE
Use Django storage for Wagtail deletion archive

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -177,7 +177,6 @@ export HUD_API_ENDPOINT=http://localhost:8000/hud-api-replace/
 # export OIDC_OP_JWKS_ENDPOINT=[Not used for test OIDC provider]
 # export OIDC_OP_ADMIN_ROLE=[Not supported by test OIDC provider]
 
-
 ###############################
 # Deletion archival storage
 ###############################

--- a/cfgov/apache/conf.d/wagtail_deletion.conf.sample
+++ b/cfgov/apache/conf.d/wagtail_deletion.conf.sample
@@ -1,7 +1,0 @@
-# Serve deleted content JSON archives at /__deleted
-PassEnv WAGTAIL_DELETION_ARCHIVE_PATH
-LoadModule autoindex_module modules/mod_autoindex.so
-Alias /__deleted/ "${WAGTAIL_DELETION_ARCHIVE_PATH}"
-<Directory "${WAGTAIL_DELETION_ARCHIVE_PATH}">
-    Options +Indexes
-</Directory>

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -271,7 +271,26 @@ STATICFILES_FINDERS = [
     "django.contrib.staticfiles.finders.FileSystemFinder",
 ]
 
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+if WAGTAIL_DELETION_ARCHIVE_PATH := os.getenv("WAGTAIL_DELETION_ARCHIVE_PATH"):
+    # Archive will be available under /admin/ + whatever this next line is:
+    WAGTAIL_DELETION_ARCHIVE_URL = "__deleted/"
+
+    STORAGES["wagtail_deletion_archival"] = {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {
+            "location": WAGTAIL_DELETION_ARCHIVE_PATH,
+        }
+    }
+
 
 # Add the frontend build output to static files.
 STATICFILES_DIRS = [
@@ -363,11 +382,14 @@ AWS_DEFAULT_ACL = None  # Default to using the ACL of the bucket
 if os.environ.get("S3_ENABLED", "False") == "True":
     AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
     AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     AWS_S3_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN")
     MEDIA_URL = os.path.join(
         AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com", AWS_LOCATION, ""
     )
+
+    STORAGES["default"] = {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+    }
 
 
 # GovDelivery

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -281,9 +281,6 @@ STORAGES = {
 }
 
 if WAGTAIL_DELETION_ARCHIVE_PATH := os.getenv("WAGTAIL_DELETION_ARCHIVE_PATH"):
-    # Archive will be available under /admin/ + whatever this next line is:
-    WAGTAIL_DELETION_ARCHIVE_URL = "__deleted/"
-
     STORAGES["wagtail_deletion_archival"] = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
         "OPTIONS": {

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -85,9 +85,9 @@ EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_HOST = os.getenv("EMAIL_HOST")
 DEFAULT_FROM_EMAIL = "wagtail@cfpb.gov"
 
-STATICFILES_STORAGE = (
-    "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
-)
+STORAGES["staticfiles"] = {
+    "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+}
 
 STATIC_ROOT = os.environ["DJANGO_STATIC_ROOT"]
 

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -41,6 +41,9 @@ BAKER_CUSTOM_CLASS = "core.testutils.baker.ActualContentTypeBaker"
 
 GOVDELIVERY_API = "core.govdelivery.MockGovDelivery"
 
+# Disable Wagtail deletion archive storage during testing.
+STORAGES.pop("wagtail_deletion_archival", None)
+
 STATICFILES_FINDERS += [
     "core.testutils.mock_staticfiles.MockStaticfilesFinder",
 ]

--- a/cfgov/wagtail_deletion_archival/apps.py
+++ b/cfgov/wagtail_deletion_archival/apps.py
@@ -1,15 +1,6 @@
 from django.apps import AppConfig
-from django.conf import settings
-
-import fs
 
 
 class WagtailDeletionArchivalConfig(AppConfig):
     name = "wagtail_deletion_archival"
     label = "wagtail_deletion_archival"
-    filesystem_name = getattr(
-        settings, "WAGTAIL_DELETION_ARCHIVE_FILESYSTEM", None
-    )
-    filesystem = (
-        fs.open_fs(filesystem_name) if filesystem_name is not None else None
-    )

--- a/cfgov/wagtail_deletion_archival/templates/wagtail_deletion_archival/import_page.html
+++ b/cfgov/wagtail_deletion_archival/templates/wagtail_deletion_archival/import_page.html
@@ -1,9 +1,9 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}Import page into {{ title }}{% endblock %}
+{% block titletag %}Import page into {{ parent_page.get_admin_display_title }}{% endblock %}
 
 {% block content %}
-    {% include "wagtailadmin/shared/header.html" with title="Import page" subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title="Import page" subtitle=parent_page.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         {% include "wagtailadmin/shared/non_field_errors.html" %}

--- a/cfgov/wagtail_deletion_archival/templates/wagtail_deletion_archival/import_page.html
+++ b/cfgov/wagtail_deletion_archival/templates/wagtail_deletion_archival/import_page.html
@@ -8,7 +8,7 @@
     <div class="nice-padding">
         {% include "wagtailadmin/shared/non_field_errors.html" %}
 
-        <form enctype="multipart/form-data" action="{% url 'import_page' parent_page.id %}" method="POST">
+        <form enctype="multipart/form-data" action="{% url 'wagtail_deletion_archive_import' parent_page.id %}" method="POST">
             {% csrf_token %}
             <ul class="fields">
                 {% for field in form %}

--- a/cfgov/wagtail_deletion_archival/tests/temp_storage.py
+++ b/cfgov/wagtail_deletion_archival/tests/temp_storage.py
@@ -1,0 +1,29 @@
+from tempfile import TemporaryDirectory
+
+from django.test import override_settings
+from django.test.utils import TestContextDecorator
+
+
+class uses_temp_archive_storage(TestContextDecorator):
+    def __init__(self):
+        super().__init__(attr_name="temp_storage", kwarg_name="temp_storage")
+
+    def enable(self):
+        self.temp_storage = TemporaryDirectory()
+
+        self.settings = override_settings(
+            STORAGES={
+                "wagtail_deletion_archival": {
+                    "BACKEND": "django.core.files.storage.FileSystemStorage",
+                    "OPTIONS": {
+                        "location": self.temp_storage.name,
+                    },
+                }
+            }
+        )
+        self.settings.enable()
+        return self.temp_storage.name
+
+    def disable(self):
+        self.settings.disable()
+        self.temp_storage.cleanup()

--- a/cfgov/wagtail_deletion_archival/tests/test_views.py
+++ b/cfgov/wagtail_deletion_archival/tests/test_views.py
@@ -1,6 +1,10 @@
 import json
+import os
+import os.path
 from io import StringIO
+from unittest import skipIf
 
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
@@ -8,59 +12,53 @@ from wagtail.models import Site
 from wagtail.test.utils import WagtailTestUtils
 
 from v1.models import BlogPage
-from wagtail_deletion_archival.utils import export_page
+from wagtail_deletion_archival.tests.temp_storage import (
+    uses_temp_archive_storage,
+)
+from wagtail_deletion_archival.utils import (
+    convert_page_to_json,
+    get_archive_storage,
+    make_archive_filename,
+)
 
 
-class ExportViewTestCase(TestCase, WagtailTestUtils):
-    def setUp(self):
-        self.root_page = Site.objects.get(is_default_site=True).root_page
-        self.page = BlogPage(
-            title="Test page",
-            slug="test-page",
-            content=[("text", "Hello, world!")],
-            live=True,
-        )
-        self.root_page.add_child(instance=self.page)
-        self.page.save()
-
-    def test_export_view(self):
-        self.login()
-        response = self.client.get(
-            reverse("export_page", kwargs={"page_id": self.page.id})
-        )
-        self.assertEqual(response.status_code, 200)
-
-        self.assertIn("Content-Disposition", response.headers)
-        self.assertEqual(
-            response.headers["Content-Disposition"],
-            'attachment; filename="test-page.json"',
-        )
-
-        self.assertIn("Content-Type", response.headers)
-        self.assertEqual(response.headers["Content-Type"], "application/json")
-
-
+@skipIf(settings.SKIP_DJANGO_MIGRATIONS, "Requires Django migrations")
 class ImportViewTestCase(TestCase, WagtailTestUtils):
     def setUp(self):
         self.root_page = Site.objects.get(is_default_site=True).root_page
 
+    def test_import_view_get(self):
+        self.login()
+        response = self.client.get(
+            reverse(
+                "wagtail_deletion_archive_import",
+                kwargs={"page_id": self.root_page.pk},
+            ),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context)
+
+    def post_to_import_view(self, **kwargs):
+        self.login()
+
+        return self.client.post(
+            reverse(
+                "wagtail_deletion_archive_import",
+                kwargs={"page_id": self.root_page.pk},
+            ),
+            kwargs,
+        )
+
     def test_import_view_post_file(self):
-        # Export a test page
         test_page = BlogPage(
             title="Test page",
             slug="test-page",
             content=[("text", "Hello, world!")],
             live=True,
         )
-        page_json = export_page(test_page)
-        page_io = StringIO(page_json)
+        page_json = convert_page_to_json(test_page)
+        response = self.post_to_import_view(page_file=StringIO(page_json))
 
-        # Log in and post it
-        self.login()
-        response = self.client.post(
-            reverse("import_page", kwargs={"page_id": self.root_page.id}),
-            {"page_file": page_io},
-        )
         self.assertEqual(response.status_code, 302)
         self.root_page.refresh_from_db()
 
@@ -76,22 +74,11 @@ class ImportViewTestCase(TestCase, WagtailTestUtils):
         )
 
     def test_import_view_post_invalid(self):
-        self.login()
-        response = self.client.post(
-            reverse("import_page", kwargs={"page_id": self.root_page.id}),
-            {},
-        )
+        response = self.post_to_import_view()
+
         self.assertEqual(response.status_code, 200)
         self.assertIn("form", response.context)
         self.assertIn("page_file", response.context["form"].errors)
-
-    def test_import_view_get(self):
-        self.login()
-        response = self.client.get(
-            reverse("import_page", kwargs={"page_id": self.root_page.id}),
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("form", response.context)
 
     def test_import_view_post_app_does_not_exist(self):
         page_json = json.dumps(
@@ -102,14 +89,8 @@ class ImportViewTestCase(TestCase, WagtailTestUtils):
                 "data": {},
             }
         )
-        page_io = StringIO(page_json)
+        response = self.post_to_import_view(page_file=StringIO(page_json))
 
-        # Log in and post it
-        self.login()
-        response = self.client.post(
-            reverse("import_page", kwargs={"page_id": self.root_page.id}),
-            {"page_file": page_io},
-        )
         self.assertTrue(len(response.context["form"].errors["page_file"]) > 0)
         self.assertIn(
             "There was an error importing this file as a page.",
@@ -125,16 +106,47 @@ class ImportViewTestCase(TestCase, WagtailTestUtils):
                 "data": {},
             }
         )
-        page_io = StringIO(page_json)
+        response = self.post_to_import_view(page_file=StringIO(page_json))
 
-        # Log in and post it
-        self.login()
-        response = self.client.post(
-            reverse("import_page", kwargs={"page_id": self.root_page.id}),
-            {"page_file": page_io},
-        )
         self.assertTrue(len(response.context["form"].errors["page_file"]) > 0)
         self.assertIn(
             "There was an error importing this file as a page.",
             response.context["form"].errors["page_file"][0],
         )
+
+
+class ArchiveViewTests(WagtailTestUtils, TestCase):
+    def test_no_storage_404(self):
+        self.assertIsNone(get_archive_storage())
+
+        self.login()
+        response = self.client.get(reverse("wagtail_deletion_archive_index"))
+        self.assertEqual(response.status_code, 404)
+
+    @uses_temp_archive_storage()
+    def test_valid_storage(self, temp_storage):
+        os.mkdir(f"{temp_storage}/subdir")
+        filename = make_archive_filename("test")
+        open(os.path.join(temp_storage, "subdir", filename), "w").close()
+
+        self.login()
+        response = self.client.get(reverse("wagtail_deletion_archive_index"))
+        self.assertContains(response, filename)
+
+        response = self.client.get(
+            reverse(
+                "wagtail_deletion_archive_serve",
+                kwargs={"path": f"subdir/{filename}"},
+            )
+        )
+        self.assertEqual(
+            response["Content-Disposition"],
+            f'attachment; filename="{filename}"',
+        )
+
+        response = self.client.get(
+            reverse(
+                "wagtail_deletion_archive_serve", kwargs={"path": "missing"}
+            )
+        )
+        self.assertEqual(response.status_code, 404)

--- a/cfgov/wagtail_deletion_archival/tests/test_wagtail_hooks.py
+++ b/cfgov/wagtail_deletion_archival/tests/test_wagtail_hooks.py
@@ -1,95 +1,20 @@
-from django.apps import apps
-from django.test import TestCase, override_settings
-from django.urls import reverse
+from django.shortcuts import reverse
+from django.test import TestCase
 
 from wagtail.models import Site
 from wagtail.test.utils import WagtailTestUtils
 
-from v1.models import BlogPage
-from wagtail_deletion_archival.wagtail_hooks import archive_page_data_receiver
 
-
-class ArchivePageOnDeletionTestCase(TestCase, WagtailTestUtils):
-    def setUp(self):
+class TestPageImportButton(WagtailTestUtils, TestCase):
+    def test_page_import_button_renders(self):
         self.login()
 
         root_page = Site.objects.get(is_default_site=True).root_page
-
-        self.test_page1 = BlogPage(title="test page 1", slug="test-page1")
-        root_page.add_child(instance=self.test_page1)
-
-        self.test_child_page = BlogPage(title="child page", slug="test-child")
-        self.test_page1.add_child(instance=self.test_child_page)
-
-        self.test_page2 = BlogPage(title="test page 2", slug="test-page2")
-        root_page.add_child(instance=self.test_page2)
-
-        self.test_page3 = BlogPage(title="test page 3", slug="test-page3")
-        root_page.add_child(instance=self.test_page3)
-
-        self.fs = apps.get_app_config("wagtail_deletion_archival").filesystem
-
-    def test_delete_page(self):
-        self.client.post(
-            reverse("wagtailadmin_pages:delete", args=(self.test_page1.pk,))
+        response = self.client.get(
+            reverse("wagtailadmin_explore", args=(root_page.pk,))
         )
 
-        # The page slug exists in the archive dir and has a JSON file in it
-        self.assertIn(self.test_page1.slug, self.fs.listdir("/"))
-        self.assertTrue(
-            self.fs.glob(f"{self.test_page1.slug}/*.json").count().files > 0
+        import_url = reverse(
+            "wagtail_deletion_archive_import", args=(root_page.pk,)
         )
-
-        # The child page slug exists in the archive dir and has a JSON file
-        self.assertIn(
-            self.test_child_page.slug,
-            self.fs.listdir(f"{self.test_page1.slug}"),
-        )
-        self.assertTrue(
-            self.fs.glob(
-                f"{self.test_page1.slug}/"
-                f"{self.test_child_page.slug}/*.json"
-            )
-            .count()
-            .files
-            > 0
-        )
-
-    def test_bulk_delete_page(self):
-        self.client.post(
-            reverse(
-                "wagtail_bulk_action",
-                args=(
-                    "wagtailcore",
-                    "page",
-                    "delete",
-                ),
-            )
-            + f"?id={self.test_page1.pk}&id={self.test_page2.pk}"
-        )
-
-        # The page slug exists in the archive dir
-        self.assertIn(self.test_page2.slug, self.fs.listdir("/"))
-
-        # And has a JSON file in it
-        self.assertTrue(
-            self.fs.glob(f"{self.test_page2.slug}/*.json").count().files > 0
-        )
-
-    def test_delete_page_confirmation(self):
-        self.client.get(
-            reverse("wagtailadmin_pages:delete", args=(self.test_page3.pk,))
-        )
-        self.assertEqual(
-            self.fs.glob(f"{self.test_page3.slug}/*.json").count().files,
-            0,
-        )
-
-    @override_settings(WAGTAIL_DELETION_ARCHIVE_FILESYSTEM=None)
-    def test_delete_page_with_no_archive_dir(self):
-        archive_page_data_receiver(None, self.test_page3)
-
-        # There should be no test-page3 directory anywhere in the filesystem
-        self.assertEqual(
-            self.fs.glob(f"**/{self.test_page3.slug}/").count().directories, 0
-        )
+        self.assertContains(response, f'<a href="{import_url}"')

--- a/cfgov/wagtail_deletion_archival/utils.py
+++ b/cfgov/wagtail_deletion_archival/utils.py
@@ -74,9 +74,9 @@ def convert_page_to_json(page):
     return page_json
 
 
-def make_archive_filename(page):
+def make_archive_filename(page_slug):
     now = timezone.now()
-    return f"{page.slug}-{now.isoformat()}.json"
+    return f"{page_slug}-{now.isoformat()}.json"
 
 
 ARCHIVE_FILENAME_RE = re.compile(
@@ -105,7 +105,7 @@ def export_page_signal_handler(sender, instance, **kwargs):
 
     page_json = convert_page_to_json(page)
 
-    page_filename = make_archive_filename(page)
+    page_filename = make_archive_filename(page.slug)
     target_path = smart_str(os.path.join(page_path, page_filename))
 
     archived_filename = archive_storage.save(
@@ -114,7 +114,7 @@ def export_page_signal_handler(sender, instance, **kwargs):
     logger.info(f"Exported {page.slug} to JSON at {archived_filename}")
 
 
-def import_page(parent_page, page_json, slug=None):
+def import_page(parent_page, page_json):
     page_data = json.loads(page_json)
 
     # Verify that we can load import the page

--- a/cfgov/wagtail_deletion_archival/wagtail_hooks.py
+++ b/cfgov/wagtail_deletion_archival/wagtail_hooks.py
@@ -1,90 +1,26 @@
-from urllib.parse import unquote
-
-from django.apps import apps
 from django.conf import settings
 from django.db.models.signals import pre_delete
-from django.urls import path as django_path
-from django.urls import reverse
-from django.utils import timezone
-from django.utils.encoding import smart_str
+from django.urls import path, reverse
 
 from wagtail import hooks
 from wagtail.admin.widgets import Button
 
-from fs import path as fs_path
-
-from wagtail_deletion_archival.utils import export_page
-from wagtail_deletion_archival.views import export_view, import_view
-
-
-def archive_page_data_receiver(sender, instance, **kwargs):
-    # Skip all this if settings.WAGTAIL_DELETION_ARCHIVE_FILESYSTEM is not set
-    if getattr(settings, "WAGTAIL_DELETION_ARCHIVE_FILESYSTEM", None) is None:
-        return
-
-    fs = apps.get_app_config("wagtail_deletion_archival").filesystem
-
-    page = instance.specific
-    site = page.get_site()
-    page_path = unquote(page.relative_url(site))
-
-    page_json = export_page(page)
-
-    now = timezone.now()
-    page_filename = f"{page.slug}-{now.isoformat()}.json"
-    target_path = smart_str(fs_path.join(page_path, page_filename))
-
-    fs.exists(page_path) or fs.makedirs(page_path)
-    fs.writetext(target_path, page_json, encoding="utf8")
+from wagtail_deletion_archival.utils import (
+    export_page_signal_handler,
+    get_archive_storage,
+)
+from wagtail_deletion_archival.views import (
+    ArchiveFileView,
+    ArchiveIndexView,
+    import_view,
+)
 
 
-@hooks.register("before_delete_page")
-def add_archival_signal_reciever(request, page):
-    from wagtail.models import Page
-
-    pre_delete.connect(archive_page_data_receiver, sender=Page)
-
-
-@hooks.register("after_delete_page")
-def remove_archival_signal_reciever(request, page):
-    from wagtail.models import Page
-
-    pre_delete.disconnect(archive_page_data_receiver, sender=Page)
-
-
-@hooks.register("before_bulk_action")
-def add_bulk_delete_signal_reciever(
-    request, action_type, objects, action_class_instance
-):
-    from wagtail.models import Page
-
-    if action_type == "delete":
-        pre_delete.connect(archive_page_data_receiver, sender=Page)
-
-
-@hooks.register("after_bulk_action")
-def remove_bulk_delete_signal_reciever(
-    request, action_type, objects, action_class_instance
-):
-    from wagtail.models import Page
-
-    if action_type == "delete":
-        pre_delete.disconnect(archive_page_data_receiver, sender=Page)
-
-
-@hooks.register("register_page_listing_more_buttons")
-def page_export_button(
-    page,
-    page_perms,
-    is_parent=False,
-    next_url=None,
-):
-    yield Button(
-        "Export",
-        reverse("export_page", args=(page.id,)),
-        priority=210,
-        icon_name="download",
-    )
+@hooks.register("register_admin_urls")
+def register_archive_storage_import_url():
+    return [
+        path("import/<int:page_id>/", import_view, name="import_page"),
+    ]
 
 
 @hooks.register("register_page_header_buttons")
@@ -97,9 +33,48 @@ def page_import_button(page, user, view_name, next_url=None):
     )
 
 
-@hooks.register("register_admin_urls")
-def register_portable_page_admin_urls():
-    return [
-        django_path("export/<int:page_id>/", export_view, name="export_page"),
-        django_path("import/<int:page_id>/", import_view, name="import_page"),
-    ]
+if get_archive_storage():
+
+    @hooks.register("register_admin_urls")
+    def register_deleted_page_archive_list_url():
+        return [
+            path(
+                settings.WAGTAIL_DELETION_ARCHIVE_URL,
+                ArchiveIndexView.as_view(),
+            ),
+            path(
+                f"{settings.WAGTAIL_DELETION_ARCHIVE_URL}<path:path>",
+                ArchiveFileView.as_view(),
+                name="wagtail_deletion_archive_serve",
+            ),
+        ]
+
+    @hooks.register("before_delete_page")
+    def add_archival_signal_reciever(request, page):
+        from wagtail.models import Page
+
+        pre_delete.connect(export_page_signal_handler, sender=Page)
+
+    @hooks.register("after_delete_page")
+    def remove_archival_signal_reciever(request, page):
+        from wagtail.models import Page
+
+        pre_delete.disconnect(export_page_signal_handler, sender=Page)
+
+    @hooks.register("before_bulk_action")
+    def add_bulk_delete_signal_reciever(
+        request, action_type, objects, action_class_instance
+    ):
+        from wagtail.models import Page
+
+        if action_type == "delete":
+            pre_delete.connect(export_page_signal_handler, sender=Page)
+
+    @hooks.register("after_bulk_action")
+    def remove_bulk_delete_signal_reciever(
+        request, action_type, objects, action_class_instance
+    ):
+        from wagtail.models import Page
+
+        if action_type == "delete":
+            pre_delete.disconnect(export_page_signal_handler, sender=Page)

--- a/cfgov/wagtail_deletion_archival/wagtail_hooks.py
+++ b/cfgov/wagtail_deletion_archival/wagtail_hooks.py
@@ -1,14 +1,11 @@
-from django.conf import settings
 from django.db.models.signals import pre_delete
 from django.urls import path, reverse
 
 from wagtail import hooks
 from wagtail.admin.widgets import Button
+from wagtail.models import Page
 
-from wagtail_deletion_archival.utils import (
-    export_page_signal_handler,
-    get_archive_storage,
-)
+from wagtail_deletion_archival.utils import export_page_signal_handler
 from wagtail_deletion_archival.views import (
     ArchiveFileView,
     ArchiveIndexView,
@@ -16,65 +13,60 @@ from wagtail_deletion_archival.views import (
 )
 
 
-@hooks.register("register_admin_urls")
-def register_archive_storage_import_url():
-    return [
-        path("import/<int:page_id>/", import_view, name="import_page"),
-    ]
-
-
 @hooks.register("register_page_header_buttons")
 def page_import_button(page, user, view_name, next_url=None):
     yield Button(
         "Import",
-        reverse("import_page", args=(page.id,)),
+        reverse("wagtail_deletion_archive_import", args=(page.id,)),
         priority=200,
         icon_name="upload",
     )
 
 
-if get_archive_storage():
+@hooks.register("register_admin_urls")
+def register_admin_urls():
+    archive_url_prefix = "__deleted/"
 
-    @hooks.register("register_admin_urls")
-    def register_deleted_page_archive_list_url():
-        return [
-            path(
-                settings.WAGTAIL_DELETION_ARCHIVE_URL,
-                ArchiveIndexView.as_view(),
-            ),
-            path(
-                f"{settings.WAGTAIL_DELETION_ARCHIVE_URL}<path:path>",
-                ArchiveFileView.as_view(),
-                name="wagtail_deletion_archive_serve",
-            ),
-        ]
+    return [
+        path(
+            "import/<int:page_id>/",
+            import_view,
+            name="wagtail_deletion_archive_import",
+        ),
+        path(
+            archive_url_prefix,
+            ArchiveIndexView.as_view(),
+            name="wagtail_deletion_archive_index",
+        ),
+        path(
+            f"{archive_url_prefix}<path:path>",
+            ArchiveFileView.as_view(),
+            name="wagtail_deletion_archive_serve",
+        ),
+    ]
 
-    @hooks.register("before_delete_page")
-    def add_archival_signal_reciever(request, page):
-        from wagtail.models import Page
 
+@hooks.register("before_delete_page")
+def add_archival_signal_reciever(request, page):
+    pre_delete.connect(export_page_signal_handler, sender=Page)
+
+
+@hooks.register("after_delete_page")
+def remove_archival_signal_reciever(request, page):
+    pre_delete.disconnect(export_page_signal_handler, sender=Page)
+
+
+@hooks.register("before_bulk_action")
+def add_bulk_delete_signal_reciever(
+    request, action_type, objects, action_class_instance
+):
+    if action_type == "delete":
         pre_delete.connect(export_page_signal_handler, sender=Page)
 
-    @hooks.register("after_delete_page")
-    def remove_archival_signal_reciever(request, page):
-        from wagtail.models import Page
 
+@hooks.register("after_bulk_action")
+def remove_bulk_delete_signal_reciever(
+    request, action_type, objects, action_class_instance
+):
+    if action_type == "delete":
         pre_delete.disconnect(export_page_signal_handler, sender=Page)
-
-    @hooks.register("before_bulk_action")
-    def add_bulk_delete_signal_reciever(
-        request, action_type, objects, action_class_instance
-    ):
-        from wagtail.models import Page
-
-        if action_type == "delete":
-            pre_delete.connect(export_page_signal_handler, sender=Page)
-
-    @hooks.register("after_bulk_action")
-    def remove_bulk_delete_signal_reciever(
-        request, action_type, objects, action_class_instance
-    ):
-        from wagtail.models import Page
-
-        if action_type == "delete":
-            pre_delete.disconnect(export_page_signal_handler, sender=Page)

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -18,8 +18,6 @@ django-storages==1.14.4
 django-treebeard==4.7.1
 edgegrid-python==1.3.1
 elasticsearch<7.11  # Keep pinned to the deployed ES version
-fs==2.4.16
-fs-s3fs==1.1.1
 govdelivery==1.4.0
 Jinja2==3.1.4
 lxml==5.2.2


### PR DESCRIPTION
These code changes propose using Django storage to store and serve the Wagtail deletion archive from #8310, instead of using Apache to serve those files.

This simplifies the configuration and makes it easier to test locally and easier to port in future to other webserver approaches.

With these changes, the deletion archive is now only available behind the Wagtail admin login, at the URL /admin/__deleted/. This URL provides a nicely formatted Wagtail report view where archives can be downloaded (instead of the current PR approach that uses Apache directory serving).

With this change, Django storage configuration has been migrated to `settings.STORAGES` from `settings.STATICFILES_STORAGE`, which was [deprecated in Django 4.2](https://docs.djangoproject.com/en/5.1/releases/4.2/#custom-file-storages) and removed in Django 5.1.

Additionally, with this change, cf.gov deployments that have not defined the `WAGTAIL_DELETION_ARCHIVE_PATH` environment variable still support importing archives; the archive-on-delete and archive download functionality is still disabled in those cases.

This commit also includes a minor bugfix to the archive import template which doesn't currently properly display the destination page title.

## Screenshots

<img width="1618" alt="image" src="https://github.com/user-attachments/assets/e94af4b7-06ad-45b8-8c84-cbb94331732a">

## Notes and todos

TODO: Unit tests! I didn't invest time in making these pending @willbarton review of the general suggestion.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance