### PR TITLE
Focus first un-hidden result on reveal

### DIFF
--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -134,8 +134,10 @@ function handleShowMore(event) {
   }
   const results = document.querySelector('.o-filterable-list-results');
   const showMoreFade = document.querySelector('#u-show-more-fade');
+  const nextResult = document.querySelector('.u-show-more > a');
   results.classList.remove('o-filterable-list-results--partial');
   showMoreFade.classList.add('u-hidden');
+  nextResult.focus();
 }
 
 /**


### PR DESCRIPTION
Closes https://github.local/Design-Development/External-Products/issues/420

This focuses the next element in the list on reveal after click the the "Show more results" button. This is slightly different that what is being ask for in that issue (setting tab index after the last tabbed result) but seems slightly more helpful. Specifically, since the next result can be off screen after activating "show more," auto-focusing the next element helpfully (imo) re-orients the user to the next item and brings it on screen.

Thoughts @niqjohnson? I can also do precisely what that issue is asking for but (imo) it's worse keyboard UX.