### PR TITLE
Give tccp tooltips a tabindex since spans aren't natively tabbable

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/tooltip.html
+++ b/cfgov/tccp/jinja2/tccp/includes/tooltip.html
@@ -1,6 +1,6 @@
 {% macro tooltip(name, heading=none, body=none, icon="help-round") -%}
 
-<span data-tooltip>
+<span tabindex="0" data-tooltip>
     {{ svg_icon(icon) }}
 </span>
 <template>


### PR DESCRIPTION
Closes https://github.local/Design-Development/External-Products/issues/419
This allows a user to read tooltips as they tab through the list of cards.

An alternative would be to auto-open all tooltips when a user focuses on the card that contains them, which would make tabbing through the list a bit quicker. I don't really have a preference either way. Thoughts @niqjohnson?