### PR TITLE
Remove references to the Trash

### DIFF
--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -56,8 +56,7 @@ class ActivityPageHandoutDocuments(Orderable):
 class ActivityPage(CFGOVPage):
     """A model for the Activity Detail page."""
 
-    # Allow Activity pages to exist under the ActivityIndexPage or the Trash
-    parent_page_types = ["ActivityIndexPage", "v1.HomePage"]
+    parent_page_types = ["ActivityIndexPage"]
     subpage_types = []
 
     date = models.DateField("Updated", default=timezone.now)

--- a/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
+++ b/cfgov/teachers_digital_platform/tests/models/test_activity_index_page.py
@@ -53,9 +53,7 @@ class ActivityIndexPageTests(WagtailPageTestCase):
         self.assertCanNotCreateAt(ActivityPage, HomePage)
 
     def test_activity_page_parent_pages(self):
-        self.assertAllowedParentPageTypes(
-            ActivityPage, {ActivityIndexPage, HomePage}
-        )
+        self.assertAllowedParentPageTypes(ActivityPage, {ActivityIndexPage})
 
     def test_can_create_activity_index_page(self):
         root_page = HomePage.objects.first()

--- a/cfgov/v1/models/filterable_page.py
+++ b/cfgov/v1/models/filterable_page.py
@@ -110,9 +110,8 @@ class AbstractFilterablePage(ShareableRoutablePageMixin, models.Model):
         return FilterablePagesDocumentSearch
 
     def get_filterable_search(self):
-        # If searching globally, use the root page of this page's Wagtail
-        # Site. If the page doesn't live under a Site (for example, it is
-        # in the Trash), use the default Site.
+        # If searching globally, use the root page of this page's Wagtail Site.
+        # If the page doesn't live under a Site, use the default Site.
         if not self.filter_children_only:
             site = self.get_site()
 


### PR DESCRIPTION
In #8310 we added functionality to allow us to delete our "Trash" site that was being used in lieu of Wagtail deletion.

Now that the Trash is no more, this commit removes a few straggling references to it.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets