### PR TITLE
Remove tox envdir configuration broken in tox 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,6 @@ commands=
 [testenv:unittest]
 # Invoke with: tox -e unittest
 recreate=False
-envdir={toxworkdir}/unittest
 deps=
     {[unittest-config]deps}
 commands={[unittest-config]commands}
@@ -105,7 +104,6 @@ commands={[unittest-config]commands}
 [testenv:lint]
 # Invoke with: tox -e lint
 recreate=False
-envdir={toxworkdir}/lint
 deps={[lint-config]deps}
 commands={[lint-config]commands}
 
@@ -134,7 +132,6 @@ commands=
 # Invoke with: tox -e validate-migrations
 # Ensure that we're not missing any migations
 recreate=False
-envdir={toxworkdir}/unittest
 changedir={[unittest-config]changedir}
 deps=
     {[unittest-config]deps}
@@ -164,7 +161,6 @@ commands=
 # NOTE: Requires gettext. Will overwrite any existing
 # */locale/*/LC_MESSAGES/django.po files.
 recreate=False
-envdir={toxworkdir}/unittest
 changedir={[unittest-config]changedir}
 deps=
     {[unittest-config]deps}


### PR DESCRIPTION
Our tox configuration tries to reuse tox environment directories, in order to (potentially) save time installing dependencies for different tasks. This worked in tox 3 but is broken in tox 4, and is explicitly discouraged by the tox developers, see

https://tox.wiki/en/latest/upgrading.html#reuse-of-environments
https://github.com/tox-dev/tox/issues/2788

This behavior is observable when running tox here, as you'll see messages like this:

```
unittest: recreate env because env type changed from {'name': 'validate-migrations', 'type': 'VirtualEnvRunner'} to {'name': 'unittest', 'type': 'VirtualEnvRunner'}
unittest: remove tox env folder /Users/chosaka/Projects/consumerfinance.gov/.tox/unittest
```

This commit removes our tox envdir directives.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)