### PR TITLE
Add wagtail hook to create menu items for translations

### DIFF
--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -61,17 +61,20 @@ class LanguageMenuItem(ActionMenuItem):
 
 @hooks.register("construct_page_action_menu")
 def add_language_links(menu_items, request, context):
-    page = context["page"]
-    return menu_items.extend(
-        [
-            LanguageMenuItem(
-                f"Edit {languages[translation.language]} page",
-                f"/admin/pages/{translation.pk}/edit/",
-            )
-            for translation in page.get_translations()
-            if translation.language != page.language
-        ]
-    )
+    try:
+        page = context["page"]
+        return menu_items.extend(
+            [
+                LanguageMenuItem(
+                    f"Edit {languages[translation.language]} page",
+                    f"/admin/pages/{translation.pk}/edit/",
+                )
+                for translation in page.get_translations()
+                if translation.language != page.language
+            ]
+        )
+    except KeyError:
+        pass
 
 
 @hooks.register("after_delete_page")

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -7,8 +7,7 @@ from django.urls import path, re_path, reverse
 from django.utils.html import format_html_join
 
 from wagtail import hooks
-from wagtail.admin import messages
-from wagtail.admin.action_menu import ActionMenuItem
+from wagtail.admin import messages, widgets
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.models import register_snippet
 
@@ -48,33 +47,18 @@ logger = logging.getLogger(__name__)
 languages = dict(settings.LANGUAGES)
 
 
-class LanguageMenuItem(ActionMenuItem):
-    icon_name = "globe"
-
-    def __init__(self, label, url):
-        self.label = label
-        self.url = url
-
-    def get_url(self, context):
-        return self.url
-
-
-@hooks.register("construct_page_action_menu")
-def add_language_links(menu_items, request, context):
-    try:
-        page = context["page"]
-        return menu_items.extend(
-            [
-                LanguageMenuItem(
-                    f"Edit {languages[translation.language]} page",
-                    f"/admin/pages/{translation.pk}/edit/",
-                )
-                for translation in page.get_translations()
-                if translation.language != page.language
-            ]
+@hooks.register("register_page_header_buttons")
+def page_header_buttons(page, user, view_name, next_url=None):
+    return [
+        widgets.Button(
+            f"Edit {languages[translation.language]} page",
+            f"/admin/pages/{translation.pk}/edit/",
+            priority=1000,
+            icon_name="globe",
         )
-    except KeyError:
-        pass
+        for translation in page.get_translations()
+        if translation.language != page.language
+    ]
 
 
 @hooks.register("after_delete_page")

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.utils.html import format_html_join
 
 from wagtail import hooks
 from wagtail.admin import messages
+from wagtail.admin.action_menu import ActionMenuItem
 from wagtail.admin.menu import MenuItem
 from wagtail.snippets.models import register_snippet
 
@@ -43,6 +44,34 @@ from v1.views.snippets import BannerViewSet
 
 
 logger = logging.getLogger(__name__)
+
+languages = dict(settings.LANGUAGES)
+
+
+class LanguageMenuItem(ActionMenuItem):
+    icon_name = "globe"
+
+    def __init__(self, label, url):
+        self.label = label
+        self.url = url
+
+    def get_url(self, context):
+        return self.url
+
+
+@hooks.register("construct_page_action_menu")
+def add_language_links(menu_items, request, context):
+    page = context["page"]
+    return menu_items.extend(
+        [
+            LanguageMenuItem(
+                f"Edit {languages[translation.language]} page",
+                f"/admin/pages/{translation.pk}/edit/",
+            )
+            for translation in page.get_translations()
+            if translation.language != page.language
+        ]
+    )
 
 
 @hooks.register("after_delete_page")


### PR DESCRIPTION
This PR adds a wagtail hook that leverages the machinery introduced to manage the `translation_links` to allow easy switching in the admin view between available versions of languages. To wit, see this screenshot:
<img width="360" alt="Screenshot 2024-10-10 at 11 03 19 PM" src="https://github.com/user-attachments/assets/14ea7296-47b0-4b6c-8e1d-31d748436d2f">

If a page has no translations, no menu item will be added. If a page has many translations, eg. http://localhost:8000/language/cfpb-in-english/, they'll all be added:

<img width="402" alt="Screenshot 2024-10-10 at 11 12 53 PM" src="https://github.com/user-attachments/assets/393f579c-3510-4ee0-adcf-fc7454613cad">

This latter case is a bit unwieldy, but, imo, rare enough that it's worth the general benefit.

This work was spurred on by the old school wagtailadmin_override used in ask-cfpb for the link between english and spanish answer pages:
<img width="379" alt="Screenshot 2024-10-10 at 11 16 18 PM" src="https://github.com/user-attachments/assets/2f43fb48-79bf-4b1d-be79-3f63f04ab084">

The idea here being that, if/when we move Ask to the now-standard way of associating translations with each other, it would be cool to retain the functionality of being able to quickly jump to different translations.
