### PR TITLE
Remove `yarn scripts`, `yarn styles`, `yarn copy` tasks

### DIFF
--- a/docs/running-virtualenv.md
+++ b/docs/running-virtualenv.md
@@ -124,14 +124,12 @@ password will expire after 60 days).
 The following yarn tasks are available:
 
 ```
-yarn scripts             # Build the Javascript with esbuild
-yarn styles              # Build the SCSS with esbuild and its PostCSS plugin
-yarn copy                # Move static files to the output directory
-yarn build               # Run scripts, styles, and copy along with app-specific scripts
+yarn build               # Build the JavaScript, SCSS, and frontend assets.
 yarn watch               # Run the build then watch JS and SCSS changes
 yarn lint                # Run frontend linting
 yarn jest                # Run frontend tests
 yarn test                # Run both
+yarn cy                  # Run Cypress integration tests
 ```
 
 ### Reinstalling the virtual environment

--- a/esbuild/build.js
+++ b/esbuild/build.js
@@ -32,14 +32,6 @@ const arg = process.argv.slice(2)[0];
     const ctx = await esbuild.context(mergedConfig);
     await ctx.watch();
     // Not disposing context here as the user will ctrl+c to end watching.
-  } else if (arg === 'scripts') {
-    const ctx = await esbuild.context(scriptsConfig);
-    await ctx.rebuild();
-    return await ctx.dispose();
-  } else if (arg === 'styles') {
-    const ctx = await esbuild.context(stylesConfig);
-    await ctx.rebuild();
-    return await ctx.dispose();
   } else {
     const ctx = await esbuild.context(mergedConfig);
     await ctx.rebuild();

--- a/package.json
+++ b/package.json
@@ -65,9 +65,6 @@
     "jest": "yarn node --experimental-vm-modules $(yarn bin jest)",
     "test": "yarn lint && yarn jest",
     "snyk": "snyk test",
-    "copy": "yarn build copy",
-    "styles": "yarn build styles",
-    "scripts": "yarn build scripts",
     "watch": "yarn build watch",
     "build": "node ./esbuild/build.js",
     "cy": "./scripts/cypress.sh"


### PR DESCRIPTION
There's a bug in the `yarn scripts` task where it needs a loader for SCSS. Instead of fixing that, I'm proposing ripping out the `yarn scripts`, `yarn styles` and `yarn copy` tasks and just having a single `yarn build` (and accompanying `yarn watch`) task. Build doesn't take _that_ long, and that simplifies our maintenance of these scripts.


## Removals

- Remove `yarn scripts`, `yarn styles`, `yarn copy` tasks

## How to test this PR

1. `yarn build` and `yarn watch` should run without error.
