### PR TITLE
Update wagtail-footnotes to fix footnote ordering

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -36,7 +36,7 @@ wagtail-autocomplete==0.11.0
 wagtail-content-audit==0.1
 wagtail_draftail_anchors==0.6.0
 wagtail-flags==5.3.1
-wagtail-footnotes==0.12
+wagtail-footnotes==0.13.0
 wagtail-inventory==3.0
 wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.12.1


### PR DESCRIPTION
This PR updates wagtail-footnotes to 0.13.0, which includes [our fix for footnote ordering](https://github.com/torchbox/wagtail-footnotes/pull/74). It makes two changes to footnotes admin UX:

- Fixes a bug where footnotes could change how they're ordered in the admin for content editors between adding footnotes and saving the draft with the new footnotes. 
- Makes it possible for content editors to reorder footnotes in the admin just like any other Wagtail content element.

Neither of these ordering problems had any impact on the final rendered page — rendered footnotes are always numbered and ordered in the the order they are referenced in content.

See GHE/Design-Development/Design-and-Content-Team/issues/545 and https://github.com/torchbox/wagtail-footnotes/issues/75 for more context.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
