### PR TITLE
Fix SIM115 by using a context manager

### DIFF
--- a/cfgov/v1/tests/management/commands/test_publish_pages.py
+++ b/cfgov/v1/tests/management/commands/test_publish_pages.py
@@ -30,10 +30,10 @@ class PublishPagesTests(TestCase):
 
     @contextmanager
     def make_tempfile(self, content):
-        tf = tempfile.NamedTemporaryFile()
-        tf.write(content)
-        tf.seek(0)
-        yield tf
+        with tempfile.NamedTemporaryFile() as tf:
+            tf.write(content)
+            tf.seek(0)
+            yield tf
 
     def test_dry_run(self):
         with self.make_tempfile(b"/a/\n/b/\n/c/\n") as tf:


### PR DESCRIPTION
Ruff started throwing a SIM115 error:

```
cfgov/v1/tests/management/commands/test_publish_pages.py:33:14: SIM115 Use a context manager for opening files
```

This fixes that by using a context management.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
