### PR TITLE
Capitalize "Sitemap" in robots.txt

### DIFF
--- a/cfgov/jinja2/robots.txt
+++ b/cfgov/jinja2/robots.txt
@@ -25,4 +25,4 @@ Disallow: /es/obtener-respuestas/buscar-por-etiqueta/
 Disallow: /consumer-tools/educator-tools/youth-financial-education/curriculum-review/tool/*
 Disallow: /paying-for-college2/*
 
-sitemap: {{ request.build_absolute_uri( url( 'sitemap' ) ) }}
+Sitemap: {{ request.build_absolute_uri( url( 'sitemap' ) ) }}


### PR DESCRIPTION
The "sitemap" directive in robots.txt should be "Sitemap".

See
- https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt
- https://en.wikipedia.org/wiki/Robots.txt#Sitemap
- https://search.gov/indexing/robotstxt.html#xml-sitemaps

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
