### PR TITLE
Fix link markup for certain non-cf.gov URLs

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from core.templatetags.svg_icon import svg_icon
 from core.utils import (
     ASK_CFPB_LINKS,
+    NON_CFPB_LINKS,
     add_link_markup,
     extract_answers_from_request,
     format_file_size,
@@ -277,3 +278,35 @@ class LinkUtilsTests(SimpleTestCase):
 
         expected_tag = BeautifulSoup(expected_html, "html.parser")
         self.assertEqual(add_link_markup(tag, path), str(expected_tag))
+
+    def test_non_cfpb_links(self):
+        cfpb_urls = [
+            "http://consumerfinance.gov",
+            "https://consumerfinance.gov",
+            "http://cfpb.gov",
+            "https://cfpb.gov",
+            "http://www.consumerfinance.gov",
+            "https://www.consumerfinance.gov",
+            "http://localhost",
+            "https://localhost",
+            "http://localhost:8000",
+            "http://content.localhost:8000",
+            "https://www.consumerfinance.gov/foo/bar/",
+        ]
+
+        for url in cfpb_urls:
+            with self.subTest(url=url):
+                self.assertFalse(NON_CFPB_LINKS.match(url))
+
+        non_cfpb_urls = [
+            "https://example.com/page/",
+            "https://example.com/foo/www.consumerfinance.gov/bar/",
+            "http://example.com/foo/cfpb.gov/bar/",
+            "https://subdomain.example.com:1234",
+            "https://subdomain.example.com:1234/foo/",
+            "http://notconsumerfinance.gov",
+        ]
+
+        for url in non_cfpb_urls:
+            with self.subTest(url=url):
+                self.assertTrue(NON_CFPB_LINKS.match(url))

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -8,8 +8,18 @@ from core.templatetags.svg_icon import svg_icon
 
 
 NON_CFPB_LINKS = re.compile(
-    r"(https?:\/\/(?:www\.)?(?![^\?]*(cfpb|consumerfinance).gov)"
-    r"(?!(content\.)?localhost).*)"
+    # HTTP or HTTPS
+    r"https?:\/\/"
+    # Negative lookahead: don't match anything that matches what follows
+    r"(?!"
+    # Match any subdomains
+    r"((\w+\.)*"
+    # Match consumerfinance.gov, cfpb.gov, or localhost
+    r"(consumerfinance\.gov|cfpb\.gov|localhost))"
+    # Match a port number, if provided
+    r"(?:\:\d+)?"
+    # Match the rest of the URL
+    r".*)"
 )
 
 LINK_PATTERN = re.compile(


### PR DESCRIPTION
Currently certain archive-it.org URLs are missing an external link icon due to an issue with the regex we use to detect non-cf.gov URLs.

For example, a URL like this:

https://archiving-service.com/1234/https://www.consumerfinance.gov/about-us/blog/fall-2015-rulemaking-agenda/

is missing its external link icon because the current regex matches the "www.consumerfinance.gov" part of the URL, even though it's in the path part, not the host part.

This commit fixes that and adds a regression test.

## How to test this PR

To test, run a local server and visit:

http://localhost:8000/about-us/blog/fall-2015-rulemaking-agenda/

and compare it against production:

https://www.consumerfinance.gov/about-us/blog/fall-2015-rulemaking-agenda/

## Screenshots

|Before|After|
|-|-|
|<img width="619" alt="image" src="https://github.com/user-attachments/assets/914f0976-8d70-4558-9edc-2a2d46b21e77">|<img width="635" alt="image" src="https://github.com/user-attachments/assets/b9273a28-4d57-44d6-8bd7-264892be469e">|

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)