### PR TITLE
TCCP: Fix link to TCCP submission page

### DIFF
--- a/cfgov/tccp/jinja2/tccp/landing_page.html
+++ b/cfgov/tccp/jinja2/tccp/landing_page.html
@@ -69,7 +69,7 @@
             </li>
            <li class="m-list__item">
                 Any credit card company can
-                <a href="/credit-card-data/terms-credit-card-plans-survey/">voluntarily contribute data</a>
+                <a href="/data-research/credit-card-data/terms-credit-card-plans-survey/">voluntarily contribute data</a>
             </li>
             <li class="m-list__item">
                 No paid advertising


### PR DESCRIPTION
Fixes a link the TCCP landing pagae

---

## Changes

- Updated link

## How to test this PR

1. Make sure the "voluntarily contribute data" linked text goes to the TCCP page in the data and research section.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)