### PR TITLE
Changes supporting the CCT 2024 data release

### DIFF
--- a/cfgov/unprocessed/apps/cfpb-chart-builder/js/charts/LineChartIndex.js
+++ b/cfgov/unprocessed/apps/cfpb-chart-builder/js/charts/LineChartIndex.js
@@ -105,26 +105,13 @@ class LineChartIndex {
         labels: {
           useHTML: true,
         },
-        plotLines: [
-          {
-            value: data.projectedDate.timestamp,
-            label: {
-              text:
-                'Values after ' + data.projectedDate.label + ' are projected',
-              rotation: 0,
-              useHTML: true,
-              x: -300,
-              y: -126,
-            },
-          },
-        ],
       },
       yAxis: {
         allowDecimals: false,
         showLastLabel: true,
         opposite: false,
         title: {
-          text: 'Index (January 2009 = 100)',
+          text: 'Index (January 2010 = 100)',
           align: 'high',
           // useHTML true value is needed to set width beyond chart marginTop.
           useHTML: true,
@@ -150,23 +137,11 @@ class LineChartIndex {
           name: 'Seasonally adjusted',
           data: data.adjusted,
           legendIndex: 1,
-          zoneAxis: 'x',
-          zones: [
-            {
-              value: data.projectedDate.timestamp,
-            },
-          ],
         },
         {
           name: 'Unadjusted',
           data: data.unadjusted,
           legendIndex: 2,
-          zoneAxis: 'x',
-          zones: [
-            {
-              value: data.projectedDate.timestamp,
-            },
-          ],
         },
       ],
       responsive: {
@@ -188,21 +163,6 @@ class LineChartIndex {
                 labels: {
                   y: 26,
                 },
-                plotLines: [
-                  {
-                    value: data.projectedDate.timestamp,
-                    label: {
-                      text:
-                        'Values after ' +
-                        data.projectedDate.label +
-                        ' are projected',
-                      rotation: 0,
-                      useHTML: true,
-                      x: -300,
-                      y: -20,
-                    },
-                  },
-                ],
               },
               yAxis: {
                 title: {

--- a/cfgov/unprocessed/apps/cfpb-chart-builder/js/utils/process-json.js
+++ b/cfgov/unprocessed/apps/cfpb-chart-builder/js/utils/process-json.js
@@ -27,7 +27,6 @@ function processDelinquencies(datasets) {
 }
 
 /**
- * Returns data starting in January 2009 for use in all line charts.
  * @param {number} data - response from requested JSON file.
  * @param {string} [group] -
  *   Optional parameter for specifying if the chart requires use of a "group"
@@ -57,24 +56,6 @@ function processNumOriginationsData(data, group, source) {
     return 'propertyError';
   }
 
-  // Remove data before January 2009.
-  let x;
-  for (x = 0; x < data.adjusted.length; x++) {
-    if (data.adjusted[x][0] < Date.UTC(2009, 0)) {
-      data.adjusted.splice(x, 1);
-      // Check array[x] again, since we removed an entry in the array.
-      x--;
-    }
-  }
-
-  for (x = 0; x < data.unadjusted.length; x++) {
-    if (data.unadjusted[x][0] < Date.UTC(2009, 0)) {
-      data.unadjusted.splice(x, 1);
-      // Check array[x] again, since we removed an entry in the array.
-      x--;
-    }
-  }
-
   data.unadjusted = data.unadjusted.sort(function (a, b) {
     return a[0] - b[0];
   });
@@ -100,7 +81,6 @@ function processNumOriginationsData(data, group, source) {
 }
 
 /**
- * Returns data starting in January 2009 for use in all bar charts.
  * @param {number} data - response from requested JSON file.
  * @param {string} [group] -
  *   Optional parameter for specifying if the chart requires use of a "group"
@@ -121,17 +101,6 @@ function processYoyData(data, group) {
   } else if (group !== null && !Object.hasOwn(data, group)) {
     // If group is not a property of the data, return an error
     return 'groupError';
-  }
-
-  // remove data before January 2009, convert the rest from decimal values to percentages
-  for (let x = 0; x < data.length; x++) {
-    if (data[x][0] < Date.UTC(2009, 0)) {
-      data.splice(x, 1);
-      // Check array[x] again, since we removed an entry in the array.
-      x--;
-    } else {
-      data[x][1] *= 100;
-    }
   }
 
   data.projectedDate = {};

--- a/cfgov/unprocessed/js/routes/on-demand/simple-chart/tilemap-chart.js
+++ b/cfgov/unprocessed/js/routes/on-demand/simple-chart/tilemap-chart.js
@@ -19,7 +19,7 @@ function makeTilemapOptions(data, dataAttributes) {
 
   let defaultObj = cloneDeep(defaultTilemap);
 
-  let styles;
+  let styles = {};
   if (styleOverrides) {
     styles = JSON.parse(styleOverrides);
     overrideStyles(styles, defaultObj, data);


### PR DESCRIPTION
- Stops cfpb-chart-builder from removing data before 2009 in its processing script
- Changes the index charts' y-axes (as per stakeholder)
- Removes projected data from index charts