### PR TITLE
FormModel: remove `false ||`

### DIFF
--- a/cfgov/unprocessed/js/modules/util/FormModel.js
+++ b/cfgov/unprocessed/js/modules/util/FormModel.js
@@ -81,7 +81,7 @@ function FormModel(form) {
 
       _fieldCache.set(element, {
         type: type,
-        label: _getLabelText(element, false || isInGroup),
+        label: _getLabelText(element, isInGroup),
         isInGroup: isInGroup,
       });
     }


### PR DESCRIPTION
This doesn't seem like it is needed? It looks like `isInGroup` will always have a value that it passes to `_getLabelText`, which has an if/else statement that checks `isInGroup`' value.

## Changes

- FormModel: remove `false ||`


## How to test this PR

1. PR checks should pass.
2. /blog should work as before.
