### PR TITLE
Privacy forms: Remove `id_description` ID

### DIFF
--- a/cfgov/privacy/jinja2/privacy/privacy-styles.html
+++ b/cfgov/privacy/jinja2/privacy/privacy-styles.html
@@ -40,9 +40,6 @@
     #submit-icon.submitting{
       display: inline;
     }
-    #id_description {
-      margin-bottom: 5px;
-    }
     .o-well {
       margin-bottom: 45px !important;
       padding-bottom: 15px;


### PR DESCRIPTION
I couldn't find a reference to this ID

## Removals

- Remove `id_description` ID
