### PR TITLE
Remove `for` attribute from pagination label

### DIFF
--- a/cfgov/agreements/jinja2/agreements/search.html
+++ b/cfgov/agreements/jinja2/agreements/search.html
@@ -81,8 +81,7 @@
 
                 <form class="m-pagination__form"
                         action="#ccagrsearch">
-                    <label class="m-pagination__label"
-                            for="m-pagination__current-page">
+                    <label class="m-pagination__label">
                         Page
                         <span class="u-visually-hidden">
                             number {{ page.number }} out

--- a/cfgov/v1/jinja2/v1/includes/molecules/pagination.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/pagination.html
@@ -64,14 +64,6 @@
             </span>
         </a>
         <form class="m-pagination__form" action="{{ fragment_id }}">
-            <label for="m-pagination__current-page-{{ index | string }}">
-                <span class="m-pagination__label">
-                    {{ _('Page') }}
-                </span>
-                <span class="u-visually-hidden">
-                    {{ current_page }} out of {{ total_pages }} total pages
-                </span>
-            </label>
             {% for (key, value_as_list) in request.GET.lists() %}
                 {% for list_item in value_as_list %}
                     {% if list_item != '' and key != 'page' %}
@@ -81,18 +73,22 @@
                     {% endif %}
                 {% endfor %}
             {% endfor %}
-            <input id="m-pagination__current-page-{{ index | string }}"
-                   class="m-pagination__current-page"
-                   name="page"
-                   type="number"
-                   min="1"
-                   max="{{ total_pages }}"
-                   pattern="[0-9]*"
-                   inputmode="numeric"
-                   value="{{ current_page }}">
-            <span class="m-pagination__label">
+            <label class="m-pagination__label">
+                {{ _('Page') }}
+                <span class="u-visually-hidden">
+                    {{ current_page }} out of {{ total_pages }} total pages
+                </span>
+                <input id="m-pagination__current-page-{{ index | string }}"
+                       class="m-pagination__current-page"
+                       name="page"
+                       type="number"
+                       min="1"
+                       max="{{ total_pages }}"
+                       pattern="[0-9]*"
+                       inputmode="numeric"
+                       value="{{ current_page }}">
                 {{- ' ' ~ _('of') ~ ' ' -}} {{- total_pages -}}
-            </span>
+            </label>
             <button class="a-btn
                            a-btn--link
                            m-pagination__btn-submit"

--- a/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
+++ b/test/unit_tests/apps/teachers-digital-platform/js/tdp-analytics-spec.js
@@ -160,8 +160,7 @@ const HTML_SNIPPET = `
         </a>
         <form class="m-pagination__form"
               action="#pagination_content">
-            <label class="m-pagination__label"
-                   for="m-pagination__current-page">
+            <label class="m-pagination__label">
                 Page
                 <span class="u-visually-hidden">
                     number 22 out


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label

> you can nest the <input> directly inside the <label>, in which case the for and id attributes are not needed because the association is implicit:


## Removals

- Remove `for` attribute from pagination label.

## How to test this PR

1. Run local server and visiting /blog and /data-research/prepaid-accounts/search-agreements/ and interact with the pagination and see that you can click the text next to the page number input to go to the input.


## Notes and todos

- The input IDs get some use in the Cypress tests, but maybe those could be pointed to something else and the IDs could be removed overall.
