### PR TITLE
Don't run builder GitHub Actions on forks

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   Build:
-    if: github.repository == 'cfpb/consumerfinance.gov'
+    if: "! github.event.pull_request.head.repo.fork"
     runs-on: ubuntu-latest
     env:
       ARTIFACT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-and-push-image:
-    if: github.repository == 'cfpb/consumerfinance.gov'
+    if: "! github.event.pull_request.head.repo.fork"
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Currently there are two GitHub Actions for this repository that attempt to gate their execution by ensuring that they don't run on forks, using the check 

```
if: github.repository == 'cfpb/consumerfinance.gov'
```

This doesn't work properly, because on PRs this still refers to this repo (cfpb/consumerfinance.gov), not the fork.

You can see an example where this didn't work right on #8617, where @lfatty opened a PR from his fork but the "Build cf.gov artifact" action [still ran](https://github.com/cfpb/consumerfinance.gov/actions/runs/11578761970/job/32233360954).

This PR attempts to fix the syntax to work properly using this check instead:

```
if: "! github.event.pull_request.head.repo.fork"
```

I've created this PR from my fork so these two actions should not run.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)