### PR TITLE
Add white-space:normal to print CSS

### DIFF
--- a/cfgov/unprocessed/css/print.scss
+++ b/cfgov/unprocessed/css/print.scss
@@ -15,6 +15,7 @@
     border-bottom: 1px solid var(--white);
     font-weight: 300;
     word-break: break-all;
+    white-space: normal;
   }
 
   a[href*="://"]:after


### PR DESCRIPTION
Long URLs were not wrapping and getting clipped in the print styles. This helps that.

## Changes

- Add white-space:normal to print CSS


## How to test this PR

1. Visit /about-us/blog/recovering-financially-from-heavy-storms-and-preparing-for-storm-season/ and either emulate the print styles (dev tools > rendering > emulate media type, or FIle > Print and view the preview. The long URL should be wrapped.


## Screenshots
<img width="609" alt="Screenshot 2024-11-07 at 5 08 47 PM" src="https://github.com/user-attachments/assets/c6342d40-26f0-4e3c-9eba-3e6d6745b7a1">

