### PR TITLE
Restore use of DATABASE_URL for DB configuration

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -53,16 +53,13 @@ export ALLOW_ADMIN_URL=True
 # export CLOUDFRONT_DISTRIBUTION_ID_FILES=<cloudfront_distribution_id_files_cf_gov>
 # export CLOUDFRONT_PURGE_HOSTNAMES=<cloudfront_purge_hostnames>
 
-#########################################################################
-# Postgres Environment Vars.
-# See also https://www.postgresql.org/docs/current/libpq-envars.html.
-#########################################################################
+#####################################################################
+# Override Django database URL.
+#
+# See https://github.com/jazzband/dj-database-url for URL formatting.
+#####################################################################
 
-# export PGHOST=localhost
-# export PGPORT=9200
-# export PGDATABASE=cfgov
-# export PGUSER=cfpb
-# export PGPASSWORD=cfpb
+# export DATABASE_URL=<database URL>
 
 #####################
 # Front end settings.

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -12,12 +12,7 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      PGDATABASE: cfgov
-      PGUSER: cfpb
-      PGPASSWORD: cfpb
-      POSTGRES_USER: cfpb
-      PGHOST: localhost
-      PGPORT: 5432
+      DATABASE_URL: postgres://cfpb:cfpb@localhost/cfgov
       MAPBOX_ACCESS_TOKEN:  ${{ secrets.MAPBOX_ACCESS_TOKEN }}
       DJANGO_ADMIN_USERNAME: admin
       DJANGO_ADMIN_PASSWORD: admin

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
+import dj_database_url
 from opensearchpy import RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
@@ -211,17 +212,12 @@ if ALLOW_ADMIN_URL:
 
 # Default database is PostgreSQL running on localhost.
 # Database name cfgov, username cfpb, password cfpb.
-# Override this by setting using the PG environment variables.
-# See also https://www.postgresql.org/docs/current/libpq-envars.html.
+# Override this by setting DATABASE_URL in the environment.
+# See https://github.com/jazzband/dj-database-url for URL formatting.
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("PGDATABASE", "cfgov"),
-        "USER": os.getenv("PGUSER", "cfpb"),
-        "PASSWORD": os.getenv("PGPASSWORD", "cfpb"),
-        "HOST": os.getenv("PGHOST", "localhost"),
-        "PORT": os.getenv("PGPORT", "5432"),
-    },
+    "default": dj_database_url.config(
+        default="postgres://cfpb:cfpb@localhost/cfgov"
+    ),
 }
 
 # Internationalization

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,11 +43,6 @@ services:
     stdin_open: true
     tty: true
     environment:
-      PGDATABASE: cfgov
-      PGUSER: cfpb
-      PGPASSWORD: cfpb
-      POSTGRES_USER: cfpb
-      PGHOST: postgres
-      PGPORT: 5432
+      DATABASE_URL: postgres://cfpb:cfpb@postgres/cfgov
       ES_HOST: elasticsearch
       SECRET_KEY: abcdefghijklmnopqrstuvwxyz

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,14 +11,14 @@ echo "Using $(python3 --version 2>&1) located at $(which python3)"
 # Do first-time set up of the database if necessary
 if [ ! -z "$RUN_MIGRATIONS" ]; then
   # Wait for the database to be ready for initialization tasks
-  until pg_isready --host="${PGHOST:-localhost}" --port="${PGPORT:-5432}"
+  until psql "$DATABASE_URL" -c '\q' >/dev/null 2>&1
   do
-    echo "Waiting for postgres at: ${PGHOST:-localhost}:${PGPORT:-5432}"
+    echo "Waiting for postgres at $DATABASE_URL"
     sleep 1;
   done
 
   # Check the DB if it needs refresh or migrations (initial-data.sh)
-  if ! psql "postgres://${PGUSER:-cfpb}:${PGPASSWORD:-cfpb}@${PGHOST:-localhost}:${PGPORT:-5432}/${PGDATABASE:-cfgov}" -c 'SELECT COUNT(*) FROM auth_user' >/dev/null 2>&1 || [ ! -z $FORCE_DB_REBUILD ]; then
+  if ! psql "$DATABASE_URL" -c 'SELECT COUNT(*) FROM auth_user' >/dev/null 2>&1 || [ ! -z $FORCE_DB_REBUILD ]; then
     echo "Doing first-time database and search index setup..."
     if [ -n "$CFGOV_PROD_DB_LOCATION" ] || [ -n "$DB_DUMP_FILE" ] || [ -n "$DB_DUMP_URL" ]; then
       echo "Running refresh-data.sh... $DB_DUMP_FILE"

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -3,6 +3,7 @@ base36==0.1.1
 backports.zoneinfo==0.2.1
 beautifulsoup4==4.11.2
 boto3==1.34.144
+dj-database-url==2.2.0
 django-autocomplete-light==3.11.0
 django-cors-headers==4.4.0
 django-csp==3.8

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ commands=
 changedir=
     {toxinidir}/cfgov
 passenv=
-    PGUSER, PGPASSWORD, PGDATABASE, PGHOST, PGPORT, ES_HOST, ES_PORT, GITHUB_ACTIONS, SKIP_DJANGO_MIGRATIONS, TEST_RUNNER
+    DATABASE_URL, ES_HOST, ES_PORT, GITHUB_ACTIONS, SKIP_DJANGO_MIGRATIONS, TEST_RUNNER
 setenv=
     DJANGO_ADMIN_USERNAME=admin
     DJANGO_ADMIN_PASSWORD=admin
@@ -136,13 +136,8 @@ changedir={[unittest-config]changedir}
 deps=
     {[unittest-config]deps}
 passenv=
-    PGUSER, PGPASSWORD, PGDATABASE, PGHOST, PGPORT
+    DATABASE_URL
 setenv=
-    PGUSER={env:PGUSER:cfpb}
-    PGPASSWORD={env:PGPASSWORD:cfpb}
-    PGDATABASE={env:PGDATABASE:cfgov}
-    PGHOST={env:PGHOST:localhost}
-    PGPORT={env:PGPORT:5432}
     DJANGO_SETTINGS_MODULE=cfgov.settings.production
     DJANGO_STATIC_ROOT={toxinidir}/collectstatic
     ALLOWED_HOSTS=["*"]


### PR DESCRIPTION
Previously cf.gov supported use of the `DATABASE_URL` environment variable to configure the Django database, as implemented by the [dj-database-url](https://github.com/jazzband/dj-database-url) package. This functionality was removed in 2022 (in 4d0b24b1d326a884545a3a066ad765958e379541) to support a since-abandoned migration to Helm. Newer EKS/Helm workflows allow us to use a single environment variable for DB configuration, motivating restoration of this capability.

With this change, we no longer rely on environment variables like `PGHOST`, `PGUSER`, etc. but instead rely on the single `DATABASE_URL` variable.

See internal WAM#8 for additional context.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)