### PR TITLE
Handle a11y in video iframe

### DIFF
--- a/cfgov/unprocessed/js/organisms/VideoPlayer.js
+++ b/cfgov/unprocessed/js/organisms/VideoPlayer.js
@@ -78,6 +78,10 @@ function VideoPlayer(element) {
    *   to video player instance.
    */
   function _videoPlayerReadyHandler(event) {
+    // Video has loaded into the iframe, so we can show it to assistive devices.
+    _iframeDom.removeAttribute('aria-hidden');
+    _iframeDom.removeAttribute('tabindex');
+
     // Add duration timestamp to video.
     const player = event.target;
     const duration = player.getDuration();

--- a/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/video-player.html
@@ -79,7 +79,8 @@
                     src="{{ video_url }}"
                     allow="fullscreen; autoplay"
                     aria-hidden="true"
-                    tabindex="-1">
+                    tabindex="-1"
+                    title="This is a placeholder for a video that will load.">
                 </iframe>
             </div>
         </div>


### PR DESCRIPTION
## Changes

- Add placeholder `title` attribute to video iframe.
- Remove `aria-hidden` and `tabindex` when the video has loaded.


## How to test this PR

1. Visit /about-us/blog/addressing-racial-inequities-consumer-finance-markets/ and load the page without JS enabled and see that there is a placeholder `title` attribute. Load the video normally and see that the `title` attribute value is replaced and the `aria-hidden` and `tabindex` values are removed.