### PR TITLE
Pagination: Swap order of buttons

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/pagination.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/pagination.html
@@ -31,6 +31,7 @@
     <nav class="m-pagination"
          role="navigation"
          aria-label="{{ _('Pagination') }}">
+
         {%- if current_page > 1 %}
         <a class="a-btn
                   m-pagination__btn-prev"
@@ -45,20 +46,7 @@
             {{- svg_icon('left') -}}
             <span>{{ _('Previous') }}</span>
         </a>
-        {%- if current_page < total_pages %}
-        <a class="a-btn
-                  m-pagination__btn-next"
-           href="?page={{ (current_page + 1) ~
-                          url_parameters(request.GET) ~
-                          fragment_id }}">
-        {%- else %}
-        <a class="a-btn
-                  a-btn--disabled
-                  m-pagination__btn-next">
-        {% endif -%}
-            <span>{{ _('Next') }}</span>
-            {{- svg_icon('right') -}}
-        </a>
+
         <form class="m-pagination__form" action="{{ fragment_id }}">
             {% for (key, value_as_list) in request.GET.lists() %}
                 {% for list_item in value_as_list %}
@@ -92,6 +80,21 @@
                 {{ _('Go') }}
             </button>
         </form>
+
+        {%- if current_page < total_pages %}
+        <a class="a-btn
+                  m-pagination__btn-next"
+           href="?page={{ (current_page + 1) ~
+                          url_parameters(request.GET) ~
+                          fragment_id }}">
+        {%- else %}
+        <a class="a-btn
+                  a-btn--disabled
+                  m-pagination__btn-next">
+        {% endif -%}
+            <span>{{ _('Next') }}</span>
+            {{- svg_icon('right') -}}
+        </a>
     </nav>
 {% endif %}
 {% endmacro %}


### PR DESCRIPTION
If you tab through the pagination buttons, the order is wrong.

![pagination](https://github.com/user-attachments/assets/3c60c12c-d9b8-4ab3-aa04-867f1c694843)

With https://github.com/cfpb/design-system/pull/2091, the pagination component uses a grid, so the order can now be corrected and it won't harm the layout. 

## Changes

- Swap order of pagination buttons to follow logical tab order.


## How to test this PR

1. Visit /blog and tab to the pagination component and see that the order follows the logical tab order.

