### PR TITLE
Wrap expandable well in sub block

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/expandable.html
@@ -73,6 +73,10 @@
                         <p>
                             {% include_block block %}
                         </p>
+                    {% elif block.block_type == 'well' %}
+                        <div class="block block--sub">
+                            {% include_block block %}
+                        </div>
                     {% else %}
                         {% include_block block %}
                     {% endif %}


### PR DESCRIPTION
Well's that appear in expandables via Wagtail didn't have any padding around them. This adds logic to the expandable template to wrap them in a sub block when they appear. I don't love the additional logic for this, but I'm following what we do for paragraphs and links.

## Changes

- Wrap expandable well in sub block


## How to test this PR

1. Visit http://localhost:8000/consumer-tools/educator-tools/resources-for-tax-preparers/virtual-tax-preparation-case-studies/ and see that the blocks inside expandables have padding.

## Screenshots

Before:
<img width="895" alt="Screenshot 2024-11-14 at 8 26 50 AM" src="https://github.com/user-attachments/assets/c2cfa533-a952-441a-ace9-fe0e1123bb02">

After:
<img width="665" alt="Screenshot 2024-11-14 at 8 26 59 AM" src="https://github.com/user-attachments/assets/a36a554b-85ca-4493-844b-c49bac14181f">
