### PR TITLE
Add before/after table starter to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,10 @@
 
 ## Screenshots
 
+| Before | After  |
+| ------ | ------ |
+|        |        |
+
 
 ## Notes and todos
 


### PR DESCRIPTION
It can be nice to put screenshots in a before/after table, which sizes them down and gives them borders. This PR adds a starter before/after table to the PR template.

## Changes

- Add before/after table starter to PR template.
