### PR TITLE
iRegs: migrate scss imports to use

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/css/main.scss
+++ b/cfgov/unprocessed/apps/regulations3k/css/main.scss
@@ -4,15 +4,15 @@
    ========================================================================== */
 
 @use '@cfpb/cfpb-design-system/src/utilities' as *;
-@import '../../../css/main';
-@import './reg-listing';
-@import './reg-landing-page';
-@import './reg-navigation';
-@import './reg-pagination';
-@import './reg-search';
-@import './reg-text';
-@import './reg-inline-interpretations';
-@import './reg-wayfinder';
+@use '../../../css/main' as *;
+@use './reg-listing' as *;
+@use './reg-landing-page' as *;
+@use './reg-navigation' as *;
+@use './reg-pagination' as *;
+@use './reg-search' as *;
+@use './reg-text' as *;
+@use './reg-inline-interpretations' as *;
+@use './reg-wayfinder' as *;
 
 .section-nav {
   @include u-clearfix;


### PR DESCRIPTION
import is deprecated in sass. Migrate to use instead.

## Changes

- iRegs: migrate scss imports to use


## How to test this PR

1. Visit an iregs page, such as http://localhost:8000/rules-policy/regulations/1002/, and ensure the sidebar and search are unchanged to prod.
