### PR TITLE
Prepaid agreements DB: Add no-results filter state

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/search_results.html
@@ -5,6 +5,7 @@
 {% import 'v1/includes/molecules/pagination.html' as pagination with context %}
 {% from 'v1/includes/organisms/expandable.html' import expandable with context %}
 
+{% if current_count and current_count > 0  %}
 <aside class="content__sidebar content--flush-top-on-small content--flush-sides-on-small filters">
     <h3>Narrow results by...</h3>
 
@@ -95,6 +96,16 @@
         <button class="a-btn u-mb15 u-hide-on-js">Apply filters</button>
     </form>
 </aside>
+{% else %}
+<aside class="content__sidebar content--flush-top-on-small content--flush-sides-on-small filters no-results">
+    <h3 class="h4">
+        Try a broader search.
+    </h3>
+    <p>
+        Enter a different search term above.
+    </p>
+</aside>
+{% endif %}
 
 <div class="content__main content--flush-all-on-small content--flush-bottom">
     <div class="results__header">

--- a/cfgov/unprocessed/apps/prepaid-agreements/css/search.scss
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/search.scss
@@ -26,7 +26,9 @@
 
 .search__results {
   .content__sidebar {
-    padding: 45px 15px 0;
+    padding: (math.div(45px, $base-font-size-px) + em)
+      (math.div(15px, $base-font-size-px) + em) 0;
+
     border: 1px solid var(--gray-40);
     background-color: var(--gray-5);
 
@@ -57,6 +59,9 @@
       margin-bottom: 0;
     }
   }
+  .content__sidebar.no-results {
+    padding: math.div(30px, $base-font-size-px) + em;
+  }
   .content__main {
     border: 0;
     border-top: 1px solid var(--gray-40);
@@ -67,10 +72,8 @@
     }
   }
   .results__count {
-    padding: (
-        math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em
-      )
-      (math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em) 0;
+    padding: (math.div(15px, $base-font-size-px) + em)
+      (math.div(15px, $base-font-size-px) + em) 0;
     border-right: 1px solid var(--gray-40);
     border-bottom: 1px solid var(--gray-40);
     background-color: var(--green-20);
@@ -81,27 +84,26 @@
     }
   }
   .results__list {
-    padding: (math.div($grid-gutter-width, $base-font-size-px) + em)
-      (math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em);
+    padding: (math.div(30px, $base-font-size-px) + em)
+      (math.div(15px, $base-font-size-px) + em);
 
     li {
       list-style-type: none;
     }
   }
   .results__item {
-    margin: math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em;
+    margin: math.div(15px, $base-font-size-px) + em;
     & + .results__item {
-      margin-top: math.div($grid-gutter-width, $base-font-size-px) + em;
+      margin-top: math.div(30px, $base-font-size-px) + em;
       h4 {
-        padding-top: math.div($grid-gutter-width, $base-font-size-px) + em;
+        padding-top: math.div(30px, $base-font-size-px) + em;
         border-top: 1px solid var(--gray-40);
       }
     }
   }
   .results__paginator {
-    margin: 0 math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em;
-    padding: 0 math.div(math.div($grid-gutter-width, 2), $base-font-size-px) +
-      em;
+    margin: 0 math.div(15px, $base-font-size-px) + em;
+    padding: 0 math.div(15px, $base-font-size-px) + em;
     max-width: 41.875rem;
   }
 }
@@ -110,12 +112,13 @@
 @include respond-to-max($bp-sm-max) {
   .search__results {
     .content__sidebar {
-      padding-top: math.div(math.div($grid-gutter-width, 2), $base-font-size-px) +
-        em;
+      padding-top: math.div(15px, $base-font-size-px) + em;
+    }
+    .content__sidebar.no-results {
+      padding: math.div(15px, $base-font-size-px) + em;
     }
     .content__main {
-      margin-top: math.div(math.div($grid-gutter-width, 2), $base-font-size-px) +
-        em;
+      margin-top: math.div(15px, $base-font-size-px) + em;
     }
     .results__count {
       border-left: 1px solid var(--gray-40);


### PR DESCRIPTION
If there are no results in a search, the narrow results filter shows up, but broken and un-functional. This PR adds some filler text to replace it when there are no results.

## Changes

- Prepaid agreements DB: Add no-results filter state.
- Standardize CSS padding to use hardcoded pixels in calculations.


## How to test this PR

1. http://localhost:8000/data-research/prepaid-accounts/search-agreements/?search_field=name&q=mortgage and see that there's a no results filter state. Try a good search to remove it.


## Screenshots

Before:
<img width="1258" alt="Screenshot 2024-11-14 at 10 35 08 AM" src="https://github.com/user-attachments/assets/6bd4ec1a-509d-48c8-a001-28f141fd7c1d">

After:
<img width="1121" alt="Screenshot 2024-11-14 at 10 35 15 AM" src="https://github.com/user-attachments/assets/14a2ca03-d8f7-4fcb-907d-ea031fd4a5af">
