### PR TITLE
Prepaid agreements DB: bugfix incorrect input value

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
@@ -70,7 +70,7 @@
                         {{ search_input.render({
                             "input_id": "searchText",
                             "input_name": "q",
-                            "input_value": ask_query,
+                            "input_value": query,
                             "input_aria_label": "The term to search for",
                             "placeholder": "Enter search term",
                             "submit_aria_label": "The term to search for"

--- a/test/cypress/integration/data-research/prepaid-agreements-search/prepaid-agreements-search.cy.js
+++ b/test/cypress/integration/data-research/prepaid-agreements-search/prepaid-agreements-search.cy.js
@@ -7,6 +7,7 @@ describe('Prepaid Agreements', () => {
     prepaidAgreementsSearch.open();
     prepaidAgreementsSearch.searchByTerm('metro');
     cy.url().should('include', 'q=metro');
+    cy.get('#searchText').should('have.value', 'metro');
   });
 
   it('should limit results when a search field is selected', () => {


### PR DESCRIPTION
In https://github.com/cfpb/consumerfinance.gov/commit/563b99ddaa34a4a7f671754d58063869e7a74419#diff-7996a09f3bb94a40123742ebd6f5d5fad5c89a49e2eee19d24149f7e5f15bf54L80 the input value was accidentally copied from the Ask CFPB search. It should actually have a different variable name.

## Changes

- Prepaid agreements DB: bugfix incorrect input value
- Add test for search term in input.


## How to test this PR

1. Visit http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and perform a search. See that the search term remains in the search input.
