### PR TITLE
TCCP: migrate tooltip from Sass import to Sass use

### DIFF
--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -1,7 +1,7 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
 @use '@cfpb/cfpb-design-system/src/utilities' as *;
-@import 'tooltip';
+@use 'tooltip' as *;
 
 @include respond-to-min($bp-sm-min) {
   .o-form__group {


### PR DESCRIPTION
## Changes

- TCCP: migrate tooltip from Sass import to Sass use
  

## How to test this PR

1. Someone with TCCP familiarity needs to check this.