### PR TITLE
Prepaid agreements: Migrate Sass imports to Sass use

### DIFF
--- a/cfgov/unprocessed/apps/prepaid-agreements/css/main.scss
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/main.scss
@@ -1,8 +1,7 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
-@import '../../../css/main';
-@import './search';
-@import './search-bar';
+@use './search' as *;
+@use './search-bar' as *;
 
 .u-readable-width {
   // Magic number: matches max-width for content set in cf-layout


### PR DESCRIPTION
## Changes

- Prepaid agreements: Migrate Sass imports to Sass use.


## How to test this PR

1. `yarn build` and http://localhost:8000/data-research/prepaid-accounts/search-agreements/ should be unchanged.
