### PR TITLE
Prepaid agreements: Remove unused CSS

### DIFF
--- a/cfgov/paying_for_college/data_sources/bls_processing.py
+++ b/cfgov/paying_for_college/data_sources/bls_processing.py
@@ -45,7 +45,7 @@ OUT_FILE = "paying_for_college/fixtures/bls_data.json"
 
 
 def load_bls_data(csvfile):
-    with open(csvfile, "rU") as f:
+    with open(csvfile) as f:
         reader = cdr(f)
         return [row for row in reader]
 

--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
@@ -44,7 +44,7 @@
             <form class="u-mt15" method="get" action="." >
                 <h3 class="h4 u-mb5">Search within</h3>
                 <div class="layout-row block block--sub block--flush-top">
-                    <div class="a-select flex-fixed">
+                    <div class="a-select">
                         {% set opts = [
                             ('All fields', 'all'),
                             ('Product name', 'name'),

--- a/cfgov/unprocessed/apps/prepaid-agreements/css/search-bar.scss
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/search-bar.scss
@@ -10,22 +10,8 @@
   flex-wrap: wrap;
 }
 
-.layout-column {
-  display: flex;
-  flex-direction: column;
-}
-
-.flex-fixed {
-  flex: none;
-}
-
 .flex-all {
   flex: 1 0 auto;
-}
-
-button.a-btn.flex-fixed {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
 }
 
 // Tablet and below.
@@ -37,7 +23,7 @@ button.a-btn.flex-fixed {
   }
 }
 
-// select
+// Dark gray drop-down adjacent to the search input.
 $select-height: $size-ii;
 
 .a-select {

--- a/cfgov/unprocessed/apps/prepaid-agreements/css/search.scss
+++ b/cfgov/unprocessed/apps/prepaid-agreements/css/search.scss
@@ -1,12 +1,6 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
 
-.search__wrapper {
-  &.o-well {
-    max-width: 100%;
-  }
-}
-
 .filters__applied,
 .filters__tags {
   display: flex;
@@ -49,10 +43,6 @@
         padding-left: 0;
         padding-right: 0;
       }
-    }
-
-    .num-results {
-      float: right;
     }
 
     .o-form__group {


### PR DESCRIPTION
The presence or absence of `flex-fixed` does not appear to make a difference to the drop-down menu on the prepaid agreements search. 

`.search__wrapper.o-well` did not appear to target anything. The only `o-well` on prepaid agreements is the database disclaimer, which appears outside of the `search__wrapper`.

`num-results` appears to have been copied over from iRegs, which has it in the markup. However, prepaid agreements does not have it in the markup.

## Removals

- Remove `flex-fixed` class, which did not appear to affect anything.
- Remove `layout-column` class, which I couldn't find references for.
- Remove `.search__wrapper.o-well` rule, which appears to be unused.
- Remove `num-results` class, which appears to be unused.



## How to test this PR

1. `yarn build` and http://localhost:8000/data-research/prepaid-accounts/search-agreements/ should appear as before across screen sizes.
