### PR TITLE
Remove unneeded 'main' imports from scss

### DIFF
--- a/cfgov/unprocessed/apps/form-explainer/css/main.scss
+++ b/cfgov/unprocessed/apps/form-explainer/css/main.scss
@@ -1,2 +1,1 @@
-@import '../../../css/main';
 @import './form-explainer';

--- a/cfgov/unprocessed/apps/paying-for-college/css/main.scss
+++ b/cfgov/unprocessed/apps/paying-for-college/css/main.scss
@@ -5,9 +5,6 @@
 // This is your project's main SCSS file.
 // Project-specific SCSS rules go after the imports.
 
-// Import Design System components.
-@import '../../../css/main';
-
 // Import the Design System enhancements
 @import 'cf-enhancements';
 

--- a/cfgov/unprocessed/css/on-demand/error.scss
+++ b/cfgov/unprocessed/css/on-demand/error.scss
@@ -1,6 +1,5 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
-@import '../main';
 
 /* ==========================================================================
    consumerfinance.gov

--- a/cfgov/unprocessed/css/on-demand/event.scss
+++ b/cfgov/unprocessed/css/on-demand/event.scss
@@ -1,6 +1,5 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
-@import '../main';
 
 /* ==========================================================================
    consumerfinance.gov

--- a/cfgov/unprocessed/css/on-demand/sidebar-contact-info.scss
+++ b/cfgov/unprocessed/css/on-demand/sidebar-contact-info.scss
@@ -1,6 +1,5 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
-@import '../main';
 
 .o-sidebar-contact-info {
   &__content {

--- a/cfgov/unprocessed/css/on-demand/simple-chart.scss
+++ b/cfgov/unprocessed/css/on-demand/simple-chart.scss
@@ -1,6 +1,5 @@
 @use 'sass:math';
 @use '@cfpb/cfpb-design-system/src/abstracts' as *;
-@import '../main';
 @import 'highcharts/css/highcharts.css';
 
 .o-simple-chart {


### PR DESCRIPTION
In LESS, these imports were `(reference)`s which allowed access to variables without actually duplicating the css. However, in the switch to scss, these imports were copied over even though they are no longer needed (as the variables are imported directly from the design system now).

The upshot is that these small css files (were) including an entire copy of main.css when built, ballooning their size like 20x (or more). This fixes that.

## Testing
 - Pull and build. Should work without errors.
 - Pages with the various components, eg. localhost:8000/consumer-tools/prepaid-cards/understand-fees/, http://localhost:8000/paying-for-college/your-financial-path-to-graduation/, etc. should look identical to prod.