### PR TITLE
Pin the version of the mozilla/oidc-testprovider image

### DIFF
--- a/docker-compose.sso.yml
+++ b/docker-compose.sso.yml
@@ -1,8 +1,6 @@
-version: '3.4'
-
 services:
   oidcprovider:
-    image: mozilla/oidc-testprovider:oidc_testprovider-latest
+    image: mozilla/oidc-testprovider:oidc_testprovider-v0.10.9
     ports:
       - "8080:8080"
     command: >


### PR DESCRIPTION
Our SSO local rig pulls the "latest" oidc-testprovider image. A [new version](https://hub.docker.com/r/mozilla/oidc-testprovider/tags?name=testprovider) that was released Oct. 29 breaks our rig with a client-id error.

<hr>

<img width="798" alt="client_id_error" src="https://github.com/user-attachments/assets/d30c0892-318d-4876-90ee-1d3b78b01956">

<hr>

There's nothing wrong with the passing of our single-digit client_id, but perhaps some new code demands a longer one.

I found that stepping back to the previous version will keep our rig humming while we explore how to address the breaking change, or wait for a fixed image if it's a bug.

## Testing
- Remove any existing oidc-testprovider docker image you may have locally.
- Run `docker compose -f docker-compose.sso.yml up` to pull the latest image and launch the SSO machinery.
- Try to log in to localhost:8000/admin
 
## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)