### PR TITLE
Migrate ruff flagged code to using format specifiers instead of percent format

### DIFF
--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -269,7 +269,7 @@ def slugify_unique(context, value):
         index = 1
 
         while slug in used_slugs:
-            slug = "%s-%d" % (original_slug, index)
+            slug = f"{original_slug}-{index}"
             index += 1
 
         used_slugs.append(slug)

--- a/cfgov/v1/management/commands/_sync_storage_base.py
+++ b/cfgov/v1/management/commands/_sync_storage_base.py
@@ -24,7 +24,7 @@ class SyncStorageCommandMixin:
         count = queryset.count()
 
         for i, instance in enumerate(queryset):
-            log_prefix = "%d/%d (%d) " % (i + 1, count, instance.pk)
+            log_prefix = f"{i + 1}/{count} ({instance.pk}) "
             self.handle_instance(instance, log_prefix)
 
     def get_storage_subdirectories():

--- a/cfgov/v1/management/commands/sync_image_storage.py
+++ b/cfgov/v1/management/commands/sync_image_storage.py
@@ -19,10 +19,6 @@ class Command(SyncStorageCommandMixin, BaseCommand):
         rendition_count = renditions.count()
 
         for j, rendition in enumerate(renditions):
-            rendition_prefix = "%d/%d (%d) " % (
-                j + 1,
-                rendition_count,
-                rendition.pk,
-            )
+            rendition_prefix = f"{j + 1}/{rendition_count} ({rendition.pk}) "
             self.stdout.write(log_prefix + rendition_prefix, ending="")
             self.save(rendition.file.name)


### PR DESCRIPTION
Ruff recently auto-updated to 0.8.0, which introduced some breaking changes.

## Changes

- Migrate ruff flagged code to using format specifiers instead of percent format.


## How to test this PR

1. BEWD lint PR check should pass.
