### PR TITLE
Video Player: fix close button CSS

### DIFF
--- a/cfgov/unprocessed/css/organisms/video-player.scss
+++ b/cfgov/unprocessed/css/organisms/video-player.scss
@@ -338,7 +338,6 @@ button.o-video-player__play-btn,
   .o-video-player__close-btn {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
-    display: block;
 
     // Pushes button out of masked window when not playing.
     margin-top: $standard-btn-height-px;


### PR DESCRIPTION
Buttons lay out their icon and divider using flexbox now (see https://github.com/cfpb/design-system/pull/2091), so explicitly setting the button to `display: block` breaks this, as is done in the video player close button.

## Changes

- Video Player: Remove `display: block;` from video close button.


## How to test this PR

1. Play a featured content video, such as that on http://localhost:8000/about-us/diversity-and-inclusion/self-assessment-financial-institutions/ and see that the divider is correctly between the text and icon.


## Screenshots

| Before | After  |
| ------ | ------ |
|      <img width="194" alt="Screenshot 2024-11-26 at 3 32 13 PM" src="https://github.com/user-attachments/assets/a79f67d5-0e6e-4f46-bbfd-97cbc41ff410">|   <img width="157" alt="Screenshot 2024-11-26 at 3 31 57 PM" src="https://github.com/user-attachments/assets/9eea3efd-911a-46e9-b290-d4566d854484">|
