### PR TITLE
Remove `o-featured-content-module--left`

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/featured-content.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/featured-content.html
@@ -28,12 +28,9 @@
 
    value.video:     (Optional) A VideoPlayer organism.
 
-   value.layout_left (Optional) If True, Use the image-on-the-left layout.
-
    ========================================================================== #}
 
-<section class="o-featured-content-module
-                {{ 'o-featured-content-module--left' if value.layout_left }}">
+<section class="o-featured-content-module">
     <div class="o-featured-content-module__text">
         <h2 class="h3">{{ value.heading }}</h2>
 

--- a/cfgov/v1/template_debug/featured_content.py
+++ b/cfgov/v1/template_debug/featured_content.py
@@ -43,20 +43,6 @@ featured_content_test_cases = {
             },
         ],
     },
-    "Image-on-the-left layout": {
-        "layout_left": True,
-        "image": {"url": FEATURED_CONTENT_IMAGE_URL},
-        "links": [
-            {
-                "text": "Consumer Financial Protection Bureau",
-                "url": "https://www.consumerfinance.gov",
-            },
-            {
-                "text": "Oficina para la Protección Financiera del Consumidor",
-                "url": "https://www.consumerfinance.gov/es/",
-            },
-        ],
-    },
     "Video": {
         "video": {"video_id": "dQw4w9WgXcQ"},
     },


### PR DESCRIPTION
This pattern appears to have been usurped by the 25/75 info unit pattern. It was not possible to set this in Wagtail, as there was no option to set it. It is only set in the debug template view. 

Accompanying DS PR https://github.com/cfpb/design-system/pull/2128

## Removals

- Remove `o-featured-content-module--left`

## How to test this PR

1. View http://localhost:8000/admin/template_debug/v1/featured_content/ and see that the left aligned version is gone.

## Notes

On arabic pages, the FCM maybe should flip, but this should happen without the need to add a modifier.
(e.g. https://www.consumerfinance.gov/language/ar/)

