### PR TITLE
Remove unused CSS

### DIFF
--- a/cfgov/unprocessed/apps/teachers-digital-platform/css/atoms/icon.scss
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/css/atoms/icon.scss
@@ -12,10 +12,6 @@
   color: var(--gold);
 }
 
-.a-icon--space-before {
-  margin-left: 0.25em;
-}
-
 .a-icon--space-after {
   margin-right: 0.25em;
 }

--- a/cfgov/unprocessed/css/enhancements/typography.scss
+++ b/cfgov/unprocessed/css/enhancements/typography.scss
@@ -25,7 +25,3 @@ dd {
 .eyebrow {
   @include heading-5;
 }
-
-.a-link__text {
-  overflow-wrap: break-word;
-}


### PR DESCRIPTION
## Removals

- Remove unused CSS `a-link__text`, which was moved to the DS.
- Remove unreferenced `a-icon--space-before` from TDP.

## How to test this PR

1. Any link should have `overflow-wrap: break-word;` in the `.a-link .a-link__text` rule.
2. TDP icons should all be before the text http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/?page=2#tdp-search-facets-and-results