### PR TITLE
Remove agreements' chose and jquery entries from prettier ignore config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,5 @@
 .github/
 .tox/
-cfgov/agreements/static/agreements/js/chosen.jquery.js
-cfgov/agreements/static/agreements/js/jquery-3.5.1.min.js
 cfgov/alerts/tests/json/
 cfgov/data_research/data/
 cfgov/retirement_api/data/


### PR DESCRIPTION
https://github.com/cfpb/consumerfinance.gov/pull/8657 removed Chosen from CC agreements. This PR removes some no longer applicable references from the prettier ignore config.

## Removals

- Remove agreements' chose and jquery entries from prettier ignore config


## How to test this PR

1. `yarn lint` should be unchanged.
