### PR TITLE
Exit linting on error from sub task

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,8 @@
+#!/bin/sh
+
+# Exit on error from any of the linting sub-tasks.
+set -e
+
 ## Run prettier. See ignored path in .prettierignore.
 yarn prettier "./**/*.{js,jsx,ts,tsx,md,css,scss}" --write
 


### PR DESCRIPTION
If there was an error in prettier, eslint, or stylelint, the other two tasks would still run and obfuscate that one of them errored. This changes the `lint.sh` to exit if any of the sub tasks throws an error.

## Changes

- Exit linting on error from sub task
