### PR TITLE
Database script updates to support containerization

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,8 +23,6 @@ if [ ! -z "$RUN_MIGRATIONS" ]; then
     if [ -n "$CFGOV_PROD_DB_LOCATION" ] || [ -n "$DB_DUMP_FILE" ] || [ -n "$DB_DUMP_URL" ]; then
       echo "Running refresh-data.sh... $DB_DUMP_FILE"
       ./refresh-data.sh "$DB_DUMP_FILE"
-      echo "Create the cache table..."
-      ./cfgov/manage.py createcachetable
 
       # refresh-data.sh runs migrations and rebuilds index,
       # unset vars to prevent further action

--- a/initial-data.sh
+++ b/initial-data.sh
@@ -12,7 +12,7 @@ set -e
 # Import Data
 import_data(){
     echo 'Running Django migrations...'
-    ./cfgov/manage.py migrate
+    ./cfgov/manage.py migrate --noinput
     echo 'Creating any necessary Django database cache tables...'
     ./cfgov/manage.py createcachetable
     echo 'Running initial_data script to configure Wagtail admin...'

--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -55,21 +55,14 @@ check_data() {
 refresh_data() {
     echo 'Importing refresh db'
     gunzip < "$refresh_dump_name" | cfgov/manage.py dbshell > /dev/null
-    SCHEMA="$(gunzip -c $refresh_dump_name | grep -m 1 'CREATE SCHEMA' | sed 's/CREATE SCHEMA \(.*\);$/\1/')"
-    PGUSER="${PGUSER:-cfpb}"
-    if [ "${PGUSER}" != "${SCHEMA}" ]; then
-      echo "Adjusting schema name to match username..."
-      echo "DROP SCHEMA IF EXISTS \"${PGUSER}\" CASCADE; \
-        ALTER SCHEMA \"${SCHEMA}\" RENAME TO \"${PGUSER}\"" | psql > /dev/null 2>&1
-    fi
-    echo 'Running any necessary migrations'
-    ./cfgov/manage.py migrate --noinput --fake-initial
-    echo 'Setting up initial data'
-    ./cfgov/manage.py runscript initial_data
+}
+
+initial_data() {
+    ./initial-data.sh
 }
 
 update_index() {
-  source ./index.sh
+    source ./index.sh
 }
 
 get_data() {
@@ -108,6 +101,7 @@ done
 get_data
 check_data
 refresh_data
+initial_data
 
 if [[ $noindex -ne 1 ]]; then
     update_index


### PR DESCRIPTION
This commit modifies several scripts to make it easier to setup the database as part of a containerized cf.gov deploy.

It removes a portion of the refresh-data.sh script that attempts to manually rename the existing 'cfpb' schema in our database dumps, to a schema named for a different Postgres user. We no longer use the PGUSER environment variable as of 59b109b2a3d85fa551a8cb37b82cdbc9ad9058e8, so this code doesn't work right now.

In the future, if we need to import a 'cfpb' schema into a database where the username is something different (for example in an RDS instance where we might have less control over the username) we might have to revisit this code.

This change also consolidates the various 'DB setup' steps we do after loading a dump -- running migrations, creating the cache table, and running our 'initial' data script, reducing some duplication.