### PR TITLE
TCCP: ITAP Changes

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -68,7 +68,7 @@
     <div class="o-filterable-list-results o-filterable-list-results--partial" id="htmx-results" aria-live="polite" aria-busy="false">
         {% include "tccp/includes/card_list.html" %}
     </div>
-    <div id="u-show-more-fade" class="u-js-only{% if form.ordering.data[0] == 'product_name' %} u-hidden{% endif %}" data-js-hook="behavior_show-more">
+    <div id="u-show-more" class="u-js-only{% if form.ordering.data[0] == 'product_name' %} u-hidden{% endif %}" data-js-hook="behavior_show-more">
         <button class="a-btn a-btn--full-on-xs">
             Show more results with higher interest rates
         </button>

--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -68,7 +68,7 @@
     <div class="o-filterable-list-results o-filterable-list-results--partial" id="htmx-results" aria-live="polite" aria-busy="false">
         {% include "tccp/includes/card_list.html" %}
     </div>
-    <div id="u-show-more" class="u-js-only{% if form.ordering.data[0] == 'product_name' %} u-hidden{% endif %}" data-js-hook="behavior_show-more">
+    <div id="u-show-more-fade" class="u-js-only{% if form.ordering.data[0] == 'product_name' %} u-hidden{% endif %}" data-js-hook="behavior_show-more">
         <button class="a-btn a-btn--full-on-xs">
             Show more results with higher interest rates
         </button>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -60,7 +60,7 @@
             card.annual_fee_estimated,
             default=('See details' if card.annual_fee_estimated is none and card.periodic_fee_type else '$0')
         ) -%}
-        {%- set show_more = loop.index > 11 and ordering_by != 'product_name' -%}
+        {%- set show_more = loop.index > 10 and ordering_by != 'product_name' -%}
         <article class="m-card m-card--tabular{% if show_more %} u-show-more{% endif %}">
             <a
                 href="{{ card.url }}"
@@ -179,7 +179,7 @@
                     {%- endif -%}
                 </dl>
                 <div class="m-card__footer">
-                    <p class="m-card__subtitle">See card details</p>
+                    <p class="m-card__link">See card details</p>
                 </div>
             </a>
         </article>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -182,7 +182,7 @@
                     {%- endif -%}
                 </dl>
                 <div class="m-card__footer">
-                    <p class="m-card__link" tabindex="{% if loop.index == 11 %}-1{% else %}0{% endif %}">See card details</p>
+                    <p class="m-card__link" data-js-hook="behavior_card-link-proxy" tabindex="{% if loop.index == 11 %}-1{% else %}0{% endif %}">See card details</p>
                 </div>
             </a>
         </article>

--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -60,13 +60,14 @@
             card.annual_fee_estimated,
             default=('See details' if card.annual_fee_estimated is none and card.periodic_fee_type else '$0')
         ) -%}
-        {%- set show_more = loop.index > 10 and ordering_by != 'product_name' -%}
+        {%- set show_more = loop.index > 11 and ordering_by != 'product_name' -%}
         <article class="m-card m-card--tabular{% if show_more %} u-show-more{% endif %}">
             <a
                 href="{{ card.url }}"
                 data-js-hook="behavior_ignore-link-targets"
                 data-ignore-link-targets="[data-tooltip]"
                 aria-label="{{ card.product_name }} from {{ card.institution_name }} with {{ card_purchase_apr }} purchase APR, {{ card_account_fee }} account fee, {{ card_rewards(card) }} card rewards{%- if card.requirements_for_opening or card.issued_by_credit_union -%}, eligibility requirements{%- endif -%}"
+                {% if loop.index == 11 %}data-js-hook="behavior_faded-card" tabindex="-1"{% endif %}
             >
                 <div class="m-card__heading-group">
                     <h2 class="h3 m-card__heading">{{ card.institution_name }}</h2>
@@ -102,8 +103,9 @@
                                         body=(
                                             'APRs change over time and are '
                                             ~ 'specific to the applicant. '
-                                            ~ 'Check rates before applying.'
-                                        )
+                                            ~ 'Check rates before applying.',
+                                        ),
+                                        tabindex=( loop.index == 11 )
                                     ) }}
                                 </span>
                             </div>
@@ -171,7 +173,8 @@
                                         ~ oxfordize(requirement_types)
                                         ~ ('. ' if card.geographic_restrictions or card.professional_affiliation)
                                         ~ 'See card details for more information.'
-                                    )
+                                    ),
+                                    tabindex=( loop.index == 11 )
                                 ) }}
                             </span>
                         </dd>
@@ -179,7 +182,7 @@
                     {%- endif -%}
                 </dl>
                 <div class="m-card__footer">
-                    <p class="m-card__link">See card details</p>
+                    <p class="m-card__link" tabindex="{% if loop.index == 11 %}-1{% else %}0{% endif %}">See card details</p>
                 </div>
             </a>
         </article>

--- a/cfgov/tccp/jinja2/tccp/includes/tooltip.html
+++ b/cfgov/tccp/jinja2/tccp/includes/tooltip.html
@@ -1,6 +1,6 @@
-{% macro tooltip(name, heading=none, body=none, icon="help-round") -%}
+{% macro tooltip(name, heading=none, body=none, icon="help-round", tabindex="0") -%}
 
-<span data-tooltip>
+<span tabindex="{% if tabindex == False %}0{% else %}-1{% endif %}" data-tooltip>
     {{ svg_icon(icon) }}
 </span>
 <template>

--- a/cfgov/tccp/jinja2/tccp/includes/tooltip.html
+++ b/cfgov/tccp/jinja2/tccp/includes/tooltip.html
@@ -1,6 +1,6 @@
 {% macro tooltip(name, heading=none, body=none, icon="help-round") -%}
 
-<span tabindex="0" data-tooltip>
+<span data-tooltip>
     {{ svg_icon(icon) }}
 </span>
 <template>

--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -385,11 +385,21 @@ html.js .o-filterable-list-results--partial {
   }
 }
 
-#u-show-more {
-  margin-top: math.div(0px, $base-font-size-px) + rem;
-  padding-top: math.div(20px, $base-font-size-px) + rem;
+// A vertical white linear gradient that overlaps the last
+// card result to emphasize that there are more cards to see
+#u-show-more-fade {
+  position: relative;
+  margin-top: math.div(-200px, $base-font-size-px) + rem;
+  padding-top: math.div(180px, $base-font-size-px) + rem;
   z-index: 1;
   cursor: pointer;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0%),
+    rgba(255, 255, 255, 70%),
+    rgba(255, 255, 255, 97%),
+    rgba(255, 255, 255, 100%)
+  );
 }
 
 .m-credit-tier-chart {

--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -160,9 +160,9 @@
     // Disable iOS link highlighting for our large cards
     -webkit-tap-highlight-color: transparent;
 
-    &:visited .m-card__subtitle {
-      border-color: $link-underline-visited;
-      color: $link-text-visited;
+    &:visited .m-card__link {
+      border-bottom: 1px dotted $link-underline;
+      color: $link-text;
     }
 
     @include respond-to-min($bp-sm-min) {
@@ -183,8 +183,8 @@
     }
 
     .m-card__subtitle {
-      border-bottom: 1px solid $link-underline-hover;
-      color: $link-text-hover;
+//      border-bottom: 1px solid $link-underline-hover;
+//      color: $link-text-hover;
     }
 
     &::after {
@@ -204,13 +204,17 @@
 
   .m-card__heading {
     margin-bottom: 0;
-    color: var(--gray);
+    color: var(--black);
     font-size: math.div(16px, $base-font-size-px) + rem;
     font-weight: 400;
     text-transform: uppercase;
   }
 
   .m-card__subtitle {
+    display: inline;
+  }
+
+  .m-card__link {
     display: inline;
     border-bottom: 1px dotted $link-underline;
     color: $link-text;
@@ -381,21 +385,11 @@ html.js .o-filterable-list-results--partial {
   }
 }
 
-// A vertical white linear gradient that overlaps the last
-// card result to emphasize that there are more cards to see
-#u-show-more-fade {
-  position: relative;
-  margin-top: math.div(-200px, $base-font-size-px) + rem;
-  padding-top: math.div(180px, $base-font-size-px) + rem;
+#u-show-more {
+  margin-top: math.div(0px, $base-font-size-px) + rem;
+  padding-top: math.div(20px, $base-font-size-px) + rem;
   z-index: 1;
   cursor: pointer;
-  background-image: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0%),
-    rgba(255, 255, 255, 70%),
-    rgba(255, 255, 255, 97%),
-    rgba(255, 255, 255, 100%)
-  );
 }
 
 .m-credit-tier-chart {

--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -182,11 +182,6 @@
         -2px 0 0 0 inset var(--gray-20);
     }
 
-    .m-card__subtitle {
-//      border-bottom: 1px solid $link-underline-hover;
-//      color: $link-text-hover;
-    }
-
     &::after {
       content: '';
       position: absolute;

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -133,8 +133,14 @@ function handleShowMore(event) {
     event.preventDefault();
   }
   const results = document.querySelector('.o-filterable-list-results');
-  const nextResult = document.querySelector('.u-show-more > a');
+  const showMoreFade = document.querySelector('#u-show-more-fade');
+  const nextResult = document.querySelector('[data-js-hook="behavior_faded-card"]');
+  nextResult.setAttribute('tabIndex', '0');
+  nextResult.querySelectorAll('[tabindex="-1"]').forEach( elem => {
+    elem.setAttribute('tabIndex', '0');
+  });
   results.classList.remove('o-filterable-list-results--partial');
+  showMoreFade.classList.add('u-hidden');
   nextResult.focus();
 }
 

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -21,6 +21,8 @@ function init() {
   behaviorAttach('submit-situations', 'click', handleFormValidation);
   // Attach handler for conditional link targets
   behaviorAttach('ignore-link-targets', 'click', handleIgnoreLinkTargets);
+  // Attach handler for "Enter" on card details link proxy
+  behaviorAttach('card-link-proxy', 'keydown', handleCardLinkProxies);
   // Make the breadcrumb on the details page go back to a filtered list
   updateBreadcrumb();
   // Move the card ordering dropdown below the expandable
@@ -38,6 +40,8 @@ function init() {
 function initializeAndReport(event) {
   initializeTooltips();
   reportFilter(event);
+  // Attach handler for "Enter" on card details link proxy
+  behaviorAttach('card-link-proxy', 'keydown', handleCardLinkProxies);
 }
 
 /**
@@ -176,6 +180,18 @@ function handleFormValidation(event) {
     location.closest('.m-form-field').scrollIntoView({ behavior: 'smooth' });
     location.classList.add('a-select--error');
     locationError.classList.remove('u-visually-hidden');
+  }
+}
+
+/**
+ * Handles "Enter" key on focusable p elements ("card link proxies"). These
+ * proxies are p elements masquerading as anchor tags.
+ * @param {Event} event - Keydown event
+ */
+function handleCardLinkProxies(event) {
+  if (event.key && event.key === 'Enter') {
+    const parentAnchor = event.target.closest('a');
+    parentAnchor.click();
   }
 }
 

--- a/cfgov/unprocessed/apps/tccp/js/index.js
+++ b/cfgov/unprocessed/apps/tccp/js/index.js
@@ -133,10 +133,8 @@ function handleShowMore(event) {
     event.preventDefault();
   }
   const results = document.querySelector('.o-filterable-list-results');
-  const showMoreFade = document.querySelector('#u-show-more-fade');
   const nextResult = document.querySelector('.u-show-more > a');
   results.classList.remove('o-filterable-list-results--partial');
-  showMoreFade.classList.add('u-hidden');
   nextResult.focus();
 }
 


### PR DESCRIPTION
This Pull Request will adjust some accessibility features. These aren't major changes, but will move things more in line with recommendations.

As a result of this PR, tab-based keyboard navigation will be improved to allow users to get more information without clicking through to see more details on the card. It will also skip the "faded" 11th card initially, sending the user instead to the "Show more results" button, then redirecting the user back to the 11th card when that button is clicked.

## Changes

- Change `tabindex` properties
- Add handling for "Enter" when then "proxy link" is focused

## How to test this PR
1. Visit `/consumer-tools/credit-cards/explore-cards/cards/` and search
2. Use keyboard navigation to `TAB` through the results. You should focus the entire "card", then the tooltips (if present), then the "proxy link" (looks like a link but it's formatted `<p>` element).
3. Hitting `Enter` while on the "proxy link" should send you to the card's details page

## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
