### PR TITLE
Use WhiteNoise for serving static files

### DIFF
--- a/cfgov/apache/conf.d/alias.conf
+++ b/cfgov/apache/conf.d/alias.conf
@@ -10,7 +10,5 @@ Alias /lln8595c61g9qnvuwvtlcwo1k6kem8.html ${STATIC_PATH}/lln8595c61g9qnvuwvtlcw
 # Akamai Sureroute
 Alias /akamai/sureroute-test-object.html ${STATIC_PATH}/akamai-sureroute-test-object.html
 Alias /utilities/pages/akamai-sureroute-test-object.htm ${STATIC_PATH}/akamai-sureroute-test-object.html
-# Main static alias
-Alias /static/ ${STATIC_PATH}/
 # Security.txt for CVE disclosure
 Alias /security.txt ${STATIC_PATH}/security.txt

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -72,6 +72,10 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.sitemaps",
+    # Including WhiteNoise before staticfiles so that WhiteNoise always
+    # serves static files, even in development.
+    # https://whitenoise.readthedocs.io/en/latest/django.html#using-whitenoise-in-development
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "wagtail.search",
@@ -138,6 +142,7 @@ MIDDLEWARE = (
     "core.middleware.DeactivateTranslationsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
 )
 
 CSP_MIDDLEWARE = ("csp.middleware.CSPMiddleware",)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -127,6 +127,8 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -140,9 +142,7 @@ MIDDLEWARE = (
     "core.middleware.SelfHealingMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "core.middleware.DeactivateTranslationsMiddleware",
-    "django.middleware.security.SecurityMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
 )
 
 CSP_MIDDLEWARE = ("csp.middleware.CSPMiddleware",)

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -72,10 +72,6 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.sitemaps",
-    # Including WhiteNoise before staticfiles so that WhiteNoise always
-    # serves static files, even in development.
-    # https://whitenoise.readthedocs.io/en/latest/django.html#using-whitenoise-in-development
-    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "wagtail.search",
@@ -127,8 +123,6 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
-    "django.middleware.security.SecurityMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -142,6 +136,7 @@ MIDDLEWARE = (
     "core.middleware.SelfHealingMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "core.middleware.DeactivateTranslationsMiddleware",
+    "django.middleware.security.SecurityMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 
@@ -277,7 +272,7 @@ STORAGES = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
 

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -277,7 +277,7 @@ STORAGES = {
         "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
     "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
 }
 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -86,7 +86,7 @@ EMAIL_HOST = os.getenv("EMAIL_HOST")
 DEFAULT_FROM_EMAIL = "wagtail@cfpb.gov"
 
 STORAGES["staticfiles"] = {
-    "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
 }
 
 STATIC_ROOT = os.environ["DJANGO_STATIC_ROOT"]

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -43,6 +43,7 @@ wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.12.1
 wagtail-treemodeladmin==1.9.2
 wagtailmedia==0.15.2
+whitenoise==6.7.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.18.2/owning_a_home_api-0.18.2-py3-none-any.whl


### PR DESCRIPTION
This change uses [WhiteNoise](https://whitenoise.readthedocs.io/en/latest/index.html) for static file serving in development and when served via Apache.

## How to test this PR

1. Run `runserver` in your preferred way and observe that static files serve successfully.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
