### PR TITLE
Switch back to Django's ManifestStaticFilesStorage

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -86,7 +86,7 @@ EMAIL_HOST = os.getenv("EMAIL_HOST")
 DEFAULT_FROM_EMAIL = "wagtail@cfpb.gov"
 
 STORAGES["staticfiles"] = {
-    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
 }
 
 STATIC_ROOT = os.environ["DJANGO_STATIC_ROOT"]


### PR DESCRIPTION
We've got some unexpected behavior with WhiteNoise's `CompressedManifestStaticFilesStorage`. This quick change switches back with Django's `ManifestStaticFilesStorage` until we can do more testing.

This backs out one change made in #8678, but not the use of WhiteNoise generally.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
