### PR TITLE
Restore all white noise

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -72,6 +72,10 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.sitemaps",
+    # Including WhiteNoise before staticfiles so that WhiteNoise always
+    # serves static files, even in development.
+    # https://whitenoise.readthedocs.io/en/latest/django.html#using-whitenoise-in-development
+    "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "wagtail.search",
@@ -123,6 +127,8 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
+    "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.http.ConditionalGetMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -136,7 +142,6 @@ MIDDLEWARE = (
     "core.middleware.SelfHealingMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
     "core.middleware.DeactivateTranslationsMiddleware",
-    "django.middleware.security.SecurityMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 )
 

--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -86,7 +86,7 @@ EMAIL_HOST = os.getenv("EMAIL_HOST")
 DEFAULT_FROM_EMAIL = "wagtail@cfpb.gov"
 
 STORAGES["staticfiles"] = {
-    "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
 }
 
 STATIC_ROOT = os.environ["DJANGO_STATIC_ROOT"]


### PR DESCRIPTION
Commit de10b0745bb946ac10257b9a0b5fab62e2dcc9bf in #8678 for some reason removed the WhiteNoise middleware entirely.

This change restores it, and reverts #8680 using WhiteNosie to compress and hash static files.

I've tested these changes on staging.

## Checklist


- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
