### PR TITLE
Fix privacy forms address selector

### DIFF
--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -58,10 +58,11 @@ class PrivacyActForm(forms.Form):
         widget=forms.EmailInput(attrs=text_input_attrs),
     )
     contact_channel = forms.ChoiceField(
+        widget=forms.RadioSelect,
         choices=[
             ("email", "Please send my records via email"),
             ("mail", "Please send my records by mail"),
-        ]
+        ],
     )
     street_address = forms.CharField(
         required=False,


### PR DESCRIPTION
The ChoiceField for the radio buttons needs to specify the radio select widget for it to get proper IDs.


## Changes

- Fix privacy forms address selector by adding a RadioSelect widget to privacy form contact_channel fields.


## How to test this PR

1. Visit http://localhost:8000/privacy/records-access/ and http://localhost:8000/privacy/disclosure-consent/ and see that you can toggle the email/address radio buttons.
