### PR TITLE
Fix Apache proxy config

### DIFF
--- a/cfgov/apache/conf.d/proxy.conf
+++ b/cfgov/apache/conf.d/proxy.conf
@@ -6,6 +6,6 @@
 # application is moved to Gunicorn.
 ServerName https://www.consumerfinance.gov
 
-# RewriteCond expr "-n env('CFGOV_APPLICATION_HOST')"
+RewriteCond expr "-n env('CFGOV_APPLICATION_HOST')"
 RewriteRule ^/(.*)$ http://${CFGOV_APPLICATION_HOST}:8000/$1 [P]
 ProxyPassReverse / http://${CFGOV_APPLICATION_HOST}:8000/


### PR DESCRIPTION
Fix our `RewriteCond` that checks for `CFGOV_APPLICATION_HOST` before proxying to Gunicorn. 


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
