### PR TITLE
TCCP: Fix tooltip content

### DIFF
--- a/cfgov/tccp/jinja2/tccp/includes/card_list.html
+++ b/cfgov/tccp/jinja2/tccp/includes/card_list.html
@@ -103,7 +103,7 @@
                                         body=(
                                             'APRs change over time and are '
                                             ~ 'specific to the applicant. '
-                                            ~ 'Check rates before applying.',
+                                            ~ 'Check rates before applying.'
                                         ),
                                         tabindex=( loop.index == 11 )
                                     ) }}


### PR DESCRIPTION
Minor fix to get tooltip content rendering correctly.

---

## How to test this PR

1. Make sure the "As of Jun. 20, 2024" tooltip content renders correctly, without the `('` and `')` around it.


## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="496" alt="before" src="https://github.com/user-attachments/assets/c2831c6c-1f32-4b15-a2ae-f2d38944465b" />  | <img width="499" alt="after" src="https://github.com/user-attachments/assets/536babcb-bfd4-49ff-9f43-e9f74a293a99" /> |
