### PR TITLE
TCCP: Fix cards with no balance transfer period

### DIFF
--- a/cfgov/tccp/jinja2/tccp/card.html
+++ b/cfgov/tccp/jinja2/tccp/card.html
@@ -700,9 +700,9 @@
                 <div class="m-payment-calculation__part">
                     {% call data_section(
                         balance_transfer_apr_term ~
-                        ' for ' ~
+                        (' for ' ~
                         '%.0f' | format(card.median_length_of_balance_transfer_apr) ~
-                        ' months'
+                        ' months' if card.median_length_of_balance_transfer_apr is not none)
                     ) %}
                         {% if card.transfer_apr_min is not none
                             and card.transfer_apr_max is not none
@@ -766,9 +766,14 @@
                 </p>
             {% endif %}
             <p>
-                After
-                {{ '%.0f' | format(card.median_length_of_balance_transfer_apr ) }}
-                months, any remaining unpaid balance on your account will be
+                {%- if card.median_length_of_balance_transfer_apr is not none -%}
+                    After
+                    {{ '%.0f' | format(card.median_length_of_balance_transfer_apr ) }}
+                    months, a
+                {%- else -%}
+                    A
+                {%- endif -%}
+                ny remaining unpaid balance on your account will be
                 subject to interest charges based on your purchase APR.
             </p>
         {% else %}


### PR DESCRIPTION
Fixes an error for cards that don't provide a median length of balance transfer.

---

## Changes

- Handle cards that offer balance transfers but don't provide a median length of balance transfer

## How to test this PR

1. Check a card that offers balance transfers but doesn't provide a median length of balance transfer, like `/consumer-tools/credit-cards/explore-cards/cards/southeast-financial-credit-union-visa-platinum-credit-card/` or `/consumer-tools/credit-cards/explore-cards/cards/first-national-bank-of-omaha-seiusm-platinum-editionr-visa-card/`, and confirm the card details page renders OK and without any reference to a transfer period
2. Check some other cards that do offer balance transfers and do specify the median length to make sure their details page hasn't changed

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)