### PR TITLE
DATAP-1586 - CCDB: remove spacing under filter headings

### DIFF
--- a/cfgov/unprocessed/apps/ccdb-search/css/main.scss
+++ b/cfgov/unprocessed/apps/ccdb-search/css/main.scss
@@ -53,11 +53,7 @@
   .o-expandable__header .o-expandable__cue-open {
     display: block !important;
   }
-
-  .o-expandable__label {
-    margin-bottom: 0.83333333em !important;
-  }
-
+  
   // Overrides for cfpb-chart-builder.
   .cfpb-chart[data-chart-type='tile_map'] {
     .highcharts-legend__tile-map {


### PR DESCRIPTION
Before:
<img width="390" alt="Screenshot 2024-12-19 at 8 02 02 AM" src="https://github.com/user-attachments/assets/f1e53dfc-ac16-4000-a2ae-0ee2a04be239" />

after:

<img width="410" alt="Screenshot 2024-12-19 at 8 02 27 AM" src="https://github.com/user-attachments/assets/a51466ee-1a74-4f84-abbf-7c71961e6fd0" />
