### PR TITLE
Return an empty list for tccp situations when invalid data gets cleaned

### DIFF
--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -23,6 +23,10 @@ class LandingPageViewTests(TestCase):
         response = self.make_request()
         self.assertEqual(response.status_code, 200)
 
+    def test_invalid_situations(self):
+        response = self.make_request("?situations=fake+and+bad")
+        self.assertEqual(response.status_code, 200)
+
     def test_situation_redirect(self):
         tier = "Credit scores from 620 to 719"
 

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -23,10 +23,6 @@ class LandingPageViewTests(TestCase):
         response = self.make_request()
         self.assertEqual(response.status_code, 200)
 
-    def test_invalid_situations(self):
-        response = self.make_request("?situations=fake+and+bad")
-        self.assertContains(response, "There are no results for your search.")
-
     def test_situation_redirect(self):
         tier = "Credit scores from 620 to 719"
 
@@ -86,6 +82,10 @@ class CardListViewTests(TestCase):
     def test_no_querystring_filters_by_good_tier(self):
         response = self.make_request()
         self.assertContains(response, "Consumer Financial Protection Bureau")
+        self.assertContains(response, "There are no results for your search.")
+
+    def test_invalid_situations(self):
+        response = self.make_request("?situations=fake+and+bad")
         self.assertContains(response, "There are no results for your search.")
 
     def test_htmx_includes_only_results(self):

--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -25,7 +25,7 @@ class LandingPageViewTests(TestCase):
 
     def test_invalid_situations(self):
         response = self.make_request("?situations=fake+and+bad")
-        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "There are no results for your search.")
 
     def test_situation_redirect(self):
         tier = "Credit scores from 620 to 719"

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -145,7 +145,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
         # If we're rendering HTML, we need to augment the response context.
         if render_format == "html":
             form = filter_backend.used_filterset.form
-            situations = form.cleaned_data["situations"]
+            situations = form.cleaned_data.get("situations", [])
 
             purchase_apr_rating_ranges = self.get_purchase_apr_rating_ranges(
                 cards


### PR DESCRIPTION
This prevents key error 500s when the situations are manually nudged