### PR TITLE
Update the wagtailcharts package and remove an outdated script

### DIFF
--- a/cfgov/v1/atomic_elements/charts.py
+++ b/cfgov/v1/atomic_elements/charts.py
@@ -98,7 +98,6 @@ class ChartBlock(WagtailChartBlock):
     # https://github.com/overcastsoftware/wagtailcharts/blob/v0.5/wagtailcharts/templates/wagtailcharts/tags/render_charts.html
     class Media:
         js = [
-            "wagtailcharts/js/accounting.js?staticroot",
             "wagtailcharts/js/chart-types.js?staticroot",
             "wagtailcharts/js/chart.js?staticroot",
             "wagtailcharts/js/stacked-100.js?staticroot",

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -43,7 +43,7 @@ wagtail-placeholder-images==0.1.1
 wagtail-sharing==2.12.1
 wagtail-treemodeladmin==1.9.2
 wagtailmedia==0.15.2
-wagtailcharts==0.6.1
+wagtailcharts==0.6.2
 whitenoise==6.7.0
 
 # These packages are installed from GitHub.


### PR DESCRIPTION
The wagtailcharts 0.6.2 release notes say 0.6.1 was not released correctly: https://github.com/overcastsoftware/wagtailcharts/releases

In addition, it appears we copied in an old list of js dependencies that included accounting.js, a script removed in 0.6. 
- 2022 list: https://github.com/overcastsoftware/wagtailcharts/blob/v0.5/wagtailcharts/templates/wagtailcharts/tags/render_charts.html
- 0.6 release note: https://github.com/overcastsoftware/wagtailcharts/blob/main/RELEASE_NOTES.md?plain=1#L12

This updates the package to 0.6.2 and removes our include of accounting.js, which is causing server errors in production.
