### PR TITLE
Remove invalid Actions workflow path directives

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,12 +2,6 @@ name: backend
 
 on:
   workflow_dispatch:
-    paths:
-      - '**.py'
-      - 'requirements/**.txt'
-      - '**.html'
-      - '**.mo'
-      - '**.po'
   pull_request:
     paths:
       - '**.py'
@@ -16,12 +10,6 @@ on:
       - '**.mo'
       - '**.po'
   merge_group:
-    paths:
-      - '**.py'
-      - 'requirements/**.txt'
-      - '**.html'
-      - '**.mo'
-      - '**.po'
 
 jobs:
   backend:

--- a/.github/workflows/filter-backend.yml
+++ b/.github/workflows/filter-backend.yml
@@ -8,12 +8,6 @@ on:
       - '**.mo'
       - '**.po'
   merge_group:
-    paths-ignore:
-      - '**.py'
-      - 'requirements/**.txt'
-      - '**.html'
-      - '**.mo'
-      - '**.po'
 
 jobs:
   backend:


### PR DESCRIPTION
The backend.yml and filter-backend.yml GitHub Actions workflow files currently contain invalid path directives. The paths and paths-ignore directives only apply to the pull_request action, not the merge_group or workflow_dispatch actions.

See docs at:

- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatch