### PR TITLE
Update Spanish homepage content

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_es.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_es.html
@@ -1,5 +1,5 @@
 {%- set hero = {
-    "heading": "<strong>A su lado</strong> en los momentos financieros de la vida." | safe,
+    "heading": "<strong>Le protegemos</strong> en las decisiones financieras más importantes." | safe,
     "body": "Somos la Oficina para la Protección Financiera del Consumidor, una agencia del gobierno de los EE. UU. dedicada a garantizar que los bancos, los prestamistas y otras instituciones financieras le traten de manera justa.",
     "image": {
         "url": static( "apps/homepage/img/hero.jpg" ),
@@ -55,29 +55,28 @@
     {
         "img_src": static( "apps/homepage/img/putting-green_submit-a-complaint.png" ),
         "card_type": "highlight",
-        "heading": "Presentar una queja sobre un producto o servicio financiero",
-        "link_text": "Iniciar un reclamo",
+        "heading": "Envíenos su queja sobre un producto o servicio financiero",
+        "link_text": "Enviar una queja",
         "link_url": "/es/enviar-una-queja/"
     },
 ] -%}
 
-## TODO: Update complaint wording to match new English wording
 {%- set announcements = [
     {
-        "heading": "El CFPB lo protege",
-        "content": "<ul><li><strong>+6.8 millones</strong> de quejas de consumidores recibieron respuestas</li><li><strong>+$21 billones</strong> en alivio financiero como resultado de las acciones del CFPB</li><li><strong>+205 millones</strong> de personas elegibles para recibir ayuda financiera</li></ul>" | safe,
+        "heading": "La CFPB le protege",
+        "content": "<ul><li><strong>+6.8 millones</strong> de quejas de los consumidores fueron respondidas</li><li><strong>+$21 billones</strong> en alivio financiero fueron entregados como resultado de las acciones de la CFPB</li><li><strong>+205 millones</strong> de personas son elegibles para recibir ayuda financiera</li></ul>" | safe,
         "link_text": "",
         "link_url": ""
     },
     {
-        "heading": "Lo protegemos de un trato injusto",
-        "content": "<p>Una parte central de nuestra misión es defender a los consumidores y asegurarnos de que sean tratados de manera justa en el mercado financiero.</p>" | safe,
-        "link_text": "Consulte las medidas que tomamos para protegerlo",
+        "heading": "Le protegemos del trato injusto",
+        "content": "<p>Parte integral de nuestra misión es defender al consumidor y asegurarnos de sea tratado de forma justa dentro del mercado financiero.</p>" | safe,
+        "link_text": "Lea nuestras publicaciones y sepa cómo trabajamos para protegerle",
         "link_url": "/activity-log/?title=&language=es&from_date=&to_date="
     }
 ] -%}
 
-{%- set breakout_cards_heading = "Obtenga ayuda para planificar sus metas futuras" -%}
+{%- set breakout_cards_heading = "Encuentre ayuda planeando sus metas futuras" -%}
 
 {%- set breakout_cards = [
     {
@@ -94,7 +93,7 @@
     },
     {
         "card_type": "breakout",
-        "link_text": "Préstamo vehicular",
+        "link_text": "Préstamos autos",
         "link_url": "/es/herramientas-del-consumidor/prestamos-para-vehiculos/",
         "img_src": static( "apps/homepage/img/key-car.png" )
     }


### PR DESCRIPTION
Update new Spanish homepage content.

---

## Changes

- Updated content for the new Spanish homepage

## How to test this PR

1. If needed, enable the `SPANISH_HOMEPAGE` flag (though it should already be enabled for a local environment)
2. Make sure the Spanish homepage, `/es/`, looks like the screenshot below
3. If you happen to read Spanish, give the content a quick skim to make sure it all makes sense


## Screenshots

| Current | New  |
| ------ | ------ |
| ![old-es](https://github.com/user-attachments/assets/5467ffc7-c560-4003-98b7-7f403f08e77a) | ![new-es](https://github.com/user-attachments/assets/b6183c78-252d-43be-886e-80c14526a732) |

## Notes and todos

- The new Spanish homepage is still behind a feature flag. When the new page launches, we'll clean up the feature flag and unused files: `home_page_legacy.html` and `hardcoded_legacy_es.html`.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets