### PR TITLE
Fix invalid paying_for_college test

### DIFF
--- a/cfgov/paying_for_college/tests/test_models.py
+++ b/cfgov/paying_for_college/tests/test_models.py
@@ -63,7 +63,7 @@ class SchoolModelsTest(TestCase):
         state="OZ",
         ope6=5555,
         ope8=555500,
-        settlement_school=None,
+        settlement_school="",
     ):
         return School.objects.create(
             school_id=school_id,


### PR DESCRIPTION
This test in paying_for_college isn't actually testing anything. The call to

```py
self.assertTrue(mock_requests.called_with, unicode_endpoint.encode("utf-8"))
```

is invalid because mock objects don't have a `called_with` method, they have [`assert_called_with`](https://docs.python.org/3.8/library/unittest.mock.html#unittest.mock.Mock.assert_called_with).

The existing code is asserting True against something that is always truth, namely, the new mock returned by the call to the non-existent `mock_requests.called_with` method. The second argument is ignored as it's treated as [the `msg` argument in `assertTrue`](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertTrue).

This PR fixes the test by correctly calling `assert_called_with` and also changing the mock to patch `request.post`, not `request.get`, as that's what's called by the notification code being tested.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)