### PR TITLE
Ruff auto-format changes for v0.9.0

### DIFF
--- a/cfgov/cdntools/management/commands/purge_by_cache_tags.py
+++ b/cfgov/cdntools/management/commands/purge_by_cache_tags.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
             "--cache_tag",
             required=True,
             nargs="+",
-            help=("The cache tag to invalidate " "(can specify multiple)"),
+            help=("The cache tag to invalidate (can specify multiple)"),
         )
         parser.add_argument(
             "--action",

--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -625,7 +625,7 @@ def handle_error(code, request, exception=None):
         # the results of a security scan, or a malformed static file reference.
 
         return HttpResponse(
-            "This request could not be processed, " f"HTTP Error {str(code)}.",
+            f"This request could not be processed, HTTP Error {str(code)}.",
             status=code,
         )
 

--- a/cfgov/core/management/commands/inactive_users.py
+++ b/cfgov/core/management/commands/inactive_users.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
             # Notify specified emails (e.g. system admins)
             if len(emails) > 0:
                 self.stdout.write(
-                    "Sending inactive user list to " "{}\n".format(
+                    "Sending inactive user list to {}\n".format(
                         ",".join(emails)
                     )
                 )

--- a/cfgov/data_research/tests/test_scripts.py
+++ b/cfgov/data_research/tests/test_scripts.py
@@ -135,12 +135,10 @@ class SourceToTableTest(django.test.TestCase):
 
             self.assertEqual(content.strip(), ",".join(self.data_row))
 
-    @mock.patch(
-        "data_research.scripts.process_mortgage_data." "read_in_s3_csv"
-    )
-    @mock.patch("data_research.scripts.process_mortgage_data." "dump_as_csv")
-    @mock.patch("data_research.scripts.process_mortgage_data." "load_counties")
-    @mock.patch("data_research.scripts.process_mortgage_data." "load_states")
+    @mock.patch("data_research.scripts.process_mortgage_data.read_in_s3_csv")
+    @mock.patch("data_research.scripts.process_mortgage_data.dump_as_csv")
+    @mock.patch("data_research.scripts.process_mortgage_data.load_counties")
+    @mock.patch("data_research.scripts.process_mortgage_data.load_states")
     def test_process_source(
         self, mock_states, mock_counties, mock_dump, mock_read
     ):
@@ -177,9 +175,7 @@ class SourceToTableTest(django.test.TestCase):
         self.assertEqual(mock_counties.call_count, 1)
         self.assertEqual(mock_states.call_count, 1)
 
-    @mock.patch(
-        "data_research.scripts.process_mortgage_data." "process_source"
-    )
+    @mock.patch("data_research.scripts.process_mortgage_data.process_source")
     @mock.patch(
         "data_research.scripts.process_mortgage_data."
         "update_through_date_constant"
@@ -193,7 +189,7 @@ class SourceToTableTest(django.test.TestCase):
         "update_county_msa_meta.run"
     )
     @mock.patch(
-        "data_research.scripts.process_mortgage_data." "export_public_csvs.run"
+        "data_research.scripts.process_mortgage_data.export_public_csvs.run"
     )
     def test_run_command(
         self,
@@ -237,9 +233,7 @@ class DataLoadIntegrityTest(django.test.TestCase):
         )
 
         # real values from a base CSV row
-        self.data_header = (
-            "date,fips,open,current,thirty,sixty,ninety," "other\n"
-        )
+        self.data_header = "date,fips,open,current,thirty,sixty,ninety,other\n"
         self.data_row = "09/01/16,12081,1952,1905,21,5,10,11\n"
         self.data_row_dict = {
             "date": "09/01/16",
@@ -639,7 +633,7 @@ class DataLoadTest(django.test.TestCase):
         self.assertEqual(NationalMortgageData.objects.count(), 1)
 
     @mock.patch(
-        "data_research.scripts." "load_mortgage_performance_csv.read_in_s3_csv"
+        "data_research.scripts.load_mortgage_performance_csv.read_in_s3_csv"
     )
     def test_load_values(self, mock_read_in):
         mock_read_in.return_value = [
@@ -660,7 +654,7 @@ class DataLoadTest(django.test.TestCase):
         self.assertEqual(CountyMortgageData.objects.count(), 1)
 
     @mock.patch(
-        "data_research.scripts." "load_mortgage_performance_csv.read_in_s3_csv"
+        "data_research.scripts.load_mortgage_performance_csv.read_in_s3_csv"
     )
     def test_load_values_return_fips(self, mock_read_in):
         mock_read_in.return_value = [
@@ -681,11 +675,10 @@ class DataLoadTest(django.test.TestCase):
         self.assertEqual(fips_list, ["12081"])
 
     @mock.patch(
-        "data_research.scripts."
-        "load_mortgage_aggregates.update_sampling_dates"
+        "data_research.scripts.load_mortgage_aggregates.update_sampling_dates"
     )
     @mock.patch(
-        "data_research.scripts." "load_mortgage_aggregates.validate_counties"
+        "data_research.scripts.load_mortgage_aggregates.validate_counties"
     )
     def test_run_aggregates(self, mock_validate_counties, mock_update_dates):
         dates = MortgageMetaData.objects.get(name="sampling_dates")
@@ -844,7 +837,7 @@ class BuildStateMsaDropdownTests(django.test.TestCase):
         mock_obj.county_fips = self.counties
         return mock_obj
 
-    @mock.patch("data_research.scripts." "update_county_msa_meta.FIPS")
+    @mock.patch("data_research.scripts.update_county_msa_meta.FIPS")
     def test_update_msa_meta(self, mock_FIPS):
         mock_FIPS = self.load_fips(mock_FIPS)
         self.assertFalse(
@@ -859,7 +852,7 @@ class BuildStateMsaDropdownTests(django.test.TestCase):
         ).json_value
         self.assertEqual(len(test_json), 2)
 
-    @mock.patch("data_research.scripts." "update_county_msa_meta.FIPS")
+    @mock.patch("data_research.scripts.update_county_msa_meta.FIPS")
     def test_update_county_meta(self, mock_FIPS):
         mock_FIPS = self.load_fips(mock_FIPS)
         self.assertFalse(
@@ -876,8 +869,7 @@ class UpdateStateMsaDropdownTests(django.test.TestCase):
     fixtures = ["mortgage_constants.json", "mortgage_metadata.json"]
 
     @mock.patch(
-        "data_research.scripts."
-        "update_county_msa_meta.update_state_to_geo_meta"
+        "data_research.scripts.update_county_msa_meta.update_state_to_geo_meta"
     )
     def test_run_rebuild(self, mock_update):
         run_update()

--- a/cfgov/paying_for_college/disclosures/scripts/load_programs.py
+++ b/cfgov/paying_for_college/disclosures/scripts/load_programs.py
@@ -211,7 +211,7 @@ def load(source, s3=False):
             data = serializer.validated_data
             if not validate_pid(data["program_code"]):
                 print(
-                    "ERROR: invalid program code: " "{}".format(
+                    "ERROR: invalid program code: {}".format(
                         data["program_code"]
                     )
                 )
@@ -234,10 +234,10 @@ def load(source, s3=False):
             program.completion_rate = data["completion_rate"]
             program.default_rate = data["default_rate"]
             program.mean_student_loan_completers = data[
-                "mean_student_" "loan_completers"
+                "mean_student_loan_completers"
             ]
             program.median_student_loan_completers = data[
-                "median_student_" "loan_completers"
+                "median_student_loan_completers"
             ]
             program.program_code = data["program_code"]
             program.program_name = strip_control_chars(data["program_name"])

--- a/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
+++ b/cfgov/paying_for_college/disclosures/scripts/notification_tester.py
@@ -13,7 +13,7 @@ BINGET = "https://httpbin.org/get"
 # test values
 OID = "9e0280139f3238cbc9702c7b0d62e5c238a835d0"
 ERRORS = "INVALID: test notification via Python"
-REPORT = "URL is {}\nOK is {}\nReason is {}\n" "Status is {}\nTime sent is {}"
+REPORT = "URL is {}\nOK is {}\nReason is {}\nStatus is {}\nTime sent is {}"
 
 
 def send_test_notifications(url=None, oid=OID, errors=ERRORS):

--- a/cfgov/paying_for_college/models/disclosures.py
+++ b/cfgov/paying_for_college/models/disclosures.py
@@ -597,7 +597,7 @@ class Notification(models.Model):
         }
         now = datetime.datetime.now()
         no_contact_msg = (
-            "School notification failed: " f"No endpoint or email info {now}"
+            f"School notification failed: No endpoint or email info {now}"
         )
         # we prefer to use endpount notification, so use it first if existing
         if school.contact:
@@ -608,26 +608,24 @@ class Notification(models.Model):
                 try:
                     resp = requests.post(endpoint, data=payload, timeout=10)
                 except requests.exceptions.ConnectionError as e:
-                    exmsg = "Error: connection error at school " f"{now} {e}\n"
+                    exmsg = f"Error: connection error at school {now} {e}\n"
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg
                 except requests.exceptions.Timeout:
-                    exmsg = (
-                        "Error: connection with school " f"timed out {now}\n"
-                    )
+                    exmsg = f"Error: connection with school timed out {now}\n"
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg
                 except requests.exceptions.RequestException as e:
-                    exmsg = "Error: request error at school: " f"{now} {e}\n"
+                    exmsg = f"Error: request error at school: {now} {e}\n"
                     self.log = self.log + exmsg
                     self.save()
                     return exmsg
                 else:
                     if resp.ok:
                         self.sent = True
-                        self.log = "School notified " f"via endpoint {now}"
+                        self.log = f"School notified via endpoint {now}"
                         self.save()
                         return self.log
                     else:
@@ -659,7 +657,7 @@ class Notification(models.Model):
                     )
                     self.sent = True
                     self.emails = school.contact.contacts
-                    self.log = "School notified via email " f"at {self.emails}"
+                    self.log = f"School notified via email at {self.emails}"
                     self.save()
                     return self.log
                 except smtplib.SMTPException as e:

--- a/cfgov/paying_for_college/tests/test_load_programs.py
+++ b/cfgov/paying_for_college/tests/test_load_programs.py
@@ -186,8 +186,7 @@ class TestLoadPrograms(django.test.TestCase):
         "load_programs.clean_string_as_string"
     )
     @patch(
-        "paying_for_college.disclosures.scripts."
-        "load_programs.standardize_rate"
+        "paying_for_college.disclosures.scripts.load_programs.standardize_rate"
     )
     def test_clean(self, mock_standardize, mock_string, mock_number):
         mock_number.return_value = "NUMBER"
@@ -225,8 +224,7 @@ class TestLoadPrograms(django.test.TestCase):
             "and Schools (ACICS) - Test"
         )
         jpr_note = (
-            "The rate reflects employment status "
-            "as of November 1, 2014 - Test"
+            "The rate reflects employment status as of November 1, 2014 - Test"
         )
         program_name = "Occupational Therapy Assistant - 981 - Test"
         mock_read_in.return_value = [

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -545,7 +545,7 @@ class TestScripts(django.test.TestCase):
         self.assertEqual(mock_write.call_count, 3)
 
     def test_unzip_file(self):
-        test_zip = f"{COLLEGE_ROOT}/data_sources/ipeds/" "test.txt.zip"
+        test_zip = f"{COLLEGE_ROOT}/data_sources/ipeds/test.txt.zip"
         self.assertTrue(update_ipeds.unzip_file(test_zip))
 
     @patch("paying_for_college.disclosures.scripts.update_ipeds.requests.get")

--- a/cfgov/paying_for_college/tests/test_views.py
+++ b/cfgov/paying_for_college/tests/test_views.py
@@ -185,25 +185,23 @@ class OfferTest(django.test.TestCase):
         )
         no_oid = "?iped=408039&pid=981&oid="
         bad_school = (
-            "?iped=xxxxxx&pid=981&" "oid=f38283b5b7c939a058889f997949efa566c61"
+            "?iped=xxxxxx&pid=981&oid=f38283b5b7c939a058889f997949efa566c61"
         )
         bad_program = (
-            "?iped=408039&pid=xxx&"
-            "oid=f38283b5b7c939a058889f997949efa566c616c5"
+            "?iped=408039&pid=xxx&oid=f38283b5b7c939a058889f997949efa566c616c5"
         )
         # puerto_rico = '?iped=243197&pid=981&oid='
         missing_oid_field = "?iped=408039&pid=981"
         missing_school_id = "?iped="
         bad_oid = (
-            "?iped=408039&pid=981&oid=f382"
-            "<script></script>f997949efa566c616c5"
+            "?iped=408039&pid=981&oid=f382<script></script>f997949efa566c616c5"
         )
         illegal_program = (
             "?iped=408039&pid=<981>&oid=f38283b"
             "5b7c939a058889f997949efa566c616c5"
         )
         no_program = (
-            "?iped=408039&pid=&oid=f38283b" "5b7c939a058889f997949efa566c616c5"
+            "?iped=408039&pid=&oid=f38283b5b7c939a058889f997949efa566c616c5"
         )
         resp = self.client.get(url + qstring)
         self.assertEqual(resp.status_code, 200)

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -26,8 +26,7 @@ class PrivacyActForm(forms.Form):
     )
     system_of_record = forms.CharField(
         label=(
-            "Name of the system of records you believe contain the "
-            "record(s)"
+            "Name of the system of records you believe contain the record(s)"
         ),
         required=False,
         widget=forms.TextInput(attrs=text_input_attrs),
@@ -35,7 +34,7 @@ class PrivacyActForm(forms.Form):
     date_of_records = forms.CharField(
         label="Date of the record(s)",
         help_text=(
-            "Or the period in which you believe that the record was " "created"
+            "Or the period in which you believe that the record was created"
         ),
         required=False,
         widget=forms.TextInput(attrs=text_input_attrs),

--- a/cfgov/regulations3k/parser/regtable.py
+++ b/cfgov/regulations3k/parser/regtable.py
@@ -30,7 +30,7 @@ class RegTable:
     def assemble_header_rows(self):
         if not self.header_rows:
             return ""
-        header_shell = "<thead>\n" "{h_rows}\n" "</thead>\n"
+        header_shell = "<thead>\n{h_rows}\n</thead>\n"
         return header_shell.format(h_rows="\n".join(self.header_rows))
 
     def parse_xml_table(self, table_soup):

--- a/cfgov/scripts/http_smoke_test.py
+++ b/cfgov/scripts/http_smoke_test.py
@@ -220,11 +220,11 @@ def check_urls(base, url_list=None):
         logger.error(f"These URLs failed: {failures}")
     if len(timeouts) > ALLOWED_TIMEOUTS:
         logger.error(
-            f"These URLs timed out after {TIMEOUT} seconds: " f"{timeouts}"
+            f"These URLs timed out after {TIMEOUT} seconds: {timeouts}"
         )
     elif timeouts:
         logger.info(
-            "{} allowed timeouts occurred:\n" "{}".format(
+            "{} allowed timeouts occurred:\n{}".format(
                 len(timeouts), "\n".join(timeouts)
             )
         )

--- a/cfgov/scripts/static_asset_smoke_test.py
+++ b/cfgov/scripts/static_asset_smoke_test.py
@@ -102,7 +102,7 @@ def check_static(url):
                 f"of {count} failed for {url}: {failures}\x1b[0m\n"
             )
     else:
-        return f"\x1b[32m{count} static links passed " f"for {url}\x1b[0m\n"
+        return f"\x1b[32m{count} static links passed for {url}\x1b[0m\n"
 
 
 if __name__ == "__main__":  # pragma: nocover
@@ -133,7 +133,7 @@ if __name__ == "__main__":  # pragma: nocover
     )
     if fail:
         logger.warning(
-            "\x1b[91mFAIL. Too many static links " "didn't return 200.\x1b[0m"
+            "\x1b[91mFAIL. Too many static links didn't return 200.\x1b[0m"
         )
     else:
         logger.info("\x1b[32mSUCCESS! Static links return 200.\x1b[0m")

--- a/cfgov/tccp/management/commands/validate_tccp.py
+++ b/cfgov/tccp/management/commands/validate_tccp.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         self.stdout.write(f"{invalid_cards.count()} cards with invalid APRs")
 
         for i, invalid_card in enumerate(invalid_cards):
-            self.stdout.write(f"{i+1}: {invalid_card.slug}")
+            self.stdout.write(f"{i + 1}: {invalid_card.slug}")
 
         self.stdout.write()
 

--- a/cfgov/v1/atomic_elements/molecules.py
+++ b/cfgov/v1/atomic_elements/molecules.py
@@ -294,8 +294,7 @@ class ContactPhone(blocks.StructBlock):
                     blocks.CharBlock(
                         max_length=15,
                         help_text=(
-                            "Do not include spaces or dashes. "
-                            "Ex. 8554112372"
+                            "Do not include spaces or dashes. Ex. 8554112372"
                         ),
                         validators=[phone_number_format_validator()],
                     ),
@@ -317,8 +316,7 @@ class ContactPhone(blocks.StructBlock):
                         required=False,
                         label="TTY",
                         help_text=(
-                            "Do not include spaces or dashes. "
-                            "Ex. 8554112372"
+                            "Do not include spaces or dashes. Ex. 8554112372"
                         ),
                         validators=[phone_number_format_validator()],
                     ),

--- a/cfgov/v1/atomic_elements/organisms.py
+++ b/cfgov/v1/atomic_elements/organisms.py
@@ -77,7 +77,7 @@ class InfoUnitGroup(blocks.StructBlock):
         required=False,
         label="Show rule lines between items",
         help_text=(
-            "Check this to show horizontal rule lines between info " "units."
+            "Check this to show horizontal rule lines between info units."
         ),
     )
 
@@ -148,9 +148,7 @@ class RelatedPosts(blocks.StructBlock):
         required=False,
         default=True,
         label="Show Heading and Icon?",
-        help_text=(
-            "This toggles the heading and " "icon for the related types."
-        ),
+        help_text=("This toggles the heading and icon for the related types."),
     )
     header_title = blocks.CharBlock(
         default="Further reading", label="Slug Title"
@@ -913,8 +911,7 @@ class ChartBlock(blocks.StructBlock):
         default=False,
         required=False,
         help_text=(
-            "Check this to add a horizontal rule line to top of "
-            "chart block."
+            "Check this to add a horizontal rule line to top of chart block."
         ),
     )
 
@@ -962,8 +959,7 @@ class MortgageChartBlock(blocks.StructBlock):
         default=False,
         required=False,
         help_text=(
-            "Check this to add a horizontal rule line to top of "
-            "chart block."
+            "Check this to add a horizontal rule line to top of chart block."
         ),
     )
 

--- a/cfgov/v1/feeds.py
+++ b/cfgov/v1/feeds.py
@@ -48,7 +48,7 @@ class FilterableFeed(Feed):
         ]
 
     def item_guid(self, item):
-        return f'{item["page_id"]}<>consumerfinance.gov'
+        return f"{item['page_id']}<>consumerfinance.gov"
 
 
 def get_appropriate_rss_feed_url_for_page(page, request=None):

--- a/cfgov/v1/management/commands/delete_page.py
+++ b/cfgov/v1/management/commands/delete_page.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
             page = Page.objects.get(pk=page_id)
 
         self.stdout.write(
-            f'Deleting{" children of" if children_only else ""} '
+            f"Deleting{' children of' if children_only else ''} "
             f'page "{page.title}", ID {page.pk}, slug {page.slug}'
         )
 

--- a/cfgov/v1/template_debug/tables.py
+++ b/cfgov/v1/template_debug/tables.py
@@ -112,7 +112,7 @@ crc_table_test_cases = {
         ),
         "phone": mark_safe('<a href="tel:202-555-1234">(202) 555-1234</a>'),
         "mailing_address": mark_safe(
-            "Example, Inc.<br/>" "P.O. Box 8000<br/>" "Washington, DC 20001"
+            "Example, Inc.<br/>P.O. Box 8000<br/>Washington, DC 20001"
         ),
     }
 }

--- a/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
+++ b/cfgov/v1/tests/atomic_elements/organisms/test_organisms.py
@@ -444,7 +444,7 @@ class ItemIntroductionTests(WagtailPageTreeTestCase):
 <div class="o-item-introduction">
     <div class="o-item-introduction__intro">
         <a class="h4" href="/landing/?categories=at-the-cfpb">
-            { svg_icon("bullhorn") }
+            {svg_icon("bullhorn")}
             <span class="u-visually-hidden">
                 Category:
             </span>

--- a/cfgov/wellbeing/views.py
+++ b/cfgov/wellbeing/views.py
@@ -49,7 +49,7 @@ class ResultsView(TranslatedTemplateView):
         {
             # Question 4
             "question": _(
-                "I can enjoy life because of the way I'm managing " "my money"
+                "I can enjoy life because of the way I'm managing my money"
             ),
             "answers": [
                 _("Not at all"),
@@ -73,8 +73,7 @@ class ResultsView(TranslatedTemplateView):
         {
             # Question 6
             "question": _(
-                "I am concerned that the money I have or will save "
-                "won't last"
+                "I am concerned that the money I have or will save won't last"
             ),
             "answers": [
                 _("Completely"),


### PR DESCRIPTION
Ruff auto-updated to v0.9.0 on GHA and is breaking. To see these breaking changes locally I ran `pip install --upgrade ruff` to update ruff (`./backend.sh` does not update ruff) and ran `ruff format`

## Changes

- Ruff auto-format changes for v0.9.0


## How to test this PR

1. PR checks should pass.