### PR TITLE
Fix incorrect Python tests using mock.called_with

### DIFF
--- a/cfgov/paying_for_college/tests/test_commands.py
+++ b/cfgov/paying_for_college/tests/test_commands.py
@@ -53,17 +53,17 @@ class CommandTests(unittest.TestCase):
         self.assertTrue(mock_update.call_count == 1)
         call_command("update_via_api", "--school_id", "999999")
         self.assertTrue(mock_update.call_count == 2)
-        self.assertTrue(mock_update.called_with(single_school=999999))
+        mock_update.assert_called_with(single_school="999999")
         call_command(
             "update_via_api", "--school_id", "999999", "--save_programs"
         )
         self.assertTrue(mock_update.call_count == 3)
-        self.assertTrue(
-            mock_update.called_with(single_school=999999, store_programs=True)
+        mock_update.assert_called_with(
+            single_school="999999", store_programs=True
         )
         call_command("update_via_api", "--save_programs")
         self.assertTrue(mock_update.call_count == 4)
-        self.assertTrue(mock_update.called_with(store_programs=True))
+        mock_update.assert_called_with(store_programs=True)
 
     @mock.patch(
         "paying_for_college.management.commands."
@@ -111,7 +111,7 @@ class CommandTests(unittest.TestCase):
         self.assertEqual(mock_retry.call_count, 1)
         call_command("retry_notifications", "--days", "2")
         self.assertEqual(mock_retry.call_count, 2)
-        self.assertTrue(mock_retry.called_with(days=2))
+        mock_retry.assert_called_with(days=2)
 
     @mock.patch(
         "paying_for_college.management.commands."
@@ -125,4 +125,4 @@ class CommandTests(unittest.TestCase):
             "send_stale_notifications", "--add-email", "fake@fake.com"
         )
         self.assertEqual(mock_send.call_count, 2)
-        self.assertTrue(mock_send.called_with(add_email=["fake@fake.com"]))
+        mock_send.assert_called_with(add_email=["fake@fake.com"])

--- a/cfgov/paying_for_college/tests/test_scripts.py
+++ b/cfgov/paying_for_college/tests/test_scripts.py
@@ -326,7 +326,9 @@ class TestScripts(django.test.TestCase):
         mock_requests.return_value = mock_response
         api_utils.api_school_query(123456, "school.name")
         self.assertEqual(mock_requests.call_count, 1)
-        self.assertTrue(mock_requests.called_with((123456, "school.name")))
+        mock_requests.assert_called_with(
+            "https://api.data.gov/ed/collegescorecard/v1/schools.json?id=123456&api_key=&fields=school.name"
+        )
 
     @unittest.skipUnless(
         connection.vendor == "postgresql", "PostgreSQL-dependent"
@@ -338,8 +340,9 @@ class TestScripts(django.test.TestCase):
         mock_get_data.return_value = self.mock_results.get("results")[0]
         update_colleges.update(single_school=408039)
         self.assertEqual(mock_get_data.call_count, 1)
-        self.assertTrue(
-            mock_get_data.called_with(408039, api_utils.build_field_string())
+        mock_get_data.assert_called_with(
+            f"https://api.data.gov/ed/collegescorecard/v1/schools.json?"
+            f"api_key=&id=408039&fields={api_utils.build_field_string()}"
         )
 
     @patch(
@@ -434,7 +437,7 @@ class TestScripts(django.test.TestCase):
         mock_requests.return_value = mock_response
         data = update_colleges.get_scorecard_data("example.com")
         self.assertEqual(mock_requests.call_count, 1)
-        self.assertTrue(mock_requests.called_with("example.com"))
+        mock_requests.assert_called_with("example.com")
         self.assertEqual(type(data), dict)
 
     @patch(

--- a/cfgov/regulations3k/tests/test_scripts.py
+++ b/cfgov/regulations3k/tests/test_scripts.py
@@ -75,7 +75,7 @@ class LinkScriptTestCase(TestCase):
     @mock.patch("regulations3k.scripts.insert_section_links.insert_links")
     def test_run_with_args(self, mock_inserter):
         run("1002")
-        self.assertTrue(mock_inserter.called_with, "1002")
+        mock_inserter.assert_called_with(reg="1002")
 
     def test_insert_links_skips_processed_file(self):
         regdown_with_link = (


### PR DESCRIPTION
This followup to #8711 fixes various Python tests that are incorrectly trying to call `called_with` on a mock object, when the correct call is [`assert_called_with`](https://docs.python.org/3.8/library/unittest.mock.html#unittest.mock.Mock.assert_called_with).

Most of these tests are in the Paying for College disclosures code, and one is in iRegulations.

Currently these tests don't actually test anything, as `assertTrue(something that is truthy)` does nothing.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)