### PR TITLE
Drop counselors with invalid zips when geocoding

### DIFF
--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -30,7 +30,22 @@ class ZipCodeBasedCounselorGeocoder:
         self.zipcodes = zipcodes
 
     def geocode(self, counselors):
-        return list(map(self.geocode_counselor, counselors))
+        return list(
+            map(
+                self.geocode_counselor,
+                filter(self.filter_zipcodes, counselors),
+            )
+        )
+
+    def filter_zipcodes(self, counselor):
+        counselor = dict(counselor)
+        zipcode = counselor["zipcd"][:5]
+
+        if zipcode not in self.zipcodes:
+            logger.warning(f"{zipcode} not in zipcodes")
+            return False
+
+        return True
 
     def geocode_counselor(self, counselor):
         counselor = dict(counselor)
@@ -41,9 +56,6 @@ class ZipCodeBasedCounselorGeocoder:
 
         zipcode = counselor["zipcd"][:5]
         logger.warning("need to geocode counselor with zipcode %s", zipcode)
-
-        if zipcode not in self.zipcodes:
-            raise KeyError(f"{zipcode} not in zipcodes")
 
         coordinates = self.zipcodes[zipcode]
         counselor.update(zip(lat_lng_keys, coordinates))

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -40,7 +40,6 @@ class ZipCodeBasedCounselorGeocoder:
         )
 
     def filter_zipcodes(self, counselor):
-        counselor = dict(counselor)
         zipcode = counselor["zipcd"][:5]
 
         if zipcode not in self.zipcodes:
@@ -50,8 +49,6 @@ class ZipCodeBasedCounselorGeocoder:
         return True
 
     def geocode_counselor(self, counselor):
-        counselor = dict(counselor)
-
         lat_lng_keys = ("agc_ADDR_LATITUDE", "agc_ADDR_LONGITUDE")
         if all(counselor.get(k) for k in lat_lng_keys):
             return counselor

--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -33,7 +33,9 @@ class ZipCodeBasedCounselorGeocoder:
         return list(
             map(
                 self.geocode_counselor,
-                filter(self.filter_zipcodes, counselors),
+                filter(
+                    self.filter_zipcodes, map(lambda c: dict(c), counselors)
+                ),
             )
         )
 

--- a/cfgov/housing_counselor/tests/management/test_geocoder.py
+++ b/cfgov/housing_counselor/tests/management/test_geocoder.py
@@ -26,9 +26,21 @@ class TestZipCodeBasedCounselorGeocoder(TestCase):
 
     def test_returns_list_of_counselors(self):
         counselors = [
-            {"agc_ADDR_LATITUDE": 1, "agc_ADDR_LONGITUDE": -1},
-            {"agc_ADDR_LATITUDE": 2, "agc_ADDR_LONGITUDE": -2},
-            {"agc_ADDR_LATITUDE": 3, "agc_ADDR_LONGITUDE": -3},
+            {
+                "agc_ADDR_LATITUDE": 1,
+                "agc_ADDR_LONGITUDE": -1,
+                "zipcd": "20001",
+            },
+            {
+                "agc_ADDR_LATITUDE": 2,
+                "agc_ADDR_LONGITUDE": -2,
+                "zipcd": "20001",
+            },
+            {
+                "agc_ADDR_LATITUDE": 3,
+                "agc_ADDR_LONGITUDE": -3,
+                "zipcd": "20001",
+            },
         ]
 
         geocoded = self.geocoder.geocode(counselors)
@@ -84,11 +96,11 @@ class TestZipCodeBasedCounselorGeocoder(TestCase):
         self.assertEqual(geocoded[0]["agc_ADDR_LATITUDE"], 123.45)
         self.assertEqual(geocoded[0]["agc_ADDR_LONGITUDE"], -78.9)
 
-    def test_raises_keyerror_if_zipcode_not_available(self):
+    def test_filters_out_bad_zips(self):
         counselor = {"zipcd": "20002"}
 
-        with self.assertRaises(KeyError):
-            self.geocoder.geocode([counselor])
+        geocoded = self.geocoder.geocode([counselor])
+        self.assertEqual(len(geocoded), 0)
 
 
 class TestBulkZipCodeGeocoder(TestCase):


### PR DESCRIPTION
Currently, if when the housing_counselor mgmt command attempts to geocode data with an invalid zipcode, it throws a `KeyError`. This bails out of the command and thus causes our daily update to fail.

Since we don't control this data, I think it would be better to simply drop the counselor with the invalid zip (while logging that this is being done). This should allow us to be more resilient to erroneous data creeping into the HUD list of counselors.