### PR TITLE
Paying for College: Dynamic Disclosures - Bug Fixes

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.scss
+++ b/cfgov/unprocessed/apps/paying-for-college/css/cf-enhancements.scss
@@ -92,11 +92,11 @@
    ========================================================================== */
 
 $char-icon-size: math.div(32px, $base-font-size-px) + em;
-$char-icon-spacing: 0.5em;
+$char-icon-spacing: 1em;
 
 @mixin char-icon {
   box-sizing: border-box;
-  padding-left: $char-icon-size + $char-icon-spacing;
+  padding-left: math.div(32px, $base-font-size-px) + $char-icon-spacing;
   position: relative;
 
   &::before {

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/index.js
@@ -15,8 +15,7 @@ import expensesView from './views/expenses-view.js';
 import metricView from './views/metric-view.js';
 import questionView from './views/question-view.js';
 import publish from './dispatchers/publish-update.js';
-
-// import('./utils/print-page.js');
+import print from './utils/print-page.js';
 
 const ready = function (callback) {
   if (document.readyState !== 'loading') {
@@ -96,6 +95,7 @@ const app = {
       financialView.updateView(getFinancial.values());
     });
     verifyOffer.init();
+    print.init();
   },
 };
 

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/utils/print-page.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/utils/print-page.js
@@ -1,11 +1,15 @@
-// TODO: Fix the print functionality
+import { analyticsSendEvent } from '@cfpb/cfpb-analytics';
+import $ from '../../../../../js/modules/util/dollar-sign.js';
 
-// import { analyticsSendEvent } from '@cfpb/cfpb-analytics';
+const print = {
 
-// $(document).ready(function () {
-//   $('.next-steps_controls > button').on('click', function (evt) {
-//     evt.preventDefault();
-//     window.print();
-//     analyticsSendEvent({ action: 'Step Completed', label: 'Print' });
-//   });
-// });
+	init: function() {
+		$('.next-steps__controls > button').on('click', function (evt) {
+	    evt.preventDefault();
+	    window.print();
+	    analyticsSendEvent({ action: 'Step Completed', label: 'Print' });
+	  });
+	}
+}
+
+export default print;

--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/financial-view.js
@@ -71,6 +71,7 @@ const financialView = {
     this.continueStep2Listener();
     this.termToggleListener();
     this.financialInputChangeListener();
+    this.enumeratePrivateLoanIDs();
   },
 
   /**


### PR DESCRIPTION
This PR will address a few bugs in our Paying for College "Dynamic Disclosures" application. It fixes a bug with Private Loans, a style bug with numeric icons and unordered lists, and a fix for the Print Button in the final step of the disclosure.

## Changes
- Run enumeratePrivateLoans() on init to fix Remove Button bug
- Fix numbered icons padding in Part 3 list
- Fix print button

## How to test this PR
1. Try to remove the first Private Loan (without adding one). There should be no error.
2. Check on the numbered icons and make sure they don't overlap text in "Next Steps"
3. Make sure the Print button in "Next Steps" shows the browser's print dialog.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
