### PR TITLE
Remove TCCP Feature Flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -638,12 +638,6 @@ FLAGS = {
     "PATH_MATCHES_FOR_QUALTRICS": [],
     # Whether robots.txt should block all robots, except for Search.gov.
     "ROBOTS_TXT_SEARCH_GOV_ONLY": [("environment is", "beta")],
-    # TCCP credit card finder
-    "TCCP": [
-        ("environment is", "dev4"),
-        ("environment is", "local"),
-        ("environment is", "test"),
-    ],
 }
 
 REGULATIONS_REFERENCE_MAPPING = [

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -5,8 +5,8 @@ from django.shortcuts import redirect, reverse
 from django.template.defaultfilters import title
 from django.urls import reverse_lazy
 from django.utils.functional import cached_property
+from django.views.generic import TemplateView
 
-from flags.views import FlaggedTemplateView, FlaggedViewMixin
 from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
@@ -22,8 +22,7 @@ from .serializers import CardSurveyDataListSerializer, CardSurveyDataSerializer
 from .situations import Situation, SituationSpeedBumps
 
 
-class LandingPageView(FlaggedTemplateView):
-    flag_name = "TCCP"
+class LandingPageView(TemplateView):
     template_name = "tccp/landing_page.html"
     heading = "Explore credit cards for your situation"
 
@@ -57,8 +56,7 @@ class LandingPageView(FlaggedTemplateView):
         )
 
 
-class AboutView(FlaggedTemplateView):
-    flag_name = "TCCP"
+class AboutView(TemplateView):
     template_name = "tccp/about.html"
     breadcrumb_items = [
         {
@@ -78,8 +76,7 @@ class AboutView(FlaggedTemplateView):
         }
 
 
-class CardListView(FlaggedViewMixin, ListAPIView):
-    flag_name = "TCCP"
+class CardListView(ListAPIView):
     model = CardSurveyData
     renderer_classes = [TemplateHTMLRenderer, JSONRenderer]
     serializer_class = CardSurveyDataListSerializer
@@ -193,8 +190,7 @@ class CardListView(FlaggedViewMixin, ListAPIView):
         return rating_ranges
 
 
-class CardDetailView(FlaggedViewMixin, RetrieveAPIView):
-    flag_name = "TCCP"
+class CardDetailView(RetrieveAPIView):
     model = CardSurveyData
     lookup_field = "slug"
     renderer_classes = [TemplateHTMLRenderer, JSONRenderer]


### PR DESCRIPTION
This PR will remove the code that leaves TCCP as a feature-flag-dependent product.

## Changes
- Change TCCP's views.py to use TemplateView instead of FlaggedTemplateView, etc
- Remove "TCCP" from flags in base.py


## How to test this PR
1. Make sure http://localhost:8000/consumer-tools/credit-cards/explore-cards/ works as expected!

## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
