### PR TITLE
Add note about rout data being off for CT in early Jan

### DIFF
--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -762,6 +762,11 @@ home price, down payment, and more can affect mortgage interest rates.
                     address on the Census Bureau’s automated address search
                     tool and the rural or underserved counties lists.'
                 ) }}
+
+                {{ expandable.render(
+                   'Why did I receive inaccurate results for Connecticut addresses in January 2025?',
+                   'If accessed between January 1, 2025, and January 22, 2025, the rural or underserved tool might have incorrectly indicated underserved status for some addresses in Connecticut as a result of recent changes by the Census Bureau in the county-equivalent codes for that state. The Bureau implemented a solution for this issue on January 23, 2025. As of that date, the rural or underserved tool produces correct results for addresses in the State of Connecticut.'
+                ) }}
             </div>
         </div>
 


### PR DESCRIPTION
Adds a small note about the rout data being inaccurate in Connecticut in early Jan. Concomitant with this PR being merged, I'll push the new data.

## Testing
- Pull
- Note the added FAQ entry at http://localhost:8000/rural-or-underserved-tool/#rural-or-underserved