### PR TITLE
Update cct snapshot management command to update landing page

### DIFF
--- a/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
+++ b/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
@@ -8,6 +8,7 @@ from wagtail.blocks import StreamValue
 
 from scripts import _atomic_helpers as atomic
 from v1.models.browse_page import BrowsePage
+from v1.models.sublanding_page import SublandingPage
 from v1.tests.wagtail_pages.helpers import publish_page
 
 
@@ -15,11 +16,14 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
     def test_data_snapshot(self):
         """Management command correctly updates data snapshot values"""
         browse_page = BrowsePage(title="Browse Page", slug="browse")
+        sl = SublandingPage(title="Consumer Credit Trends", slug="cct")
 
         # Adds a STU market to a browse page
         browse_page.content = StreamValue(
             browse_page.content.stream_block, [atomic.data_snapshot], True
         )
+
+        publish_page(child=sl)
         publish_page(child=browse_page)
 
         # Call management command to update values
@@ -47,6 +51,9 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
         self.assertNotContains(response, "In year-over-year inquiries")
         self.assertNotContains(response, "In year-over-year credit tightness")
 
+        landing_response = self.client.get("/cct/")
+        self.assertContains(landing_response, "October 02, 2018")
+
     def test_data_snapshot_with_inquiry_and_tightness(self):
         """Management command correctly updates data snapshot values
         for market that contains inquiry and tightness data"""
@@ -55,12 +62,16 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
             slug="browse",
         )
 
+        sl = SublandingPage(title="Consumer Credit Trends", slug="cct")
+
         # Adds a AUT market to a browse page
         browse_page.content = StreamValue(
             browse_page.content.stream_block,
             [atomic.data_snapshot_with_optional_fields],
             True,
         )
+
+        publish_page(child=sl)
         publish_page(child=browse_page)
 
         # Call management command to update values

--- a/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
+++ b/cfgov/v1/tests/management/commands/test_update_data_snapshot_values.py
@@ -23,8 +23,12 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
             browse_page.content.stream_block, [atomic.data_snapshot], True
         )
 
-        publish_page(child=sl)
+        sl.content = StreamValue(
+            sl.content.stream_block, [atomic.full_width_text], True
+        )
+
         publish_page(child=browse_page)
+        publish_page(child=sl)
 
         # Call management command to update values
         filename = os.path.join(
@@ -71,8 +75,12 @@ class UpdateDataSnapshotValuesTestCase(TestCase):
             True,
         )
 
-        publish_page(child=sl)
+        sl.content = StreamValue(
+            sl.content.stream_block, [atomic.full_width_text], True
+        )
+
         publish_page(child=browse_page)
+        publish_page(child=sl)
 
         # Call management command to update values
         filename = os.path.join(


### PR DESCRIPTION
This is the last manual piece of the otherwise automated CCT update process. This now updates the cct sublanding page with the date from the snapshot file so the whole update is fully automated.