### PR TITLE
Set margin/padding properly on mobile breadcrumbs

### DIFF
--- a/cfgov/tccp/jinja2/tccp/cards.html
+++ b/cfgov/tccp/jinja2/tccp/cards.html
@@ -31,10 +31,6 @@
 <link rel="stylesheet" href="{{ static('apps/tccp/css/main.css') }}">
 {% endblock %}
 
-{% block content_modifiers -%}
-    {{ super() }} u-layout-grid--full-width-breadcrumbs
-{%- endblock %}
-
 {% block content_main_modifiers -%}
     {{ super() }} htmx-container
 {%- endblock %}

--- a/cfgov/unprocessed/css/enhancements/layout-base.scss
+++ b/cfgov/unprocessed/css/enhancements/layout-base.scss
@@ -46,10 +46,10 @@
     // Tablet and below.
     @include respond-to-max($bp-sm-max) {
       &__breadcrumbs {
-        padding-left: math.div(30px, $base-font-size-px) + rem;
-        padding-right: math.div(30px, $base-font-size-px) + rem;
-        margin-left: math.div(-30px, $base-font-size-px) + rem;
-        margin-right: math.div(-30px, $base-font-size-px) + rem;
+        padding-left: math.div(15px, $base-font-size-px) + rem;
+        padding-right: math.div(15px, $base-font-size-px) + rem;
+        margin-left: math.div(-15px, $base-font-size-px) + rem;
+        margin-right: math.div(-15px, $base-font-size-px) + rem;
         background: var(--gray-5);
         border-bottom: 1px solid var(--gray-40);
       }
@@ -58,8 +58,10 @@
     // Tablet only.
     @include respond-to-range($bp-sm-min, $bp-sm-max) {
       &__breadcrumbs {
-        padding-left: math.div(15px, $base-font-size-px) + rem;
-        padding-right: math.div(15px, $base-font-size-px) + rem;
+        padding-left: math.div(30px, $base-font-size-px) + rem;
+        padding-right: math.div(30px, $base-font-size-px) + rem;
+        margin-left: math.div(-30px, $base-font-size-px) + rem;
+        margin-right: math.div(-30px, $base-font-size-px) + rem;
       }
     }
 
@@ -98,11 +100,6 @@
     .u-layout-grid__wrapper {
       max-width: initial;
     }
-  }
-
-  // Modifier to allow breadcrumbs on full-width layouts, as in TCCP
-  .u-layout-grid--full-width-breadcrumbs {
-    overflow-x: hidden;
   }
 
   // Set default line width.


### PR DESCRIPTION
@anselmbradford noted in https://github.com/cfpb/consumerfinance.gov/pull/8732 that the underlying issue was probably in the breadcrumbs behavior itself and so I went looking to see *why* the breadcrumbs were causing the scrollbar in mobile.

Turns out, we use a negative margin + padding hack to bleed the background into the gutters at mobile/tablet. This was incorrectly set to 30px at BOTH tablet and mobile sizes, which caused the calculated width of the breadcrumbs container to be 30px larger than the browser width. I halved this at mobile which fixes the issue everything. That is, this breadcrumbs bug was happening in multiple places, not just tccp!

I also fixed what I believe is a bug in the tablet view, where the breadcrumbs aren't aligned with content (15px gutter instead of 30px). It's aligned in both mobile and desktop, so I figured we should align it at tablet too.

This supersedes https://github.com/cfpb/consumerfinance.gov/pull/8732, so I stripped out the special-casing there.