### PR TITLE
Disable automatic Django user creation with SSO

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -368,7 +368,7 @@ else:
                 os.getenv("ES_USER", "admin"),
                 os.getenv("ES_PASS", "admin"),
             ),
-            "use_ssl": True, 
+            "use_ssl": True,
             "verify_certs": False,
         }
     }
@@ -816,3 +816,6 @@ if ENABLE_SSO:
     # Now we do some role/group-mapping for admins and regular users
     # Upstream "role" for users who get is_superuser
     OIDC_OP_ADMIN_ROLE = os.environ.get("OIDC_OP_ADMIN_ROLE")
+
+    # Require manual Wagtail user creation.
+    OIDC_CREATE_USER = False

--- a/cfgov/regulations3k/parser/patterns.py
+++ b/cfgov/regulations3k/parser/patterns.py
@@ -377,6 +377,6 @@ dot_id_patterns = {
 }
 
 interp_reference_pattern = r"(\d{1,3})(\([a-z]{1,2}\))?(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?(\([A-Z]{1,2}\))?(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?"  # noqa: E501
-interp_inferred_section_pattern = r"(\([a-z]{1,2}\))(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?(\([A-Z]{1,2}\))?(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?"  # noqa: E501'
+interp_inferred_section_pattern = r"(\([a-z]{1,2}\))(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?(\([A-Z]{1,2}\))?(\(\d{1,2}\))?(\([ivxlcdm]{1,5}\))?"  # noqa: E501
 
 LEVEL_STATE = IdLevelState()


### PR DESCRIPTION
This commit implements `OIDC_CREATE_USER = False`, preventing Django users from being created automatically just because they exist in the SSO provider.

See documentation for this setting here:
https://mozilla-django-oidc.readthedocs.io/en/stable/settings.html#OIDC_CREATE_USER