### PR TITLE
Bump docs Jinja2 version from 3.1.5 to 3.1.6

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,5 @@
 Click==8.1.7
-Jinja2==3.1.5
+Jinja2==3.1.6
 livereload==2.6.3
 Markdown==3.4.4
 mkdocs==1.5.3


### PR DESCRIPTION
Followup to f680164542f0de13b04705f23249b9286880c83a.