### PR TITLE
Fix: Properly handle posting of long GitHub alerts

### DIFF
--- a/cfgov/alerts/github_alert.py
+++ b/cfgov/alerts/github_alert.py
@@ -28,8 +28,14 @@ class GithubAlert:
     def post(self, title, body, labels=None) -> ShortIssue:
         if not labels:
             labels = ["alert"]
+
         # Truncate the title if needed, max is 256 chars
         title = title[:256]
+
+        # Truncate the body if needed, max seems to be 65536 chars, see
+        # https://github.com/dead-claudia/github-limits?tab=readme-ov-file#issue-description
+        body = body[:65536]
+
         issue = self.matching_issue(title)
         if issue:  # Issue already exists
             if issue.is_closed():


### PR DESCRIPTION
When cf.gov requests generate errors with excessively long tracebacks, we're not able to post them to GitHub issues.

GH doesn't seem to document an official limit but according to https://github.com/dead-claudia/github-limits?tab=readme-ov-file#issue-description the limit is 65536 characters. When we post excessively long issues to GH, we get a 422 Validation Failed error, which prevents us from recording them.

This commit truncates the stack trace so that we can at least record the error message.

See internal DEVPLAT-1465 for additional context.