### PR TITLE
Fix: Better handling of errors on 500 page

### DIFF
--- a/cfgov/cfgov/urls.py
+++ b/cfgov/cfgov/urls.py
@@ -619,10 +619,16 @@ def handle_error(code, request, exception=None):
             context={"request": request},
             status=code,
         )
-    except AttributeError:
-        # for certain URL's, it seems like our middleware doesn't run
-        # Thankfully, these are probably not errors real users see -- usually
-        # the results of a security scan, or a malformed static file reference.
+    except Exception:
+        # If we encounter an exception when rendering a 500 error page, we
+        # want to handle it so that we don't trigger infinite recursion
+        # (error -> try rendering error page -> another error -> etc).
+        # In that case, we fall back to a plain text error HTTP response.
+        #
+        # For other errors (like 404s), we do want to raise the exception,
+        # so that we (hopefully correctly) log and render the 500 page.
+        if code != 500:
+            raise
 
         return HttpResponse(
             f"This request could not be processed, HTTP Error {str(code)}.",


### PR DESCRIPTION
Currently if our 500 error page itself triggers another error (say, if the connection to the database is down, and the error page tries to access the DB to query flag state), we fall into an infinite recursion of error handling.

Ideally our 500 error page should be static, and not access the database or other resources that might trigger another error.

As a more immediate fix, we can change 500 errors to a simpler text response if we're not able to render the proper 500 page. Other errors (like 404s) should still be able to trigger the 500 page if their own error page (like the 404 page) fail to render for whatever reason.

See internal DEVPLAT-1465 for additional context.