### PR TITLE
Change .css check to work in safari

### DIFF
--- a/cfgov/unprocessed/js/modules/util/dollar-sign.js
+++ b/cfgov/unprocessed/js/modules/util/dollar-sign.js
@@ -593,7 +593,7 @@ Query.prototype.css = function (param, value) {
   }
   for (const key in obj) {
     this.elements.forEach((elem) => {
-      if (Object.prototype.hasOwnProperty.call(elem.style, key)) {
+      if (elem.style[key] !== undefined) {
         let val = obj[key];
         if (pixelStyles.indexOf(key) > -1) val = pixelator(val);
         elem.style[key] = val;


### PR DESCRIPTION
The previous check wasn't working in Safari, whereas the new one works cross-browser.

## Testing
 - Open http://localhost:8000/consumer-tools/retirement/before-you-claim/ in Safari
 - Fill out the form and notice the chart is broken
 - Pull and build
 - Refresh, fill out the form again, notice it's fixed.
 - Do the same in Chrome