### PR TITLE
Enable notifications on articles

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/article.html
+++ b/cfgov/v1/jinja2/v1/includes/article.html
@@ -53,6 +53,12 @@
         {% with value = item_intro_data -%}
             {% include 'v1/includes/organisms/item-introduction.html' %}
         {%- endwith %}
+
+        {% for block in page.header -%}
+            {% if block.block_type == 'notification' %}
+                {{ render_block.render(block, loop.index) }}
+            {% endif %}
+        {% endfor %}
     </header>
 
     <div>


### PR DESCRIPTION
Notifications appear as an option in Wagtail for blog pages, but they do not render in the template. This adds a block so that they render. 

## Changes

- Enable notifications on articles.


## How to test this PR

1. Edit a blog page and add a notification in the header section, under general content. 
2. Preview the blog page and see that there is a notification visible on the page. 


## Screenshots
<img width="1242" alt="Screenshot 2025-04-03 at 12 54 04 PM" src="https://github.com/user-attachments/assets/4266bff3-0e85-4e1c-9683-e2769320aa04" />
