### PR TITLE
Remove `a-btn--secondary` class from privacy act statement links

### DIFF
--- a/cfgov/diversity_inclusion/jinja2/diversity_inclusion/voluntary-assessment-form.html
+++ b/cfgov/diversity_inclusion/jinja2/diversity_inclusion/voluntary-assessment-form.html
@@ -173,7 +173,7 @@
                     <input class="a-btn"
                            type="submit"
                            value="Submit">
-                    <a class="a-btn a-btn--link a-btn--secondary"
+                    <a class="a-btn a-btn--link"
                        href="{{ url('diversity_inclusion:privacy') }}"
                        rel="noopener noreferrer"
                        target="_blank">

--- a/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
@@ -74,7 +74,7 @@
 
         <div class="o-email-signup__buttons">
             <button class="a-btn">{{ _('Sign up') }}</button>
-            <a class="a-btn a-btn--link a-btn--secondary"
+            <a class="a-btn a-btn--link"
                href="{{ pageurl(value.disclaimer_page) if value.disclaimer_page else disclaimer_url }}"
                target="_blank"
                rel="noopener noreferrer">

--- a/test/unit_tests/mocks/emailSignupSnippet.js
+++ b/test/unit_tests/mocks/emailSignupSnippet.js
@@ -33,7 +33,7 @@ export default `
         </div>
         <div class="o-email-signup__buttons">
             <button class="a-btn">Sign up</button>
-            <a class="a-btn a-btn--link a-btn--secondary"
+            <a class="a-btn a-btn--link"
                href="/owning-a-home/privacy-act-statement/"
                target="_blank"
                rel="noopener noreferrer">


### PR DESCRIPTION
## Changes

- Remove `a-btn--secondary` class from privacy act statement links


## How to test this PR

1. Pull branch, `yarn build`, and run local server.
2. View http://localhost:8000/about-us/diversity-and-inclusion/voluntary-assessment-onboarding-form/ and http://localhost:8000/about-us/blog/13000-lessons-learned/ and see that the privacy act statement link is not gray by default.


## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="384" alt="Screenshot 2025-04-10 at 1 06 24 PM" src="https://github.com/user-attachments/assets/2181cb6c-7b9b-43d8-9750-7c4bf048148e" /> | <img width="387" alt="Screenshot 2025-04-10 at 1 06 16 PM" src="https://github.com/user-attachments/assets/3c58276b-f9ac-4826-a5da-0a4bf7f6f306" /> |
| <img width="426" alt="Screenshot 2025-04-10 at 1 09 28 PM" src="https://github.com/user-attachments/assets/bd5d21df-cc05-479c-a873-3627ca3971b6" /> | <img width="346" alt="Screenshot 2025-04-10 at 1 09 45 PM" src="https://github.com/user-attachments/assets/9892d188-20f8-400b-bcfd-29b66c992b3e" /> |
