### PR TITLE
Removes the top margin from the first full width text div

### DIFF
--- a/cfgov/unprocessed/css/organisms/full-width-text-group.scss
+++ b/cfgov/unprocessed/css/organisms/full-width-text-group.scss
@@ -34,6 +34,9 @@
   .m-full-width-text {
     margin-top: math.div(30px, $base-font-size-px) + em;
     margin-bottom: math.div(30px, $base-font-size-px) + em;
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   .m-full-width-text + .m-call-to-action {


### PR DESCRIPTION
See https://github.local/Design-Development/Design-and-Content-Team/issues/623 for background.

The top and bottom margins applied to `full-width-text` elements are needed for when there are multiple, eg, `content` sections in one `full width text` organism. However, this clashed with the outer logic for removing `block` top margin via, eg, `block--flush-top`, which gets automatically added to the first block on a page.

This fix makes it so that the first `full-width-text` element in a group doesn't get top margin, thus preventing the margin stacking.

As an aside, this was unnoticeable in quite a few cases due to margin collapsing, but the initial spacing on `u-layout-grid__main` is provided by a combination of margin AND padding, which prevents the collapse and causes the unsightly extra space.

As an extra fun rabbit hole, the way our grid layout works, the margin on `u-layout-grid__main` would not have been collapsable even without padding, which I didn't know before investigating this bug.

## Testing
- Pull and build
- Check the following for correct spacing
  - http://localhost:8000/data-research/financial-well-being-survey-data/
  - http://localhost:8000/rules-policy/regulations/
  - http://localhost:8000/data-research/mortgage-performance-trends/
- Create a full width text block with multiple `content` elements
  - Ensure these elements have proper spacing