### PR TITLE
Add authors to metadata report

### DIFF
--- a/cfgov/v1/templates/v1/_list_page_metadata.html
+++ b/cfgov/v1/templates/v1/_list_page_metadata.html
@@ -10,6 +10,7 @@
     <th>Tags</th>
     <th>Categories</th>
     <th>Content Owner(s)</th>
+    <th>Author(s)</th>
 {% endblock %}
 
 {% block extra_page_data %}
@@ -39,6 +40,9 @@
     </td>
     <td>
         {{ page.content_owners.names|join:", " }}
+    </td>
+    <td>
+        {{ page.authors.names|join:", " }}
     </td>
 {% endblock %}
 

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -87,6 +87,7 @@ class PageMetadataReportView(PageReportView):
         "tags.names",
         "categories.all",
         "content_owners.names",
+        "authors.names",
     ]
     export_headings = dict(
         [
@@ -98,6 +99,7 @@ class PageMetadataReportView(PageReportView):
             ("tags.names", "Tags"),
             ("categories.all", "Categories"),
             ("content_owners.names", "Content Owner(s)"),
+            ("authors.names", "Authors"),
         ],
         **PageReportView.export_headings,
     )


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR adds the "Authors" field to the metadata report.

---

<!-- Feel free to delete any sections that are not applicable to this PR. -->


## Additions

- "authors" field on report, both HTML view and export


## How to test this PR

1. localhost
2. /admin/reports/page-metadata/
3. View this page and also "Export as CSV" to confirm the new field