### PR TITLE
Add public archive link to footer

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/footer.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/footer.html
@@ -187,6 +187,10 @@
                         <a class="m-list__link"
                            href="https://oig.federalreserve.gov/">Office of Inspector General</a>
                     </li>
+                    <li class="m-list__item">
+                        <a class="m-list__link"
+                           href="https://archive-it.org/organizations/2800">Public Archive</a>
+                    </li>
                     {% if language == 'es'%}
                     <li class="m-list__item">
                         <a class="m-list__link" href="/cfpb-ombudsman/">


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR adds a link to the CFPB public archive, via Archive-It, to the site-wide footer.



## How to test this PR

1. localhost
2. View any rendered page
