### PR TITLE
ROUT: Simplify dom queries and strings

### DIFF
--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/address-utils.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/address-utils.js
@@ -1,4 +1,4 @@
-import { addEl, getEl, getEls, removeClass } from './dom-tools.js';
+import { addEl, removeClass } from './dom-tools.js';
 
 import PLUS_ROUND_ICON from '@cfpb/cfpb-design-system/icons/plus-round.svg';
 
@@ -65,16 +65,16 @@ function isValid(row) {
  * @param {object} result - Address data.
  */
 function render(result) {
-  let rowCount = getEls('#' + result.type + ' tbody tr').length;
+  let rowCount = document.querySelectorAll(`#${result.type} tbody tr`).length;
   if (result.type === 'rural' || result.type === 'notRural') {
-    rowCount = getEls('#' + result.type + ' tbody tr').length / 2;
+    rowCount = document.querySelectorAll(`#${result.type} tbody tr`).length / 2;
   }
 
   let hideRow = false;
   if (rowCount >= 5) {
     hideRow = true;
-    removeClass('#' + result.type + 'More', 'u-hidden');
-    removeClass('#' + result.type + 'All', 'u-hidden');
+    removeClass(`#${result.type}More`, 'u-hidden');
+    removeClass(`#${result.type}All`, 'u-hidden');
   }
 
   let rural;
@@ -117,8 +117,8 @@ function render(result) {
       </tr>`;
   }
 
-  removeClass('#' + result.type, 'u-hidden');
-  addEl(getEl('#' + result.type + ' tbody'), rowHTML);
+  removeClass(`#${result.type}`, 'u-hidden');
+  addEl(document.querySelector(`#${result.type} tbody`), rowHTML);
 }
 
 /**

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/call-census.js
@@ -1,6 +1,6 @@
 import jsonpPModule from 'jsonp-p';
 const jsonpP = jsonpPModule.default;
-import { addEl, createEl, getEl, removeClass } from './dom-tools.js';
+import { addEl, createEl, removeClass } from './dom-tools.js';
 import { incrementTotal } from './count.js';
 
 /**
@@ -10,11 +10,12 @@ import { incrementTotal } from './count.js';
  * @param {Function} cb - Callback to call.
  */
 function callCensus(address, ruralCounties, cb) {
-  let url =
-    'https://geocoding.geo.census.gov/geocoder/locations/onelineaddress?';
-  url += 'address=' + address;
-  url += '&benchmark=4';
-  url += '&format=jsonp';
+  const url =
+    'https://geocoding.geo.census.gov/geocoder/locations/onelineaddress?' +
+    'address=' +
+    address +
+    '&benchmark=4' +
+    '&format=jsonp';
 
   jsonpP(url)
     .promise.then(function (data) {
@@ -22,9 +23,9 @@ function callCensus(address, ruralCounties, cb) {
     })
     .catch(function (error) {
       if (error) {
-        const addressElement = createEl('<li>' + address + '</li>');
+        const addressElement = createEl(`<li>${address}</li>`);
 
-        addEl(getEl('#process-error-desc'), addressElement);
+        addEl(document.querySelector('#process-error-desc'), addressElement);
         removeClass('#process-error', 'u-hidden');
 
         incrementTotal();

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -15,8 +15,6 @@ import {
   addClass,
   hasClass,
   removeClass,
-  getEl,
-  getEls,
   getParentEls,
 } from './dom-tools.js';
 import { resetError, setError, getUploadName, isCSV } from './file-input.js';
@@ -75,7 +73,7 @@ function censusAPI(data, ruralCounties) {
       .catch(function (err) {
         console.log(err);
         const addressElement = createEl('<li>' + result.address + '</li>');
-        addEl(getEl('#process-error-desc'), addressElement);
+        addEl(document.querySelector('#process-error-desc'), addressElement);
         removeClass('#process-error', 'u-hidden');
       });
   } else {
@@ -95,25 +93,27 @@ function censusAPI(data, ruralCounties) {
 function processAddresses(addresses) {
   const processed = [];
 
-  getRuralCounties(getEl('#year').value).then(function (ruralCounties) {
-    addresses.forEach(function (address) {
-      if (addressUtils.isDup(address, processed)) {
-        // setup the result to render
-        const result = {};
-        result.input = address;
-        result.address = 'Duplicate';
-        result.countyName = '-';
-        result.block = '-';
-        result.type = 'duplicate';
-        addressUtils.render(result);
-        updateCount(result.type);
-      } else {
-        // if its not dup
-        callCensus(address, ruralCounties, censusAPI);
-        processed.push(address);
-      }
-    });
-  });
+  getRuralCounties(document.querySelector('#year').value).then(
+    function (ruralCounties) {
+      addresses.forEach(function (address) {
+        if (addressUtils.isDup(address, processed)) {
+          // setup the result to render
+          const result = {};
+          result.input = address;
+          result.address = 'Duplicate';
+          result.countyName = '-';
+          result.block = '-';
+          result.type = 'duplicate';
+          addressUtils.render(result);
+          updateCount(result.type);
+        } else {
+          // if its not dup
+          callCensus(address, ruralCounties, censusAPI);
+          processed.push(address);
+        }
+      });
+    },
+  );
 }
 
 // On submit of address entered manually.
@@ -126,11 +126,13 @@ addressFormDom.addEventListener('submit', function (evt) {
 
   contentControl.setup();
 
-  [].slice.call(getEls('.input-address')).forEach(function (element) {
-    if (element.value !== '') {
-      addresses.push(element.value);
-    }
-  });
+  [].slice
+    .call(document.querySelectorAll('.input-address'))
+    .forEach(function (element) {
+      if (element.value !== '') {
+        addresses.push(element.value);
+      }
+    });
 
   if (addresses.length > 1) {
     removeClass('#results-total', 'u-hidden');
@@ -144,11 +146,11 @@ addressFormDom.addEventListener('submit', function (evt) {
 const fileChangeDom = document.querySelector('#file');
 fileChangeDom.addEventListener('change', function () {
   let rowCount = 0;
-  const fileElement = getEl('#file');
+  const fileElement = document.querySelector('#file');
   const fileValue = fileElement.value;
 
   textInputs.reset();
-  getEl('#file-name').value = getUploadName(fileValue);
+  document.querySelector('#file-name').value = getUploadName(fileValue);
 
   resetError();
 
@@ -186,7 +188,7 @@ fileChangeDom.addEventListener('change', function () {
             'You entered ' +
               rowCount +
               ' addresses for ' +
-              getEl('#year').value +
+              document.querySelector('#year').value +
               ' safe harbor designation. We have a limit of ' +
               MAX_CSV_ROWS +
               ' addresses. You can run the first ' +
@@ -216,7 +218,7 @@ geocodeCSVDom.addEventListener('submit', function (evt) {
   evt.preventDefault();
 
   window.location.hash = 'rural-or-underserved';
-  let fileElement = getEl('#file-name');
+  let fileElement = document.querySelector('#file-name');
   const fileValue = fileElement.value;
   if (
     fileValue === '' ||
@@ -231,7 +233,7 @@ geocodeCSVDom.addEventListener('submit', function (evt) {
     let pass = true;
     let rowCount = 0;
     let addresses = [];
-    fileElement = getEl('#file');
+    fileElement = document.querySelector('#file');
     textInputs.reset();
 
     // Parse the csv to get the
@@ -270,7 +272,7 @@ geocodeCSVDom.addEventListener('submit', function (evt) {
             'You entered ' +
               rowCount +
               ' addresses for ' +
-              getEl('#year').value +
+              document.querySelector('#year').value +
               ' safe harbor designation. We have a limit of ' +
               MAX_CSV_ROWS +
               ' addresses. You can run the first ' +
@@ -322,7 +324,7 @@ bindEvents('.button-more', 'click', function (evt) {
   const moreButton = evt.target;
   evt.preventDefault();
   const tableID = getElData(moreButton, 'table');
-  const tableRows = getEls('#' + tableID + ' tbody tr.data');
+  const tableRows = document.querySelectorAll('#' + tableID + ' tbody tr.data');
   const tableRowsLength = tableRows.length;
   const lengthShown = Array.prototype.filter.call(tableRows, function (item) {
     return !item.classList.contains('u-hidden');
@@ -340,9 +342,9 @@ bindEvents('.button-more', 'click', function (evt) {
 bindEvents('.view-all', 'click', function (evt) {
   evt.preventDefault();
   const tableID = getElData(evt.target, 'table');
-  removeClass('#' + tableID + ' tbody tr.data', 'u-hidden');
-  addClass('#' + tableID + 'More', 'u-hidden');
-  addClass('#' + tableID + 'All', 'u-hidden');
+  removeClass(`#${tableID} tbody tr.data`, 'u-hidden');
+  addClass(`#${tableID}More`, 'u-hidden');
+  addClass(`#${tableID}All`, 'u-hidden');
 });
 
 // print
@@ -430,7 +432,7 @@ function generateCSV() {
 
   // loop through each row
   [].slice
-    .call(getEls('.rout-results-table tbody tr td'))
+    .call(document.querySelectorAll('.rout-results-table tbody tr td'))
     .forEach(_loopHandler);
 
   return theCSV;

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/count.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/count.js
@@ -1,10 +1,4 @@
-import {
-  addClass,
-  changeElHTML,
-  changeElText,
-  getEl,
-  getEls,
-} from './dom-tools.js';
+import { addClass, changeElHTML, changeElText } from './dom-tools.js';
 
 let types = {};
 let totalCount = 0;
@@ -30,8 +24,11 @@ function updateAddressCount(number) {
  * Add one to the total address count.
  */
 function incrementTotal() {
-  const totalCountElement = getEl('#totalCnt');
-  const addressCount = parseInt(getEl('#addressCount').textContent, 10);
+  const totalCountElement = document.querySelector('#totalCnt');
+  const addressCount = parseInt(
+    document.querySelector('#addressCount').textContent,
+    10,
+  );
 
   // add one to the total
   totalCount++;
@@ -52,7 +49,7 @@ function incrementTotal() {
 function updateCount(type) {
   let noun = 'addresses';
   let verb = 'are';
-  const countElements = getEls('.' + type + '-cnt');
+  const countElements = document.querySelectorAll('.' + type + '-cnt');
   // add one to correct type
   let typeCount = types[type] || 0;
   types[type] = ++typeCount;

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
@@ -46,7 +46,7 @@ function applyAll(elements, applyFn) {
   if (elements instanceof HTMLElement) {
     elements = [elements];
   } else if (typeof elements === 'string') {
-    elements = getEls(elements);
+    elements = document.querySelectorAll(elements);
   }
 
   return [].slice.call(elements || []).forEach(applyFn);
@@ -76,7 +76,7 @@ function bindEvents(elements, events, callback) {
 function addEl(parent, child) {
   return fastDom.mutate(function () {
     const el = createEl(child);
-    return getEl(parent).appendChild(el);
+    return document.querySelector(parent).appendChild(el);
   });
 }
 
@@ -85,7 +85,7 @@ function addEl(parent, child) {
  * @param {string} attributeName - A value to add to a data- attribute.
  */
 function getElData(selector, attributeName) {
-  return getEl(selector).getAttribute('data-' + attributeName);
+  return document.querySelector(selector).getAttribute('data-' + attributeName);
 }
 
 /**
@@ -210,30 +210,6 @@ function _filter(element, propName, filter) {
 }
 
 /**
- * @param {HTMLElement|string} selector - An HTML element node or CSS selector.
- * @returns {HTMLElement} An HTML node returned by the passed selector,
- *  or the selector passed into this method.
- */
-function getEl(selector) {
-  if (_isEl(selector)) {
-    return selector;
-  }
-  return document.querySelector(selector);
-}
-
-/**
- * @param {HTMLElement|string} selector - An HTML element node or CSS selector.
- * @returns {NodeList} A list of HTML nodes returned by the passed selector,
- *  or the selector passed into this method.
- */
-function getEls(selector) {
-  if (_isEl(selector)) {
-    return selector;
-  }
-  return document.querySelectorAll(selector);
-}
-
-/**
  * @param {HTMLElement} element - An element.
  * @param {string} filterNode - The string to filter by.
  */
@@ -274,8 +250,6 @@ export {
   addClass,
   hasClass,
   removeClass,
-  getEl,
-  getEls,
   getParentEls,
   getNextEls,
   nextFrame,

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/dom-tools.js
@@ -70,22 +70,24 @@ function bindEvents(elements, events, callback) {
 }
 
 /**
- * @param {HTMLElement|string} parent - An HTML element node or CSS selector.
+ * @param {HTMLElement} parent - An HTML element node.
  * @param {HTMLElement|string} child - An HTML element node or snippet.
+ * @returns {HTMLElement} - The appended element
  */
 function addEl(parent, child) {
   return fastDom.mutate(function () {
     const el = createEl(child);
-    return document.querySelector(parent).appendChild(el);
+    return parent.appendChild(el);
   });
 }
 
 /**
- * @param {string} selector - A CSS selector.
+ * @param {HTMLElement} element - An HTMLElement.
  * @param {string} attributeName - A value to add to a data- attribute.
+ * @returns {string} - The value of the selected data attribute
  */
-function getElData(selector, attributeName) {
-  return document.querySelector(selector).getAttribute('data-' + attributeName);
+function getElData(element, attributeName) {
+  return element.getAttribute(`data-${attributeName}`);
 }
 
 /**

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
@@ -1,10 +1,10 @@
-import { changeElHTML, addClass, removeClass, getEl } from './dom-tools.js';
+import { changeElHTML, addClass, removeClass } from './dom-tools.js';
 
 /**
  * Reset the file input value.
  */
 function resetFileName() {
-  getEl('#file-name').value = 'No file chosen';
+  document.querySelector('#file-name').value = 'No file chosen';
 }
 
 /**
@@ -12,7 +12,7 @@ function resetFileName() {
  * @param {string} fileName - A filename.
  */
 function setFileName(fileName) {
-  getEl('#file-name').value = fileName;
+  document.querySelector('#file-name').value = fileName;
 }
 
 /**

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/text-inputs.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/text-inputs.js
@@ -4,7 +4,6 @@ import {
   removeEl,
   addClass,
   removeClass,
-  getEl,
 } from './dom-tools.js';
 
 let count = 1;
@@ -38,13 +37,15 @@ function add() {
 
   const previous = count - 1;
 
-  if (getEl('#address' + previous).value === '') {
+  if (document.querySelector('#address' + previous).value === '') {
     addClass('#address' + previous, 'error');
   } else {
     removeClass('#address' + previous, 'error');
   }
 
-  const addressElementContainer = getEl('#address1').cloneNode(true);
+  const addressElementContainer = document
+    .querySelector('#address1')
+    .cloneNode(true);
   addressElementContainer.setAttribute('id', 'address' + count);
   const addressElement = addressElementContainer.querySelector('input');
   addressElement.setAttribute('name', 'address' + count);

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/text-inputs.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/text-inputs.js
@@ -50,7 +50,7 @@ function add() {
   const addressElement = addressElementContainer.querySelector('input');
   addressElement.setAttribute('name', 'address' + count);
   addressElement.value = '';
-  addEl('.input-container', addressElementContainer);
+  addEl(document.querySelector('.input-container'), addressElementContainer);
   addressElement.focus();
 }
 


### PR DESCRIPTION
## Changes

- ROUT: Simplify dom queries to use native querySelector calls directly, instead of through helper.
- Convert concatenated strings to template literals.


## How to test this PR

1. Visit http://localhost:8000/rural-or-underserved-tool/ and see that the tool works the same.
2. `getEl` calls should be `document.querySelector`
3. `getEls` calls should be `document.querySelectorAll`
