### PR TITLE
Tweak ROUT design and file upload component

### DIFF
--- a/cfgov/jinja2/rural-or-underserved/index.html
+++ b/cfgov/jinja2/rural-or-underserved/index.html
@@ -118,7 +118,7 @@ home price, down payment, and more can affect mortgage interest rates.
 
                 <div class="content-l__col content-l__col-1-2">
                     <div class="block block--border block--bg block--sub">
-                        <h4>Enter addresses manually</h4>
+                        <h3>Enter addresses manually</h3>
                         <form id="geocode">
                             <p>
                                 Include street address, city, state/territory
@@ -144,8 +144,11 @@ home price, down payment, and more can affect mortgage interest rates.
                                 </span>
                             </p>
                             <p>
-                                <a href="#" id="add-another" title="Add another address">
-                                    Add another address
+                                <a href="#" class="a-link"
+                                   id="add-another"
+                                   title="Add another address">
+                                   +
+                                   <span class="a-link__text">Add another address</span>
                                 </a>
                             </p>
                             <button class="a-btn" type="submit">
@@ -156,7 +159,7 @@ home price, down payment, and more can affect mortgage interest rates.
                 </div>
                 <div class="content-l__col content-l__col-1-2">
                     <div class="block block--border block--bg block--sub">
-                        <h4>Upload a CSV file</h4>
+                        <h3>Upload a CSV file</h3>
                         <form id="geocode-csv">
                             <p>
                                 To check on more than one loan, upload a Comma Separated Values (CSV) file with addresses for up to 250 properties. The file must use our CSV template:
@@ -167,25 +170,29 @@ home price, down payment, and more can affect mortgage interest rates.
 
                             <p>
                                 <div class="m-form-field m-form-field--file-input">
+
                                     <!-- Actual hidden file upload component. -->
                                     <label>
                                         <input type="file" id="file">
                                         <span class="u-visually-hidden">Choose a file to upload</span>
                                     </label>
                                     <!-- Styled faux overlay component. -->
-                                    <button class="a-btn
-                                                   a-btn--secondary
-                                                   a-btn--flush-right">
-                                        Select file
-                                    </button>
-                                    <label class="u-visually-hidden"
-                                           for="file-name">
-                                        Choose a file to upload
-                                    </label>
-                                    <input id="file-name"
-                                           name="file-name"
-                                           class="a-text-input"
-                                           value="No file chosen">
+                                    <div>
+                                        <button class="a-btn
+                                                    a-btn--secondary"
+                                                aria-label="Choose a file to upload">
+                                            Select file
+                                        </button>
+                                    </div>
+                                    <div id="file-list-wrapper" class="u-hidden">
+                                        <h4>File added</h4>
+                                        <ul>
+                                            <li id="file-name">
+                                                No file chosen
+                                            </li>
+                                        </ul>
+                                        <p>To remove or replace your file, select a new file and upload again.</p>
+                                    </div>
                                 </div>
                             </p>
 
@@ -220,7 +227,7 @@ home price, down payment, and more can affect mortgage interest rates.
                     </h2>
                 </div>
                 <p class="hide-print content-l__col content-l__col-1-4">
-                    <a class="a-btn a-btn--secondary" href="/rural-or-underserved-tool/">
+                    <a class="a-btn" href="/rural-or-underserved-tool/">
                         Start a new search
                     </a>
                 </p>
@@ -317,7 +324,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                   block--padded-top
                                   block--padded-bottom
                                   m-btn-group">
-                            <button data-table="rural" class="button-more u-hidden a-btn a-btn--secondary no-decoration" id="ruralMore">View 10 more</button>
+                            <button data-table="rural" class="button-more u-hidden a-btn no-decoration" id="ruralMore">View 10 more</button>
                             <button data-table="rural" class="view-all u-hidden a-btn a-btn--link" id="ruralAll">View all</button>
                         </p>
                     </div>
@@ -350,7 +357,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                   block--padded-top
                                   block--padded-bottom
                                   m-btn-group">
-                            <button data-table="notRural" class="button-more u-hidden a-btn a-btn--secondary no-decoration" id="notRuralMore">View 10 more</button>
+                            <button data-table="notRural" class="button-more u-hidden a-btn no-decoration" id="notRuralMore">View 10 more</button>
                             <button data-table="notRural" class="view-all u-hidden a-btn a-btn--link" id="notRuralAll">View all</button>
                         </p>
                     </div>
@@ -386,7 +393,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                   block--padded-top
                                   block--padded-bottom
                                   m-btn-group">
-                            <button data-table="notFound" class="button-more u-hidden a-btn a-btn--secondary no-decoration" id="notFoundMore">View 10 more</button>
+                            <button data-table="notFound" class="button-more u-hidden a-btn no-decoration" id="notFoundMore">View 10 more</button>
                             <button data-table="notFound" class="view-all u-hidden a-btn a-btn--link" id="notFoundAll">View all</button>
                         </p>
                     </div>
@@ -422,7 +429,7 @@ home price, down payment, and more can affect mortgage interest rates.
                                   block--padded-top
                                   block--padded-bottom
                                   m-btn-group">
-                            <button data-table="duplicate" class="button-more u-hidden a-btn a-btn--secondary no-decoration" id="duplicateMore">View 10 more</button>
+                            <button data-table="duplicate" class="button-more u-hidden a-btn no-decoration" id="duplicateMore">View 10 more</button>
                             <button data-table="duplicate" class="view-all u-hidden a-btn a-btn--link" id="duplicateAll">View all</button>
                         </p>
                     </div>

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/common.js
@@ -17,7 +17,13 @@ import {
   removeClass,
   getParentEls,
 } from './dom-tools.js';
-import { resetError, setError, getUploadName, isCSV } from './file-input.js';
+import {
+  resetFileName,
+  resetError,
+  setError,
+  getUploadName,
+  isCSV,
+} from './file-input.js';
 import Papaparse from 'papaparse';
 import getRuralCounties from './get-rural-counties.js';
 import * as textInputs from './text-inputs.js';
@@ -150,7 +156,8 @@ fileChangeDom.addEventListener('change', function () {
   const fileValue = fileElement.value;
 
   textInputs.reset();
-  document.querySelector('#file-name').value = getUploadName(fileValue);
+  document.querySelector('#file-name').innerHTML = getUploadName(fileValue);
+  removeClass('#file-list-wrapper', 'u-hidden');
 
   resetError();
 
@@ -209,6 +216,8 @@ fileChangeDom.addEventListener('change', function () {
         ' For more information about CSV files, view our' +
         ' Frequently Asked Questions below.',
     );
+
+    resetFileName();
   }
 });
 
@@ -218,7 +227,7 @@ geocodeCSVDom.addEventListener('submit', function (evt) {
   evt.preventDefault();
 
   window.location.hash = 'rural-or-underserved';
-  let fileElement = document.querySelector('#file-name');
+  let fileElement = document.querySelector('#file');
   const fileValue = fileElement.value;
   if (
     fileValue === '' ||

--- a/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
+++ b/cfgov/unprocessed/apps/rural-or-underserved-tool/js/file-input.js
@@ -1,18 +1,7 @@
 import { changeElHTML, addClass, removeClass } from './dom-tools.js';
 
-/**
- * Reset the file input value.
- */
 function resetFileName() {
-  document.querySelector('#file-name').value = 'No file chosen';
-}
-
-/**
- * Set a filename for a file input.
- * @param {string} fileName - A filename.
- */
-function setFileName(fileName) {
-  document.querySelector('#file-name').value = fileName;
+  addClass('#file-list-wrapper', 'u-hidden');
 }
 
 /**
@@ -55,11 +44,4 @@ function isCSV(fileName) {
   return fileName.slice(fileName.lastIndexOf('.') + 1) === 'csv';
 }
 
-export {
-  resetFileName,
-  setFileName,
-  resetError,
-  setError,
-  getUploadName,
-  isCSV,
-};
+export { resetFileName, resetError, setError, getUploadName, isCSV };

--- a/cfgov/unprocessed/css/molecules/file-input.scss
+++ b/cfgov/unprocessed/css/molecules/file-input.scss
@@ -1,12 +1,15 @@
+@use 'sass:math';
+@use '@cfpb/cfpb-design-system/src/abstracts' as *;
+
 .m-form-field--file-input {
   position: relative;
   display: grid;
-  grid-template-columns: auto auto 1fr;
+  gap: math.div(15px, $base-font-size-px) + rem;
 
   /*
-      Labels have a max-width set in cf-core,
-      so this is needed to match the overlaid input width.
-    */
+    Labels have a max-width set in cf-core,
+    so this is needed to match the overlaid input width.
+  */
   max-width: 41.875rem;
 
   // Hide and size native input on top of custom input.
@@ -27,11 +30,6 @@
   .a-btn {
     position: relative;
     z-index: 1;
-
-    &--flush-right {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
   }
 
   label,


### PR DESCRIPTION
## Changes

- ROUT: Update file upload button appearance and remove `a-btn--flush-right` class.
- ROUT: Change secondary buttons to primary on the start new search, and view more buttons.
- ROUT: Bump well header up to H3, add "+" to "Add another address" link.


## How to test this PR

1. Pull branch, yarn build and visit http://localhost:8000/rural-or-underserved-tool/#rural-or-underserved and compare to production in terms of uploading CSV files.
2. Visit http://localhost:8000/privacy/records-access/ and https://www.consumerfinance.gov/privacy/disclosure-consent/ and make sure you can still add files.


## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="266" alt="Screenshot 2025-04-23 at 7 00 49 PM" src="https://github.com/user-attachments/assets/53c683b3-ee8c-4554-a3ec-781682694133" />|<img width="269" alt="Screenshot 2025-04-23 at 7 00 45 PM" src="https://github.com/user-attachments/assets/cd700134-ec45-4140-af8e-f590e67787d4" />|
|<img width="1211" alt="Screenshot 2025-04-23 at 6 57 54 PM" src="https://github.com/user-attachments/assets/51263541-d5da-4b39-b30e-229d27c5586b" />|<img width="1210" alt="Screenshot 2025-04-23 at 6 58 01 PM" src="https://github.com/user-attachments/assets/bbf2cb6a-6e49-4544-a244-6745561662fd" />|
|<img width="1211" alt="Screenshot 2025-04-23 at 6 57 54 PM" src="https://github.com/user-attachments/assets/6ea4803f-987f-4226-954c-96760f101a35" />|<img width="1210" alt="Screenshot 2025-04-23 at 6 58 01 PM" src="https://github.com/user-attachments/assets/e937e636-65d4-4494-82f8-c46cd0ce9076" />|


## Notes and todos

- There's an existing bug in the file upload, where the native component overlays the button and prevents the buttons hover state from showing. The touch area is also larger than the button area. I left this for now.


## Checklist

<!-- Feel free to delete any checkboxes that are not applicable to this PR. -->

- [ ] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Future todos are captured in comments and/or tickets
- [ ] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance

### Front-end testing

<!--
When new (or significantly modified) front-end functionality is present, the following things should be tested.
Feel free to delete this section if not applicable to this PR.
-->

#### Browser testing

Check the current browser support cutoff list](https://cfpb.github.io/consumerfinance.gov/browser-support#current-browser-support-metrics) for browsers that are advisable
to prioritize for testing.

#### Accessibility

- [ ] Keyboard friendly (navigable with tab, space, enter, arrow keys, etc.)
- [ ] Screen reader friendly
- [ ] Does not introduce new errors or warnings in [WAVE](https://wave.webaim.org/extension/)

#### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Does not introduce new lint warnings
- [ ] Flexible from small to large screens
