### PR TITLE
Convert FAHC error to field-level error

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -84,30 +84,22 @@
                                 Search by ZIP code:
                             </label>
 
-                            {% if zipcode and error_message %}
-                            <div class="u-mb15">
-                                <div class="m-notification
-                                            m-notification--error
-                                            m-notification--visible">
-                                    {{ svg_icon('warning-round') }}
-                                    <div class="m-notification__content" role="alert">
-                                        <div class="m-notification__message">
-                                            {{ error_message }}
-                                        </div>
-                                        <div class="m-notification__explanation">
-                                            {{ error_help }}
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            {% endif %}
-
                             <input id="hud-hca-api-query"
                                     type="text"
                                     name="zipcode"
                                     class="a-text-input a-text-input--full{% if zipcode and error_message %} a-text-input--error{% endif %}"
                                     value="{% if zipcode %}{{ zipcode }}{% endif %}"
                                     placeholder="Please enter a five-digit ZIP code">
+
+                            {% if zipcode and error_message %}
+                            <div class="a-form-alert a-form-alert--error" role="alert">
+                                {{ svg_icon('error-round') }}
+                                <span class="a-form-alert__text">
+                                    {{ error_message }}
+                                    {{ error_help }}
+                                </span>
+                            </div>
+                            {% endif %}
                         </div>
 
                         <p>


### PR DESCRIPTION
Convert alert to field level error (see https://cfpb.github.io/design-system/components/alerts#error-1)

## Changes

- Convert FAHC error to field-level error.


## How to test this PR

1. Pull branch and build and visit http://localhost:8000/find-a-housing-counselor/ and screen sizes. Enter an incorrect zip enter an incorrect error dialog.


## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="1200" alt="Screenshot 2025-04-24 at 12 40 56 PM" src="https://github.com/user-attachments/assets/c10147fa-12ee-4cfc-8662-33017440c1d8" />|<img width="1229" alt="Screenshot 2025-04-24 at 12 25 10 PM" src="https://github.com/user-attachments/assets/03a4e330-cfaa-4296-af64-6d2515a20461" />|

## Note

The spacing between the icon and text for the alert is too close. This needs fixing in the DS directly.