### PR TITLE
Fix Apache image to expose port 8080, not 80

### DIFF
--- a/.github/workflows/apache.yml
+++ b/.github/workflows/apache.yml
@@ -19,7 +19,7 @@ jobs:
         run: docker build cfgov/apache -t cfgov-apache:latest
 
       - name: Run cfgov-apache image with no proxy configured
-        run: docker run -d -p 8000:80 cfgov-apache:latest && sleep 5
+        run: docker run -d -p 8000:8080 cfgov-apache:latest && sleep 5
 
       - name: Test cfgov-apache image with no proxy configured
         # Expect this to show the default Apache 404 Not Found page, since we
@@ -33,7 +33,7 @@ jobs:
         run: |
           docker volume create tmp
           docker run -d \
-            -p 8001:80 \
+            -p 8001:8080 \
             --read-only \
             -v tmp:/usr/local/apache2/logs \
             cfgov-apache:latest && sleep 5
@@ -55,7 +55,7 @@ jobs:
             nginxdemos/hello:0.4
           docker run -d \
             --network testing \
-            -p 8003:80 \
+            -p 8003:8080 \
             -e CFGOV_APPLICATION_PROXY=http://hello \
             cfgov-apache:latest && sleep 5
 

--- a/cfgov/apache/Dockerfile
+++ b/cfgov/apache/Dockerfile
@@ -1,7 +1,7 @@
 FROM httpd:2.4-alpine
 
 # Define default Apache ENV variables.
-ENV APACHE_PORT="80"
+ENV APACHE_PORT="8080"
 ENV APACHE_USER="www-data"
 ENV APACHE_GROUP="www-data"
 ENV APACHE_SERVER_ROOT="/usr/local/apache2"
@@ -55,7 +55,7 @@ RUN CURRENT_LIBXML2=$( \
         apk upgrade --no-cache libxml2; \
     fi
 
-EXPOSE 80
+EXPOSE 8080
 
 USER www-data
 


### PR DESCRIPTION
Because we want the cf.gov Apache image to run as a non-root user, it can't bind to local port 80. Use 8080 instead.