### PR TITLE
Add last modified datestamp

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/macros/time.html
+++ b/cfgov/v1/jinja2/v1/includes/macros/time.html
@@ -15,6 +15,11 @@
    show_value_for: (Optional) Object of fields to show.
                    Default is true for 'date', 'time', and 'timezone'.
 
+   text_format: (Optional) Boolean that, if true, changes month abbreviations
+                from, for example, "NOV" to "Nov." and does not include leading
+                zeros in front of days.
+                Default is false.
+
    ========================================================================== #}
 
 {% macro render(datetime,

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -1,6 +1,6 @@
 {%- import 'v1/includes/macros/time.html' as time -%}
 
-{% if page.last_published_at %}
+{% if page and page.last_published_at %}
 <div class="block">
     <p><strong>Page last updated {{ time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=True ) }}.</strong></p>
     <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -2,7 +2,8 @@
 
 {% if page and page.last_published_at %}
 <div class="block">
-    <p><strong>Page last updated {{ time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=True ) }}.</strong></p>
+    <p><hr></p>
+    <p>Page last modified {{ time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=True ) }}</p>
     <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>
  </div>
  {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -3,7 +3,7 @@
 {% if page and page.last_published_at %}
 <div class="block">
     <p><hr></p>
-    <p>Page last modified {{ time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=True ) }}</p>
+    <p>Page last modified {{ time.render( page.last_published_at, { 'date': true, 'time': true, 'timezone': true }, text_format=True ) }}</p>
     <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>
  </div>
  {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -2,8 +2,7 @@
 
 {% if page.last_published_at %}
 <div class="block">
-
-    <p><strong>Page last updated {{- time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=false ) }}.</strong></p>
+    <p><strong>Page last updated {{ time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=True ) }}.</strong></p>
     <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>
  </div>
  {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -1,6 +1,9 @@
+{%- import 'v1/includes/macros/time.html' as time -%}
+
 {% if page.last_published_at %}
 <div class="block">
-    <p><strong>Page last updated {{ page.last_published_at.strftime('%Y-%m-%d, %I:%M:%S %p %z') }}.</strong></p>
+
+    <p><strong>Page last updated {{- time.render( page.last_published_at, { 'date': true, 'time':true, 'timezone':true }, text_format=false ) }}.</strong></p>
     <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>
  </div>
  {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -1,6 +1,6 @@
 {% if page.last_published_at %}
 <div class="block">
     <p><strong>Page last updated {{ page.last_published_at.strftime('%Y-%m-%d, %I:%M:%S %p %z') }}.</strong></p>
-    <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{request.path}}">View older versions of this page at our public archive.</a></p>
+    <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">View older versions of this page at our public archive.</a></p>
  </div>
  {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -1,0 +1,6 @@
+{% if page.last_published_at %}
+<div class="block">
+    <p><strong>Page last updated {{ page.last_published_at.strftime('%Y-%m-%d, %I:%M:%S %p %z') }}.</strong></p>
+    <p><a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{request.path}}">View older versions of this page at our public archive.</a></p>
+ </div>
+ {% endif %}

--- a/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
@@ -27,6 +27,7 @@
                         id="content__main">
                     {% block content_main scoped -%}{%- endblock %}
                     {% include 'v1/layouts/_footnotes.html' %}
+                    {% include 'v1/layouts/_last-modified.html' %}
                 </div>
             {% endblock %}
         </div>

--- a/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-2-1.html
@@ -21,6 +21,7 @@
                 <div class="u-layout-grid__main">
                     {% block content_main scoped -%}{%- endblock %}
                     {% include 'v1/layouts/_footnotes.html' %}
+                    {% include 'v1/layouts/_last-modified.html' %}
                 </div>
                 <aside class="u-layout-grid__sidebar">
                     {% block content_sidebar scoped -%}{%- endblock %}

--- a/cfgov/v1/jinja2/v1/layouts/layout-full.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-full.html
@@ -22,6 +22,7 @@
                 <div class="u-layout-grid__main {% block content_main_modifiers -%}{%- endblock %}">
                     {% block content_main scoped -%}{%- endblock %}
                     {% include 'v1/layouts/_footnotes.html' %}
+                    {% include 'v1/layouts/_last-modified.html' %}
                 </div>
             {% endblock %}
         </div>


### PR DESCRIPTION
## Additions

- Add last modified datestamp to jinja templates.

## How to test this PR

1. Pull branch and visit a page and look for a date stamp and archive link in the content area footer.


## Screenshots

<img width="463" alt="Screenshot 2025-04-25 at 9 22 10 AM" src="https://github.com/user-attachments/assets/80e9634f-fc83-425c-afb6-e102badc5cbf" />


## Notes and todos

- Not sure how to do the timezone yet!
