### PR TITLE
FAHC: Remove placeholder

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -100,7 +100,7 @@
 
                             <label class="a-label a-label--heading" for="hud-hca-api-query">
                                 Search by ZIP code
-                                <small class="a-label__helper a-label__helper--block">Please enter a valid five-digit ZIP code</small>
+                                <small class="a-label__helper a-label__helper--block">Please enter a valid five-digit ZIP code.</small>
                             </label>
 
                             <input id="hud-hca-api-query"

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -108,7 +108,6 @@
                                     name="zipcode"
                                     class="a-text-input a-text-input--full{% if zipcode and invalid_zip_error_message %} a-text-input--error{% endif %}"
                                     value="{% if zipcode %}{{ zipcode }}{% endif %}"
-                                    placeholder="_ _ _ _ _"
                                     maxlength="5">
 
                             {% if zipcode and invalid_zip_error_message %}


### PR DESCRIPTION
@natalia-fitzgerald recommends we do not include the `placeholder`.

## Removals

- FAHC: Remove placeholder

## How to test this PR

1. Visit http://localhost:8000/find-a-housing-counselor/ and see that there's no placeholder in the zip code input field.

## Screenshots

Before:
<img width="534" alt="Screenshot 2025-04-25 at 8 59 00 AM" src="https://github.com/user-attachments/assets/0fd71ccc-b143-493b-8ae5-d94059ee9fe3" />

After:
<img width="538" alt="Screenshot 2025-04-25 at 8 58 51 AM" src="https://github.com/user-attachments/assets/a62a4034-5ca0-44ec-a112-381cb9e103ef" />
