### PR TITLE
Update FAHC to use standard search input

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -42,6 +42,7 @@
 
         <div class="block
                     block--flush-top
+                    block--flush-bottom
                     u-screen-only">
             <h1>Find a housing counselor</h1>
             <p>
@@ -59,6 +60,8 @@
                    href="https://www.hud.gov/program_offices/housing/sfh/hcc/hcc_home">
                     <span class="a-link__text">list of nationwide HUD-approved counseling agencies</span></a>.
             </p>
+
+            <h2 class="h3">Search by ZIP code</h2>
             <p>
                 Using the search box below, you can find one
                 near you. <strong>Not every housing
@@ -68,48 +71,34 @@
             </p>
         </div>
 
-        <div class="block block--border u-screen-only">
-            {#
-                Set the `no-js` class on page load,
-                which is reverted if and when the map is
-                loaded via JavaScript.
-            #}
+        <div class="block u-hide-if-js">
+            {% include "v1/includes/snippets/no_js_notification.html" %}
+        </div>
+
+        <div class="block block--border u-mb30 u-mt30 u-screen-only u-js-only">
             <section id="hud_search_container"
-                     class="no-js hud-search-container">
+                     class="hud-search-container">
                 <div class="hud-search-container__text">
                     <form class="o-form" action="#hud_search_container">
                         <div class="m-form-field u-mb15">
 
-                            {% if zipcode and failed_fetch_error_message %}
-                            <div class="u-mb15">
-                                <div class="m-notification
-                                            m-notification--error
-                                            m-notification--visible">
-                                    {{ svg_icon('warning-round') }}
-                                    <div class="m-notification__content" role="alert">
-                                        <div class="m-notification__message">
-                                            {{ failed_fetch_error_message }}
-                                        </div>
-                                        <div class="m-notification__explanation">
-                                            {{ failed_fetch_error_explanation }}
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            {% endif %}
-
                             <label class="a-label a-label--heading" for="hud-hca-api-query">
-                                Search by ZIP code
+                                ZIP code
                                 <small class="a-label__helper a-label__helper--block">Please enter a valid five-digit ZIP code</small>
                             </label>
 
-                            <input id="hud-hca-api-query"
-                                    type="text"
-                                    name="zipcode"
-                                    class="a-text-input a-text-input--full{% if zipcode and invalid_zip_error_message %} a-text-input--error{% endif %}"
-                                    value="{% if zipcode %}{{ zipcode }}{% endif %}"
-                                    placeholder="_ _ _ _ _"
-                                    maxlength="5">
+                            {% import 'v1/includes/organisms/search-input.html' as search_input %}
+                            {{ search_input.render({
+                                "input_aria_describedby_id": "o-search-bar_error-message",
+                                "input_id": "hud-hca-api-query",
+                                "input_name": "zipcode",
+                                "input_value": zipcode if zipcode else '',
+                                "input_aria_label": _('Search by ZIP Code'),
+                                "has_autocomplete": autocomplete,
+                                "placeholder": '',
+                                "submit_aria_label": 'Search by ZIP Code',
+                                "max_length": 5
+                            }) }}
 
                             {% if zipcode and invalid_zip_error_message %}
                             <div class="a-form-alert a-form-alert--error" role="alert">
@@ -121,25 +110,6 @@
                             {% endif %}
                         </div>
 
-                        <p>
-                            <button class="a-btn a-btn--full-on-xs"
-                                    type="submit"
-                                    data-cy="btn-fahc-submit">
-                                Find a counselor
-                            </button>
-                        </p>
-                        <p>
-                            This tool is powered by
-                            <a class="a-link"
-                                href="https://data.hud.gov/housing_counseling.html">
-                                <span class="a-link__text">HUD's</span>
-                                {{ svg_icon('external-link') }}</a>
-                            official list of housing counselors.
-                        </p>
-                        <p>
-                            If you notice errors in the housing counselor data,
-                            contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
-                        </p>
                     </form>
 
                     {% if zipcode and zipcode_valid %}
@@ -165,6 +135,24 @@
                 {% endif %}
             </section>
         </div>
+
+        {% if zipcode and failed_fetch_error_message %}
+        <div class="u-mb20">
+            <div class="m-notification
+                        m-notification--error
+                        m-notification--visible">
+                {{ svg_icon('warning-round') }}
+                <div class="m-notification__content" role="alert">
+                    <div class="m-notification__message">
+                        {{ failed_fetch_error_message }}
+                    </div>
+                    <div class="m-notification__explanation">
+                        {{ failed_fetch_error_explanation }}
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% endif %}
 
         {% if zipcode and zipcode_valid %}
         <div class="block" id="hud_results-list_container">
@@ -201,8 +189,8 @@
             </div>
 
             <table class="o-table
-                            o-table--stack-on-small
-                            u-w100pct">
+                          o-table--stack-on-small
+                          u-w100pct">
                 <thead>
                     <tr>
                         <th>Agency</th>
@@ -304,6 +292,17 @@
             </table>
         </div>
         {% endif %}
+
+    <p>
+        This tool is powered by
+        <a class="a-link"
+            href="https://data.hud.gov/housing_counseling.html">
+            <span class="a-link__text">HUD's</span>
+            {{ svg_icon('external-link') }}</a>
+        official list of housing counselors.<br>
+        If you notice errors in the housing counselor data,
+        contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+    </p>
 
     <div class="block
                 u-screen-only">

--- a/cfgov/housing_counselor/views.py
+++ b/cfgov/housing_counselor/views.py
@@ -57,7 +57,7 @@ class HousingCounselorView(TemplateView, HousingCounselorS3URLMixin):
     template_name = "housing_counselor/index.html"
 
     invalid_zip_msg = {
-        "invalid_zip_error_message": "Please enter a valid five-digit ZIP  \
+        "invalid_zip_error_message": "You must enter a valid 5-digit ZIP \
             code.",
     }
 

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
@@ -15,7 +15,7 @@
 
 // Tablet and above.
 @include respond-to-min($bp-sm-min) {
-  #hud-hca-api-query {
+  .hud-search-container__text {
     max-width: math.div(480px, $base-font-size-px) + em;
   }
 }

--- a/cfgov/v1/jinja2/v1/includes/snippets/no_js_notification.html
+++ b/cfgov/v1/jinja2/v1/includes/snippets/no_js_notification.html
@@ -4,7 +4,7 @@
     {{ svg_icon('error-round') }}
     <div class="m-notification__content">
         <div class="m-notification__message">
-            {{ _("This tool is not supported in your browser.") }}
+            {{ _("This tool is not supported in your browser.") }}<br>
             {{ _("Please try a newer browser or confirm that JavaScript is enabled.") }}
         </div>
     </div>


### PR DESCRIPTION
Supercedes https://github.com/cfpb/consumerfinance.gov/pull/8779/

## Changes

- Update FAHC to use standard search input
- Add standard no-js notification.
- Add line break to two sentences in standard no-js notification.


## How to test this PR

1. Visit http://localhost:8000/find-a-housing-counselor/ and see that the functionality is unchanged.


## Screenshots
<img width="1239" alt="Screenshot 2025-04-25 at 12 46 58 PM" src="https://github.com/user-attachments/assets/5c380cb9-bb8c-48ae-a1c9-e041968ffacc" />

---

<img width="1271" alt="Screenshot 2025-04-25 at 12 47 10 PM" src="https://github.com/user-attachments/assets/fc87d267-b7ef-40e8-9798-27c3b56427a2" />

---

<img width="1246" alt="Screenshot 2025-04-25 at 12 47 23 PM" src="https://github.com/user-attachments/assets/1ad914b9-cacb-4909-bf77-c9d933d6242e" />
