### PR TITLE
Fix positioning of last modified date when there's a prefooter

### DIFF
--- a/cfgov/v1/jinja2/v1/browse-basic/index.html
+++ b/cfgov/v1/jinja2/v1/browse-basic/index.html
@@ -36,10 +36,4 @@
         {% endif %}
     {%- endfor %}
 
-    {% if page.sidefoot %}
-        <aside class="o-prefooter">
-            {{ streamfield_sidefoot.render(page.sidefoot) }}
-        </aside>
-    {% endif %}
-
 {% endblock %}

--- a/cfgov/v1/jinja2/v1/browse-filterable/index.html
+++ b/cfgov/v1/jinja2/v1/browse-filterable/index.html
@@ -28,10 +28,4 @@
     <div class="block">
         {% include "v1/includes/organisms/filterable-list-results.html" %}
     </div>
-
-    {% if page.sidefoot %}
-        <aside class="o-prefooter">
-            {{ streamfield_sidefoot.render(page.sidefoot) }}
-        </aside>
-    {% endif %}
 {% endblock %}

--- a/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
+++ b/cfgov/v1/jinja2/v1/layouts/layout-1-3.html
@@ -23,11 +23,17 @@
                     {% import 'v1/includes/organisms/secondary-nav.html' as secondary_nav with context %}
                     {{ secondary_nav.render() }}
                 </aside>
-                <div class="u-layout-grid__main"
-                        id="content__main">
+                <div id="content__main"
+                     class="u-layout-grid__main">
                     {% block content_main scoped -%}{%- endblock %}
                     {% include 'v1/layouts/_footnotes.html' %}
                     {% include 'v1/layouts/_last-modified.html' %}
+                    {% if page.sidefoot %}
+                        <aside class="o-prefooter">
+                            {{ streamfield_sidefoot.render(page.sidefoot) }}
+                            {% block prefooter_more_content scoped -%}{%- endblock %}
+                        </aside>
+                    {% endif %}
                 </div>
             {% endblock %}
         </div>

--- a/cfgov/v1/jinja2/v1/newsroom/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/index.html
@@ -31,39 +31,37 @@
     <div class="block">
         {% include "v1/includes/organisms/filterable-list-results.html" %}
     </div>
-
-    <aside class="o-prefooter">
-        {% if page.sidefoot %}
-            {{ streamfield_sidefoot.render(page.sidefoot) }}
-        {% endif %}
-        <div class="block
-                    block--bg
-                    block--flush-sides
-                    block--flush-bottom
-                    block--border-top">
-            <div class="content-l">
-                <section class="block
-                                block--flush-top
-                                content-l__col
-                                content-l__col-1-2">
-                    {% import 'v1/includes/molecules/related-content.html' as related_links %}
-                    {{- related_links.render({
-                        'heading': 'Related links',
-                        'links': [
-                        {
-                            'url': '/about-us/blog/',
-                            'text': 'The blog'
-                        },
-                        {
-                            'url': '/about-us/the-bureau/',
-                            'text': 'About us'
-                        }
-                    ]}) -}}
-                </section>
-                <section class="block content-l__col content-l__col-1-2">
-                    {% include 'v1/includes/templates/upcoming-events.html' %}
-                </section>
-            </div>
-        </div>
-    </aside>
 {% endblock %}
+
+{% block prefooter_more_content %}
+    <div class="block
+                block--bg
+                block--flush-sides
+                block--flush-bottom
+                block--border-top">
+        <div class="content-l">
+            <section class="block
+                            block--flush-top
+                            content-l__col
+                            content-l__col-1-2">
+                {% import 'v1/includes/molecules/related-content.html' as related_links %}
+                {{- related_links.render({
+                    'heading': 'Related links',
+                    'links': [
+                    {
+                        'url': '/about-us/blog/',
+                        'text': 'The blog'
+                    },
+                    {
+                        'url': '/about-us/the-bureau/',
+                        'text': 'About us'
+                    }
+                ]}) -}}
+            </section>
+            <section class="block content-l__col content-l__col-1-2">
+                {% include 'v1/includes/templates/upcoming-events.html' %}
+            </section>
+        </div>
+    </div>
+{% endblock %}
+


### PR DESCRIPTION
## Changes

- Fix positioning of last modified date when there's a prefooter by elevating the prefooter block to the `layout-1-3.html` template.
- Add an overridable `prefooter_more_content` block for adding additional content to the prefooter.

## How to test this PR

1. Visit pages touched by this change and see that the last modified appears above the prefooter

http://localhost:8000/consumer-tools/educator-tools/library-resources/outreach-materials-to-use-outside-the-library/
http://localhost:8000/about-us/newsroom/?categories=press-release
