### PR TITLE
Convert skip nav buttons to primary appearance, instead of super

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -144,8 +144,9 @@
 
                     {% if zipcode and zipcode_valid %}
                     <div class="skip-nav">
-                        <a class="skip-nav__link
-                                    skip-nav__link--flush-left"
+                        <a class="a-btn
+                                  skip-nav__link
+                                  skip-nav__link--flush-left"
                             href="#hud_results-list_container">
                             Skip to results
                         </a>

--- a/cfgov/unprocessed/css/skip-nav.scss
+++ b/cfgov/unprocessed/css/skip-nav.scss
@@ -19,26 +19,14 @@
     z-index: 11;
 
     &:focus {
-      @include a-btn;
-
-      // TODO: refactor a-btn mixin to allow overriding of values.
-      /* stylelint-disable no-duplicate-selectors */
-      & {
-        /* stylelint-enable */
-        // Adjustments to button to make it appear like a super button.
-        padding: (math.div(11px, 18px) + em) (math.div(29px, 18px) + em);
-        font-size: math.div(18px, $base-font-size-px) + em;
-
-        top: 15px;
-        left: 15px;
-        height: auto;
-        width: auto;
-        overflow: visible;
-        outline: 0;
-        transition:
-          transform 0.1s ease,
-          background 0.2s linear;
-      }
+      top: 15px;
+      left: 15px;
+      height: auto;
+      width: auto;
+      overflow: visible;
+      transition:
+        transform 0.1s ease,
+        background 0.2s linear;
     }
 
     &--flush-left:focus {

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -256,7 +256,7 @@ itemscope itemtype="https://schema.org/FAQPage"
     <div class="a-overlay u-hidden"></div>
 
     <div class="skip-nav">
-        <a class="skip-nav__link"
+        <a class="a-btn skip-nav__link"
           href="{% block skip_nav_target %}#main{% endblock %}">
             {{ _('Skip to main content') }}
         </a>

--- a/test/unit_tests/js/modules/footer-button-spec.js
+++ b/test/unit_tests/js/modules/footer-button-spec.js
@@ -6,7 +6,7 @@ let footerBtnDom;
 
 const HTML_SNIPPET = `
 <div class="skip-nav">
-    <a class="skip-nav__link" href="#main">
+    <a class="a-btn skip-nav__link" href="#main">
         Skip to main content
     </a>
 </div>


### PR DESCRIPTION
The "super button" appearance was deprecated awhile back and isn't in the design system any longer. This PR downgrades the faux-super button skip nav buttons and converts them to regular primary buttons.

## Changes

- Convert skip nav buttons to primary appearance, instead of super


## How to test this PR

1. Tab and shift+tab on any page to see the skip-nav button. 
2. Visit http://localhost:8000/find-a-housing-counselor/ and perform a zip code search and then tab beyond the search input to see the skip nav button next to the map.


## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="638" alt="Screenshot 2025-04-25 at 3 08 59 PM" src="https://github.com/user-attachments/assets/e81b3f09-4f57-4f4a-9c44-893746ac7f44" /> |
<img width="603" alt="Screenshot 2025-04-25 at 3 09 08 PM" src="https://github.com/user-attachments/assets/c9c2cf2b-db83-4a81-8c17-ffc3beb9baba" />
|