### PR TITLE
Newsroom: fix prefooter content alignment

### DIFF
--- a/cfgov/v1/jinja2/v1/newsroom/index.html
+++ b/cfgov/v1/jinja2/v1/newsroom/index.html
@@ -40,8 +40,7 @@
                 block--flush-bottom
                 block--border-top">
         <div class="content-l">
-            <section class="block
-                            block--flush-top
+            <section class="u-mb60
                             content-l__col
                             content-l__col-1-2">
                 {% import 'v1/includes/molecules/related-content.html' as related_links %}
@@ -58,7 +57,7 @@
                     }
                 ]}) -}}
             </section>
-            <section class="block content-l__col content-l__col-1-2">
+            <section class="content-l__col content-l__col-1-2">
                 {% include 'v1/includes/templates/upcoming-events.html' %}
             </section>
         </div>


### PR DESCRIPTION
## Changes

- Newsroom: fix prefooter content alignment


## How to test this PR

1. Visit http://localhost:8000/about-us/newsroom/?categories=press-release and compare the prefooter to production across screen sizes.


## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="754" alt="Screenshot 2025-04-25 at 5 45 00 PM" src="https://github.com/user-attachments/assets/669d3c7a-7835-445d-96c5-2101dcf5bfd2" />|<img width="893" alt="Screenshot 2025-04-25 at 5 44 24 PM" src="https://github.com/user-attachments/assets/52b8dc31-cf7c-41c2-a441-9e2da7f30402" />|
|<img width="372" alt="Screenshot 2025-04-25 at 5 44 50 PM" src="https://github.com/user-attachments/assets/484e9508-c566-4455-b4d9-74113d89bd59" />|<img width="375" alt="Screenshot 2025-04-25 at 5 44 37 PM" src="https://github.com/user-attachments/assets/a5462191-479e-4599-8b47-f24cad361351" />|
