### PR TITLE
Remove unused sidefooter/prefooter from form explainer pages

### DIFF
--- a/cfgov/form_explainer/jinja2/form-explainer/index.html
+++ b/cfgov/form_explainer/jinja2/form-explainer/index.html
@@ -21,12 +21,6 @@
     {%- endfor %}
 {% endblock %}
 
-{% if page.sidefoot %}
-    <aside class="o-prefooter">
-        {{ streamfield_sidefoot.render(page.sidefoot) }}
-    </aside>
-{% endif %}
-
 {% block javascript scoped %}
     {{ super() }}
     <script src="{{ static('apps/form-explainer/js/index.js') }}"></script>

--- a/cfgov/form_explainer/models.py
+++ b/cfgov/form_explainer/models.py
@@ -47,7 +47,6 @@ class FormExplainerPage(CFGOVPage):
     edit_handler = TabbedInterface(
         [
             ObjectList(content_panels, heading="General Content"),
-            ObjectList(CFGOVPage.sidefoot_panels, heading="Sidebar"),
             ObjectList(CFGOVPage.settings_panels, heading="Configuration"),
         ]
     )


### PR DESCRIPTION

## Removals

- Remove unused sidefooter/prefooter from form explainer pages.

## How to test this PR

1. Visit http://localhost:8000/owning-a-home/loan-estimate/ and see it is unchanged from production. Edit the page in wagtail and see that their is no longer a "Sidebar" option to edit.
