### PR TITLE
Add user-agent to ssa request

### DIFF
--- a/cfgov/retirement_api/utils/ss_calculator.py
+++ b/cfgov/retirement_api/utils/ss_calculator.py
@@ -38,6 +38,10 @@ from .ss_utilities import (
 )
 
 
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+)
 TIMEOUT_SECONDS = 20
 LOGGER = logging.getLogger(__name__)
 
@@ -514,7 +518,10 @@ def get_retire_data(params, language):
             return results
     try:
         req = requests.post(
-            RESULT_URL, data=results["data"]["params"], timeout=TIMEOUT_SECONDS
+            RESULT_URL,
+            data=results["data"]["params"],
+            timeout=TIMEOUT_SECONDS,
+            headers={"User-Agent": USER_AGENT},
         )
     except requests.exceptions.ConnectionError as e:
         results["error"] = f"connection error at SSA's website: {e}"


### PR DESCRIPTION
SSA has made some changes to their website recently (see also #8786). One of these changes is breaking `before you claim`. I unbroke it by including a normal browser UA string in our backend request.

It's likely that there are a bunch of efforts right now to scrape/crawl the SSA web presence, so this was most likely added as a speed bump.

hattip to @niqjohnson who noticed this