### PR TITLE
FAHC: additional refinement of UI

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -64,9 +64,8 @@
             <h2 class="h3">Search by ZIP code</h2>
             <p>
                 Use the search box below to find a housing counselor near you.
-                <strong>Not every housing counselor offers all services,
+                Not every housing counselor offers all services,
                 so be sure to check the list of services offered by each agency.
-                </strong>
             </p>
         </div>
 

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -63,11 +63,10 @@
 
             <h2 class="h3">Search by ZIP code</h2>
             <p>
-                Using the search box below, you can find one
-                near you. <strong>Not every housing
-                counselor offers all services, so please
-                look at the list of services offered by
-                each agency.</strong>
+                Use the search box below to find a housing counselor near you.
+                <strong>Not every housing counselor offers all services,
+                so be sure to check the list of services offered by each agency.
+                </strong>
             </p>
         </div>
 
@@ -84,7 +83,7 @@
 
                             <label class="a-label a-label--heading" for="hud-hca-api-query">
                                 ZIP code
-                                <small class="a-label__helper a-label__helper--block">Please enter a valid five-digit ZIP code</small>
+                                <small class="a-label__helper a-label__helper--block">Enter a valid 5-digit ZIP code.</small>
                             </label>
 
                             {% import 'v1/includes/organisms/search-input.html' as search_input %}
@@ -97,7 +96,8 @@
                                 "has_autocomplete": autocomplete,
                                 "placeholder": '',
                                 "submit_aria_label": 'Search by ZIP Code',
-                                "max_length": 5
+                                "max_length": 5,
+                                "has_error": True if zipcode and invalid_zip_error_message else False,
                             }) }}
 
                             {% if zipcode and invalid_zip_error_message %}
@@ -109,20 +109,47 @@
                             </div>
                             {% endif %}
                         </div>
-
                     </form>
 
-                    {% if zipcode and zipcode_valid %}
-                    <div class="skip-nav">
-                        <a class="a-btn
-                                  skip-nav__link
-                                  skip-nav__link--flush-left"
-                            href="#hud_results-list_container">
-                            Skip to results
-                        </a>
+                    {% if zipcode and failed_fetch_error_message %}
+                    <div class="u-mb20">
+                        <div class="m-notification
+                                    m-notification--error
+                                    m-notification--visible">
+                            {{ svg_icon('warning-round') }}
+                            <div class="m-notification__content" role="alert">
+                                <div class="m-notification__message">
+                                    {{ failed_fetch_error_message }}
+                                </div>
+                                <div class="m-notification__explanation">
+                                    {{ failed_fetch_error_explanation }}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     {% endif %}
 
+                    <p>
+                        This tool is powered by
+                        <a class="a-link"
+                            href="https://data.hud.gov/housing_counseling.html">
+                            <span class="a-link__text">HUD's</span>
+                            {{ svg_icon('external-link') }}</a>
+                        official list of housing counselors.
+                        If you notice errors in the housing counselor data,
+                        contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
+                    </p>
+
+                    {% if zipcode and zipcode_valid %}
+                        <div class="skip-nav">
+                            <a class="a-btn
+                                    skip-nav__link
+                                    skip-nav__link--flush-left"
+                                href="#hud_results-list_container">
+                                Skip to results
+                            </a>
+                        </div>
+                    {% endif %}
                 </div>
                 {% if zipcode and zipcode_valid %}
                     <div class="hud-search-container__map">
@@ -136,24 +163,6 @@
                 {% endif %}
             </section>
         </div>
-
-        {% if zipcode and failed_fetch_error_message %}
-        <div class="u-mb20">
-            <div class="m-notification
-                        m-notification--error
-                        m-notification--visible">
-                {{ svg_icon('warning-round') }}
-                <div class="m-notification__content" role="alert">
-                    <div class="m-notification__message">
-                        {{ failed_fetch_error_message }}
-                    </div>
-                    <div class="m-notification__explanation">
-                        {{ failed_fetch_error_explanation }}
-                    </div>
-                </div>
-            </div>
-        </div>
-        {% endif %}
 
         {% if zipcode and zipcode_valid %}
         <div class="block" id="hud_results-list_container">
@@ -293,17 +302,6 @@
             </table>
         </div>
         {% endif %}
-
-    <p>
-        This tool is powered by
-        <a class="a-link"
-            href="https://data.hud.gov/housing_counseling.html">
-            <span class="a-link__text">HUD's</span>
-            {{ svg_icon('external-link') }}</a>
-        official list of housing counselors.<br>
-        If you notice errors in the housing counselor data,
-        contact <a href="mailto:housing.counseling@hud.gov">housing.counseling@hud.gov</a>.
-    </p>
 
     <div class="block
                 u-screen-only">

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -116,7 +116,7 @@
                         <div class="m-notification
                                     m-notification--error
                                     m-notification--visible">
-                            {{ svg_icon('warning-round') }}
+                            {{ svg_icon('error-round') }}
                             <div class="m-notification__content" role="alert">
                                 <div class="m-notification__message">
                                     {{ failed_fetch_error_message }}

--- a/cfgov/housing_counselor/views.py
+++ b/cfgov/housing_counselor/views.py
@@ -62,8 +62,8 @@ class HousingCounselorView(TemplateView, HousingCounselorS3URLMixin):
     }
 
     failed_fetch_msg = {
-        "failed_fetch_error_message": "Sorry, there was an error retrieving \
-            your results.",
+        "failed_fetch_error_message": "There was a problem retrieving \
+            your results",
         "failed_fetch_error_explanation": "Please try again later.",
     }
 

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
@@ -16,7 +16,7 @@
 // Tablet and above.
 @include respond-to-min($bp-sm-min) {
   .hud-search-container__text {
-    max-width: math.div(480px, $base-font-size-px) + em;
+    max-width: 41.875rem;
   }
 }
 
@@ -29,8 +29,6 @@
   .hud-search-container__text {
     flex: 1;
 
-    // Magic number of 270px below keeps full input placeholder in view.
-    min-width: math.div(270px, $base-font-size-px) + em;
     padding: math.div($grid-gutter-width, $base-font-size-px) + em;
   }
 

--- a/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
@@ -26,6 +26,8 @@
 
    value.max_length: The maximum length of characters for the input.
 
+   value.has_error: Whether to show the error styling for the input field.
+
    ========================================================================== #}
 
 {% macro render(value) %}
@@ -41,7 +43,7 @@
                id="{{ value.input_id }}"
                name="{{ value.input_name }}"
                value="{{ value.input_value or '' }}"
-               class="a-text-input"
+               class="a-text-input{% if value.has_error %} a-text-input--error{% endif %}"
                placeholder="{{ value.placeholder }}"
                title="{{ value.placeholder }}"
                autocomplete="off"


### PR DESCRIPTION
@natalia-fitzgerald requested the following:

## Changes

- Move text to the bottom of the well (inside of the well)
- Place form level alert within the well under the search input
- Remove period from form level alert heading
- Update the helper text to "Enter a valid 5-digit ZIP code. "
- Confirm that the validation text reads: "You must enter a valid 5-digit ZIP code."
- Tweak to language under "Search by ZIP code"

Addtiionally,
- Add error state to search input template.
- Adjust max-width to our standard 41.875rem

## How to test this PR

1. Check http://localhost:8000/find-a-housing-counselor/ and see the changes per the screenshots below. The floating skip nav button appears on tabbing.


## Screenshots

<img width="1260" alt="Screenshot 2025-04-29 at 10 51 31 AM" src="https://github.com/user-attachments/assets/6e7b7c21-aa96-4903-a51c-e3b2af01482d" />

<img width="1252" alt="Screenshot 2025-04-29 at 10 52 14 AM" src="https://github.com/user-attachments/assets/ee45bf0a-a0c9-4a8c-ba7f-eddaaab03222" />

<img width="534" alt="Screenshot 2025-04-29 at 10 52 26 AM" src="https://github.com/user-attachments/assets/5fa9a8c7-2835-4324-9cdf-e9b50cfc12ec" />

<img width="525" alt="Screenshot 2025-04-29 at 10 53 41 AM" src="https://github.com/user-attachments/assets/e149018f-8f23-4633-8a61-97609967f357" />
