### PR TITLE
Protect dict access in privacy/disclosure forms

### DIFF
--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -154,7 +154,7 @@ class PrivacyActForm(forms.Form):
         return loader.render_to_string(self.email_template, data)
 
     def format_subject(self):
-        name = self.cleaned_data.get("requestor_name", "")
+        name = self.cleaned_data["requestor_name"]
         truncated_name = (name[:20] + "...") if len(name) > 24 else name
         return self.email_subject + truncated_name
 

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -164,7 +164,7 @@ class PrivacyActForm(forms.Form):
             body=self.email_body(),
             from_email=settings.DEFAULT_FROM_EMAIL,
             to=[settings.PRIVACY_EMAIL_TARGET],
-            reply_to=[self.cleaned_data.get("requestor_email")],
+            reply_to=[self.cleaned_data["requestor_email"]],
         )
         email.content_subtype = "html"
 

--- a/cfgov/privacy/forms.py
+++ b/cfgov/privacy/forms.py
@@ -99,11 +99,11 @@ class PrivacyActForm(forms.Form):
     def require_address_if_mailing(self):
         data = self.cleaned_data
         msg = "Mailing address is required if requesting records by mail."
-        if data["contact_channel"] == "mail" and not (
-            data["street_address"]
-            and data["city"]
-            and data["state"]
-            and data["zip_code"]
+        if data.get("contact_channel") == "mail" and not (
+            data.get("street_address")
+            and data.get("city")
+            and data.get("state")
+            and data.get("zip_code")
         ):
             self.add_error("street_address", forms.ValidationError(msg))
 
@@ -154,7 +154,7 @@ class PrivacyActForm(forms.Form):
         return loader.render_to_string(self.email_template, data)
 
     def format_subject(self):
-        name = self.cleaned_data["requestor_name"]
+        name = self.cleaned_data.get("requestor_name", "")
         truncated_name = (name[:20] + "...") if len(name) > 24 else name
         return self.email_subject + truncated_name
 
@@ -164,7 +164,7 @@ class PrivacyActForm(forms.Form):
             body=self.email_body(),
             from_email=settings.DEFAULT_FROM_EMAIL,
             to=[settings.PRIVACY_EMAIL_TARGET],
-            reply_to=[self.cleaned_data["requestor_email"]],
+            reply_to=[self.cleaned_data.get("requestor_email")],
         )
         email.content_subtype = "html"
 

--- a/cfgov/privacy/tests/test_forms.py
+++ b/cfgov/privacy/tests/test_forms.py
@@ -22,6 +22,10 @@ class RecordsAccessFormTests(TestCase):
         )
         self.assertTrue(form.is_valid())
 
+    def test_invalid_data_has_errors(self):
+        form = RecordsAccessForm(data={}, files=self.minimum_files)
+        self.assertFalse(form.is_valid())
+
     def test_mailing_address_required(self):
         data = self.minimum_data.copy()
         data.update({"contact_channel": "mail"})
@@ -64,7 +68,7 @@ class RecordsAccessFormTests(TestCase):
         form.is_valid()  # so form.cleaned_data will be populated
         self.assertEqual(
             form.format_subject(),
-            "Records request from consumerfinance.gov: Rufus Xavier Sarsapa…",
+            "Records request from consumerfinance.gov: Rufus Xavier Sarsapa...",  # noqa E501
         )
 
     def test_email_body(self):


### PR DESCRIPTION
I imagine this was missed because the fields are required on the frontend, that is, it can only be triggered via script/shell.

This silently swallows bad data without triggering an email, which seems like the best response to invalid triggering scripts.