### PR TITLE
Allow configurable S3 file storage paths

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -73,7 +73,7 @@ export NODE_ENV=development
 # Amazon Web Services (AWS) S3.
 ###############################
 
-#export S3_ENABLED=<boolean_s3_enabled>
+#export S3_ENABLED=1
 #export AWS_ACCESS_KEY_ID=<aws_access_key_id>
 #export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
 #export AWS_STORAGE_BUCKET_NAME=<aws_storage_bucket_name>

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -9,7 +9,7 @@ import dj_database_url
 from opensearchpy import RequestsHttpConnection
 from requests_aws4auth import AWS4Auth
 
-from cfgov.util import admin_emails, environment_json
+from cfgov.util import admin_emails, environment_json, get_s3_media_config
 
 
 # Repository root is 4 levels above this file
@@ -377,26 +377,17 @@ OPENSEARCH_DSL_SIGNAL_PROCESSOR = (
     "search.elasticsearch_helpers.WagtailSignalProcessor"
 )
 
-# S3 Configuration
-# https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
-AWS_LOCATION = "f"  # A path prefix that will be prepended to all uploads
-AWS_QUERYSTRING_AUTH = False  # do not add auth-related query params to URL
-AWS_S3_FILE_OVERWRITE = False
-AWS_S3_SECURE_URLS = True  # True = use https; False = use http
-AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
-AWS_DEFAULT_ACL = None  # Default to using the ACL of the bucket
-
-if os.environ.get("S3_ENABLED", "False") == "True":
-    AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
-    AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
-    AWS_S3_CUSTOM_DOMAIN = os.environ.get("AWS_S3_CUSTOM_DOMAIN")
-    MEDIA_URL = os.path.join(
-        AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com", AWS_LOCATION, ""
-    )
-
+if os.getenv("S3_ENABLED"):
+    MEDIA_URL, storage_options = get_s3_media_config()
     STORAGES["default"] = {
-        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": storage_options,
     }
+
+# This environment variable is also used in get_s3_media_config above.
+# This is defined here as its own setting to maintain existing functionality
+# in various applications that read/write data from/to S3.
+AWS_STORAGE_BUCKET_NAME = os.getenv("AWS_STORAGE_BUCKET_NAME")
 
 # GovDelivery
 GOVDELIVERY_ACCOUNT_CODE = os.environ.get("GOVDELIVERY_ACCOUNT_CODE")

--- a/cfgov/cfgov/tests/test_util.py
+++ b/cfgov/cfgov/tests/test_util.py
@@ -1,10 +1,12 @@
 import os
-from unittest import mock
+from unittest.mock import patch
 
 from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
-from cfgov.util import admin_emails, environment_json
+from storages.backends.s3 import S3Storage
+
+from cfgov.util import admin_emails, environment_json, get_s3_media_config
 
 
 class AdminEmailsTestCase(SimpleTestCase):
@@ -19,28 +21,75 @@ class AdminEmailsTestCase(SimpleTestCase):
 
 
 class EnvironmentJsonTestCase(SimpleTestCase):
-    @mock.patch.dict(os.environ, {})
+    @patch.dict(os.environ, {})
     def test_with_variable_dne(self):
         with self.assertRaises(ImproperlyConfigured):
             environment_json("TEST_VAR")
 
-    @mock.patch.dict(os.environ, {"TEST_VAR": ""})
+    @patch.dict(os.environ, {"TEST_VAR": ""})
     def test_with_empty(self):
         with self.assertRaises(ImproperlyConfigured):
             environment_json("TEST_VAR")
 
-    @mock.patch.dict(os.environ, {"TEST_VAR": '["foo", "bar", ]'})
+    @patch.dict(os.environ, {"TEST_VAR": '["foo", "bar", ]'})
     def test_with_invalid_json(self):
         with self.assertRaises(ImproperlyConfigured):
             environment_json("TEST_VAR")
 
-    @mock.patch.dict(os.environ, {})
+    @patch.dict(os.environ, {})
     def test_with_default(self):
         self.assertEqual(environment_json("TEST_VAR", default="[]"), [])
 
-    @mock.patch.dict(os.environ, {"TEST_VAR": '["foo", "bar"]'})
+    @patch.dict(os.environ, {"TEST_VAR": '["foo", "bar"]'})
     def test_with_json_value(self):
         self.assertEqual(
             environment_json("TEST_VAR", default="Foo"),
             ["foo", "bar"],
+        )
+
+
+class S3MediaConfigTests(SimpleTestCase):
+    def assertS3Config(self, env, expected_media_url, file_path, expected_url):
+        with patch.dict("os.environ", env, clear=True):
+            media_url, storage_options = get_s3_media_config()
+            storage = S3Storage(**storage_options)
+
+            self.assertEqual(storage.url(file_path), expected_url)
+            self.assertEqual(media_url, expected_media_url)
+
+    def test_requires_bucket_name(self):
+        with self.assertRaises(KeyError) as e:
+            self.assertS3Config({}, "ignore", "ignore", "ignore")
+        self.assertEqual(e.exception.args, ("AWS_STORAGE_BUCKET_NAME",))
+
+    def test_no_custom_domain(self):
+        self.assertS3Config(
+            {
+                "AWS_STORAGE_BUCKET_NAME": "my-bucket",
+            },
+            "https://my-bucket.s3.amazonaws.com/f/",
+            "documents/test.pdf",
+            "https://my-bucket.s3.amazonaws.com/f/documents/test.pdf",
+        )
+
+    def test_custom_location(self):
+        self.assertS3Config(
+            {
+                "AWS_STORAGE_BUCKET_NAME": "my-bucket",
+                "AWS_S3_STORAGE_LOCATION": "my-files",
+            },
+            "https://my-bucket.s3.amazonaws.com/my-files/",
+            "documents/test.pdf",
+            "https://my-bucket.s3.amazonaws.com/my-files/documents/test.pdf",
+        )
+
+    def test_custom_domain(self):
+        self.assertS3Config(
+            {
+                "AWS_STORAGE_BUCKET_NAME": "my-bucket",
+                "AWS_S3_CUSTOM_DOMAIN": "my-bucket.com",
+            },
+            "https://my-bucket.com/f/",
+            "documents/test.pdf",
+            "https://my-bucket.com/f/documents/test.pdf",
         )

--- a/cfgov/cfgov/util.py
+++ b/cfgov/cfgov/util.py
@@ -24,3 +24,36 @@ def environment_json(variable_name, message=None, default=None):
         raise ImproperlyConfigured(message) from err
 
     return json_value
+
+
+def get_s3_media_config():
+    """Generate S3 file storage configuration from environment.
+
+    Returns tuple of (MEDIA_URL, storage options).
+    """
+    bucket_name = os.environ["AWS_STORAGE_BUCKET_NAME"]
+    location = os.getenv("AWS_S3_STORAGE_LOCATION") or "f"
+    custom_domain = os.getenv("AWS_S3_CUSTOM_DOMAIN")
+
+    media_domain = custom_domain or f"{bucket_name}.s3.amazonaws.com"
+    media_url = f"https://{media_domain}/{location}/"
+
+    storage_options = {
+        # Bucket to use for file storage.
+        "bucket_name": bucket_name,
+        # Default to bucket ACL.
+        "default_acl": None,
+        # Do not add auth-related query parameters to S3 URLs.
+        # Assumes public access to bucket URLs.
+        "querystring_auth": False,
+        # Don't overwrite, instead add characters to duplicate filenames.
+        # Required by Wagtail, see:
+        # https://docs.wagtail.org/en/stable/deployment/under_the_hood.html#cloud-storage.
+        "file_overwrite": False,
+        # Where in the bucket files get written.
+        "location": location,
+        # Optionally specify a custom domain for S3 URLs.
+        "custom_domain": custom_domain,
+    }
+
+    return media_url, storage_options


### PR DESCRIPTION
Currently, when cf.gov configures Django to store files to S3, files are always written under a hardcoded `/f/` path. This change makes it possible to configure the base path for S3 storage reading/writing, via a new `AWS_S3_STORAGE_LOCATION` environment variable.

This change also modernizes the way we configure the django-storages S3 backend, using storage options instead of numerous Django settings.

This change should have no impact on any existing cf.gov environments, production or otherwise, but makes it possible for multiple cf.govs to share the same S3 bucket for file storage. (This is something that has long been lacking from our internal dev server setup, and will be leveraged as part of future EKS deployments.)