### PR TITLE
Add URLs to search snippets

### DIFF
--- a/cfgov/searchgov/jinja2/searchgov/index.html
+++ b/cfgov/searchgov/jinja2/searchgov/index.html
@@ -19,9 +19,13 @@
     {{ self.desc() }}
 {%- endblock og_desc %}
 
+{% block css %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ static('apps/searchgov/css/main.css') }}">
+{% endblock %}
+
 
 {% block content_main %}
-<style>.search-result > h2{font-weight:400} .search-result p {color: var(--black)} .recommended {border-top: 2px solid var(--black); border-bottom: 2px solid var(--black)}</style>
     {% set results_header = _('Search results') %}
     <h1>{{ results_header if query else search_header }}</h1>
     {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}

--- a/cfgov/searchgov/jinja2/searchgov/recommended.html
+++ b/cfgov/searchgov/jinja2/searchgov/recommended.html
@@ -3,8 +3,8 @@
 {%- macro render(recommended) -%}
 {% if recommended | length %}
   {% set rec_hed = _('Recommended') %}
-  <div class="block u-mb45 recommended">
-    <h3 class="u-mt45">{{rec_hed}}</h3>
+  <div class="block block--flush-top u-mb45 recommended">
+    <h2 class="h5 u-mt45">{{rec_hed}}</h2>
     {% for result in recommended %}
       {{ render_result(result, "description") }}
     {% endfor %}

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -14,7 +14,8 @@
   <div class="block block--sub u-mb45">
     <a href="{{result.url}}">
       <article class="search-result">
-        <h3 class="h4 u-mb10">{{bold_matches(result.title)}}</h3>
+        <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>
+        <div class="search-result__url u-mb10">{{result.url}}</div>
         <p>{{bold_matches(result[key])}}</p>
       </article>
     </a>

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -11,7 +11,7 @@
 {%- endmacro -%}
 
 {%- macro render(result, key="snippet") -%}
-  <div class="block block--sub u-mb45">
+  <div class="u-mt45 u-mb45">
     <a href="{{result.url}}">
       <article class="search-result">
         <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>

--- a/cfgov/unprocessed/apps/searchgov/css/main.scss
+++ b/cfgov/unprocessed/apps/searchgov/css/main.scss
@@ -24,7 +24,7 @@
     margin-bottom: math.div(-10px, $base-font-size-px) + rem;
   }
 
-  .block--sub.u-mb45 {
+  .block--sub.u-mb45:last-child {
     margin-bottom: math.div(30px, $base-font-size-px) + rem !important;
   }
 }

--- a/cfgov/unprocessed/apps/searchgov/css/main.scss
+++ b/cfgov/unprocessed/apps/searchgov/css/main.scss
@@ -1,0 +1,30 @@
+@use 'sass:math';
+@use '@cfpb/cfpb-design-system/src/abstracts' as *;
+
+.search-result {
+  p {
+    color: var(--black);
+  }
+
+  &__url {
+    margin-top: math.div(4px, $base-font-size-px) + rem;
+    color: var(--gray-dark);
+    font-size: math.div(14px, $base-font-size-px) + rem;
+    max-width: math.div(670px, $base-font-size-px) + rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.recommended {
+  border-bottom: 2px solid $block-border;
+
+  > h2 {
+    margin-bottom: math.div(-10px, $base-font-size-px) + rem;
+  }
+
+  .block--sub.u-mb45 {
+    margin-bottom: math.div(30px, $base-font-size-px) + rem !important;
+  }
+}

--- a/esbuild/styles.js
+++ b/esbuild/styles.js
@@ -26,6 +26,7 @@ const styledApps = [
   'teachers-digital-platform',
   'filing-instruction-guide',
   'tccp',
+  'searchgov',
 ];
 
 const cssPaths = [


### PR DESCRIPTION
Shows URLs in search result snippets.

---

## Additions

- URLs to search result snippets

## Changes

- Tweak best bet styles
- Since I added another few lines of CSS, I moved to an app-specific stylesheet to keep everything in one place

## How to test this PR

1. Perform a search for any term and note the URLs at the end of each result.

## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="803" alt="before" src="https://github.com/user-attachments/assets/3c342888-bd09-45ef-9576-012ab3058799" />  | <img width="802" alt="after" src="https://github.com/user-attachments/assets/22907dab-2bec-4be9-b01e-cba790c87823" /> |


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)