### PR TITLE
Add dimensions to Spanish logo image

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/header.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/header.html
@@ -75,9 +75,10 @@
                              {{ static('img/logo_es_228x40@4x.png') }} 912w,
                              {{ static('img/logo_es_286x50.png') }} 286w,
                              {{ static('img/logo_es_286x50@2x.png') }} 572w"
-                     sizes="(max-width: 900px) 228px,
-                            286px"
-                     alt="Oficina para la Protección Financiera del Consumidor">
+                     sizes="(max-width: 900px) 228px, 286px"
+                     alt="Oficina para la Protección Financiera del Consumidor"
+                     width="286"
+                     height="50">
             </a>
             {% else %}
             <a class="o-header__logo" href="/">
@@ -89,8 +90,7 @@
                              {{ static('img/logo_161x34@4x.png') }} 644w,
                              {{ static('img/logo_237x50.png') }} 237w,
                              {{ static('img/logo_237x50@2x.png') }} 474w"
-                     sizes="(max-width: 900px) 161px,
-                            237px"
+                     sizes="(max-width: 900px) 161px, 237px"
                      alt="Consumer Financial Protection Bureau"
                      width="237"
                      height="50">


### PR DESCRIPTION
We have dimensions for the english logo image. It seems like we should have this for the Spanish image.

## Changes

- Add dimensions to Spanish logo image.


## How to test this PR

1. Spanish pages should have an unchanged logo dimensions.