### PR TITLE
Fix unhandled error from invalid TCCP formatter

### DIFF
--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -122,6 +122,10 @@ class CardListViewTests(TestCase):
         response = self.make_request("?credit_tier=foo")
         self.assertContains(response, "There are no results for your search.")
 
+    def test_unsupported_formatter_uses_standard_404_handling(self):
+        with self.assertRaises(Http404):
+            self.make_request("?format=invalid")
+
 
 class CardDetailViewTests(TestCase):
     @classmethod
@@ -153,6 +157,10 @@ class CardDetailViewTests(TestCase):
     def test_get_invalid_uses_standard_404_handling(self):
         with self.assertRaises(Http404):
             self.make_request("invalid-card")
+
+    def test_unsupported_formatter_uses_standard_404_handling(self):
+        with self.assertRaises(Http404):
+            self.make_request("invalid-card", "?format=invalid")
 
     def test_get_invalid_json(self):
         response = self.make_request("invalid-card", "?format=json")


### PR DESCRIPTION
Requests to a TCCP card detail page with an invalid DRF formatter currently result in an unhandled exception, for example

http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/vinton-county-national-bank-consumer-credit-card/?format=invalid

This commit fixes the current exception handling logic to properly handle this case, and also applies it to the list view, so that selecting an invalid formatter shows the regular 404 page, and not DRF's simpler one:

http://localhost:8000/consumer-tools/credit-cards/explore-cards/cards/?format=invalid

Unit tests have been added for these cases.