### PR TITLE
Specifically target page search for iregs and tdp

### DIFF
--- a/cfgov/unprocessed/apps/regulations3k/js/search.js
+++ b/cfgov/unprocessed/apps/regulations3k/js/search.js
@@ -84,7 +84,7 @@ function handleSubmit(event) {
     event.preventDefault();
   }
   const filters = document.querySelectorAll('input:checked');
-  const searchField = document.querySelector('input[name=q]');
+  const searchField = document.getElementById('query');
   const searchTerms = getSearchValues(searchField, filters);
   const baseUrl = window.location.href.split('?')[0];
   const searchParams = serializeFormFields(searchTerms);
@@ -108,7 +108,7 @@ function handleFilter(event) {
   } catch {}
   const searchContainer = document.querySelector('#regs3k-results');
   const filters = document.querySelectorAll('input:checked');
-  const searchField = document.querySelector('input[name=q]');
+  const searchField = document.getElementById('query');
   const searchTerms = getSearchValues(searchField, filters);
   const baseUrl = window.location.href.split('?')[0];
   const searchParams = serializeFormFields(searchTerms);

--- a/cfgov/unprocessed/apps/teachers-digital-platform/js/search.js
+++ b/cfgov/unprocessed/apps/teachers-digital-platform/js/search.js
@@ -106,7 +106,7 @@ function clearFilters(event) {
  * Trigger a form submit after Clear Search is clicked.
  */
 function clearSearch() {
-  document.querySelector('input[name=q]').value = '';
+  document.getElementById('search-text').value = '';
   handleSubmit(event);
 }
 
@@ -135,7 +135,7 @@ function fetchSearchResults(filters = []) {
     '#tdp-search-facets-and-results',
   );
   const baseUrl = window.location.href.split('?')[0];
-  const searchField = document.querySelector('input[name=q]');
+  const searchField = document.getElementById('search-text');
   const searchTerms = getSearchValues(searchField, filters);
   const searchParams = serializeFormFields(searchTerms);
 


### PR DESCRIPTION
Fixes page search bug that was preventing iregs and tdp JS from selecting the correct `input`

(The code was assuming `input[name=q]` was globally unique, which is no longer true!)