### PR TITLE
Temporarily remove livereload from docs to satisfy snyk

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,5 @@
 Click==8.1.7
 Jinja2==3.1.6
-livereload==2.6.3
 Markdown==3.4.4
 mkdocs==1.5.3
 mkdocs-bootstrap==1.1.1


### PR DESCRIPTION
I don't think there's enough active work on the docs to justify cleaning this up in another manner