### PR TITLE
Remove wildcard ALLOWED_HOSTS from settings.base

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -309,7 +309,8 @@ STATIC_ROOT = os.getenv("DJANGO_STATIC_ROOT", REPOSITORY_ROOT / "collectstatic")
 # Serve files under cfgov/root at the root of the website.
 WHITENOISE_ROOT = PROJECT_ROOT / "root"
 
-ALLOWED_HOSTS = ["*"]
+# To be overridden by other settings files.
+ALLOWED_HOSTS = []
 
 # Wagtail settings
 WAGTAIL_SITE_NAME = "consumerfinance.gov"

--- a/cfgov/cfgov/settings/local.py
+++ b/cfgov/cfgov/settings/local.py
@@ -4,6 +4,7 @@ from .base import *
 DEBUG = True
 ALLOW_ADMIN_URL = True
 SECRET_KEY = "not-secret-key-for-testing"
+ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS += (
     "sslserver",

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -2,6 +2,7 @@ from .base import *
 
 
 SECRET_KEY = "not-secret-key-for-testing"
+ALLOWED_HOSTS = ["*"]
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Currently settings.base defines [`ALLOWED_HOSTS`](https://docs.djangoproject.com/en/5.2/ref/settings/#allowed-hosts) as a wildcard `["*"]` which triggers a Veracode error. In practice we always override this setting in production via settings.production.

This change moves the wildcard into settings.test and settings.local to avoid the definition in our base settings. Production is unaffected by this change.

Addresses internal https://github.local/Design-Development/cfgov/issues/4612