### PR TITLE
Provide custom search.gov access to page language

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -52,6 +52,7 @@ itemscope itemtype="https://schema.org/FAQPage"
             {{ _('Consumer Financial Protection Bureau') }}
         {%- endblock title -%}
     </title>
+    <meta name="searchgov_custom1" content="{{language}}">
     <meta name="template" content="{{ self._TemplateReference__context.name }}">
     <meta name="description"
           content="


### PR DESCRIPTION
Using page facets for language search seems a more fruitful way to do multi-language search than our existing multi-search.gov-site setup (see [this nice comment by @chosak](https://github.com/cfpb/consumerfinance.gov/pull/8789#discussion_r2093151491)

This is the first, non-intrusive step in using the facet API. My plan is as follows:
 - Merge this, allow search.gov to crawl the site and pick up the custom language tags
 - Test switching site search to faceted search, adding a language param to the form and passing this through as a facet
 - Once the tags are in place (and provided we get confirmation from the search.gov team that this is the right thing to do), delete the spanish, beta, and spanish beta search.gov "sites" and switch the live search to faceted search.

The cutover process might be awkward, I have an email out to the search.gov team to figure out the best way to do this with no/low downtime for spanish search. That said, that shouldn't impact the mergeability of this PR.

As to why search.gov doesn't just use the html tag `lang` attribute? 🤷 