### PR TITLE
Address vulnerabilites in cfgov Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,16 @@ RUN \
     pip install -r requirements/deployment_container.txt && \
     apk del .build-deps
 
+# Remove setuptools to prevent the built image from triggering CVE-2025-47273,
+# which is present in setuptools<78.1.1:
+#
+# https://nvd.nist.gov/vuln/detail/CVE-2025-47273
+#
+# As long as cf.gov is on Python 3.8, we can't upgrade setuptools past v75.3:
+#
+# https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7540
+RUN pip uninstall -y setuptools
+
 # The application will run on port 8000
 EXPOSE 8000
 
@@ -157,6 +167,14 @@ COPY test.sql.gz .
 
 # Copy our static build over from node-builder
 COPY --from=node-builder ${APP_HOME} ${APP_HOME}
+
+# Delete unprocessed frontend code, which was only needed by node-builder.
+# This avoids false positive image vulnerabilities in source Node packages.
+#
+# Also delete an unused test keyfile from the ndg-httpsclient Python package.
+# This avoids a false positive due to storing a private keyfile in the image.
+RUN rm -rf ./cfgov/unprocessed && \
+    rm /usr/local/lib/python3.8/site-packages/ndg/httpsclient/test/pki/localhost.key
 
 # Run Django's collectstatic to collect assets from the frontend build.
 #


### PR DESCRIPTION
This change modifies the cfgov Dockerfile to address several image vulnerabilities identified by Prisma:

1. Our version of setuptools is vulnerable to [CVE-2025-47273](https://nvd.nist.gov/vuln/detail/CVE-2025-47273). We can't upgrade setuptools until we upgrade Python past 3.8. As a workaround, we can remove setuptools from the built image.
2. The unprocessed frontend code is left behind in the built image, which can trigger false positive vulnerabilities in source libraries. We can remove that unprocessed code from the built image.
3. One of our Python libraries (ndg-httpsclient, required by edgegrid-python) includes a sample private SSH key, which is flagged as a vulnerability. We can remove this file as it's only used for testing of the library.

With these fixes, Prisma reports no vulnerability/compliance issues.