### PR TITLE
Fix: Handle unsupported POSTs to TCCP views

### DIFF
--- a/cfgov/tccp/tests/test_views.py
+++ b/cfgov/tccp/tests/test_views.py
@@ -126,6 +126,12 @@ class CardListViewTests(TestCase):
         with self.assertRaises(Http404):
             self.make_request("?format=invalid")
 
+    def test_post_handled_properly(self):
+        view = HtmxMiddleware(CardListView.as_view())
+        request = RequestFactory().post("/")
+        response = view(request)
+        self.assertEqual(response.status_code, 405)
+
 
 class CardDetailViewTests(TestCase):
     @classmethod
@@ -171,3 +177,9 @@ class CardDetailViewTests(TestCase):
             json.loads(response.content),
             {"detail": "No CardSurveyData matches the given query."},
         )
+
+    def test_post_handled_properly(self):
+        view = CardDetailView.as_view()
+        request = RequestFactory().post("/")
+        response = view(request)
+        self.assertEqual(response.status_code, 405)

--- a/cfgov/tccp/views.py
+++ b/cfgov/tccp/views.py
@@ -89,11 +89,14 @@ class DRFExceptionMixin:
         nicer error message to the user.
 
         If the user specified an invalid or unsupported renderer (for example
-        with ?format=invalid), also show our standard Django error template.
+        with ?format=invalid), also show our standard Django error template,
+        as long as this is a GET request.
         """
         renderer = getattr(self.request, "accepted_renderer", None)
 
-        if (renderer is None) or (renderer.format == "html"):
+        if (self.request.method == "GET") and (
+            (renderer is None) or (renderer.format == "html")
+        ):
             raise exc
 
         return super().handle_exception(exc)


### PR DESCRIPTION
HTTP POST requests are not supported to TCCP views, for example https://www.consumerfinance.gov/consumer-tools/credit-cards/explore-cards/cards/. These currently trigger an unhandled 500 error due to a logic bug in the custom TCCP exception handler.

This change fixes the logic so that rest_framework.MethodNotSupported errors are properly handled by DRF logic that converts them to standard Django 405 errors.