### PR TITLE
Include the page meta description in a search.gov custom tag

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -52,7 +52,6 @@ itemscope itemtype="https://schema.org/FAQPage"
             {{ _('Consumer Financial Protection Bureau') }}
         {%- endblock title -%}
     </title>
-    <meta name="searchgov_custom1" content="{{ language }}">
     <meta name="template" content="{{ self._TemplateReference__context.name }}">
     <meta name="description"
           content="
@@ -60,6 +59,8 @@ itemscope itemtype="https://schema.org/FAQPage"
                 {{- meta_description if page else '' -}}
             {%- endblock -%}
           ">
+    <meta name="searchgov_custom1" content="{{ language }}">
+    <meta name="searchgov_custom2" content="{{ self.desc() }}">
 
     {# Always open preview panel links in a new tab. #}
     {% if request.in_preview_panel %}


### PR DESCRIPTION
We've been up and down on the usefulness of the "snippets" returned by search.gov. One possible path we've been considering is replacing them with the page description from the meta tag. While there are possible solutions for this other than a custom tag, it does feel tidy to have the description teased out (and queryable!) in search.gov.