### PR TITLE
Content update to explore-rates

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -37,7 +37,7 @@ home price, down payment, and more can affect mortgage interest rates.
             <section class="page-intro content-l">
                 <div class="content-l__col content-l__col-2-3">
                     <h1>Explore interest rates</h1>
-                    <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  Check back often -- the rates in the tool are updated every Wednesday and Friday.</p>
+                    <p class="lead">Use this tool throughout your homebuying process to explore the range of mortgage interest rates you can expect to receive.  See how your credit score, loan type, home price, and down payment amount can affect your rate.   Knowing your options and what to expect helps ensure that you get a mortgage that is right for you.  The rates were last updated April 1, 2025.</p>
                     <div class="page-intro__cols">
                         <p class="page-intro__cols-first">
                             Keep in mind that the interest rate is important,


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR modifies the introductory text of `/owning-a-home/explore-rates` to more accurately reflect the current state of data.

## How to test this PR

1. localhost
2. view `/owning-a-home/explore-rates/`
3. Compare to production


## Screenshots

| Before | After  |
| ------ | ------ |
|     <img width="808" alt="Screenshot 2025-05-29 at 1 59 01 PM" src="https://github.com/user-attachments/assets/113fb92d-9c19-4d79-84dd-c8fb5559b469" />  |    <img width="714" alt="Screenshot 2025-05-29 at 2 00 05 PM" src="https://github.com/user-attachments/assets/7037a797-5126-40fe-b75b-0c4730b33b81" /> |

