### PR TITLE
Set tdp activity page meta descriptions to their modified summary

### DIFF
--- a/cfgov/teachers_digital_platform/models/pages.py
+++ b/cfgov/teachers_digital_platform/models/pages.py
@@ -301,5 +301,12 @@ class ActivityPage(CFGOVPage):
             if topic_list:
                 return ", ".join(topic_list)
 
+    def get_meta_description(self):
+        return (
+            "Financial literacy activity where "
+            + self.summary[:1].lower()
+            + self.summary[1:]
+        )
+
     class Meta:
         verbose_name = "TDP Activity page"


### PR DESCRIPTION
No TDP activity page has a meta description. This is an SEO/search issue which we can rectify by repurposing the pages' `summary`s.

## Testing
- Pull
- Load up an [activity page](http://localhost:8000/consumer-tools/educator-tools/youth-financial-education/teach/activities/understanding-jobs-teens-taxes/)
- Look in the source or elements panel for a friendly meta description tag (instead of a blank one).