### PR TITLE
Remove snippet from search results link

### DIFF
--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -12,12 +12,12 @@
 
 {%- macro render(result, key="snippet") -%}
   <div class="search-result">
-    <a href="{{result.url}}">
-      <article>
+    <article>
+      <a href="{{result.url}}">
         <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>
-        <div class="search-result__url u-mb10">{{result.url}}</div>
-        <p>{{bold_matches(result[key])}}</p>
-      </article>
-    </a>
+        <div class="search-result__url u-mb5">{{result.url}}</div>
+      </a>
+      <p>{{bold_matches(result[key])}}</p>
+    </article>
   </div>
 {%- endmacro -%}

--- a/cfgov/unprocessed/apps/searchgov/css/main.scss
+++ b/cfgov/unprocessed/apps/searchgov/css/main.scss
@@ -12,8 +12,10 @@
 
   a {
     display: block;
+    // Give a little breathing room in outlined focus state
     padding: math.div(4px, $base-font-size-px) + rem;
     margin: math.div(-4px, $base-font-size-px) + rem;
+    margin-bottom: math.div(1px, $base-font-size-px) + rem;
   }
 
   p {


### PR DESCRIPTION
Makes the snippet plain text in search results. See github.local/Design-Development/External-Products/issues/653 for details.

---

## Changes

- Only the title and URL of each search result are in the link now; the snippet is plain text
- Slight adjustments to margins to keep the focus state outlines looking nice

## How to test this PR

1. Do any global site search and make sure only the result title and URL are links

## Screenshots

| Before | After  |
| ------ | ------ |
| ![before](https://github.com/user-attachments/assets/aafd0c8b-0aa9-4434-8012-8de77a2d1120) | ![after](https://github.com/user-attachments/assets/f88eb831-5a6c-476b-a4ad-bb6056d034e8) |


## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)