### PR TITLE
TCCP: Remove field-level alert customization

### DIFF
--- a/cfgov/unprocessed/apps/tccp/css/main.scss
+++ b/cfgov/unprocessed/apps/tccp/css/main.scss
@@ -626,11 +626,6 @@ html.js form[hx-boost] {
   }
 }
 
-.a-form-alert__text {
-  display: block;
-  margin-left: math.div(20px, $base-font-size-px) + em;
-}
-
 // Our page has no sidebar but there are a handful of
 // elements that we want to cap at a width slightly longer
 // than our standard cf.gov line length.


### PR DESCRIPTION
TCCP has a customization for field-level alerts that adds a large gap between the icon and text. I'm guessing this was maybe targeting an earlier version of the field-level alert. 

## Removals

- Remove field-level alert customization

## How to test this PR

1. Go to http://localhost:8000/consumer-tools/credit-cards/explore-cards/ and try submitting the form without selecting an item in the form. There should be a field-level alert without a wide gap.


## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="427" alt="Screenshot 2025-06-03 at 4 43 20 PM" src="https://github.com/user-attachments/assets/943f38dc-54ea-44b9-a0c8-18bc52836250" /> | <img width="417" alt="Screenshot 2025-06-03 at 4 47 34 PM" src="https://github.com/user-attachments/assets/57f28f74-3b02-457f-add3-90503753640f" /> |
