### PR TITLE
Fix labelling of search component

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -87,9 +87,9 @@
 
                             {% import 'v1/includes/organisms/search-input.html' as search_input %}
                             {{ search_input.render({
-                                "input_aria_describedby_id": "o-search-bar_error-message",
-                                "input_id": "hud-hca-api-query",
-                                "input_name": "zipcode",
+                                "input_aria_describedby_id": 'o-search-bar_error-message' if zipcode and invalid_zip_error_message else '',
+                                "input_id": 'hud-hca-api-query',
+                                "input_name": 'zipcode',
                                 "input_value": zipcode if zipcode else '',
                                 "input_aria_label": _('Search by ZIP Code'),
                                 "has_autocomplete": autocomplete,
@@ -100,7 +100,7 @@
                             }) }}
 
                             {% if zipcode and invalid_zip_error_message %}
-                            <div class="a-form-alert a-form-alert--error" role="alert">
+                            <div id="o-search-bar_error-message" class="a-form-alert a-form-alert--error" role="alert">
                                 {{ svg_icon('error-round') }}
                                 <span class="a-form-alert__text">
                                     {{ invalid_zip_error_message }}

--- a/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/search-input.html
@@ -16,7 +16,7 @@
 
    value.input_aria_label: Hidden text for the input search label.
 
-   value.input_input_aria_describedby_id: ID for an error box that describes this element.
+   value.input_aria_describedby_id: ID for an error box that describes this element.
 
    value.has_autocomplete: Whether it has an autocomplete or not.
 
@@ -35,8 +35,7 @@
 <div class="o-search-input">
     <div class="o-search-input__input{% if value.has_autocomplete %} m-autocomplete{% endif %}">
         <label for="{{ value.input_id }}"
-               class="o-search-input__input-label"
-               aria-label="{{ value.input_aria_label }}">
+               class="o-search-input__input-label">
             {{ svg_icon('search') }}
         </label>
         <input type="search"
@@ -50,6 +49,8 @@
                maxlength="{{ value.max_length or '75' }}"
                {% if value.input_aria_describedby_id %}
                aria-describedby="{{ value.input_aria_describedby_id }}"
+               {% else %}
+               aria-label="{{ value.input_aria_label }}"
                {% endif %}>
         <button type="reset"
                 onclick="document.getElementById('{{ value.input_id }}').setAttribute('value','')"


### PR DESCRIPTION
Axe 


## Changes

- Move search input `aria-label` from its associated label to the input itself.
- Fix issue with `aria-describedby` where this was being set without an associated ID.


## How to test this PR

1. Visit http://localhost:8000/find-a-housing-counselor/ and expand the global search and run a deque axe scan and there should be no flagged errors.
2. Enter an erroneous zip code to trigger an field-level error message and again run a scan and there should be no issues.
3. Use voiceover with the above to see that the search input is described in a regular and error state.
