### PR TITLE
Prepaid: Fix heading level order

### DIFF
--- a/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
+++ b/cfgov/prepaid_agreements/jinja2/prepaid_agreements/index.html
@@ -42,7 +42,7 @@
 
         <div class="search__wrapper block block--sub">
             <form class="u-mt15" method="get" action="." >
-                <h3 class="h4 u-mb5">Search within</h3>
+                <h2 class="h4 u-mb5">Search within</h2>
                 <div class="layout-row block block--sub block--flush-top">
                     <div class="a-select">
                         {% set opts = [


### PR DESCRIPTION
Fixes 

<img width="614" alt="Screenshot 2025-06-06 at 8 12 44 AM" src="https://github.com/user-attachments/assets/637984dd-1ff8-4f84-aaf0-a66750768364" />


## Changes

- Fix heading level order


## How to test this PR

1. The heading "search within" should be visually unchanged between http://localhost:8000/data-research/prepaid-accounts/search-agreements/ and production.