### PR TITLE
Adds format param to searchgov to allow json responses

### DIFF
--- a/cfgov/searchgov/forms.py
+++ b/cfgov/searchgov/forms.py
@@ -4,6 +4,7 @@ from django import forms
 class SearchForm(forms.Form):
     q = forms.CharField(strip=True)
     page = forms.IntegerField(required=False)
+    format = forms.ChoiceField(required=False, choices=[("json", "json")])
 
     def clean_page(self):
         raw = self.cleaned_data["page"]

--- a/cfgov/searchgov/tests/test_forms.py
+++ b/cfgov/searchgov/tests/test_forms.py
@@ -4,12 +4,6 @@ from searchgov.forms import SearchForm
 
 
 class SearchFormTestCase(TestCase):
-    def test_clean_term(self):
-        form = SearchForm(data={"q": "    payday^~`[]#<>;|%\\{\\}\\"})
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.cleaned_data["q"], "payday")
-        self.assertEqual(1, form.cleaned_data["page"])
-
     def test_clean_page(self):
         form = SearchForm(data={"q": "payday", "page": 3})
         self.assertTrue(form.is_valid())
@@ -22,3 +16,12 @@ class SearchFormTestCase(TestCase):
     def test_invalid_page(self):
         form = SearchForm(data={"q": "payday", "page": "fake"})
         self.assertFalse(form.is_valid())
+
+    def test_json_page(self):
+        form = SearchForm(data={"q": "payday", "page": "4", "format": "json"})
+        self.assertTrue(form.is_valid())
+
+        bad_form = SearchForm(
+            data={"q": "payday", "page": "4", "format": "something_else"}
+        )
+        self.assertFalse(bad_form.is_valid())

--- a/cfgov/searchgov/tests/test_views.py
+++ b/cfgov/searchgov/tests/test_views.py
@@ -53,3 +53,13 @@ class EncodeUrlTestCase(TestCase):
             encode_url({"query": "term&does=encode"}),
             API_ENDPOINT.format("query=term%26does%3Dencode"),
         )
+
+
+class JsonTestCase(TestCase):
+    def test_json_response(self):
+        response = self.client.get("/search/?q=mortgage&format=json")
+        self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_html_response(self):
+        response = self.client.get("/search/?q=mortgage")
+        self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")

--- a/cfgov/searchgov/views.py
+++ b/cfgov/searchgov/views.py
@@ -2,6 +2,7 @@ import math
 from urllib.parse import urlencode
 
 from django.conf import settings
+from django.http import JsonResponse
 
 import requests
 
@@ -102,17 +103,21 @@ class SearchView(TranslatedTemplateView):
                         res["title"] = res["title"][:-39]
                 else:
                     count = 0
-        context.update(
-            {
-                "query": query,
-                "count": count,
-                "start_index": start_index,
-                "end_index": end_index,
-                "total_pages": total_pages,
-                "current_page": current_page,
-                "recommended": recommended,
-                "results": results,
-            }
-        )
+
+        context_data = {
+            "query": query,
+            "count": count,
+            "start_index": start_index,
+            "end_index": end_index,
+            "total_pages": total_pages,
+            "current_page": current_page,
+            "recommended": recommended,
+            "results": results,
+        }
+
+        if form.cleaned_data.get("format") == "json":
+            return JsonResponse(context_data)
+
+        context.update(context_data)
 
         return self.render_to_response(context)


### PR DESCRIPTION
Since we're mostly passing through a response from search.gov, this seemed simpler and more appropriate than using Djagno Rest Framework (not sure if @chosak agrees though!)

## Testing
- Pull and add &format=json to a request, eg http://localhost:8000/search/?q=mortgages&format=json
- Invalid formats are swallowed/result in an empty page