### PR TITLE
Update searchgov template to render results local to the deployment

### DIFF
--- a/cfgov/searchgov/jinja2/searchgov/index.html
+++ b/cfgov/searchgov/jinja2/searchgov/index.html
@@ -69,11 +69,13 @@
         </div>
       {% endif %}
 
-      {{render_recommended(recommended)}}
+      {%- set domain = '/'.join(request.build_absolute_uri().split('/')[:3]) -%}
+
+      {{render_recommended(recommended, domain)}}
 
       <h2 class="u-visually-hidden">Results</h2>
       {% for res in results -%}
-        {{render_result(res)}}
+        {{render_result(res, domain)}}
       {%- endfor %}
       </div>
       <div class="block block--sub">

--- a/cfgov/searchgov/jinja2/searchgov/recommended.html
+++ b/cfgov/searchgov/jinja2/searchgov/recommended.html
@@ -1,12 +1,12 @@
 {% from './result.html' import render as render_result %}
 
-{%- macro render(recommended) -%}
+{%- macro render(recommended, domain) -%}
 {% if recommended | length %}
   {% set rec_hed = _('Recommended') %}
   <div class="block block--flush-top u-mb45 recommended">
     <h2 class="h5 u-mt45">{{rec_hed}}</h2>
     {% for result in recommended %}
-      {{ render_result(result, "description") }}
+      {{ render_result(result, domain, "description") }}
     {% endfor %}
   </div>
 {% endif %}

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -10,12 +10,17 @@
   {% endfor %}
 {%- endmacro -%}
 
-{%- macro render(result, key="snippet") -%}
+{%- macro replace_url(url, domain) -%}
+  {{url.replace("https://www.consumerfinance.gov", domain)}}
+{%- endmacro -%}
+
+{%- macro render(result, domain, key="snippet") -%}
+  {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>
-      <a href="{{result.url}}">
+      <a href="{{url}}">
         <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>
-        <div class="search-result__url u-mb5">{{result.url}}</div>
+        <div class="search-result__url u-mb5">{{url}}</div>
       </a>
       <p>{{bold_matches(result[key])}}</p>
     </article>


### PR DESCRIPTION
This is generally useful when testing and also better for dev servers and beta. This will also allow us to remove our beta and beta_es search.gov sites and associated logic + vars.

## Testing
 - Pull
 - Visit http://localhost:8000/search/?q=mortgage
 - Note both the recommended results and the normal results have both actual urls and url labels updated to reflect the local protocol+domain+port (in this case http://localhost:8000).