### PR TITLE
Add git to the centos7 artifact-builder container

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 FROM centos7-py38 AS cfgov-artifact-builder
 
 RUN \
-    yum install -y gcc && \
+    yum install -y gcc git && \
     source /opt/rh/rh-python38/enable && \
     pip install --no-cache-dir -U pip setuptools wheel
 


### PR DESCRIPTION
Testing CCDB API code in the cfgov context requires that we install a branch of the ccdb5-api repo via cfgov's requirements/libraries.txt file.

The libraries.txt file normally imports wheel artifacts that don't require git. But for testing, we use a "git+https" protocol and ".git" suffix to install a branch, and that process invokes git.

It appears that when we moved to the centos7 container for building artifacts, we lost the ability to add packages via this "git+https" method.

Attempts to build a cfgov artifact for deploying ccdb5-api code to a dev server now fail on this error:

```bash
ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```

build reference: https://github.com/cfpb/consumerfinance.gov/actions/runs/15600446370/job/43939229340

I didn't want to pollute our GHCR registry with test images, so I'm posting this PR for feedback.
