### PR TITLE
Remove code supporting beta search site

### DIFF
--- a/cfgov/searchgov/tests/test_views.py
+++ b/cfgov/searchgov/tests/test_views.py
@@ -12,29 +12,13 @@ from searchgov.views import (
 
 
 class GetAffiliateTestCase(TestCase):
-    @patch("searchgov.views.environment_is")
-    def test_is_cfpb(self, test_patch):
-        test_patch.return_value = False
+    def test_is_cfpb(self):
         affiliate = get_affiliate({"current_language": "en"})
         self.assertEqual(affiliate, "cfpb")
 
-    @patch("searchgov.views.environment_is")
-    def test_is_cfpb_beta(self, test_patch):
-        test_patch.return_value = True
-        affiliate = get_affiliate({"current_language": "en"})
-        self.assertEqual(affiliate, "cfpb_beta")
-
-    @patch("searchgov.views.environment_is")
-    def test_is_cfpb_es(self, test_patch):
-        test_patch.return_value = False
+    def test_is_cfpb_es(self):
         affiliate = get_affiliate({"current_language": "es"})
         self.assertEqual(affiliate, "cfpb_es")
-
-    @patch("searchgov.views.environment_is")
-    def test_is_cfpb_beta_es(self, test_patch):
-        test_patch.return_value = True
-        affiliate = get_affiliate({"current_language": "es"})
-        self.assertEqual(affiliate, "cfpb_beta_es")
 
 
 class GetApiKeyTestCase(TestCase):

--- a/cfgov/searchgov/views.py
+++ b/cfgov/searchgov/views.py
@@ -6,7 +6,6 @@ from django.http import JsonResponse
 
 import requests
 
-from core.feature_flags import environment_is
 from core.views import TranslatedTemplateView
 
 from .forms import SearchForm
@@ -20,18 +19,12 @@ RESULTS_PER_PAGE = 20
 def get_affiliate(context):
     """Given a request, return the appropriate affiliate for Search.gov.
     Our default affiliate code is "cfpb". We have a separate Spanish-language
-    index named "cfpb_es". We then have two additional indexes, "cfpb_beta"
-    and "cfpb_beta_es", for use on beta.consumerfinance.gov.
+    index named "cfpb_es".
     """
-    affiliate = "cfpb"
-
-    if environment_is("beta"):
-        affiliate += "_beta"
-
     if context.get("current_language") == "es":
-        affiliate += "_es"
+        return "cfpb_es"
 
-    return affiliate
+    return "cfpb"
 
 
 def get_api_key(context):

--- a/docs/site-search.md
+++ b/docs/site-search.md
@@ -13,10 +13,6 @@ We maintain several independent search indexes on Search.gov for various purpose
   [www.consumerfinance.gov](https://www.consumerfinance.gov).
 - `cfpb_es`: Spanish-language search for pages under
   [www.consumerfinance.gov/es/](https://www.consumerfinance.gov/es/).
-- `cfpb_beta`: An alternate English-language search index for
-  [beta.consumerfinance.gov](https://beta.consumerfinance.gov).
-- `cfpb_beta_es`: An alternate Spanish-language search index for
-  [beta.consumerfinance.gov/es/](https://beta.consumerfinance.gov/es/).
 
 These search indexes are hardcoded depending on the page being viewed.
 


### PR DESCRIPTION
The beta site and spanish beta site in search.gov have been removed and no longer need this supporting code. A separate change will come to adjust internal envvars.