### PR TITLE
Include Puerto Rico in geocoding URI

### DIFF
--- a/cfgov/housing_counselor/geocoder.py
+++ b/cfgov/housing_counselor/geocoder.py
@@ -183,7 +183,7 @@ class BulkZipCodeGeocoder:
         return (
             "https://api.mapbox.com"
             "/geocoding/v5/mapbox.places-permanent/{zipcodes}.json"
-            "?types=postcode&autocomplete=false&limit=1"
+            "?country=us,pr&types=postcode&autocomplete=false&limit=1"
             "&access_token={access_token}"
         ).format(zipcodes=";".join(zipcodes), access_token=self.access_token)
 


### PR DESCRIPTION
Including this param excludes puerto rico, which is incorrect.

I haven't noticed any ill-effects/differences in response from dropping it.