### PR TITLE
Display Guam to the left of Hawaii on the fahc map

### DIFF
--- a/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/js/common.js
@@ -131,7 +131,10 @@ function updateMap(data) {
 
     data.counseling_agencies.forEach((val, i) => {
       const lat = val.agc_ADDR_LATITUDE;
-      const lng = val.agc_ADDR_LONGITUDE;
+      let lng = val.agc_ADDR_LONGITUDE;
+      //Operate only on negative longitudes
+      //So Guam will be left of HI on the map
+      if (lng > 0) lng = lng - 360;
       const position = new window.L.LatLng(lat, lng);
 
       if (lat > ymax) ymax = lat;


### PR DESCRIPTION
Current:
<img width="1207" alt="Screenshot 2025-06-30 at 10 07 15 AM" src="https://github.com/user-attachments/assets/acf0293b-1be6-4440-ae21-eb83f935c2d2" />

With this PR:
<img width="1242" alt="Screenshot 2025-06-30 at 10 08 00 AM" src="https://github.com/user-attachments/assets/1edde8ba-930c-4848-bc3b-bda7f92ea4f5" />

Is it helpful to show HI housing counselors to people in Guam? Maybe not. But, avoiding that question, this is a better experience as things stand.