### PR TITLE
Add GitHub Action to validate Docker image build

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-docker-images:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,20 @@
+name: Build cf.gov Docker images
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build cfgov image
+        run: docker build -t cfgov:latest .
+
+      - name: Build cfgov-apache image
+        run: docker build -t cfgov-apache:latest cfgov/apache


### PR DESCRIPTION
We don't currently have a GitHub Action that makes sure that our Docker images (`cfgov` and `cfgov-apache`) build successfully after all PRs. We recently had a couple of PRs that broke the frontend build in the Docker context.

This PR adds a new GitHub Action that verifies that those images can build.