### PR TITLE
Remove google optimize legacy code cruft and AB_TESTING flag

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -501,8 +501,6 @@ CSP_SCRIPT_SRC = (
     "*.googleanalytics.com",
     "*.google-analytics.com",
     "*.googletagmanager.com",
-    "*.googleoptimize.com",
-    "optimize.google.com",
     "api.mapbox.com",
     "js-agent.newrelic.com",
     "bam.nr-data.net",
@@ -524,7 +522,6 @@ CSP_STYLE_SRC = (
     "'unsafe-inline'",
     "*.consumerfinance.gov",
     "*.googletagmanager.com",
-    "optimize.google.com",
     "fonts.googleapis.com",
     "api.mapbox.com",
     "www.ssa.gov/accessibility/andi/",
@@ -539,7 +536,6 @@ CSP_IMG_SRC = (
     "img.youtube.com",
     "*.google-analytics.com",
     "*.googletagmanager.com",
-    "optimize.google.com",
     "api.mapbox.com",
     "*.tiles.mapbox.com",
     "blob:",
@@ -557,8 +553,6 @@ CSP_FRAME_SRC = (
     "*.consumerfinance.gov",
     "*.googletagmanager.com",
     "*.google-analytics.com",
-    "*.googleoptimize.com",
-    "optimize.google.com",
     "www.youtube.com",
     "*.qualtrics.com",
     "mailto:",
@@ -572,7 +566,6 @@ CSP_CONNECT_SRC = (
     "'self'",
     "*.consumerfinance.gov",
     "*.google-analytics.com",
-    "*.googleoptimize.com",
     "*.tiles.mapbox.com",
     "api.mapbox.com",
     "bam.nr-data.net",
@@ -610,10 +603,6 @@ FLAGS = {
     "CFPB_RECRUITING": [],
     # When enabled, display a "technical issues" banner on /complaintdatabase
     "CCDB_TECHNICAL_ISSUES": [],
-    # Google Optimize code snippets for A/B testing
-    # When enabled this flag will add various Google Optimize code snippets.
-    # Intended for use with path conditions.
-    "AB_TESTING": [],
     # Manually enabled when Beta is being used for an external test.
     # Controls the /beta_external_testing endpoint, which Jenkins jobs
     # query to determine whether to refresh Beta database.

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -182,22 +182,6 @@ itemscope itemtype="https://schema.org/FAQPage"
     {# Don't load certain scripts in the Wagtail preview panel. -#}
     {% if not request.in_preview_panel %}
 
-    {% if flag_enabled('AB_TESTING') %}
-    {# Begin Google Optimize #}
-    {# Optimize anti-flicker snippet. #}
-    <style>.async-hide { opacity: 0 !important} </style>
-    <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-    })(window,document.documentElement,'async-hide','dataLayer',4000,
-    {'GTM-KMMLRS':true});</script>
-    {#
-      NOTE: We don't include the googleoptimize.com/optimize.js script call here
-      because we are including optimize via GTM.
-    #}
-    {# End Google Optimize #}
-    {% endif %}
-
     {# Begin Google Tag Manager #}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -30,7 +30,7 @@ FLAGS = {
 }
 ```
 
-By convention our flag names are all uppercase, with underscores instead of whitespace. A comment is expected above each flag with a short description fo what happens when it is enabled.
+By convention our flag names are all uppercase, with underscores instead of whitespace. A comment is expected above each flag with a short description of what happens when it is enabled.
 
 ## Checking a flag
 


### PR DESCRIPTION
Google Optimize settings were added in https://github.com/cfpb/consumerfinance.gov/pull/7444, however, since that time Google Optimize has been sunset https://support.google.com/analytics/answer/12979939?hl=en

This PR removes the references to `optimize.google.com` and `googleoptimize.com`. Additionally, it removes the `AB_TESTING` flag.

## Removals

- Remove google optimize legacy code cruft.
- Remove `AB_TESTING` optimize flag.

## How to test this PR

1. PR checks should pass.

## Notes
I left the `fonts.gstatic.com` settings, since they may be used by google analytics too (not sure if they actually are).

## Todo

Follow the Feature Flag hygiene instructions after this is merged https://cfpb.github.io/consumerfinance.gov/feature-flags/#hygiene
