### PR TITLE
Adding "send-notifications" parameter to signup block

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/email-signup.html
@@ -83,6 +83,7 @@
         </div>
 
         <input type="hidden" name="code" value="{{ value.code }}">
+        <input type="hidden" name="send-notifications" value=true>
     </form>
 {% endif %}
 </div>


### PR DESCRIPTION
<!-- Enter an explanation of what the pull request does and why. -->
This PR attempts to send a `send-notifications` value on submission of our GovDelivery email signup form, which should force the submitter to confirm via email that they want to be signed up.

(This comes from internal stakeholder discussions with GovDelivery on how to accomplish this, which is desired because we have an increasing number of bots and other invalid traffic getting added to subscriber lists.)

## How to test this PR

1. see below


## Notes and todos

- This is repurposing a parameter from [GovDelivery's "add a subscription" documentation](https://developers.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm%20Cloud%20V1/API_CommCloudV1_Subscriptions_AddSubscription.htm%3FTocPath%3DCommunications%2520Cloud%2520API%2520v1%7CResources%7CSubscriptions%7C_____1), which is written assuming an XML file is being submitted, so I'm not entirely sure I'm doing it properly.
- I am not sure this can be tested on a local environment because the email signup module doesn't appear to grab the API code properly in that environment?
- This is **not** urgent. I pinged several folks as reviewers because I figure, for someone who is already at least somewhat familiar with how this email signup code works, this should be a relatively light thing to knock out when time allows. If I'm wrong in that assumption, please let me know and we can ask the stakeholders involved to re-submit through more appropriate channels to get bandwidth established.