### PR TITLE
Update meta description tags for non-Wagtail pages

### DIFF
--- a/cfgov/agreements/jinja2/agreements/archive.html
+++ b/cfgov/agreements/jinja2/agreements/archive.html
@@ -1,3 +1,5 @@
+{% set manual_desc="Access all Credit Card agreements collected from the most recent or earlier quarterly collection periods." %}
+
 {% extends "agreements/base_agreements.html" %}
 
 {% block title -%}

--- a/cfgov/agreements/jinja2/agreements/base_agreements.html
+++ b/cfgov/agreements/jinja2/agreements/base_agreements.html
@@ -1,3 +1,5 @@
+{% set manual_desc="We maintain a database of credit card agreements from more than 600 card issuers. Using the database, you can search for an agreement by the name of the issuer." %}
+
 {% extends "v1/layouts/layout-2-1.html" %}
 
 {% block javascript scoped %}

--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -1,3 +1,4 @@
+{% set manual_desc="Use our tool to find a HUD-approved housing counseling agency near you. Housing counselors throughout the country can provide advice on buying a home, renting, defaults, forbearances, foreclosures, and credit issues." %}
 {% extends "v1/layouts/layout-full.html" %}
 {% import "v1/includes/molecules/social-media.html" as social_media with context %}
 

--- a/cfgov/jinja2/know-before-you-owe/index.html
+++ b/cfgov/jinja2/know-before-you-owe/index.html
@@ -1,3 +1,4 @@
+{% set manual_desc="Learn how the Loan Estimate and Closing Disclosure forms can help people compare mortgage loans more easily and avoid suprises at closing. Access tools and resources that help buyers and professionals during the mortgage process." %}
 {% extends 'v1/layouts/layout-full.html' %}
 
 {% import 'v1/includes/organisms/video-player.html' as video_player with context %}

--- a/cfgov/retirement_api/jinja2/retirement_api/about.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/about.html
@@ -1,3 +1,5 @@
+{% set manual_desc="Learn how our Planning for Retirement tool works and how we generate estimates based on age and work income." %}
+
 {% extends 'v1/layouts/layout-2-1.html' %}
 
 {% block title %}

--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -5,6 +5,8 @@
 }]%}
 {% endif %}
 
+{% set manual_desc="The age you claim Social Security affects the amount of monthly benefits you’ll receive. We’ll help you think through this decision." %}
+
 {% extends 'v1/layouts/layout-full.html' %}
 
 {% block title %}

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -56,7 +56,13 @@ itemscope itemtype="https://schema.org/FAQPage"
     <meta name="description"
           content="
             {%- block desc -%}
-                {{- meta_description if page else '' -}}
+                {% if page %}
+                {{- meta_description -}}
+                {% elif manual_desc %}
+                {{- manual_desc -}}
+                {% else %}
+                {{- '' -}}
+                {%- endif -%}
             {%- endblock -%}
           ">
     <meta name="searchgov_custom1" content="{{ language }}">


### PR DESCRIPTION
Several of our pages lack `meta name="description"` tags in the header. These tags usually come from Wagtail, but when it is not a Wagtail page, they are blank. 

To fix that, I've added a variable, `manual_desc`, that can be set before importing layout jinja templates. When `page` is not available, the script will check for `manual_desc` and use that as the meta description tag content.

I've also added descriptions for several pages, as requested by @ajbush .

## Changes
- Added `manual_desc` variable to `base.html`. 
- Added `manual_desc` to several jinja files (see modified files for details)


## How to test this PR
1. Load up pages that now have meta description tags:
      - localhost/find-a-housing-counselor/
      - localhost/consumer-tools/retirement/before-you-claim/
      - localhost/consumer-tools/retirement/before-you-claim/about/
      - localhost/credit-cards/agreements/
      - localhost/credit-cards/agreements/archive/
      - localhost/know-before-you-owe/
2. You should find meta descriptions like the following in the HTML:
      ```
      <meta name="description" content="Learn how the Loan Estimate and Closing Disclosure
      forms can help people compare mortgage loans more easily and avoid suprises at closing.
      Access tools and resources that help buyers and professionals during the mortgage process.">
      ```
      They should **NOT** look like this:
      ```
      <meta name="description" content>
      ```


## Checklist
- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
