### PR TITLE
Update Mouseflow CSP

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -572,7 +572,7 @@ CSP_CONNECT_SRC = (
     "gov-bam.nr-data.net",
     "s3.amazonaws.com",
     "public.govdelivery.com",
-    "n2.mouseflow.com",
+    "*.mouseflow.com",
     "*.qualtrics.com",
     "raw.githubusercontent.com",
 )


### PR DESCRIPTION
Update the allowed Mouseflow URL in `CSP_CONNECT_SRC`; it now matches other allowed Mouseflow URLs. See github.local/Design-Development/External-Products/issues/685 for details.

---

## Changes

- Allowed Mouseflow URLs in `CSP_CONNECT_SRC`

## How to test this PR

I'm not sure there's a way to test this locally. As noted in the issue, the URL `us01.rec.mouseflow.com` needs to be allowed in `CSP_CONNECT_SRC`.

## Notes and todos

- We'll need to do a delete-purge in Akamai once this change is deployed for all pages to pick up the change.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets