### PR TITLE
Remove non-clickable tag pattern

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/organisms/secondary-nav-fig.html
+++ b/cfgov/v1/jinja2/v1/includes/organisms/secondary-nav-fig.html
@@ -19,10 +19,7 @@
 {% macro render(version_status=none, effective_start_date=none, effective_end_date=none) %}
 <div class="o-fig__sidebar">
     <div class="u-hide-on-tablet">
-        {% if version_status %}
-            <div class="a-tag-filter u-mb20">
-                {{ version_status }}
-            </div>
+        {% if version_status and effective_start_date and effective_end_date %}
             <p>
                 Effective {{ effective_start_date }} to {{ effective_end_date }}
             </p>


### PR DESCRIPTION


## Removals

- Remove non-clickable tag pattern.


## How to test this PR

1. Visit http://localhost:8000/data-research/small-business-lending/filing-instructions-guide/2024-guide-archive-v1/ and see that the non-clickable "Archived" tag is gone, as well as the "effective None to None" dates


## Screenshots

| Before | After  |
| ------ | ------ |
|      <img width="389" height="358" alt="Screenshot 2025-07-16 at 6 01 26 PM" src="https://github.com/user-attachments/assets/a6d4b76c-04bf-4917-a236-b7760f248fb5" /> | <img width="411" height="366" alt="Screenshot 2025-07-16 at 6 01 39 PM" src="https://github.com/user-attachments/assets/74cc14ab-3fdd-4723-8db0-e56a946f49c3" /> |
