### PR TITLE
Fix unhandled link parsing exception

### DIFF
--- a/cfgov/core/tests/test_utils.py
+++ b/cfgov/core/tests/test_utils.py
@@ -406,3 +406,9 @@ class TextMatchesHrefTests(SimpleTestCase):
         ]:
             with self.subTest(text=text, href=href):
                 self.assertFalse(text_matches_href(text, href))
+
+    def test_urlparse_exceptions(self):
+        # https://discuss.python.org/t/urlparse-can-sometimes-raise-an-exception-should-it/44465
+        self.assertFalse(text_matches_href("https://\uff03", "https://foo"))
+        self.assertFalse(text_matches_href("https://\uff03", "https://\uff1a"))
+        self.assertTrue(text_matches_href("https://\uff03", "https://\uff03"))

--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -146,7 +146,10 @@ def text_matches_href(text, href):
         elif "://" not in url:
             url = "https://RELATIVE/" + url.lstrip("/")
 
-        return urlparse(url)
+        try:
+            return urlparse(url)
+        except ValueError:
+            return None
 
     def normalize_domain(domain):
         if domain.startswith("www."):
@@ -155,6 +158,10 @@ def text_matches_href(text, href):
 
     def normalize(url):
         parsed = parse_potential_url(url)
+
+        if parsed is None:
+            return url
+
         netloc = parsed.netloc or "RELATIVE"
         path = parsed.path.rstrip("/")
 


### PR DESCRIPTION
Commit bf5a764d744573b32f128124ec80f222d3f4040f (#8848) introduced a bug in our link parsing logic that would raise an unhandled exception for certain links. Links with text containing certain invalid characters would trigger a ValueError in urlparse, which cause a 500 error on pages like:

https://www.consumerfinance.gov/about-us/blog/guide-covid-19-economic-stimulus-checks-zh/

This commit fixes that bug and adds appropriate unit tests.