### PR TITLE
Docs: Remove reference to missing k8s page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,6 @@ nav:
   - Running this Project:
       - Running in a Virtual Environment: running-virtualenv.md
       - Running in Docker: running-docker.md
-      - Running in Kubernetes: running-k8s.md
       - Running documentation site locally: running-docs.md
       - Debugging and Monitoring: debugging-monitoring.md
       - Artifacts and Deployment: deployment.md


### PR DESCRIPTION
Commit 6f18cb6cb69e34739208a358d6b45725b0b9d466 removed a documentation page related to Kubernetes, but did not remove a reference to it from the docs table of contents. This causes documentation builds to fail.

See for example failing GitHub Action here:
https://github.com/cfpb/consumerfinance.gov/actions/runs/16422811362/job/46405557057