### PR TITLE
Fix broken httpd proxying behavior

### DIFF
--- a/cfgov/apache/conf.d/proxy.conf
+++ b/cfgov/apache/conf.d/proxy.conf
@@ -5,6 +5,11 @@
 # application is moved to Gunicorn.
 ServerName https://www.consumerfinance.gov
 
-RewriteCond expr "-n env('CFGOV_APPLICATION_PROXY')"
-RewriteRule ^/(.*)$ ${CFGOV_APPLICATION_PROXY}/$1 [P]
-ProxyPassReverse / ${CFGOV_APPLICATION_PROXY}/
+<If "-n env('CFGOV_APPLICATION_PROXY')">
+    Define CFGOV_APPLICATION_PROXY_ENABLED
+</If>
+
+<IfDefine CFGOV_APPLICATION_PROXY_ENABLED>
+    RewriteRule ^/(.*)$ ${CFGOV_APPLICATION_PROXY}/$1 [P]
+    ProxyPassReverse / ${CFGOV_APPLICATION_PROXY}/
+</IfDefine>

--- a/cfgov/apache/conf/httpd.conf
+++ b/cfgov/apache/conf/httpd.conf
@@ -31,6 +31,7 @@ PassEnv APACHE_UPLOADS_F_ALIAS
 PassEnv APACHE_HTTPS_FORWARDED_HOST
 PassEnv APACHE_PORT
 PassEnv LIMIT_REQUEST_BODY
+PassEnv CFGOV_APPLICATION_PROXY
 
 # These values are needed for running in containerized Apache
 PassEnv APACHE_USER


### PR DESCRIPTION
Apache httpd [version 2.4.64](https://www.apachelounge.com/changelog-2.4.html) made some changes to proxying behavior that broke how our cfgov-apache container works in some cases. See for example failing GitHub Action [here]( https://github.com/cfpb/consumerfinance.gov/actions/runs/16422622672/job/46404916793).

The issue was actually an undiscovered bug in the existing proxying logic added back in 7c686cd6050127d22db62eb47348d58cd2ffa2ad.