### PR TITLE
Update password min-length to 14 chars

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -420,7 +420,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         "OPTIONS": {
-            "min_length": 12,
+            "min_length": 14,
         },
     },
     {


### PR DESCRIPTION
Changes password min-length to 14, up from 12.

This will not immediately affect existing accounts unless we mass invalidate them.

