### PR TITLE
Fix retirement error animations and error display

### DIFF
--- a/cfgov/retirement_api/jinja2/retirement_api/claiming.html
+++ b/cfgov/retirement_api/jinja2/retirement_api/claiming.html
@@ -83,7 +83,7 @@
                 <h2 class="content-l__col content-l__col-2-3"><strong>{{STEP}} 1: </strong>{{ _("Explore how the age you start collecting Social Security affects your retirement benefits") }}</h2>
                 <form id="step-one-form" name="step-one-form" action="#" class="content-l__col content-l__col-2-3">
                     <p class="h3 step-one-instructions">{{ _("Enter your information below to calculate your estimated benefits.") }}</p>
-                    <div class="m-notification m-notification--warning">
+                    <div style="display: none" class="m-notification m-notification--visible m-notification--warning">
                         {{ svg_icon('warning-round') }}
                         <div class="m-notification__content">
                             <div class="m-notification__message">Error message.</div>

--- a/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
+++ b/cfgov/unprocessed/apps/retirement/js/views/graph-view.js
@@ -242,13 +242,15 @@ function getYourEstimates() {
   const salaryInputElm = document.querySelector('#salary-input');
   const salary = convertStringToNumber(salaryInputElm.value);
 
-  // Hide warnings, show loading indicator
-  $('.m-notification').slideUp();
-  highlightAgeFields(false);
+  //show loading indicator
   const loadIndDom = document.querySelector('#get-your-estimates');
   loadIndDom.classList.remove('a-btn--hide-icon');
   fetchApiData(dates.concat, salary).then((resp) => {
     if (resp.error === '') {
+      // Hide warnings
+      $('.m-notification').slideUp();
+      highlightAgeFields(false);
+
       updateDataFromApi(resp);
       $('.step-two .question').css('display', 'inline-block');
       $(
@@ -277,7 +279,7 @@ function getYourEstimates() {
         );
       }
     } else {
-      $('.m-notification').slideDown();
+      $('.m-notification').slideDown('flex');
       $('.m-notification .m-notification__content').html(resp.note);
       if (resp.current_age >= 71 || resp.current_age < 21) {
         highlightAgeFields(true);

--- a/cfgov/unprocessed/js/modules/util/dollar-sign.js
+++ b/cfgov/unprocessed/js/modules/util/dollar-sign.js
@@ -433,11 +433,14 @@ Query.prototype.slideUp = function (duration = 500) {
   return this;
 };
 
-Query.prototype.slideDown = function (duration = 500) {
+Query.prototype.slideDown = function (
+  defaultDisplay = 'block',
+  duration = 500,
+) {
   this.elements.forEach((elem) => {
     elem.style.removeProperty('display');
     let display = document.defaultView.getComputedStyle(elem).display;
-    if (display === 'none') display = 'block';
+    if (display === 'none') display = defaultDisplay;
     elem.style.display = display;
     const height = elem.offsetHeight;
     for (const key in slideDownVars.styles) {


### PR DESCRIPTION
Currently, due to a bug in `dollar-sign.js` (or rather, different assumptions in jquery vs. that library), notifications are broken on retirement/before-you-claim. This makes the `slideUp`/`slideDown` calls mutually exclusive on whether there is an error, so that they won't conflict and break.

The notification molecule has also been redesigned to use `display: flex`, so there's some logic in this PR to use that as well, otherwise the notification icon will appear on its own line.

<img width="839" height="297" alt="Screenshot 2025-07-28 at 11 29 30 AM" src="https://github.com/user-attachments/assets/70c50914-36b3-4d8d-9f1c-f73f978cb81c" />

