### PR TITLE
Remove fahc pdf link

### DIFF
--- a/cfgov/housing_counselor/jinja2/housing_counselor/index.html
+++ b/cfgov/housing_counselor/jinja2/housing_counselor/index.html
@@ -171,28 +171,12 @@
         {% if zipcode and zipcode_valid %}
         <div class="block" id="hud_results-list_container">
             <div class="results-header">
-                <ul class="m-list
-                           m-list--horizontal
-                           hud-hca-api-results-actions">
-                    <li class="m-list__item">
-                        <a class="a-link"
-                            id="hud_print-page-link"
-                            href="#">
-                            <span class="a-link__text">Print list</span>
-                            {{ svg_icon('print') }}
-                        </a>
-                    </li>
-                    <li class="m-list__item">
-                        <a class="a-link"
-                            id="generate-pdf-link"
-                            href="{{ pdf_url }}"
-                            target="_blank"
-                            rel="noopener noreferrer">
-                            <span class="a-link__text">Save list as <abbr title="Portable Document Format">PDF</abbr></span>
-                            {{ svg_icon('download') }}
-                        </a>
-                    </li>
-                </ul>
+                <a class="a-link"
+                    id="hud_print-page-link"
+                    href="#">
+                    <span class="a-link__text">Print list</span>
+                    {{ svg_icon('print') }}
+                </a>
 
                 <h2 class="h4">
                     Displaying the

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud-print.scss
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud-print.scss
@@ -99,8 +99,13 @@
   /* Hide unneeded content */
   .o-header,
   .o-footer,
-  .hud-hca-api-results-actions,
+  #hud_print-page-link,
   svg {
     display: none !important;
+  }
+
+  .no-js .u-hide-if-js {
+    visibility: hidden;
+    margin-bottom: -130px;
   }
 }

--- a/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
+++ b/cfgov/unprocessed/apps/find-a-housing-counselor/css/hud.scss
@@ -9,6 +9,10 @@
   padding: math.div(math.div($grid-gutter-width, 2), $base-font-size-px) + em;
 }
 
+#hud_print-page-link {
+  float: right;
+}
+
 #hud-hca-api-map-canvas {
   height: 320px;
 }
@@ -48,23 +52,6 @@
 
 #hud-hca-api-map-canvas img {
   max-width: none;
-}
-
-.hud-hca-api-results-actions {
-  @include respond-to-min($bp-xs-max) {
-    & {
-      // Margin makes a gap between result header links and result text.
-      margin-left: 20px;
-      float: right;
-    }
-  }
-
-  // Remove underline from PDF abbreviation and icons in links.
-  & abbr,
-  & svg {
-    border-bottom: none;
-    text-decoration: none;
-  }
 }
 
 // Top-align entries in the table.


### PR DESCRIPTION
The print button (and the browser's print functionality) already allows a user to print the list as a pdf. Generating and storing these pdfs is unnecessary. First removing the link to the pdfs, then will remove the pdfs and generating logic in a separate PR.

This PR also contains a minor improvement to the print version of the no-js page.

<img width="1230" height="279" alt="Screenshot 2025-08-08 at 10 24 58 AM" src="https://github.com/user-attachments/assets/6549429a-e62e-4515-b8b8-9a8555989869" />
