### PR TITLE
Pull in sqlite=3.50.4 from alpine edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN \
         curl \
         postgresql \
     && \
+    apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ \
+      sqlite \
+    && \
     pip install --upgrade pip setuptools wheel && \
     pip install -r requirements/deployment_container.txt && \
     apk del .build-deps


### PR DESCRIPTION
Looks like `python:3.8-alpine` isn't going past alpine `3.20`, so I'm manually pulling in the `edge` branch of alpine here for the sqlite install.

## Testing
 - Image should build
 - Exec into container and `apk info sqlite` should show `sqlite-3.50.4-r0`