### PR TITLE
Update s3 domain in housing counselor app

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -327,7 +327,7 @@ SEARCHGOV_ES_API_KEY = os.environ.get("SEARCHGOV_ES_API_KEY")
 MAPBOX_ACCESS_TOKEN = os.environ.get("MAPBOX_ACCESS_TOKEN")
 
 HOUSING_COUNSELOR_S3_PATH_TEMPLATE = (
-    "https://s3.amazonaws.com/files.consumerfinance.gov"
+    "https://files.consumerfinance.gov"
     "/a/assets/hud/{file_format}s/{zipcode}.{file_format}"
 )
 

--- a/cfgov/housing_counselor/tests/test_views.py
+++ b/cfgov/housing_counselor/tests/test_views.py
@@ -14,13 +14,13 @@ class HousingCounselorS3URLMixinTestCase(TestCase):
     def test_s3_json_url(self):
         self.assertEqual(
             HousingCounselorS3URLMixin.s3_json_url(20001),
-            "https://s3.amazonaws.com/files.consumerfinance.gov/a/assets/hud/jsons/20001.json",  # noqa: E501
+            "https://files.consumerfinance.gov/a/assets/hud/jsons/20001.json",  # noqa: E501
         )
 
     def test_s3_pdf_url(self):
         self.assertEqual(
             HousingCounselorS3URLMixin.s3_pdf_url(20009),
-            "https://s3.amazonaws.com/files.consumerfinance.gov/a/assets/hud/pdfs/20009.pdf",  # noqa: E501
+            "https://files.consumerfinance.gov/a/assets/hud/pdfs/20009.pdf",  # noqa: E501
         )
 
 


### PR DESCRIPTION
This now refers to the standard location of files.consumerfinance.gov