### PR TITLE
Use encoded meta descriptions via search.gov faceted search

### DIFF
--- a/cfgov/searchgov/jinja2/searchgov/recommended.html
+++ b/cfgov/searchgov/jinja2/searchgov/recommended.html
@@ -6,7 +6,7 @@
   <div class="block block--flush-top u-mb45 recommended">
     <h2 class="h5 u-mt45">{{rec_hed}}</h2>
     {% for result in recommended %}
-      {{ render_result(result, domain, "description") }}
+      {{ render_result(result, domain) }}
     {% endfor %}
   </div>
 {% endif %}

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -14,7 +14,7 @@
   {{url.replace("https://www.consumerfinance.gov", domain)}}
 {%- endmacro -%}
 
-{%- macro render(result, domain, key="snippet") -%}
+{%- macro render(result, domain, key="description") -%}
   {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>

--- a/cfgov/searchgov/tests/test_views.py
+++ b/cfgov/searchgov/tests/test_views.py
@@ -5,9 +5,11 @@ from django.test import TestCase
 
 from searchgov.views import (
     API_ENDPOINT,
+    decode_meta,
     encode_url,
     get_affiliate,
     get_api_key,
+    recreate_unencoded,
 )
 
 
@@ -36,6 +38,21 @@ class EncodeUrlTestCase(TestCase):
         self.assertEqual(
             encode_url({"query": "term&does=encode"}),
             API_ENDPOINT.format("query=term%26does%3Dencode"),
+        )
+
+
+class RecreateUnencodedTestCase(TestCase):
+    def test_combines_lowercased_split(self):
+        self.assertEqual(recreate_unencoded(["abc", "def"]), "Abc, def")
+
+
+class DecodeMetaTestCase(TestCase):
+    def test_decodes_encoded(self):
+        self.assertEqual(decode_meta("mfrggzdf"), "abcde")
+
+    def test_decodes_and_unescapes(self):
+        self.assertEqual(
+            decode_meta("MFRCM4LVN52DWYZGOF2W65B3MQ======"), 'ab"c"d'
         )
 
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "postinstall": "node scripts/yarn/apps-install && ./scripts/check-npm-cache.sh",
     "fonts": "./scripts/fonts.sh",
     "lint": "./scripts/lint.sh",
-    "jest": "yarn node --experimental-vm-modules $(yarn bin jest)",
+    "jest": "node --experimental-vm-modules $(yarn bin jest)",
     "test": "yarn lint && yarn jest",
     "snyk": "snyk test",
     "watch": "yarn build watch",

--- a/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
+++ b/test/unit_tests/apps/financial-well-being/js/fwb-questions-spec.js
@@ -1,5 +1,7 @@
 import fwbQuestions from '../../../../../cfgov/unprocessed/apps/financial-well-being/js/fwb-questions.js';
 import { simulateEvent } from '../../../../util/simulate-event.js';
+import { jest } from '@jest/globals';
+jest.useFakeTimers();
 
 let formDom;
 let submitBtnDom;

--- a/test/unit_tests/js/organisms/FilterableListControls-spec.js
+++ b/test/unit_tests/js/organisms/FilterableListControls-spec.js
@@ -1,4 +1,6 @@
 import FilterableListControls from '../../../../cfgov/unprocessed/js/organisms/FilterableListControls.js';
+import { jest } from '@jest/globals';
+jest.useFakeTimers();
 
 const BASE_CLASS = 'o-filterable-list-controls';
 const HTML_SNIPPET = `

--- a/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
+++ b/test/unit_tests/js/organisms/MegaMenuMobile-spec.js
@@ -48,7 +48,7 @@ describe('MegaMenuMobile', () => {
         isExpanded = firstPanel.getAttribute('data-open');
         expect(isExpanded).toEqual('true');
 
-        window.setTimeout(resolveSecondClick, 1000);
+        window.setTimeout(resolveSecondClick, 200);
       }
 
       /**
@@ -71,7 +71,7 @@ describe('MegaMenuMobile', () => {
 
       simulateEvent('click', menuTrigger);
 
-      window.setTimeout(resolveFirstClick, 1000);
+      window.setTimeout(resolveFirstClick, 200);
     });
 
     it('should not be expanded by default', () => {
@@ -98,7 +98,7 @@ describe('MegaMenuMobile', () => {
 
       simulateEvent('click', menuTrigger);
 
-      window.setTimeout(resolveFirstClick, 1000);
+      window.setTimeout(resolveFirstClick, 200);
     });
 
     it('should collapse on the first level sub-menu back button click', (done) => {
@@ -118,7 +118,7 @@ describe('MegaMenuMobile', () => {
       function resolveFirstClick() {
         simulateEvent('click', subTrigger);
 
-        window.setTimeout(resolveSecondClick, 1000);
+        window.setTimeout(resolveSecondClick, 200);
       }
 
       /**
@@ -127,7 +127,7 @@ describe('MegaMenuMobile', () => {
       function resolveSecondClick() {
         simulateEvent('click', subAltTrigger);
 
-        window.setTimeout(resolveThirdClick, 1000);
+        window.setTimeout(resolveThirdClick, 200);
       }
 
       /**
@@ -142,7 +142,7 @@ describe('MegaMenuMobile', () => {
 
       simulateEvent('click', menuTrigger);
 
-      window.setTimeout(resolveFirstClick, 1000);
+      window.setTimeout(resolveFirstClick, 200);
     });
   });
 });


### PR DESCRIPTION
Now that search.gov has picked up our encoded meta descriptions from https://github.com/cfpb/consumerfinance.gov/pull/8865, we can use them in search.

## Testing
 - Pull
 - Search for a term, results should populate as expected. Best bets/recommended data should still exist.

<img width="837" height="719" alt="Screenshot 2025-08-14 at 10 51 20 PM" src="https://github.com/user-attachments/assets/842dc4c2-6ade-4ba7-ae8e-a3c49b2ac165" />
