### PR TITLE
Pin node to v24.5.0 to get around jest-related bug in v24.6.0

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-            node-version: '24.x'
+            node-version: '24.5.0'
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
We're being bit by: https://github.com/nodejs/node/issues/59480

When this is fixed/when there's an upgrade path we should revert this.