### PR TITLE
Remove deprecated VSCode ruff setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,5 @@
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "ruff.importStrategy": "useBundled",
-  "ruff.lint.run": "onSave"
+  "ruff.importStrategy": "useBundled"
 }


### PR DESCRIPTION
The VSCode setting `ruff.lint.run` has been deprecated, see https://docs.astral.sh/ruff/editors/migration/ for details. From that page:

> This setting is no longer relevant for the native language server, which runs on every keystroke by default.

This resolves a warning when loading this project in VSCode.