### PR TITLE
Future-proof tag regex, which will break in 3.11

### DIFF
--- a/cfgov/core/utils.py
+++ b/cfgov/core/utils.py
@@ -42,6 +42,8 @@ LINK_ICON_TEXT_CLASSES = ["a-link__text"]
 # Regular expression format string that will match any tag <tag_name> (that is
 # not self-closing) and group its contents.
 TAG_RE = (
+    # Make '.' match new lines, ignore case
+    r"(?s)(?i)"
     # Match an <tag_name[ attributes]>. If tag_name is not followed by a space
     # and any characters except >, it must be followed by >.
     r"<{tag_name}(?:\s+[^>]*?|)>"
@@ -49,8 +51,6 @@ TAG_RE = (
     r".+?(?=</{tag_name}>)"
     # Then match the closing </tag>
     r"</{tag_name}>"
-    # Make '.' match new lines, ignore case
-    r"(?s)(?i)"
 )
 
 # Match <body…>…</body>


### PR DESCRIPTION
per [the docs](https://docs.python.org/3/library/re.html#:~:text=Changed%20in%20version%203.11%3A%20This%20construction%20can%20only%20be%20used%20at%20the%20start%20of%20the%20expression.), this fixes code that would otherwise break in python 3.11+