### PR TITLE
Bump ccdb5-api from version 1.7.2 to 1.7.4

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -48,4 +48,4 @@ whitenoise==6.7.0
 
 # These packages are installed from GitHub.
 https://github.com/cfpb/owning-a-home-api/releases/download/0.19.0/owning_a_home_api-0.19.0-py3-none-any.whl
-https://github.com/cfpb/ccdb5-api/releases/download/1.7.2/ccdb5_api-1.7.2-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.7.4/ccdb5_api-1.7.4-py3-none-any.whl


### PR DESCRIPTION
See release notes:

https://github.com/cfpb/ccdb5-api/releases/tag/1.7.3
https://github.com/cfpb/ccdb5-api/releases/tag/1.7.4