### PR TITLE
Migrate wagtail-sharing config to settings

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -20,11 +20,9 @@ export DJANGO_ADMIN_PASSWORD=admin
 
 ######################################################
 # Wagtail-Sharing - for sharing unpublished drafts.
-#
-# Used in initial_data script to set sharing hostname.
 # See https://github.com/cfpb/wagtail-sharing.
 #####################################################
-export WAGTAIL_SHARING_HOSTNAME=content.localhost
+export WAGTAILSHARING_HOST=content.localhost:8000
 
 ########################################
 # Application feature related variables.

--- a/cfgov/ask_cfpb/tests/test_views.py
+++ b/cfgov/ask_cfpb/tests/test_views.py
@@ -2,13 +2,10 @@ import json
 from unittest import mock
 
 from django.http import Http404
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.utils import timezone
 
-from wagtail.models import Site
-
 from model_bakery import baker
-from wagtailsharing.models import SharingSite
 
 from ask_cfpb.models import (
     ENGLISH_PARENT_SLUG,
@@ -21,6 +18,10 @@ from ask_cfpb.models import (
 now = timezone.now()
 
 
+@override_settings(
+    WAGTAILSHARING_ROUTER="wagtailsharing.routers.settings.SettingsHostRouter",
+    WAGTAILSHARING_HOST="preview.localhost:8000",
+)
 class AnswerPagePreviewTestCase(TestCase):
     def setUp(self):
         from ask_cfpb.models import Answer
@@ -88,19 +89,6 @@ class AnswerPagePreviewTestCase(TestCase):
         )
         self.english_parent_page.add_child(instance=self.english_answer_page2)
         self.english_answer_page2.save_revision().publish()
-        self.site = baker.make(
-            Site,
-            root_page=self.ROOT_PAGE,
-            hostname="localhost",
-            port=8000,
-            is_default_site=True,
-        )
-        self.sharing_site = baker.make(
-            SharingSite,
-            site=self.site,
-            hostname="preview.localhost",
-            port=8000,
-        )
 
     @mock.patch("ask_cfpb.views.ServeView.serve")
     def test_live_plus_draft_with_sharing(self, mock_serve):

--- a/cfgov/ask_cfpb/views.py
+++ b/cfgov/ask_cfpb/views.py
@@ -7,7 +7,7 @@ from django.template.defaultfilters import slugify
 
 from wagtail.snippets.views.snippets import SnippetViewSet
 
-from wagtailsharing.models import SharingSite
+from wagtailsharing.routers import get_router
 from wagtailsharing.views import ServeView
 
 from ask_cfpb.forms import AutocompleteForm, SearchForm, legacy_facet_validator
@@ -26,10 +26,7 @@ def view_answer(request, slug, language, answer_id):
     # We can't call answer_page.serve(request) yet because that would bypass
     # wagtail-sharing, which provides views of unpublished revisions.
     # First, we see if a sharing site is present in the request:
-    try:
-        sharing_site = SharingSite.find_for_request(request)
-    except SharingSite.DoesNotExist:
-        sharing_site = None
+    sharing_site, _ = get_router().route(request, request.path)
     # handle draft pages first
     if answer_page.live is False:
         if sharing_site is None:

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -788,3 +788,6 @@ if ENABLE_SSO:
 
     # Require manual Wagtail user creation.
     OIDC_CREATE_USER = False
+
+if WAGTAILSHARING_HOST := os.getenv("WAGTAILSHARING_HOST"):
+    WAGTAILSHARING_ROUTER = "wagtailsharing.routers.settings.SettingsHostRouter"

--- a/cfgov/scripts/initial_data.py
+++ b/cfgov/scripts/initial_data.py
@@ -8,8 +8,6 @@ from django.db import transaction
 
 from wagtail.models import Page, Site
 
-from wagtailsharing.models import SharingSite
-
 from v1.models import HomePage
 
 
@@ -24,8 +22,6 @@ def run():
     admin_username = os.getenv("DJANGO_ADMIN_USERNAME")
     admin_password = os.getenv("DJANGO_ADMIN_PASSWORD")
     http_port = int(os.getenv("DJANGO_HTTP_PORT", default_site.port))
-
-    wagtail_sharing_hostname = os.getenv("WAGTAIL_SHARING_HOSTNAME")
 
     # If specified in the environment, create or activate superuser.
     if admin_username and admin_password:
@@ -80,15 +76,3 @@ def run():
         default_site.port = http_port
         default_site.save()
         logger.info(f"Configured default Wagtail Site: {default_site}")
-
-    # Setup a sharing site for the default Wagtail site if a sharing hostname
-    # has been configured in the environment.
-    if wagtail_sharing_hostname:
-        sharing_site, _ = SharingSite.objects.update_or_create(
-            site=default_site,
-            defaults={
-                "hostname": wagtail_sharing_hostname,
-                "port": http_port,
-            },
-        )
-        logger.info(f"Configured wagtail-sharing site: {sharing_site}")

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -231,10 +231,6 @@ and then does the following:
 - Updates the default Wagtail site to use the port defined by the
   `DJANGO_HTTP_PORT` environment variable, if defined; otherwise this port is
   set to 80.
-- If it doesn't already exist, creates a new
-  [wagtail-sharing](https://github.com/cfpb/wagtail-sharing) `SharingSite` with
-  a hostname and port defined by the `WAGTAIL_SHARING_HOSTNAME` and
-  `DJANGO_HTTP_PORT` environment variables.
 
 This script must be run inside the Docker `python` container:
 

--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -40,7 +40,7 @@ wagtail-flags==5.3.1
 wagtail-footnotes==0.13.0
 wagtail-inventory==3.0
 wagtail-placeholder-images==0.1.1
-wagtail-sharing==2.12.1
+wagtail-sharing==2.13
 wagtail-treemodeladmin==1.9.2
 wagtailmedia==0.15.2
 wagtailcharts==0.6.2


### PR DESCRIPTION
The 2.13 release of wagtail-sharing allows configuration via Django setting, avoiding the need to run a management command for this purpose. This simplifies deployments and configurations in multiple environments.

This commit upgrades wagtail-sharing from 2.12.1 to 2.13, and migrates the config to use a setting derived from the WAGTAILSHARING_HOST environment variable.

This variable has already been populated on our internal deployment repo. See internal DEVPLAT-1547 for additional context.