### PR TITLE
Add ability to configure email host settings

### DIFF
--- a/cfgov/cfgov/settings/production.py
+++ b/cfgov/cfgov/settings/production.py
@@ -82,7 +82,11 @@ if "syslog" in default_loggers:
     }
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_HOST = os.getenv("EMAIL_HOST")
+EMAIL_HOST = os.getenv("EMAIL_HOST", "")
+EMAIL_PORT = os.getenv("EMAIL_PORT", 25)
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", False)
 DEFAULT_FROM_EMAIL = "wagtail@cfpb.gov"
 
 STORAGES["staticfiles"] = {


### PR DESCRIPTION
See Django documentation here: https://docs.djangoproject.com/en/5.2/topics/email/

This is needed for deployment to our new AWS environment.