### PR TITLE
Add and update Explore Interest Rates notifications

### DIFF
--- a/cfgov/jinja2/owning-a-home/explore-rates/index.html
+++ b/cfgov/jinja2/owning-a-home/explore-rates/index.html
@@ -1,4 +1,5 @@
 {% extends "v1/layouts/layout-full.html" %}
+{% import 'v1/includes/molecules/notification.html' as notification with context %}
 
 {% set breadcrumb_items = [{
     "title": "Buying a House",
@@ -63,8 +64,15 @@ home price, down payment, and more can affect mortgage interest rates.
                     </div>
                 </div>
                 <!-- /.content-l__col-1-3 -->
+                <div class="page-intro__alert">
+                    {{ notification.render(
+                        'warning',
+                        true,
+                        'Data not currently being updated',
+                        'The interest rates used in this tool reflect data from April 1, 2025. Further updates to the data aren\'t currently scheduled.' 
+                    ) }}
+                </div>
             </section>
-
             <div class="rc-results content__main" id="rate-results" aria-live="polite">
                 <h2 id="rc-summary" class="rate-checker-heading data-enabled clear">In <strong class="location"></strong>, most lenders in our data are offering rates at or below <strong class="rate" id="median-rate"></strong>.</h2>
                 <div id="accessible-data-results" class="u-visually-hidden">
@@ -553,7 +561,7 @@ home price, down payment, and more can affect mortgage interest rates.
             <div class="block">
                 {% import 'v1/includes/molecules/notification.html' as notification %}
                 {{- notification.render(
-                    'warning',
+                    'information',
                     true,
                     'Check your credit',
                     'If you haven’t checked your credit report recently, do so now. ' ~

--- a/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.scss
+++ b/cfgov/unprocessed/apps/owning-a-home/css/explore-rates.scss
@@ -42,6 +42,12 @@
     &__cols-first {
       flex-basis: fit-content;
     }
+
+    &__alert {
+      padding: math.div(30px, $base-font-size-px) + em;
+      padding-bottom: 0;
+    }
+
   }
 
   .rc-illu-inner {


### PR DESCRIPTION
This PR adds a banner notification regarding the Explore Interest Rates tool data.

## Additions
- Add notification about data staleness

## Changes
- Change notification lower on the page from `warning` to `information`


## How to test this PR
1. Pull this PR down, set it up, then check out the explore interest rates tool.
2. Look for the banner/notification (see screenshot below) 

## Screenshots
<img width="1225" height="774" alt="image" src="https://github.com/user-attachments/assets/b7283879-2352-4458-997d-f0ae34168d10" />

## Checklist
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
