### PR TITLE
Fix dynamic disclosure expenses updating

### DIFF
--- a/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/expenses-view.js
+++ b/cfgov/unprocessed/apps/paying-for-college/js/disclosures/views/expenses-view.js
@@ -114,19 +114,21 @@ const expensesView = {
   keyupListener: function () {
     this.$reviewAndEvaluate.each(() => {
       $('[data-expenses]').each((elmo) => {
-        elmo.addEventListener('keyup focusout', function () {
-          clearTimeout(expensesView.keyupDelay);
-          expensesView.currentInput = $(this).attr('id');
-          if ($(this).is(':focus')) {
-            expensesView.keyupDelay = setTimeout(function () {
+        ['keyup', 'focusout'].forEach((eventName) => {
+          elmo.addEventListener(eventName, function () {
+            clearTimeout(expensesView.keyupDelay);
+            expensesView.currentInput = this.id;
+            if (this === document.activeElement) {
+              expensesView.keyupDelay = setTimeout(function () {
+                expensesView.inputHandler(expensesView.currentInput);
+                expensesView.updateView(getExpenses.values());
+              }, 500);
+            } else {
               expensesView.inputHandler(expensesView.currentInput);
+              expensesView.currentInput = 'none';
               expensesView.updateView(getExpenses.values());
-            }, 500);
-          } else {
-            expensesView.inputHandler(expensesView.currentInput);
-            expensesView.currentInput = 'none';
-            expensesView.updateView(getExpenses.values());
-          }
+            }
+          });
         });
       });
     });
@@ -138,7 +140,7 @@ const expensesView = {
   expenseInputChangeListener: function () {
     $('[data-expenses]').each((elmo) => {
       elmo.addEventListener('change', function () {
-        const expenses = $(this).data('expenses');
+        const expenses = this.dataset.expenses;
         if (expenses) {
           analyticsSendEvent({ action: 'Value Edited', label: expenses });
         }


### PR DESCRIPTION
Discovered a couple of small bugs that were preventing the "Estimated budget after you leave school" total from updating when the inputs are adjusted:

1. `addEventListener` can only take one event as an argument; we were passing `'keyup focusout'`. Looks like this is a remnant of our old jQuery `on` syntax, which could take multiple events as an argument.
2. Speaking of remnants from jQuery, `$(this)` needed to be changed to plain old `this` in a few spots

I know both of these functions could be refactored even more, but I couldn't remember the history behind some of the decisions (e.g. why do we fire the analytics event on `change` but update the numbers on `keyup`?) and wanted to make the smallest change possible just to get this working again. @anselmbradford or @mistergone, feel free to continue refactoring if you have time and interest.

---

## Changes

- Fix remnants from jQuery removal

## How to test this PR

1. Load a sample disclosure, like [this one](http://localhost:8000/paying-for-college2/understanding-your-financial-aid-offer/offer/?iped=475121&pid=5468&oid=5B59F8EC045AE9CCE7A52ACB8B801D42714D6A12&book=540&gib=0&gpl=0&hous=9819&insi=0.0000&insl=0&inst=25&leng=0&mta=0&othg=2374&othr=7209&parl=0&pelg=7395&perl=0&ppl=0&prvl=0&prvf=0.0000&prvi=0.0000&schg=0&stag=0&subl=4500&totl=57620&tran=1998&tuit=17100&unsl=4734&wkst=0#info-right)
2. Hit the "continue to step 2" button, then scroll to the "Estimated budget after you leave school (adjust as needed)" form
3. Change some of the inputs and make sure the:
    * "Total left at the end of the month" changes on `keyup` or `focusout`
    * "Value Edited" analytics event is fired 

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)