### PR TITLE
Add DAP to CSP_CONNECT_SRC

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -561,6 +561,7 @@ CSP_FONT_SRC = ("'self'", "fonts.gstatic.com")
 CSP_CONNECT_SRC = (
     "'self'",
     "*.consumerfinance.gov",
+    "dap.digitalgov.gov",
     "*.google-analytics.com",
     "*.tiles.mapbox.com",
     "api.mapbox.com",


### PR DESCRIPTION
We're currently getting a console error on every page, `Refused to connect to 'https://dap.digitalgov.gov/Federated.js.map' because it violates the following Content Security Policy directive: "connect-src 'self' *.consumerfinance.gov *.google-analytics.com *.tiles.mapbox.com api.mapbox.com bam.nr-data.net gov-bam.nr-data.net s3.amazonaws.com public.govdelivery.com *.mouseflow.com *.qualtrics.com raw.githubusercontent.com".`

@anselmbradford, I can't test this change locally since the DAP script isn't getting injected for me locally, so I'm not actually sure if we also still need it in `CSP_SCRIPT_SRC`. [These setup instructions](https://github.com/digital-analytics-program/gov-wide-code?tab=readme-ov-file#content-security-policy) from DAP suggest we do, though I'm not sure if we're injecting the script exactly as they recommend. At any rate, I left it in `CSP_SCRIPT_SRC` for now, but feel free to remove that if you can test locally and find it's not needed.

---

## Additions

- `dap.digitalgov.gov` to `CSP_CONNECT_SRC` allowlist

## How to test this PR

1. Not sure if it's possible to test this locally, but if it is, make sure you're no longer getting the `connect-src` error on every page

## Notes and todos

- After this is deployed, we need to delete purge the Akamai cache for the whole site to have the new headers picked up.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)