### PR TITLE
Add "*.cfpb.gov" to CSP image sources

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -526,6 +526,7 @@ CSP_STYLE_SRC = (
 # These specify valid image sources
 CSP_IMG_SRC = (
     "'self'",
+    "*.cfpb.gov",
     "*.consumerfinance.gov",
     "www.ecfr.gov",
     "s3.amazonaws.com",


### PR DESCRIPTION
Allow loading of images from any .cfpb.gov domain.

Internal context: DEVPLAT-1653.