### PR TITLE
Optionally support persistent DB connections

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -219,10 +219,18 @@ if ALLOW_ADMIN_URL:
 # Database name cfgov, username cfpb, password cfpb.
 # Override this by setting DATABASE_URL in the environment.
 # See https://github.com/jazzband/dj-database-url for URL formatting.
+_db_config = {
+    "default": "postgres://cfpb:cfpb@localhost/cfgov",
+}
+
+if _db_conn_max_age := os.getenv("CONN_MAX_AGE"):
+    _db_config.update({
+        "conn_max_age": int(_db_conn_max_age),
+        "conn_health_checks": True,
+    })
+
 DATABASES = {
-    "default": dj_database_url.config(
-        default="postgres://cfpb:cfpb@localhost/cfgov"
-    ),
+    "default": dj_database_url.config(**_db_config)
 }
 
 # Internationalization


### PR DESCRIPTION
This change allows the `CONN_MAX_AGE` environment variable to set the maximum age to use for Django persistent database connections. By default we have this disabled (Django's default), which closes the DB connection after each request.

With this environment variable set, we can keep persistent connections to reduce the overhead of opening/closing them each time. This also enables connection health checks to prevent issues with stale connections, network issues, etc.

The default/local behavior remains unchanged unless this environment variable is set, for simplicity and more consistent local behavior.