### PR TITLE
set verify_certs to True, as we do in CCDB and Complaint Explorer unl…

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -367,7 +367,7 @@ else:
                 os.getenv("ES_PASS", "admin"),
             ),
             "use_ssl": True,
-            "verify_certs": False,
+            "verify_certs": True,
         }
     }
 


### PR DESCRIPTION
This turns on cert verification for requests to OpenSearch, as we do for CCDB and Complaint Explorer searches.

In addition to enforcing verified https requests, we'll stop polluting the cfgov logs with security warnings.