### PR TITLE
Remove gevent test key files from cfgov Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,10 +172,13 @@ COPY --from=node-builder ${APP_HOME} ${APP_HOME}
 # Delete unprocessed frontend code, which was only needed by node-builder.
 # This avoids false positive image vulnerabilities in source Node packages.
 #
-# Also delete an unused test keyfile from the ndg-httpsclient Python package.
-# This avoids a false positive due to storing a private keyfile in the image.
+# Also delete an unused test keyfiles from the gevent and ndg-httpsclient
+# Python packages. This avoids a false positive due to storing private
+# keyfiles in the image.
 RUN rm -rf ./cfgov/unprocessed && \
-    rm /usr/local/lib/python3.8/site-packages/ndg/httpsclient/test/pki/localhost.key
+    rm -f /usr/local/lib/python3.8/site-packages/gevent/tests/*.key && \
+    rm -f /usr/local/lib/python3.8/site-packages/gevent/tests/*.pem && \
+    rm -f /usr/local/lib/python3.8/site-packages/ndg/httpsclient/test/pki/localhost.key
 
 # Run Django's collectstatic to collect assets from the frontend build.
 #


### PR DESCRIPTION
The gevent Python package used for the cfgov Docker image includes several test key files. These aren't used at runtime but do trip our image vulnerability scanning software. They can be removed as part of the build process, as we already do for a similar key in the ndg-httpsclient Python package.