### PR TITLE
Update PostgreSQL image versions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,7 +32,7 @@ jobs:
       postgres:
         # https://help.github.com/en/actions/configuring-and-managing-workflows/creating-postgresql-service-containers
         # https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml
-        image: postgres:13
+        image: postgres:17
         env:
           POSTGRES_USER: cfpb
           POSTGRES_PASSWORD: cfpb

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -25,7 +25,7 @@ jobs:
         options: -e="discovery.type=single-node" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
 
       postgres:
-        image: postgres:13
+        image: postgres:17
         env:
           POSTGRES_USER: cfpb
           POSTGRES_PASSWORD: cfpb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - 127.0.0.1:5601:5601
 
   postgres:
-    image: postgres:13-alpine
+    image: postgres:17-alpine
     user: postgres
     restart: always
     volumes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The standard technology stack for development of consumerfinance.gov within the 
 - [Python 3.8](https://docs.python.org/3.8/) and [pip (Python package manager)](https://pip.pypa.io/en/stable/user_guide/)
 - [Jinja2 templates](https://jinja.palletsprojects.com/) for front-end rendering. See [`requirements/libraries.txt`](https://github.com/cfpb/consumerfinance.gov/tree/main/requirements/libraries.txt) for version.
 - [Wagtail CMS](https://wagtail.io) for content administration. See [`requirements/wagtail.txt`](https://github.com/cfpb/consumerfinance.gov/tree/main/requirements/wagtail.txt) for version.
-- [PostgreSQL 13.13](https://www.postgresql.org/) is the database we use in production and locally.
+- [PostgreSQL 17](https://www.postgresql.org/) is the database we use in production and locally.
 - [Psycopg](https://www.psycopg.org/) is the Python library that lets Python talk to Postgres. See [`requirements/libraries.txt`](https://github.com/cfpb/consumerfinance.gov/tree/main/requirements/libraries.txt) for current version.
 - Additional dependencies, listed below.
 


### PR DESCRIPTION
This updates the version of PostgreSQL we're using in our local compose setup as well as in GitHub actions from 13 to 17 to match what we're running in production.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
