### PR TITLE
Upgrade to Wagtail 6.4.2

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -204,7 +204,9 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "cfgov.wsgi.application"
 
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 3000  # For heavy Wagtail pages
+# See https://docs.wagtail.org/en/latest/releases/
+# 6.4.html#data-upload-max-number-fields-update
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 10_000
 
 # Default database is PostgreSQL running on localhost.
 # Database name cfgov, username cfpb, password cfpb.

--- a/cfgov/cfgov/settings/test.py
+++ b/cfgov/cfgov/settings/test.py
@@ -65,6 +65,15 @@ OPENSEARCH_DSL_AUTOSYNC = False
 # Disable `use_ssl` for unit tests
 OPENSEARCH_DSL["default"]["use_ssl"] = False
 
+# TODO: Remove this setting when we're on django-tasks >= 0.10.
+# See https://docs.wagtail.org/en/latest/releases/6.4.html#background-tasks-
+# run-at-end-of-current-transaction for details.
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        "ENQUEUE_ON_COMMIT": False,
+    }
+}
 
 SKIP_DJANGO_MIGRATIONS = os.getenv("SKIP_DJANGO_MIGRATIONS", False)
 if SKIP_DJANGO_MIGRATIONS:

--- a/requirements/wagtail.txt
+++ b/requirements/wagtail.txt
@@ -1,1 +1,1 @@
-wagtail==6.3.8
+wagtail==6.4.2

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -74,7 +74,9 @@ export class AdminPage {
   removeContact() {
     this.getFirstOptionsDropdown().click();
     cy.get('a[href^="/admin/snippets/v1/contact/delete/"]:first').click();
-    cy.get('form[action*="/admin/snippets/v1/contact/delete"] button[type="submit"]').click();
+    cy.get(
+      'form[action*="/admin/snippets/v1/contact/delete"] button[type="submit"]',
+    ).click();
   }
 
   addMortgageData(name) {

--- a/test/cypress/integration/admin/admin-helpers.cy.js
+++ b/test/cypress/integration/admin/admin-helpers.cy.js
@@ -74,7 +74,7 @@ export class AdminPage {
   removeContact() {
     this.getFirstOptionsDropdown().click();
     cy.get('a[href^="/admin/snippets/v1/contact/delete/"]:first').click();
-    cy.get('[value="Yes, delete"]').click();
+    cy.get('form[action*="/admin/snippets/v1/contact/delete"] button[type="submit"]').click();
   }
 
   addMortgageData(name) {


### PR DESCRIPTION
Upgrade Wagtail to 6.4.2, an interim step to getting to Wagtail 7.0.6.

---

## Changes

- Bump Wagtail to 6.4.2
- Bump `DATA_UPLOAD_MAX_NUMBER_FIELDS` to 10,000 as recommended in the [Wagtail 6.4 docs](https://docs.wagtail.org/en/latest/releases/6.4.html#data-upload-max-number-fields-update)
- Work around some unit tests that fail until we're on `django-tasks >= 0.10`
- Update a Cypress test to work with changed HTML in the Wagtail admin

## How to test this PR

1. All automated tests should pass locally:
  * Python unit tests with `tox`
  * JavaScript unit tests with `yarn test` 
  * Cypress integration tests with `yarn cy` (you may have to rerun this if you see failures, sometimes Cypress can be flaky)
2. Everything should work as expected when running the site locally (see GHE/Design-Development/cfgov/issues/4644 for the manual test plan I ran through)

## Notes and todos

- This is an interim step to get to Wagtail 7.0.6, which we'll be upgrading to in the next week or so, but we wanted to get 6.4.2 deployed first to make sure everything was OK with that version

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets
- [x] Project documentation has been updated, potentially one or more of:
  - [This repo’s docs](https://cfpb.github.io/consumerfinance.gov/) (edit the files in the `/docs` folder) – for basic, close-to-the-code docs on working with this repo
  - CFGOV/platform wiki on GHE – for internal CFPB developer guidance
  - CFPB/hubcap wiki on GHE – for internal CFPB design and content guidance