### PR TITLE
Pin GitHub Action references to SHAs

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
             node-version: '24.5.0'
 

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -36,17 +36,17 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 2
 
     - name: Set up Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
           node-version: '24.x'
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: 3.13
 
@@ -70,7 +70,7 @@ jobs:
       run: ./scripts/cypress-fast-specs.sh
 
     - name: Run Cypress
-      uses: cypress-io/github-action@783cb3f07983868532cabaedaa1e6c00ff4786a8
+      uses: cypress-io/github-action@783cb3f07983868532cabaedaa1e6c00ff4786a8 # v7
       with:
         build: yarn build
         start: python cfgov/manage.py runserver 0.0.0.0:8000
@@ -80,7 +80,7 @@ jobs:
           MAPBOX_ACCESS_TOKEN:  ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           CYPRESS_ENVIRONMENT: github
     - name: Store any Cypress failure screenshots
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: failure()
       with:
         name: cypress_failure_screenshots

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on:
       - ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Zip Scannable Files
         run: >
           find . -path '*test*' -prune -o \( -name '*.py' -o -name '*.js' -o
@@ -48,7 +48,7 @@ jobs:
           --fail_on_severity="Very High, High" --summary_output true
 
       - name: Archive Results.json & Results.txt from Veracode Static Pipeline Scanner
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Veracode SAST Pipeline Results
           path: results.*
@@ -56,7 +56,7 @@ jobs:
     runs-on:
       - ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: SCA Scan
         env:
           SRCCLR_API_TOKEN: ${{secrets.SRCCLR_API_TOKEN}}
@@ -66,7 +66,7 @@ jobs:
           curl -sSL https://download.sourceclear.com/ci.sh | sh -s scan
           --json=SCA-App-Issues.json
       - name: Upload SCA issues artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: Veracode SCA Scan Results
           path: SCA-App-Issues.json


### PR DESCRIPTION
Instead of referencing 3rd-party GitHub Actions with a general version number (like V3), we should use the specific SHA.

These unpinned actions were missed in 0dbc3f14f5c778105d2c4dd15a1085a22a07a04f.