### PR TITLE
Bump docker-build-push action version

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: cfpb/actions/docker-build-push@1be1a44a38e05b7092c844511a0d214e93b43c21
+      - uses: cfpb/actions/docker-build-push@1ed507b96522475e6d11e5af41c55251b16f19a6
         with:
           image-name: cfgov
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This new version uses pinned SHAs for its 3rd-party actions:

https://github.com/cfpb/actions/pull/5