### PR TITLE
Update lxml version from 5.3.1 to 6.1.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -20,7 +20,7 @@ django-treebeard==4.7.1
 edgegrid-python==1.3.1
 govdelivery==1.5
 Jinja2==3.1.6
-lxml==5.3.1
+lxml==6.1.0
 mozilla-django-oidc==4.0.1
 opensearch-py==3.0.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
Addresses CVE-2026-41066.