### PR TITLE
Refactor Veracode workflow to remove baseline step

### DIFF
--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -39,7 +39,7 @@ jobs:
           --veracode_api_id "$VERACODE_API_ID"
           --veracode_api_key "$VERACODE_API_KEY"
           --request_policy "$VERACODE_POLICY"
-        
+
           java -jar pipeline-scan.jar
           --veracode_api_id "$VERACODE_API_ID"
           --veracode_api_key "$VERACODE_API_KEY"
@@ -48,11 +48,6 @@ jobs:
           --app_id="cfgov"
           --summary_output true
 
-      - name: Archive Results.json & Results.txt from Veracode Static Pipeline Scanner
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: Veracode SAST Pipeline Results
-          path: results.*
   Veracode_SCA:
     runs-on:
       - ubuntu-latest
@@ -66,8 +61,3 @@ jobs:
         run: >
           curl -sSL https://download.sourceclear.com/ci.sh | sh -s scan
           --json=SCA-App-Issues.json
-      - name: Upload SCA issues artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: Veracode SCA Scan Results
-          path: SCA-App-Issues.json

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -20,12 +20,6 @@ jobs:
       - name: Setup Veracode
         run: |
           curl -fsS https://tools.veracode.com/veracode-cli/install | sh
-      - name: Get baseline from private repo
-        run: |
-          gh api repos/cfpb-internal/veracode-baselines/contents/cfgov/baseline.json \
-            --jq '.content' | base64 -d > baseline.json
-        env:
-          GH_TOKEN: ${{ secrets.VERACODE_PAT }}
 
       - name: Download Veracode Static Pipeline Scanner
         run: >
@@ -41,11 +35,19 @@ jobs:
       - name: Veracode Static Pipeline Scanner
         continue-on-error: true
         run: >
-          java -jar pipeline-scan.jar --veracode_api_id
-          "${{secrets.VERACODE_API_ID}}" --veracode_api_key
-          "${{secrets.VERACODE_API_KEY}}" --file
-          "./cfgov-gha.zip"  --baseline_file baseline.json --app_id="cfgov"
-          --fail_on_severity="Very High, High" --summary_output true
+          java -jar pipeline-scan.jar
+          --veracode_api_id "${{secrets.VERACODE_API_ID}}"
+          --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
+          --request-policy "CFPB-Policy"
+        
+          java -jar pipeline-scan.jar
+          --veracode_api_id "${{secrets.VERACODE_API_ID}}"
+          --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
+          --file "./cfgov-gha.zip"
+          --policy-file "CFPB-Policy.json"
+          --app_id="cfgov"
+          --fail_on_severity="Very High, High"
+          --summary_output true
 
       - name: Archive Results.json & Results.txt from Veracode Static Pipeline Scanner
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -33,18 +33,17 @@ jobs:
         run: |
           echo ${{secrets.VERACODE_API_ID}}
       - name: Veracode Static Pipeline Scanner
-        continue-on-error: true
         run: >
           java -jar pipeline-scan.jar
           --veracode_api_id "${{secrets.VERACODE_API_ID}}"
           --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
-          --request-policy "CFPB-Policy"
+          --request_policy "CFPB-Policy"
         
           java -jar pipeline-scan.jar
           --veracode_api_id "${{secrets.VERACODE_API_ID}}"
           --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
           --file "./cfgov-gha.zip"
-          --policy-file "CFPB-Policy.json"
+          --policy_file "CFPB-Policy.json"
           --app_id="cfgov"
           --fail_on_severity="Very High, High"
           --summary_output true

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -45,7 +45,6 @@ jobs:
           --file "./cfgov-gha.zip"
           --policy_file "CFPB-Policy.json"
           --app_id="cfgov"
-          --fail_on_severity="Very High, High"
           --summary_output true
 
       - name: Archive Results.json & Results.txt from Veracode Static Pipeline Scanner

--- a/.github/workflows/veracode.yml
+++ b/.github/workflows/veracode.yml
@@ -28,22 +28,23 @@ jobs:
           -o veracode.zip
 
           unzip -o veracode.zip
-      - name: Verify No Secret Leak
-        continue-on-error: true
-        run: |
-          echo ${{secrets.VERACODE_API_ID}}
+
       - name: Veracode Static Pipeline Scanner
+        env:
+          VERACODE_API_ID: ${{ secrets.VERACODE_API_ID }}
+          VERACODE_API_KEY: ${{ secrets.VERACODE_API_KEY }}
+          VERACODE_POLICY: CFPB-Policy
         run: >
           java -jar pipeline-scan.jar
-          --veracode_api_id "${{secrets.VERACODE_API_ID}}"
-          --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
-          --request_policy "CFPB-Policy"
+          --veracode_api_id "$VERACODE_API_ID"
+          --veracode_api_key "$VERACODE_API_KEY"
+          --request_policy "$VERACODE_POLICY"
         
           java -jar pipeline-scan.jar
-          --veracode_api_id "${{secrets.VERACODE_API_ID}}"
-          --veracode_api_key "${{secrets.VERACODE_API_KEY}}"
+          --veracode_api_id "$VERACODE_API_ID"
+          --veracode_api_key "$VERACODE_API_KEY"
           --file "./cfgov-gha.zip"
-          --policy_file "CFPB-Policy.json"
+          --policy_file "$VERACODE_POLICY.json"
           --app_id="cfgov"
           --summary_output true
 


### PR DESCRIPTION
Removed baseline retrieval step and updated Veracode scan commands to include request policy and policy file.
