### PR TITLE
Upgrade urllib3 to version 2.7.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -27,7 +27,7 @@ psycopg2-binary==2.9.10
 python-dateutil==2.9.0
 regdown==1.1
 s3transfer==0.10.2
-urllib3==2.6.3
+urllib3==2.7.0
 wagtail-autocomplete==0.12.0
 wagtail-content-audit==0.3.0
 wagtail_draftail_anchors==0.6.0


### PR DESCRIPTION
Updated urllib3 version from 2.6.3 to 2.7.0.

Addresses https://nvd.nist.gov/vuln/detail/CVE-2026-44431 and https://nvd.nist.gov/vuln/detail/CVE-2026-44432.