### PR TITLE
Redirect all /language/ pages

### DIFF
--- a/cfgov/core/regex-redirects.csv
+++ b/cfgov/core/regex-redirects.csv
@@ -16,6 +16,9 @@ pattern,target_url,status_code
 # Temporarily redirect all blog posts to the blog landing page
 /(about-us/)?blog/.+,/about-us/blog/,302
 
+# Temporarily redirect all language hub pages to /language/
+/language/.+,/language/,302
+
 # Redirects intended to catch sub-pages
 /practitioner-resources/(.*),/consumer-tools/educator-tools/$1,301
 /rules-policy/innovation/(.*),/rules-policy/competition-innovation/$1,301


### PR DESCRIPTION
Redirect all `/language/` pages. See GHE/Design-Development/cfgov/issues/4686 for details.

---

## Additions

- Regex redirect to 302 redirect any URL under `/language/` to `/language/`

## How to test this PR

1. Try going to any URL under `/language/` and make sure you're redirected to `/language/` Some existing URLs are `/language/ko/`, `/language/cfpb-in-english/`, and `/language/tl/shopping-for-your-auto-loan/`.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)