### PR TITLE
Homepage: Add hero heading selector enhancement to use h1

### DIFF
--- a/cfgov/unprocessed/css/enhancements/heroes.scss
+++ b/cfgov/unprocessed/css/enhancements/heroes.scss
@@ -1,0 +1,16 @@
+@use '@cfpb/cfpb-design-system/src/elements/abstracts' as *;
+
+.m-hero--jumbo {
+  // Large desktop.
+  @include respond-to-min($bp-lg-min) {
+    // Override the existing selector in the DS.
+    .m-hero__heading {
+      @include heading-1($is-responsive: false);
+    }
+
+    // TODO: Migrate this selector into the DS and replace the above.
+    .m-hero__heading:has(+ .m-hero__subhead) {
+      @include u-superheading;
+    }
+  }
+}

--- a/cfgov/unprocessed/css/main.scss
+++ b/cfgov/unprocessed/css/main.scss
@@ -11,21 +11,13 @@
 @use '@cfpb/cfpb-design-system/src/' as *;
 @use '@cfpb/cfpb-design-system/src/components/cfpb-tooltips/tooltip' as *;
 
-// Enhancements that are on a migration path to being added to CF.
-// CF Core
+// Enhancements that are on a migration path to being added to the DS.
 @use 'enhancements/utilities' as *;
-
-// CF Typography
 @use 'enhancements/typography' as *;
-
-// CF Layout
 @use 'enhancements/layout' as *;
-
-// CF Forms
 @use 'enhancements/forms' as *;
-
-// CF Tables
 @use 'enhancements/tables' as *;
+@use 'enhancements/heroes' as *;
 
 /* Base patterns
    ========================================================================== */

--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -1,6 +1,6 @@
 {%- set hero = {
-    "heading": "Lorem ipusm dolor sit amet consectetur",
-    "body": "The CFPB works to create and support innovative and resilient consumer financial markets where consumers can choose the products and services that meet their individual needs.",
+    "heading": "The CFPB works to create and support innovative and resilient consumer financial markets where consumers can choose the products and services that meet their individual needs.",
+    "body": "",
     "image": {
         "url": static( "apps/homepage/img/hero.jpg" ),
         "height": 575,

--- a/cfgov/v1/jinja2/v1/includes/molecules/hero.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/hero.html
@@ -71,9 +71,11 @@
                 <br> {{ value.heading_continued }}
                 {% endif %}
             </h1>
+            {% if value.body %}
             <div class="m-hero__subhead">
                 {{ value.body | safe }}
             </div>
+            {% endif %}
         </div>
         <div class="m-hero__image-wrapper">
         {% if img %}


### PR DESCRIPTION
Add hero heading selector enhancement to use h1, not superheading, if there isn't a subheading

## Changes

- Homepage: Add hero heading selector enhancement to use h1, not superheading, if there isn't a subheading.


## How to test this PR

1. `yarn build` and run a local server and visit the homepage and see that the hero heading is an h1 instead of a superheading. Spanish homepage /es/ should still be a super heading.