### PR TITLE
Fix previewing pages on redirected URLs

### DIFF
--- a/cfgov/core/middleware.py
+++ b/cfgov/core/middleware.py
@@ -247,6 +247,12 @@ class RedirectMiddleware:
         return HttpResponseRedirect(url)
 
     def __call__(self, request):
+        # Don't apply this middleware to URLs matching pages being previewed
+        # in the Wagtail page editor.
+        # https://github.com/wagtail/wagtail/blob/v7.0.6/wagtail/models/preview.py#L35-L36
+        if getattr(request, "is_dummy", False):
+            return self.get_response(request)
+
         path = request.path
 
         # Try exact match first.

--- a/cfgov/core/tests/middleware/test_redirect_middleware.py
+++ b/cfgov/core/tests/middleware/test_redirect_middleware.py
@@ -39,6 +39,13 @@ class TestRedirectMiddleware(SimpleTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, b"OK")
 
+    def test_dummy_request_passes_through(self):
+        request = RequestFactory().get("/retirement/")
+        request.is_dummy = True  # type: ignore
+        response = self.middleware(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"OK")
+
     def test_regex_with_capture_group(self):
         request = RequestFactory().get("/payments/some-case/")
         response = self.middleware(request)


### PR DESCRIPTION
Commit 90084845d65d17cdbf793dd77766e7b415930254 introduced new redirect logic that broke previewing of Wagtail pages whose URL would be redirected. In the Wagtail editor, previewing such pages shows the preview of the redirected URL, not the page itself.

This commit fixes that behavior by skipping the redirect middleware if the request comes from a Wagtail admin preview, determined by looking for `is_dummy` on the request object.