### PR TITLE
Update link to strategic plan

### DIFF
--- a/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
+++ b/cfgov/v1/jinja2/v1/home_page/_hardcoded_en.html
@@ -23,7 +23,7 @@
         "card_type": "highlight",
         "heading": "CFPB vision, mission, and values",
         "link_text": "Read the 2026-2030 strategic plan",
-        "link_url": "/rules-policy/notice-opportunities-comment/open-notices/we-invite-your-feedback-on-our-draft-strategic-plan-for-fy-2026-2030/"
+        "link_url": "https://files.consumerfinance.gov/f/documents/cfpb_strategic-plan_fy2026-fy2030.pdf"
     },
 ] -%}
 


### PR DESCRIPTION
Update link to strategic plan on the homepage.

---

## Changes

- Update link to the strategic plan on the homepage

## How to test this PR

1. The strategic plan link on the homepage should go directly to the PDF now

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)