### PR TITLE
Update language redirects

### DIFF
--- a/cfgov/core/redirects.csv
+++ b/cfgov/core/redirects.csv
@@ -7,6 +7,16 @@
 # For redirects that need regex pattern matching, use regex-redirects.csv instead.
 source_path,target_url,status_code
 
+# Temporarily redirect non-English sending money pages to their English equivalent
+/consumer-tools/sending-money/es/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/zh/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/vi/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/ko/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/tl/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/ru/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/ar/,/consumer-tools/sending-money/,302
+/consumer-tools/sending-money/ht/,/consumer-tools/sending-money/,302
+
 # Permanent redirects that exceed Wagtail's 255-character limit for fields
 /askcfpb/194/i-used-the-title-services-and-lenders-title-insurance-companies-or-owners-title-insurance-company-listed-by-my-lender-on-my-gfe-but-was-charged-more-than-10-percent-more-than-my-gfe-said-i-would-be-now-my-lender-wont-pay-me-back-what-can-i-do.html,/ask-cfpb/can-my-final-mortgage-costs-increase-from-what-was-on-my-loan-estimate-en-172/,301
 /askcfpb/191/my-lender-or-broker-gave-me-a-gfe-for-15-year-loan-but-when-i-got-to-the-closing-the-documents-said-it-was-a-30-year-loan-my-lender-or-broker-said-not-to-worry-i-can-refinance-later-but-thats-not-in-any-of-my-paperwork-and-i-dont-want-to-close-a-loan-whos.html,/ask-cfpb/my-rate-or-the-fees-changed-between-my-loan-estimate-and-my-closing-disclosure-what-do-i-do-en-184/,301

--- a/cfgov/core/regex-redirects.csv
+++ b/cfgov/core/regex-redirects.csv
@@ -16,8 +16,9 @@ pattern,target_url,status_code
 # Temporarily redirect all blog posts to the blog landing page
 /(about-us/)?blog/.+,/about-us/blog/,302
 
-# Temporarily redirect all language hub pages to /language/
-/language/.+,/language/,302
+# Temporarily redirect all non-English pages to their English equivalent
+/language/.*,/,302
+/consumer-tools/sending-money/.+,/consumer-tools/sending-money/,302
 
 # Redirects intended to catch sub-pages
 /practitioner-resources/(.*),/consumer-tools/educator-tools/$1,301

--- a/cfgov/core/regex-redirects.csv
+++ b/cfgov/core/regex-redirects.csv
@@ -18,7 +18,6 @@ pattern,target_url,status_code
 
 # Temporarily redirect all non-English pages to their English equivalent
 /language/.*,/,302
-/consumer-tools/sending-money/.+,/consumer-tools/sending-money/,302
 
 # Redirects intended to catch sub-pages
 /practitioner-resources/(.*),/consumer-tools/educator-tools/$1,301


### PR DESCRIPTION
Update language redirects, see GHE/Design-Development/cfgov/issues/4700 for details

---

## Changes

- `/language/` and everything under it should now redirect to the homepage
- Everything under `/consumer-tools/sending-money/` should redirect to `/consumer-tools/sending-money/`

## How to test this PR

1. Try some `/language/` URLs, like `/language/` or `/language/ko/`, and make sure they redirect to the homepage
2. Try some `/consumer-tools/sending-money/` URLs, like `/consumer-tools/sending-money/es/`, and make sure they redirect to `/consumer-tools/sending-money/`

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)