### PR TITLE
Remove archive link

### DIFF
--- a/cfgov/v1/jinja2/v1/layouts/_last-modified.html
+++ b/cfgov/v1/jinja2/v1/layouts/_last-modified.html
@@ -4,12 +4,5 @@
 <div class="block u-screen-only">
     <p><hr></p>
     <p>Page last modified {{ time.render( page.last_published_at, { 'date': true, 'time': true, 'timezone': true }, text_format=True ) }}</p>
-    <p>
-        <a class="a-link a-link--jump" href="https://wayback.archive-it.org/23481/*/https://www.consumerfinance.gov{{ request.path }}">
-            <span class="a-link__text">
-                View older versions of this page at our public archive.
-            </span>
-        </a>
-    </p>
  </div>
  {% endif %}


### PR DESCRIPTION
Remove the archive link from the end of all pages. See GHE/Design-Development/cfgov/issues/4708 for details.

---

## Removals

- Remove link to the Archive-It version of the page

## How to test this PR

1. Browse around some pages, make sure the link to Archive-It no longer appears underneath the last modified date at the end of every page.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)