### PR TITLE
Bump yarn to 4.16.0 | add 3d npmMinimalAgeGate cool down

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -12,6 +12,11 @@ enableTelemetry: false
 
 nodeLinker: node-modules
 
+npmMinimalAgeGate: '3d'
+
+npmPreapprovedPackages:
+  - '@cfpb/*'
+
 # We need to cache binaries for different architectures
 # so that GitHub Actions can find the binary for its platform.
 supportedArchitectures:

--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
     "cfgov/unprocessed/apps/*"
   ],
   "type": "module",
-  "packageManager": "yarn@4.14.1"
+  "packageManager": "yarn@4.16.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10c0
 
 "@asamuzakjp/css-color@npm:^3.2.0":


### PR DESCRIPTION
## Changes

- Bump yarn to 4.16.0 
- Add 3d npmMinimalAgeGate cool down to prevent packages less than 3 days old from being installed by default (`@cfpb` packages exempt).


## How to test this PR

1. PR check should pass.