### PR TITLE
Update global search for API changes

### DIFF
--- a/cfgov/searchgov/jinja2/searchgov/recommended.html
+++ b/cfgov/searchgov/jinja2/searchgov/recommended.html
@@ -6,7 +6,7 @@
   <div class="block block--flush-top u-mb45 recommended">
     <h2 class="h5 u-mt45">{{rec_hed}}</h2>
     {% for result in recommended %}
-      {{ render_result(result, domain) }}
+      {{ render_result(result, domain, key="description") }}
     {% endfor %}
   </div>
 {% endif %}

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -14,7 +14,7 @@
   {{url.replace("https://www.consumerfinance.gov", domain)}}
 {%- endmacro -%}
 
-{%- macro render(result, domain, key="description") -%}
+{%- macro render(result, domain, key="snippet") -%}
   {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>

--- a/cfgov/searchgov/tests/test_views.py
+++ b/cfgov/searchgov/tests/test_views.py
@@ -8,6 +8,7 @@ from searchgov.views import (
     encode_url,
     get_affiliate,
     get_api_key,
+    strip_title_suffix,
 )
 
 
@@ -37,6 +38,14 @@ class EncodeUrlTestCase(TestCase):
             encode_url({"query": "term&does=encode"}),
             API_ENDPOINT.format("query=term%26does%3Dencode"),
         )
+
+
+class StripTitleSuffixTestCase(TestCase):
+    def test_strip_suffix(self):
+        cleaned_title = strip_title_suffix(
+            "Page Title | Consumer Financial Protection Bureau"
+        )
+        self.assertEqual(cleaned_title, "Page Title")
 
 
 class JsonTestCase(TestCase):

--- a/cfgov/searchgov/tests/test_views.py
+++ b/cfgov/searchgov/tests/test_views.py
@@ -5,11 +5,9 @@ from django.test import TestCase
 
 from searchgov.views import (
     API_ENDPOINT,
-    decode_meta,
     encode_url,
     get_affiliate,
     get_api_key,
-    recreate_unencoded,
 )
 
 
@@ -38,21 +36,6 @@ class EncodeUrlTestCase(TestCase):
         self.assertEqual(
             encode_url({"query": "term&does=encode"}),
             API_ENDPOINT.format("query=term%26does%3Dencode"),
-        )
-
-
-class RecreateUnencodedTestCase(TestCase):
-    def test_combines_lowercased_split(self):
-        self.assertEqual(recreate_unencoded(["abc", "def"]), "Abc, def")
-
-
-class DecodeMetaTestCase(TestCase):
-    def test_decodes_encoded(self):
-        self.assertEqual(decode_meta("mfrggzdf"), "abcde")
-
-    def test_decodes_and_unescapes(self):
-        self.assertEqual(
-            decode_meta("MFRCM4LVN52DWYZGOF2W65B3MQ======"), 'ab"c"d'
         )
 
 

--- a/cfgov/searchgov/views.py
+++ b/cfgov/searchgov/views.py
@@ -1,7 +1,5 @@
 import math
-from base64 import b32decode
-from binascii import Error
-from html import unescape
+import re
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -40,14 +38,6 @@ def encode_url(params):
     return API_ENDPOINT.format(urlencode(params))
 
 
-def recreate_unencoded(parts):
-    return ", ".join(parts).capitalize()
-
-
-def decode_meta(encoded):
-    return unescape(b32decode(encoded.upper()).decode("utf-8"))
-
-
 class SearchView(TranslatedTemplateView):
     template_name = "searchgov/index.html"
 
@@ -72,7 +62,6 @@ class SearchView(TranslatedTemplateView):
             response = requests.get(
                 encode_url(
                     {
-                        "include_facets": "true",
                         "affiliate": affiliate,
                         "access_key": api_key,
                         "limit": RESULTS_PER_PAGE,
@@ -105,21 +94,8 @@ class SearchView(TranslatedTemplateView):
 
                     # Post proprocess results
                     for res in results:
-                        # Strip | CFPB suffix
-                        encoded_list = res.get("searchgov_custom2")
-                        if encoded_list:
-                            # Hack due to search.gov caching old data
-                            try:
-                                res["description"] = decode_meta(
-                                    encoded_list[0]
-                                )
-                            # binascii Error points to likely unencoded data
-                            except Error:
-                                res["description"] = recreate_unencoded(
-                                    encoded_list
-                                )
-                        else:
-                            res["description"] = res["snippet"]
+                        # Strip " | CFPB" suffix
+                        res["title"] = re.sub(r" \| .*", "", res["title"])
 
                 else:
                     count = 0

--- a/cfgov/searchgov/views.py
+++ b/cfgov/searchgov/views.py
@@ -38,6 +38,17 @@ def encode_url(params):
     return API_ENDPOINT.format(urlencode(params))
 
 
+def strip_title_suffix(title):
+    """Remove the ' | Consumer Financial Protection Bureau' from the end
+    of search result titles. Becuase one or more words may be enclosed by
+    \ue000 and \ue001 characters if they match a search term, we have to be
+    a little flexible with the regex.
+    """
+    suffix_regex = r" \| .*"
+    cleaned_title = re.sub(suffix_regex, "", title)
+    return cleaned_title
+
+
 class SearchView(TranslatedTemplateView):
     template_name = "searchgov/index.html"
 
@@ -95,7 +106,7 @@ class SearchView(TranslatedTemplateView):
                     # Post proprocess results
                     for res in results:
                         # Strip " | CFPB" suffix
-                        res["title"] = re.sub(r" \| .*", "", res["title"])
+                        res["title"] = strip_title_suffix(res["title"])
 
                 else:
                     count = 0

--- a/cfgov/v1/jinja2/v1/layouts/base.html
+++ b/cfgov/v1/jinja2/v1/layouts/base.html
@@ -59,10 +59,7 @@ itemscope itemtype="https://schema.org/FAQPage"
                 {{- meta_description if page else '' -}}
             {%- endblock -%}
           ">
-    <meta name="searchgov_custom1" content="{{ language }}">
-    {# Base32 encoding used to avoid an issue with Search.gov custom fields losing capitalization. -#}
-    <meta name="searchgov_custom2" content="{{ encode_b32_string(self.desc()) }}">
-
+    
     {# Always open preview panel links in a new tab. #}
     {% if request.in_preview_panel %}
     <base target="_blank">

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -1,5 +1,3 @@
-from base64 import b32encode
-
 from jinja2 import pass_context
 from jinja2.ext import Extension
 
@@ -53,10 +51,6 @@ def unique_id_in_context(context):
         return get_unique_id()
 
 
-def encode_b32_string(s):
-    return b32encode(s.encode("utf-8")).decode("utf-8")
-
-
 class V1Extension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
@@ -69,7 +63,6 @@ class V1Extension(Extension):
                 "get_unique_id": get_unique_id,
                 "is_filter_selected": pass_context(is_filter_selected),
                 "unique_id_in_context": pass_context(unique_id_in_context),
-                "encode_b32_string": encode_b32_string,
                 "app_url": app_url,
                 "app_page_url": app_page_url,
             }

--- a/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
+++ b/cfgov/v1/tests/jinja2tags/test_jinja2tags.py
@@ -98,16 +98,3 @@ class TestGetCategoryIcon(SimpleTestCase):
         self.checkRender(
             "{{ get_category_icon('Invalid category name') }}", "None"
         )
-
-
-class TestEncodeB32String(SimpleTestCase):
-    def setUp(self):
-        self.jinja_engine = engines["wagtail-env"]
-
-    def test_encode_b32_string(self):
-        s = (
-            "{%- block desc -%}cfpb{%- endblock -%}"
-            "{{encode_b32_string(self.desc())}}"
-        )
-        template = self.jinja_engine.from_string(s)
-        self.assertEqual(template.render(), "cfpbMNTHAYQ=")


### PR DESCRIPTION
The search.gov API that powers cf.gov global site search has changed in a couple of ways recently:

1. They've removed custom facets, which we were using to get page language and render better search result descriptions than the default snippet 
2. Something has changed that has re-introduced the " | Consumer Financial Protection Bureau" from page `<title>`s into search result titles.

This PR removes our handling custom facets and strips the " | CFPB" suffix from search result titles.

See GHE/Design-Development/cfgov/issues/4707 for more details. Also see #8993, #8889, #8865, #8803, #8815, and #8809 for where most of this was added.

---

## Additions

- Strip out the " | Consumer Financial Protection Bureau" from search result titles

## Removals

- Everything related to custom search.gov facets, which are now no longer indexed or returned in API results

## How to test this PR

1. Do some searches, like http://localhost:8000/search/?q=mortgage and http://localhost:8000/search/?q=bureau
2. Make sure result titles don't have " | Consumer Financial Protection Bureau" on the end of them as they do in production
3. Make sure best bets, result descriptions/snippets, result links, result count, and pagination work as they do in production

## Notes and todos

- See the inline note I added to the bit that removes the " | Consumer Financial Protection Bureau" suffix. Is there a better way to do this and still account for all the possibilities?

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets