### PR TITLE
Update plugin-postcss-sass to branch into component/non-component and css/scss pathways

### DIFF
--- a/esbuild/plugins/plugin-postcss-sass.js
+++ b/esbuild/plugins/plugin-postcss-sass.js
@@ -1,37 +1,53 @@
-import { readdirSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import postcss from 'postcss';
 import cssnano from 'cssnano';
 import autoprefixer from 'autoprefixer';
 import * as sass from 'sass';
 
+const loadPaths = [
+  ...readdirSync('./node_modules/@cfpb').map(
+    (v) => `./node_modules/@cfpb/${v}/src`,
+  ),
+  './node_modules/',
+];
+
+// Convert scss to css…
+async function compileSass(filePath) {
+  const result = sass.compile(filePath, { loadPaths });
+  return result.css;
+}
+
+// … Process css.
+const postCssProcessor = postcss([autoprefixer, cssnano]);
+async function processCss(source, from) {
+  return postCssProcessor.process(source, { from });
+}
+
+// … The actual plugin definition.
 const pluginPostCssSass = () => ({
   name: 'postcss-sass',
+
   setup(build) {
-    build.onLoad({ filter: /.\.scss$/ }, async (args) => {
-      const sassResult = await sass.compile(args.path, {
-        loadPaths: [
-          ...readdirSync('./node_modules/@cfpb').map(
-            (v) => `./node_modules/@cfpb/${v}/src`,
-          ),
-          './node_modules/',
-        ],
-      });
+    build.onLoad({ filter: /\.(css|scss)$/ }, async (args) => {
+      // Web Component style files may be styles.component.scss or styles.component.css,
+      const isComponent = /\.component\.(css|scss)$/.test(args.path);
 
-      const result = await postcss([autoprefixer, cssnano]).process(
-        sassResult.css,
-        {
-          from: args.path,
-        },
-      );
+      // CSS may come in via .css or .scss files.
+      const isScss = args.path.endsWith('.scss');
 
-      // If the suffix is .component.scss, we're going to assume this
-      // will be inlined into a web component, so we'll change the loader
-      // from css to text.
-      const inlineRegex = /^(?!.*\.component\.scss$).*\.scss$/;
+      let source;
+
+      if (isScss) {
+        source = await compileSass(args.path);
+      } else {
+        source = readFileSync(args.path, 'utf8');
+      }
+
+      const result = await processCss(source, args.path);
 
       return {
         contents: result.css,
-        loader: inlineRegex.exec(args.path) ? 'css' : 'text',
+        loader: isComponent ? 'text' : 'css',
       };
     });
   },


### PR DESCRIPTION
We may have either CSS or SCSS files come into the project. Additionally, the DS web components need their CSS imports inlined via the "text" loader. The web component style files currently follow the convention of being named `styles.component.scss` or  `styles.component.css`. Currently, only `*.component.scss` files are inlined.

This PR updates the `plugin-postcss-sass` plugin to branch into css/scss and component/non-component pathways for SASS compiling and CSS post-processing.

## Changes

- Update plugin-postcss-sass to branch into component/non-component and css/scss pathways.


## How to test this PR

1. `yarn build && yarn start` should pass
2. The file upload component on http://localhost:8000/rural-or-underserved-tool/#rural-or-underserved should still have `:host` styles.
3. http://localhost:8000/data-research/consumer-complaints/search/ should still render.
4. http://localhost:8000/data-research/mortgage-performance-trends/mortgages-90-or-more-days-delinquent/ should still render highcharts.