### PR TITLE
Fix custom menu item icons

### DIFF
--- a/cfgov/permissions_viewer/wagtail_hooks.py
+++ b/cfgov/permissions_viewer/wagtail_hooks.py
@@ -31,7 +31,7 @@ def register_settings_menu_item():
     return MenuItem(
         "Permissions",
         reverse("permissions:index"),
-        classname="icon icon-unlocked",
+        icon_name="lock-open",
     )
 
 

--- a/cfgov/v1/views/reports.py
+++ b/cfgov/v1/views/reports.py
@@ -86,7 +86,7 @@ def generate_filename(type):
 
 
 class PageMetadataReportView(PageReportView):
-    header_icon = "doc-empty-inverse"
+    header_icon = "doc-full-inverse"
     page_title = "Page Metadata (for Live Pages)"
 
     list_export = PageReportView.list_export + [

--- a/cfgov/v1/wagtail_hooks.py
+++ b/cfgov/v1/wagtail_hooks.py
@@ -128,7 +128,7 @@ def register_django_admin_menu_item():
     return StaffOnlyMenuItem(
         "Django Admin",
         reverse("admin:index"),
-        classname="icon icon-redirect",
+        icon_name="glasses",
         order=99999,
     )
 
@@ -138,7 +138,7 @@ def register_page_metadata_report_menu_item():
     return MenuItem(
         "Page Metadata",
         reverse("page_metadata_report"),
-        classname="icon icon-" + PageMetadataReportView.header_icon,
+        icon_name=PageMetadataReportView.header_icon,
     )
 
 
@@ -163,7 +163,7 @@ def register_page_drafts_report_menu_item():
     return MenuItem(
         "Draft Pages",
         reverse("page_drafts_report"),
-        classname="icon icon-" + DraftReportView.header_icon,
+        icon_name=DraftReportView.header_icon,
     )
 
 
@@ -188,7 +188,7 @@ def register_documents_report_menu_item():
     return MenuItem(
         "Documents",
         reverse("documents_report"),
-        classname="icon icon-" + DocumentsReportView.header_icon,
+        icon_name=DocumentsReportView.header_icon,
     )
 
 
@@ -213,7 +213,7 @@ def register_enforcements_actions_report_menu_item():
     return MenuItem(
         "Enforcement Actions",
         reverse("enforcement_report"),
-        classname="icon icon-" + EnforcementActionsReportView.header_icon,
+        icon_name=EnforcementActionsReportView.header_icon,
     )
 
 
@@ -238,7 +238,7 @@ def register_images_report_menu_item():
     return MenuItem(
         "Images",
         reverse("images_report"),
-        classname="icon icon-" + ImagesReportView.header_icon,
+        icon_name=ImagesReportView.header_icon,
     )
 
 
@@ -263,7 +263,7 @@ def register_ask_report_menu_item():
     return MenuItem(
         "Ask CFPB",
         reverse("ask_report"),
-        classname="icon icon-" + AskReportView.header_icon,
+        icon_name=AskReportView.header_icon,
     )
 
 
@@ -288,7 +288,7 @@ def register_category_icons_report_menu_item():
     return MenuItem(
         "Category Icons",
         reverse("category_icons_report"),
-        classname="icon icon-" + CategoryIconReportView.header_icon,
+        icon_name=CategoryIconReportView.header_icon,
     )
 
 
@@ -313,7 +313,7 @@ def register_translated_pages_report_menu_item():
     return MenuItem(
         "Translated Pages",
         reverse("translated_pages_report"),
-        classname="icon icon-" + TranslatedPagesReportView.header_icon,
+        icon_name=TranslatedPagesReportView.header_icon,
     )
 
 


### PR DESCRIPTION
Fixes icons in custom menu items.

---

## Changes

- Correctly sets custom menu item icons
- Changed icons for the page metadata report since it now sits right above a report with the same icon
- Changed icons for the Django admin to be appropriately nerdier

## How to test this PR

1. Confirm that every item in the left-side menu in the Wagtail admin has an icon

## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="191" height="847" alt="before" src="https://github.com/user-attachments/assets/b5606c89-8298-42d1-9821-7d27d3a93c6b" /> | <img width="194" height="842" alt="after" src="https://github.com/user-attachments/assets/cf1e48d6-1656-4aca-a60e-3ccf3c4df25f" /> |

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)