### PR TITLE
Temporarily allow blog and newsroom subpages

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -113,4 +113,8 @@ class EventArchivePage(BrowseFilterablePage):
 class NewsroomLandingPage(BrowseFilterablePage):
     template = "v1/newsroom/index.html"
     filterable_categories = ["Newsroom"]
-    subpage_types = ["NewsroomPage"]
+    # TODO: Remove "LegacyNewsroomPage" after archived pages move
+    subpage_types = [
+        "NewsroomPage",
+        "LegacyNewsroomPage",
+    ]

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -61,7 +61,13 @@ class SublandingFilterablePage(AbstractFilterablePage, CFGOVPage):
         "searchable using standard search filters module."
     )
 
-    subpage_types = ["DocumentDetailPage", "BlogPage"]
+    # TODO: Remove "LegacyBlogPage", "NewsroomPage" after archived pages move
+    subpage_types = [
+        "DocumentDetailPage",
+        "BlogPage",
+        "LegacyBlogPage",
+        "NewsroomPage",
+    ]
 
 
 class ResearchHubPage(SublandingFilterablePage):


### PR DESCRIPTION
Temporarily allow a few more subpage types to live under the page types used for the blog and newsroom landing pages. This is to allow us to move blog and newsroom pages to the archive; see GHE/Design-Development/cfgov/issues/4710 for details.

---

## Additions

- Extra allowed subpage types

## How to test this PR

1. Confirm that pages of the added allowed page types can be moved (or created) under the proper parent page types

## Notes and todos

- As noted in the code comments, we'll remove the extra subpage types once we've moved the pages to be archived.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets