### PR TITLE
Unregister service worker to prevent pointless requests

### DIFF
--- a/cfgov/cfgov/urls/__init__.py
+++ b/cfgov/cfgov/urls/__init__.py
@@ -354,6 +354,14 @@ urlpatterns = [
         ),
     ),
     re_path(
+        r"^regulations3k-service-worker.js$",
+        TemplateView.as_view(
+            template_name="regulations3k-service-worker.js",
+            content_type="application/javascript",
+        ),
+        name="regulations3k-service-worker.js",
+    ),
+    re_path(
         r"^sitemap\.xml$",
         akamai_no_store(sitemap),
         {"sitemaps": {"site": Sitemap}},

--- a/cfgov/unprocessed/unregister.js
+++ b/cfgov/unprocessed/unregister.js
@@ -1,11 +1,11 @@
-self.addEventListener('install', () => {
+globalThis.addEventListener('install', () => {
   // Force the waiting service worker to become the active service worker immediately
-  self.skipWaiting(); 
+  globalThis.skipWaiting(); 
 });
 
-self.addEventListener('activate', () => {
+globalThis.addEventListener('activate', () => {
   // Unregister itself from the browser
-  self.registration.unregister()
+  globalThis.registration.unregister()
     .then(() => {
       // Clear all caches associated with this domain
       return caches.keys();
@@ -17,7 +17,7 @@ self.addEventListener('activate', () => {
     })
     .then(() => {
       // Force all open tabs/clients to reload to apply changes immediately
-      return self.clients.matchAll({ type: 'window' });
+      return globalThis.clients.matchAll({ type: 'window' });
     })
     .then((clients) => {
       clients.forEach((client) => {

--- a/cfgov/unprocessed/unregister.js
+++ b/cfgov/unprocessed/unregister.js
@@ -1,0 +1,29 @@
+self.addEventListener('install', () => {
+  // Force the waiting service worker to become the active service worker immediately
+  self.skipWaiting(); 
+});
+
+self.addEventListener('activate', () => {
+  // Unregister itself from the browser
+  self.registration.unregister()
+    .then(() => {
+      // Clear all caches associated with this domain
+      return caches.keys();
+    })
+    .then((cacheNames) => {
+      return Promise.all(
+        cacheNames.map((cacheName) => caches.delete(cacheName))
+      );
+    })
+    .then(() => {
+      // Force all open tabs/clients to reload to apply changes immediately
+      return self.clients.matchAll({ type: 'window' });
+    })
+    .then((clients) => {
+      clients.forEach((client) => {
+        if (client.url && 'navigate' in client) {
+          client.navigate(client.url);
+        }
+      });
+    });
+});

--- a/esbuild/copy.js
+++ b/esbuild/copy.js
@@ -45,6 +45,11 @@ async function copy(baseConfig) {
     `${modules}/@fontsource-variable/source-sans-3/files/source-sans-3-latin-wght-normal.woff2`,
     `${baseConfig.outdir}/fonts/source-sans-3-latin-wght-normal.woff2`,
   );
+
+  copyFile(
+    `${unprocessed}/unregister.js`,
+    `${baseConfig.outdir}/regulations3k-service-worker.js`
+  )
 }
 
 export { copy };


### PR DESCRIPTION
After https://github.com/cfpb/consumerfinance.gov/pull/9038, we still have quite a lot of requests for /regulations3k-service-worker.js as people with a previously registered service worker have their browsers checking for updates.

This replaces that 404ing request with something that will unregister said worker. After a month or so, we can remove this code.