### PR TITLE
Remove legacy blog post/newsroom notification

### DIFF
--- a/cfgov/v1/jinja2/v1/blog/legacy_blog_page.html
+++ b/cfgov/v1/jinja2/v1/blog/legacy_blog_page.html
@@ -7,22 +7,6 @@
 {%- endblock %}
 
 {% block content_main %}
-    {% import 'v1/includes/molecules/notification.html' as notification %}
-    {% set canonical_archive_url = 'https://wayback.archive-it.org/23462/20241001120000/' ~ request.build_absolute_uri(request.path) | lower %}
-
-    <div class="u-mb15">
-      {{- notification.render(
-          type='information',
-          is_visible=true,
-          message='Archived content',
-          explanation='This content has been archived, and its original formatting has been removed.',
-          links=[ {
-              'text': 'View this page as it was originally published',
-              'url': canonical_archive_url
-          } ]
-      ) }}
-    </div>
-
     {% include 'v1/includes/article.html' %}
     {% block post_article_content %}
 


### PR DESCRIPTION
Remove the notification from legacy blog and newsroom pages. Since those pages will now appear in an archive section with its own, very similar banner, this additional notification was deemed unnecessary. See GHE/Design-Development/cfgov/issues/4709 for details.

---

## Removals

- Notification on legacy blog and newsroom pages

## How to test this PR

1. Go to any legacy blog or newsroom page and confirm the notification doesn't appear.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)