### PR TITLE
Security: Potential XSS in Jinja2 Template via Unescaped Output

### DIFF
--- a/cfgov/agreements/jinja2/agreements/_json.html
+++ b/cfgov/agreements/jinja2/agreements/_json.html
@@ -9,8 +9,8 @@
   window.cfpbIssuers = [
   {%- for issuer in issuers -%}
    {
-    value:"{{issuer.slug}}",
-    label:"{{issuer.name}}"
+    value:{{ issuer.slug|to_json }},
+    label:{{ issuer.name|to_json }}
    }{{ "," if not loop.last else "" }}
   {%- endfor -%}
   ]


### PR DESCRIPTION
## Summary

Security: Potential XSS in Jinja2 Template via Unescaped Output

## Problem

**Severity**: `Medium` | **File**: `cfgov/agreements/jinja2/agreements/_json.html:L10`

In `cfgov/agreements/jinja2/agreements/_json.html`, the template outputs `issuer.slug` and `issuer.name` directly into a JavaScript array without HTML escaping. While Jinja2 auto-escapes by default, the `| safe` filter or `{% autoescape false %}` context could bypass this. The values are placed inside double-quoted strings but without explicit escaping, malicious content could break out of the string context.

## Solution

Ensure proper JSON escaping for dynamic values in JavaScript contexts. Use a proper JSON serialization approach or explicitly escape values. Consider using Django's `json_script` or a custom filter that properly escapes for JavaScript string contexts, handling both HTML and JavaScript special characters.

## Changes

- `cfgov/agreements/jinja2/agreements/_json.html` (modified)