### PR TITLE
Update archive banner content

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/blocks/banner-archived.html
+++ b/cfgov/v1/jinja2/v1/includes/blocks/banner-archived.html
@@ -6,8 +6,5 @@
     explanation=(
       'This is archived content from the Consumer Financial Protection Bureau website. '
       'The information here may be outdated and links may no longer function. '
-      'Please contact '
-      '<a href="mailto:CFPB_website@consumerfinance.gov">CFPB_website@consumerfinance.gov</a> '
-      'if you have any questions about the archive.'
-    ) | safe
+    )
 ) }}


### PR DESCRIPTION
Update content of the archive banner per feedback. See GHE/Design-Development/cfgov/issues/4709 for details.

---

## Changes

- Update the content of the archive banner

## How to test this PR

1. Go to any archived page and make sure the banner matches the screenshot.

## Screenshots

<img width="1198" height="694" alt="archive-banner-update" src="https://github.com/user-attachments/assets/9cecfaa0-c916-4053-8066-25d4ac888a4f" />

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)