### PR TITLE
Fix: Make LIVE links consistently point to www

### DIFF
--- a/cfgov/wagtailadmin_overrides/templates/wagtailadmin/shared/page_status_tag_new.html
+++ b/cfgov/wagtailadmin_overrides/templates/wagtailadmin/shared/page_status_tag_new.html
@@ -1,0 +1,47 @@
+{% load i18n wagtailadmin_tags %}
+{% comment %}
+
+    Variables accepted by this template:
+
+    - `page` - A wagtail page object
+    - `classes` - String of extra css classes to pass to this component
+{% endcomment %}
+
+{% comment %} Unable to use pageurl template tag here due to issues in unit tests where request is not yet available - see #10157 {% endcomment %}
+{% if page.live and page.full_url is not None %}
+    {% test_page_is_public page as is_public %}
+    {% trans 'Live' as live_label %}
+    {% comment %} Two copies of the tag, visibility is toggled by the privacy switch JS {% endcomment %}
+    <a
+        href="{{ page.full_url }}"
+        target="_blank"
+        rel="noreferrer"
+        class="{% classnames 'page-status-tag' is_public|yesno:',w-hidden' %}"
+        aria-label="{% trans 'Visible to all. Visit the live page' %}"
+        data-controller="w-tooltip w-zone"
+        data-action="w-privacy:changed@document->w-zone#switch"
+        data-w-tooltip-content-value="{% trans 'Visible to all' %}"
+        data-w-tooltip-offset-value="[0, 13]"
+        data-w-zone-inactive-class="w-hidden"
+        data-w-zone-switch-key-value="isPublic"
+    >
+        {% icon classname='w-w-4 w-h-4 w-mr-1' name="view" %}
+        {{ live_label }}
+    </a>
+    <a
+        href="{{ page.full_url }}"
+        target="_blank"
+        rel="noreferrer"
+        class="{% classnames 'page-status-tag' is_public|yesno:'w-hidden,' %}"
+        aria-label="{% trans 'Private. Visit the live page' %}"
+        data-controller="w-tooltip w-zone"
+        data-action="w-privacy:changed@document->w-zone#switch"
+        data-w-tooltip-content-value="{% trans 'Private' %}"
+        data-w-tooltip-offset-value="[0, 13]"
+        data-w-zone-inactive-class="w-hidden"
+        data-w-zone-switch-key-value="!isPublic"
+    >
+        {% icon classname='w-w-4 w-h-4 w-mr-1' name="no-view" %}
+        {{ live_label }}
+    </a>
+{% endif %}


### PR DESCRIPTION
This project overrides the Wagtail page status tag template to always use the "full" page URL:
https://github.com/cfpb/consumerfinance.gov/blob/c6703651d2abffcba4fbec3e95ea8aa187acdc07/cfgov/wagtailadmin_overrides/templates/wagtailadmin/shared/page_status_tag.html This is to enforce LIVE links to www.cf.gov even when browsing Wagtail on an alternate domain name.

This functionality was working only partially; some LIVE links weren't pointing to www as desired. This change adds an additional template override to accomplish this.

The content of this file comes from
https://github.com/wagtail/wagtail/blob/cb3ed5a2891466f99aa213575caf40ef273a307b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html with page.url replaced by page.full_url, to be consistent with the existing override.

See internal cfgov#4679 for context.