### PR TITLE
Add archived pill to activity log

### DIFF
--- a/cfgov/unprocessed/css/main.scss
+++ b/cfgov/unprocessed/css/main.scss
@@ -59,6 +59,7 @@
 @use 'organisms/filterable-list-controls' as *;
 @use 'organisms/full-width-text-group' as *;
 @use 'organisms/header' as *;
+@use 'organisms/heading-archived' as *;
 @use 'organisms/info-unit-group' as *;
 @use 'organisms/item-introduction' as *;
 @use 'organisms/mega-menu' as *;

--- a/cfgov/unprocessed/css/molecules/pill.scss
+++ b/cfgov/unprocessed/css/molecules/pill.scss
@@ -7,16 +7,8 @@
   width: fit-content;
   height: 100%;
   padding: math.div(5px, $base-font-size-px) + rem math.div(7px, $base-font-size-px) + rem;
-  margin-right: math.div(5px, $base-font-size-px) + rem;
   border-radius: $btn-border-radius-size;
   line-height: 1;
-
-  // Mobile only.
-  @include respond-to-max($bp-xs-max) {
-    display: block;
-    margin-right: 0;
-    margin-bottom: math.div(5px, $base-font-size-px) + rem;
-  }
 
   &--archived {
     background-color: var(--teal-mid-dark);

--- a/cfgov/unprocessed/css/organisms/heading-archived.scss
+++ b/cfgov/unprocessed/css/organisms/heading-archived.scss
@@ -1,0 +1,13 @@
+@use 'sass:math';
+@use '@cfpb/cfpb-design-system/src/abstracts' as *;
+
+.o-heading-archived {
+  display: flex;
+  column-gap: math.div(5px, $base-font-size-px) + rem;
+
+  // Mobile only.
+  @include respond-to-max($bp-xs-max) {
+    flex-direction: column;
+    row-gap: math.div(5px, $base-font-size-px) + rem;
+  }
+}

--- a/cfgov/unprocessed/css/organisms/heading-archived.scss
+++ b/cfgov/unprocessed/css/organisms/heading-archived.scss
@@ -3,11 +3,10 @@
 
 .o-heading-archived {
   display: flex;
-  column-gap: math.div(5px, $base-font-size-px) + rem;
+  gap: math.div(5px, $base-font-size-px) + rem;
 
   // Mobile only.
   @include respond-to-max($bp-xs-max) {
     flex-direction: column;
-    row-gap: math.div(5px, $base-font-size-px) + rem;
   }
 }

--- a/cfgov/v1/jinja2/v1/activity-log/_activity-list.html
+++ b/cfgov/v1/jinja2/v1/activity-log/_activity-list.html
@@ -1,4 +1,5 @@
 {% import 'v1/includes/macros/category-slug.html' as category_slug %}
+{% import 'v1/includes/molecules/pill-archived.html' as pill_archived %}
 
 {% macro render(posts) %}
     {% set page_url = pageurl(page) %}
@@ -30,11 +31,18 @@
                     {% endif %}
                 </td>
                 <td class="u-w65pct">
+                    {% if post.in_archive -%}
+                        <div class="o-heading-archived">
+                            {{ pill_archived }}
+                    {%- endif %}
                     <a href="{{ post.url }}">
                         <span class="h4 u-mb0">
                             {{- post.preview_title -}}
                         </span>
                     </a>
+                    {% if post.in_archive -%}
+                        </div>
+                    {%- endif %}
                 </td>
                 <td class="u-w15pct">
                     {% import 'v1/includes/macros/time.html' as time %}

--- a/cfgov/v1/serializers.py
+++ b/cfgov/v1/serializers.py
@@ -28,6 +28,7 @@ class FilterPageSerializer(serializers.Serializer):
     title = serializers.ReadOnlyField()
     url = serializers.SerializerMethodField()
     tags = serializers.SerializerMethodField()
+    in_archive = serializers.ReadOnlyField()
 
     def get_categories(self, page):
         category_mapping = dict(CFGOVPageCategory.name.field.flatchoices)

--- a/cfgov/v1/tests/test_serializers.py
+++ b/cfgov/v1/tests/test_serializers.py
@@ -61,6 +61,7 @@ class FilterablePageSerializerTests(TestCase):
                 "full_url": "http://localhost/blog/",
                 "image_alt": "",
                 "image_url": None,
+                "in_archive": False,
                 "is_blog": True,
                 "is_event": False,
                 "is_report": False,
@@ -105,6 +106,7 @@ class FilterablePageSerializerTests(TestCase):
                 "full_url": "http://localhost/event/",
                 "image_alt": "",
                 "image_url": None,
+                "in_archive": False,
                 "is_blog": False,
                 "is_event": True,
                 "is_report": False,
@@ -142,6 +144,7 @@ class FilterablePageSerializerTests(TestCase):
                     "https://api.mapbox.com/styles/v1/mapbox/streets-v11/static/"
                     "-77.039628,38.898238,12/276x155?access_token=None"
                 ),
+                "in_archive": False,
                 "is_blog": False,
                 "is_event": True,
                 "is_report": False,
@@ -181,6 +184,7 @@ class FilterablePageSerializerTests(TestCase):
                 "full_url": "http://localhost/event/",
                 "image_alt": "Venue image alt text",
                 "image_url": "/f/images/event-serialization.width-540.png",
+                "in_archive": False,
                 "is_blog": False,
                 "is_event": True,
                 "is_report": False,


### PR DESCRIPTION
Add the archived pill to archived items in the activity log.

---

## Additions

- `in_archive` serializer
- `heading-archived` organism

## Changes

- Refactored archive pill CSS to set margins between elements in the organism instead of the molecule

## How to test this PR

1. Move some pages that appear in the activity log to `/archive/`
2. Confirm the archived pill appears next to those pages titles in the activity log and matches the screenshots

## Screenshots

| Desktop | Mobile  |
| ------ | ------ |
| <img width="1199" height="593" alt="activity-log-desktop" src="https://github.com/user-attachments/assets/d9b39175-ac7d-4f60-8da3-ddeb9e81b789" /> | <img width="402" height="745" alt="activity-log-mobile" src="https://github.com/user-attachments/assets/229c1212-94c7-4f2e-92f4-0b6a58afc468" /> |

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)