### PR TITLE
Fix filtering of pages with invalid categories

### DIFF
--- a/cfgov/v1/serializers.py
+++ b/cfgov/v1/serializers.py
@@ -36,7 +36,15 @@ class FilterPageSerializer(serializers.Serializer):
         categories = []
         for category in page.categories.all():
             category_slug = category.name
-            category_name = category_mapping[category_slug]
+            category_name = category_mapping.get(category_slug)
+
+            # This can happen if a page was assigned a category that was
+            # subsequently removed from the list in v1.ref.categories. The
+            # obsolete category slug is still associated with the page in the
+            # database, but there's no category name to display. Skip it.
+            if category_name is None:
+                continue
+
             categories.append(
                 {
                     "slug": category_slug,

--- a/cfgov/v1/tests/test_serializers.py
+++ b/cfgov/v1/tests/test_serializers.py
@@ -37,6 +37,7 @@ class FilterablePageSerializerTests(TestCase):
         blog.categories.add(
             CFGOVPageCategory(name="info-for-consumers"),
             CFGOVPageCategory(name="at-the-cfpb"),
+            CFGOVPageCategory(name="invalid-category"),
         )
         blog.tags.add("Payments", "Mortgages")
 


### PR DESCRIPTION
In certain cases, pages in the database may have been assigned page categories which have since been deleted. These can, in some cases, cause errors when they show up in filterable list search results.

This fix ignores any invalid categories when pages are serialized from search results. Previously this would cause an unhandled KeyError.