### PR TITLE
Show archived pill in site search results

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -823,4 +823,4 @@ PERMISSIONS_POLICY = {
 # This part of the website contains archived content.
 # All URLs starting with /archive/ will show an "archived" banner.
 # Set this locally to "*" for testing purposes only, to enable site-wide.
-ARCHIVE_BASE_PATH = "archive"
+ARCHIVE_BASE_PATH = "/archive/"

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -1,3 +1,5 @@
+{% import 'v1/includes/molecules/pill-archived.html' as pill_archived %}
+
 {%- macro bold_matches(text) -%}
   {% for char in text -%}
     {%- if char == "\ue000" -%}
@@ -18,6 +20,11 @@
   {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>
+      {% if url_in_archive(url) -%}
+      <div class="o-heading-archived">
+        {{ pill_archived }}
+      </div>
+      {%- endif %}
       <a href="{{url}}">
         <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>
         <div class="search-result__url u-mb5">{{url}}</div>

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -7,29 +7,29 @@
     {%- elif char == "\ue001" -%}
       </b>
     {%- else -%}
-      {{char}}
+      {{ char }}
     {%- endif -%}
   {% endfor %}
 {%- endmacro -%}
 
 {%- macro replace_url(url, domain) -%}
-  {{url.replace("https://www.consumerfinance.gov", domain)}}
+  {{ url.replace("https://www.consumerfinance.gov", domain) }}
 {%- endmacro -%}
 
 {%- macro render(result, domain, key="snippet") -%}
   {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>
-      <a href="{{url}}">
+      <a href="{{ url }}">
         <h3 class="h4 u-mb0">
           {%- if url_in_archive(url) -%}
-            {{  pill_archived  }}
+            {{ pill_archived }}
           {%- endif -%}
-          {{bold_matches(result.title)}}
+          {{ bold_matches(result.title) }}
         </h3>
-        <div class="search-result__url u-mb5">{{url}}</div>
+        <div class="search-result__url u-mb5">{{ url }}</div>
       </a>
-      <p>{{bold_matches(result[key])}}</p>
+      <p>{{ bold_matches(result[key]) }}</p>
     </article>
   </div>
 {%- endmacro -%}

--- a/cfgov/searchgov/jinja2/searchgov/result.html
+++ b/cfgov/searchgov/jinja2/searchgov/result.html
@@ -20,13 +20,13 @@
   {%- set url = replace_url(result.url, domain) %}
   <div class="search-result">
     <article>
-      {% if url_in_archive(url) -%}
-      <div class="o-heading-archived">
-        {{ pill_archived }}
-      </div>
-      {%- endif %}
       <a href="{{url}}">
-        <h3 class="h4 u-mb0">{{bold_matches(result.title)}}</h3>
+        <h3 class="h4 u-mb0">
+          {%- if url_in_archive(url) -%}
+            {{  pill_archived  }}
+          {%- endif -%}
+          {{bold_matches(result.title)}}
+        </h3>
         <div class="search-result__url u-mb5">{{url}}</div>
       </a>
       <p>{{bold_matches(result[key])}}</p>

--- a/cfgov/unprocessed/apps/searchgov/css/main.scss
+++ b/cfgov/unprocessed/apps/searchgov/css/main.scss
@@ -23,6 +23,10 @@
     color: var(--black);
   }
 
+  .m-pill {
+    margin-right: math.div(5px, $base-font-size-px) + rem;
+  }
+
   &__url {
     margin-top: math.div(4px, $base-font-size-px) + rem;
     color: var(--gray-dark);

--- a/cfgov/v1/jinja2tags/__init__.py
+++ b/cfgov/v1/jinja2tags/__init__.py
@@ -3,6 +3,7 @@ from jinja2.ext import Extension
 
 from v1.templatetags.app_urls import app_page_url, app_url
 from v1.util import ref
+from v1.util.archive import url_in_archive
 from v1.util.util import get_unique_id
 
 from .datetimes import DatetimesExtension
@@ -65,6 +66,7 @@ class V1Extension(Extension):
                 "unique_id_in_context": pass_context(unique_id_in_context),
                 "app_url": app_url,
                 "app_page_url": app_page_url,
+                "url_in_archive": url_in_archive,
             }
         )
 

--- a/cfgov/v1/models/base.py
+++ b/cfgov/v1/models/base.py
@@ -29,6 +29,7 @@ from v1.atomic_elements import molecules, organisms
 from v1.models.banners import Banner
 from v1.models.snippets import ReusableText
 from v1.util import ref
+from v1.util.archive import url_in_archive
 from v1.util.util import validate_social_sharing_image
 
 
@@ -433,19 +434,10 @@ class CFGOVPage(Page):
     def in_archive(self) -> bool:
         """Returns boolean indicating whether page lives in site archive area.
 
-        Uses settings.ARCHIVE_BASE_PATH to determine site archive area.
-        If this is set to "*", applies to all pages.
-
         Uses Page.url_path which starts with the root page slug (e.g. /cfgov/).
         Pages under /archive/ will have a url_path of e.g. /cfgov/archive/.
         """
-        if settings.ARCHIVE_BASE_PATH == "*":
-            return True
-
-        path_parts = self.url_path.strip("/").split("/")
-        return (
-            len(path_parts) > 1 and path_parts[1] == settings.ARCHIVE_BASE_PATH
-        )
+        return url_in_archive("/" + "/".join(self.url_path.split("/")[2:]))
 
 
 class CFGOVPageCategory(models.Model):

--- a/cfgov/v1/tests/models/test_base.py
+++ b/cfgov/v1/tests/models/test_base.py
@@ -623,7 +623,7 @@ class TestCFGOVPageTranslations(TestCase):
         )
 
 
-@override_settings(ARCHIVE_BASE_PATH="test-archive")
+@override_settings(ARCHIVE_BASE_PATH="/test-archive/")
 class TestCFGOVPageArchive(TestCase):
     def test_in_archive(self):
         self.assertFalse(CFGOVPage(url_path="/home/").in_archive)

--- a/cfgov/v1/tests/util/test_archive.py
+++ b/cfgov/v1/tests/util/test_archive.py
@@ -1,0 +1,27 @@
+from django.test import SimpleTestCase, override_settings
+
+from v1.util.archive import url_in_archive
+
+
+@override_settings(ARCHIVE_BASE_PATH="/test-archive/")
+class URLInArchiveTests(SimpleTestCase):
+    def test_valid_cases(self):
+        for url in [
+            "/test-archive/",
+            "/test-archive/page/",
+            "/test-archive/page/?query=1",
+            "https://www.consumerfinance.gov/test-archive/",
+            "https://www.other.com/test-archive/foo/",
+        ]:
+            with self.subTest(url=url):
+                self.assertTrue(url_in_archive(url))
+
+    def test_invalid_cases(self):
+        for url in [
+            "test-archive",
+            "test-archive/",
+            "/foo/bar/",
+            "/foo/bar/test-archive/",
+        ]:
+            with self.subTest(url=url):
+                self.assertFalse(url_in_archive(url))

--- a/cfgov/v1/util/archive.py
+++ b/cfgov/v1/util/archive.py
@@ -1,0 +1,15 @@
+from urllib.parse import urlparse
+
+from django.conf import settings
+
+
+def url_in_archive(url) -> bool:
+    """Returns boolean indicating whether a URL lives in the site archive area.
+
+    Uses settings.ARCHIVE_BASE_PATH to determine site archive area.
+    If this is set to "*", applies to all URLs.
+    """
+    if settings.ARCHIVE_BASE_PATH == "*":
+        return True
+
+    return urlparse(url).path.startswith(settings.ARCHIVE_BASE_PATH)


### PR DESCRIPTION
This change modifies the site search results page so that archived pages show the "archived" slug next to them.

To test, run a local server with `SEARCHGOV_API_KEY` properly defined, set `settings.ARCHIVE_BASE_PATH = "*"` and visit http://localhost:8000/search/?q=cfpb.