### PR TITLE
Redirect Spanish tools

### DIFF
--- a/cfgov/cfgov/urls/__init__.py
+++ b/cfgov/cfgov/urls/__init__.py
@@ -212,10 +212,6 @@ urlpatterns = [
             permanent=True,
         ),
     ),
-    re_path(
-        r"^es/herramientas-del-consumidor/jubilacion/",
-        include("retirement_api.es_urls", namespace="retirement_api_es"),
-    ),
     # CCDB5-API
     re_path(
         r"^data-research/consumer-complaints/search/api/v1/",
@@ -331,10 +327,6 @@ urlpatterns = [
     ),
     re_path(
         r"^consumer-tools/financial-well-being/", include("wellbeing.urls")
-    ),
-    re_path(
-        r"^es/herramientas-del-consumidor/bienestar-financiero/",
-        include("wellbeing.es_urls"),
     ),
     re_path(
         r"^about-us/diversity-and-inclusion/",

--- a/cfgov/core/redirects.csv
+++ b/cfgov/core/redirects.csv
@@ -390,6 +390,13 @@ source_path,target_url,status_code
 /es/desastres-y-emergencias/preparese-antes-de-que-ocurra-un-desastre-o-una-emergencia/,/consumer-tools/disasters-and-emergencies/get-prepared-before-disaster-emergency-strikes/,302
 /es/desastres-y-emergencias/empiece-a-recuperarse-y-reconstruir-su-vida-financiera/,/consumer-tools/disasters-and-emergencies/start-recovering-and-rebuilding-your-financial-life/,302
 
+# Temporarily redirect Spanish tools to their English equivalent
+/es/herramientas-del-consumidor/bienestar-financiero/,/consumer-tools/financial-well-being/,302
+/es/herramientas-del-consumidor/bienestar-financiero/mas-sobre/,/consumer-tools/financial-well-being/about/,302
+/es/herramientas-del-consumidor/jubilacion/,/consumer-tools/retirement/,302
+/es/herramientas-del-consumidor/jubilacion/antes-de-solicitar/,/consumer-tools/retirement/before-you-claim/,302
+/es/herramientas-del-consumidor/jubilacion/antes-de-solicitar/mas-sobre/,/consumer-tools/retirement/before-you-claim/,302
+
 # Temporarily redirect one-off Spanish pages to their English equivalent
 /es/comprar-casa/,/mortgage/,302
 /es/opciones-de-ahorro-con-el-reembolso-de-sus-taxes/,/consumer-tools/guide-to-filing-your-taxes/,302

--- a/cfgov/retirement_api/tests/test_views.py
+++ b/cfgov/retirement_api/tests/test_views.py
@@ -13,10 +13,13 @@ from retirement_api.views import (
 )
 
 
-try:
-    from django.urls import reverse
-except ImportError:
-    from django.core.urlresolvers import reverse
+# TODO: URLs will no longer resolve so reverse is not needed.
+# We'll keep the test commented out for now so it will still
+# be here when we remove the full app.
+# try:
+#     from django.urls import reverse
+# except ImportError:
+#     from django.core.urlresolvers import reverse
 
 
 today = datetime.datetime.now().date()
@@ -47,10 +50,12 @@ class ViewTests(TestCase):
     req_invalid.GET["income"] = "x"
     return_keys = ["data", "error"]
 
-    def test_base_view(self):
-        url = reverse("retirement_api_es:claiming")
-        response = self.client.get(url)
-        self.assertTrue(response.status_code == 200)
+    # TODO: This URL will no longer resolve. We'll keep the test commented
+    # out for now so it will still be here when we remove the full app.
+    # def test_base_view(self):
+    #     url = reverse("retirement_api_en:claiming")
+    #     response = self.client.get(url)
+    #     self.assertTrue(response.status_code == 200)
 
     def test_param_check(self):
         self.assertEqual(param_check(self.req_good, "dob"), "1955-05-05")
@@ -123,7 +128,9 @@ class ViewTests(TestCase):
         response = estimator(request, dob="1955-05-05")
         self.assertTrue(response.status_code == 400)
 
-    def test_about_pages(self):
-        url = reverse("retirement_api_es:about")
-        response = self.client.get(url)
-        self.assertTrue(response.status_code == 200)
+    # TODO: This URL will no longer resolve. We'll keep the test commented
+    # out for now so it will still be here when we remove the full app.
+    # def test_about_pages(self):
+    #     url = reverse("retirement_api_en:about")
+    #     response = self.client.get(url)
+    #     self.assertTrue(response.status_code == 200)

--- a/cfgov/wellbeing/jinja2/wellbeing/about.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/about.html
@@ -27,20 +27,6 @@
 {% block content_main %}
     <h1>{{ _('Why financial well-being?') }}</h1>
 
-    {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-    {{ translation_links.render(
-        links=[
-        {
-            'href': url('fwb_about_en'),
-            'language': 'en',
-            'text': 'English'
-        },{
-            'href': url('fwb_about_es'),
-            'language': 'es',
-            'text': 'Spanish'
-        }]
-    ) }}
-
     <p class="lead-paragraph">
         {{ _('At the CFPB, we work to help consumers like you take control of your financial life to reach your own life goals,') }}
         {{ _('achieve financial peace of mind, and avoid pitfalls that can derail you.') }}

--- a/cfgov/wellbeing/jinja2/wellbeing/error.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/error.html
@@ -21,20 +21,6 @@
     <div class="block block--flush-top">
         <h1>{{ _('There was a problem with your submission') }}</h1>
 
-        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render(
-            links=[
-            {
-                'href': url('fwb_error_en'),
-                'language': 'en',
-                'text': 'English'
-            },{
-                'href': url('fwb_error_es'),
-                'language': 'es',
-                'text': 'Spanish'
-            }]
-        ) }}
-
         <p class="lead-paragraph">
             {{ _('Please use your browser’s back button to return to the questionnaire and retake it to receive your score.') }}
         </p>

--- a/cfgov/wellbeing/jinja2/wellbeing/home.html
+++ b/cfgov/wellbeing/jinja2/wellbeing/home.html
@@ -64,20 +64,6 @@
 
         <h2>{{ _('Here’s how it works:') }}</h2>
 
-        {% import 'v1/includes/molecules/translation-links.html' as translation_links with context %}
-        {{ translation_links.render(
-            links=[
-            {
-                'href': url('fwb_home_en'),
-                'language': 'en',
-                'text': 'English'
-            },{
-                'href': url('fwb_home_es'),
-                'language': 'es',
-                'text': 'Spanish'
-            }]
-        ) }}
-
         <p>
             <b>{{ _('Answer the questions and get your score.') }}</b>
             {{ _('You won’t be asked about any personal financial data—it’s not that kind of questionnaire.') }}


### PR DESCRIPTION
Redirect Spanish retirement and financial well-being tools to their English equivalents and remove any language switcher links in them.

---

## Additions

- Redirects for Spanish retirement and financial well-being tools

## Removals

- Language switcher in financial well-being tool

## How to test this PR

1. Make sure the removed Spanish URLs redirect you to the equivalent English page
2. Make sure the English financial well-being tool, `/consumer-tools/financial-well-being/`, still works

## Notes and todos

- With the sunsetting of the Spanish retirement tool, we can now totally remove the `retirement_api` app from the codebase. I'll open a separate issue to start that work.

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [x] Future todos are captured in comments and/or tickets