### PR TITLE
Remove subpage types needed for archive

### DIFF
--- a/cfgov/v1/models/browse_filterable_page.py
+++ b/cfgov/v1/models/browse_filterable_page.py
@@ -113,8 +113,4 @@ class EventArchivePage(BrowseFilterablePage):
 class NewsroomLandingPage(BrowseFilterablePage):
     template = "v1/newsroom/index.html"
     filterable_categories = ["Newsroom"]
-    # TODO: Remove "LegacyNewsroomPage" after archived pages move
-    subpage_types = [
-        "NewsroomPage",
-        "LegacyNewsroomPage",
-    ]
+    subpage_types = ["NewsroomPage"]

--- a/cfgov/v1/models/sublanding_filterable_page.py
+++ b/cfgov/v1/models/sublanding_filterable_page.py
@@ -61,12 +61,9 @@ class SublandingFilterablePage(AbstractFilterablePage, CFGOVPage):
         "searchable using standard search filters module."
     )
 
-    # TODO: Remove "LegacyBlogPage", "NewsroomPage" after archived pages move
     subpage_types = [
         "DocumentDetailPage",
         "BlogPage",
-        "LegacyBlogPage",
-        "NewsroomPage",
     ]
 
 


### PR DESCRIPTION
Removes the extra allowed subpage types added in #9104 to move pages into the archive.

---

## Removals

- Extra allowed subpage types for browse and sublanding filterable pages

## How to test this PR

1. Try creating a new page under either the blog or newsroom and make sure only the remaining options are available (you won't even get a choice of what page type to use if you create a newsroom child page)
2. Everything in the archive should still work as before

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)