### PR TITLE
Support larger OpenSearch connection pools

### DIFF
--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -339,6 +339,7 @@ OPENSEARCH_DSL = {
         ),
         "use_ssl": True,
         "verify_certs": not os.getenv("OPENSEARCH_DSL_SKIP_CERT_VERIFICATION"),
+        "pool_maxsize": int(os.getenv("ES_POOL_MAXSIZE", "1")),
     }
 }
 


### PR DESCRIPTION
The OpenSearch client used by django-opensearch-dsl currently lacks configuration of a connection pool, which means it uses the default connection pool size of 1. In practice, this means that every request to OS makes a new connection and then discards it when the request is done.

Our current production setup uses Gunicorn gevent workers. Each worker is configured to handle a maximum number of incoming requests, each of which may potentially create and then discard a new connection to OS. This is costly - we've seen OpenSearch connection issues under periods of heavy load (for example when the CDN is broadly invalidated), alongside OS log messages like "Connection pool is full, discarding connection" which point to this as a problem.

This change adds a new "pool_maxsize" configuration option to the Django OPENSEARCH_DSL setting, which defaults to 1 (fine for local development) but can be set by the ES_POOL_MAXSIZE environment variable (which we will have to do in our internal deployment code).

In production, this variable should be set to match the value of GUNICORN_WORKER_CONNECTIONS, which defines the maximum number of simultaneous requests handled by a Gunicorn worker.

@wpears I see you added this to ccdb5-api in https://github.com/cfpb/ccdb5-api/pull/245; if you're cool with it I'll open another PR there that also uses this ES_POOL_MAXSIZE variable. You have it set to 10 over there - If you think the worker logic above is sound, should these be in sync? 