### PR TITLE
Fix submit a complaint underline

### DIFF
--- a/cfgov/v1/jinja2/v1/includes/molecules/global-header-cta.html
+++ b/cfgov/v1/jinja2/v1/includes/molecules/global-header-cta.html
@@ -19,9 +19,9 @@
         {% set complaint_link = '/es/enviar-una-queja/' if language == 'es' else '/complaint/' %}
         {# TODO: Padding should be on link, not CTA itself #}
     <div class="m-global-header-cta">
-        <a href="{{ complaint_link }}">
+        <a class="a-link" href="{{ complaint_link }}">
             {{ svg_icon('complaint') }}
-            {{ _('Submit a Complaint') }}
+            <span class="a-link__text">{{ _('Submit a Complaint') }}</span>
         </a>
     </div>
     {% endif %}


### PR DESCRIPTION
The submit a complaint link was running the underline between the icon and text. It shouldn't.

## Changes

- Fix submit a complaint underline by adding DS classes to link.


## How to test this PR

1. `yarn build && yarn start` and the submit a complaint link should not have preceding underline.


## Screenshots

| Before | After  |
| ------ | ------ |
|<img width="186" height="53" alt="Screenshot 2026-07-01 at 12 56 06 PM" src="https://github.com/user-attachments/assets/2f1b528f-382e-4d4a-825c-24e4dbbf0fd9" />|<img width="191" height="59" alt="Screenshot 2026-07-01 at 12 56 01 PM" src="https://github.com/user-attachments/assets/dcfcc6e9-0ce0-4098-b562-7ab08d9060d7" />|