### PR TITLE
Replace a-tagline with `cfpb-tagline`

### DIFF
--- a/cfgov/unprocessed/css/molecules/global-eyebrow.scss
+++ b/cfgov/unprocessed/css/molecules/global-eyebrow.scss
@@ -31,7 +31,7 @@
     border-bottom: 1px solid var(--gray-40);
 
     /* This is to allow vertical overlap with the languages */
-    .a-tagline {
+    cfpb-tagline {
       float: left;
     }
 
@@ -42,7 +42,7 @@
       }
 
       /* Prevent spacing issues since the languages aren't displayed */
-      .a-tagline {
+      cfpb-tagline {
         float: none;
       }
     }

--- a/cfgov/unprocessed/css/print.scss
+++ b/cfgov/unprocessed/css/print.scss
@@ -167,7 +167,7 @@
     }
   }
 
-  .a-tagline {
+  cfpb-tagline {
     // Force the background image in the tagline to be visible when printing.
     color-adjust: exact;
   }

--- a/cfgov/unprocessed/js/routes/common.js
+++ b/cfgov/unprocessed/js/routes/common.js
@@ -4,9 +4,10 @@
 
 // GLOBAL ATOMIC ELEMENTS.
 
-import { CfpbFileUpload } from '@cfpb/cfpb-design-system';
+import { CfpbFileUpload, CfpbTagline } from '@cfpb/cfpb-design-system';
 
 CfpbFileUpload.init();
+CfpbTagline.init();
 
 // Organisms.
 import { Footer } from '../organisms/Footer.js';

--- a/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
@@ -14,7 +14,10 @@
   ========================================================================== #}
 
 {% macro render( is_large ) %}
-<cfpb-tagline{% if is_large %} islarge{% endif %}>
+{# TODO: The aria-label is set within the shadowdom, 
+   but isn't translated, so we're adding it again here for the translation. #}
+<cfpb-tagline{% if is_large %} islarge{% endif %}
+  aria-label="{{ _('Official website of the') }} {{ _('United States government') }}">
   {{ _('An official website of the') }}
   <span class="u-nowrap">{{ _('United States government') }}</span>
 </cfpb-tagline>

--- a/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
+++ b/cfgov/v1/jinja2/v1/includes/atoms/tagline.html
@@ -1,25 +1,21 @@
 
 {# ==========================================================================
 
-   tagline.render()
+  tagline.render()
 
-   ==========================================================================
+  ==========================================================================
 
-   Description:
+  Description:
 
-   Render HTML for the United States government site tagline.
+  Render HTML for the United States government site tagline.
 
-   is_large: Whether to use a larger font-size for the tagline text.
+  is_large: Whether to use a larger font-size for the tagline text.
 
-   ========================================================================== #}
+  ========================================================================== #}
 
 {% macro render( is_large ) %}
-<div class="a-tagline{{ ' a-tagline--large' if is_large else '' }}"
-     aria-label="{{ _('Official website of the') }} {{ _('United States government') }}">
-   <span class="u-usa-flag"></span>
-   <div class="a-tagline__text">
-      {{ _('An official website of the') }}
-      <span class="u-nowrap">{{ _('United States government') }}</span>
-   </div>
-</div>
+<cfpb-tagline{% if is_large %} islarge{% endif %}>
+  {{ _('An official website of the') }}
+  <span class="u-nowrap">{{ _('United States government') }}</span>
+</cfpb-tagline>
 {% endmacro %}

--- a/test/cypress/integration/components/header/global-search-helpers.cy.js
+++ b/test/cypress/integration/components/header/global-search-helpers.cy.js
@@ -8,7 +8,7 @@ export class GlobalSearch {
   }
 
   footerTagline() {
-    return cy.get('.o-footer .a-tagline');
+    return cy.get('.o-footer cfpb-tagline');
   }
 
   trigger() {


### PR DESCRIPTION
## Changes

- Replace a-tagline with `cfpb-tagline`


## How to test this PR

1. `yarn build` and tagline in the global eyebrow and footer should look unchanged.
