### PR TITLE
Bump ccdb5-api from 1.11 to 1.13

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -42,4 +42,4 @@ wagtailcharts==0.6.2
 whitenoise==6.7.0
 
 # This package is installed from GitHub.
-https://github.com/cfpb/ccdb5-api/releases/download/1.11/ccdb5_api-1.11-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.13/ccdb5_api-1.13-py3-none-any.whl


### PR DESCRIPTION
Use a larger OpenSearch connection pool, that respects the ES_POOL_MAXSIZE environment variable. Needed to address CCDB search timeouts.