### PR TITLE
Optimize OpenSearch queries for filterable lists

### DIFF
--- a/cfgov/search/elasticsearch_helpers.py
+++ b/cfgov/search/elasticsearch_helpers.py
@@ -2,6 +2,7 @@ import os
 import re
 import socket
 import sys
+from contextlib import contextmanager
 from unittest import SkipTest
 from unittest.mock import patch
 
@@ -18,6 +19,7 @@ from wagtail.signals import (
 
 from django_opensearch_dsl.signals import RealTimeSignalProcessor
 from opensearchpy import analyzer, token_filter, tokenizer
+from opensearchpy.transport import Transport
 
 from search.models import Synonym
 
@@ -92,6 +94,7 @@ class ElasticsearchTestsMixin:
     - Skips all tests if running locally without Elasticsearch.
     - Makes Elasticsearch updates blocking.
     - Provides a helper method to simplify the search_index command.
+    - Provides a helper method to count Elasticsearch requests in tests.
     """
 
     @classmethod
@@ -159,6 +162,36 @@ class ElasticsearchTestsMixin:
             force=True,
             stdout=stdout,
         )
+
+    class RequestCounter:
+        def __init__(self):
+            self.count = 0
+
+    @contextmanager
+    def assertNumElasticsearchRequests(self, expected):
+        """Count Elasticsearch HTTP requests made within the context.
+
+        Use this in tests to count how many ES requests are made.
+
+        class MyTests(ElasticsearchTestsMixin):
+            def test_something(self):
+                with self.assertNumElasticsearchRequests(2):
+                    make_requests_to_elasticsearch()
+        """
+
+        counter = self.RequestCounter()
+        original_perform_request = Transport.perform_request
+
+        def counting_perform_request(self, *args, **kwargs):
+            counter.count += 1
+            return original_perform_request(self, *args, **kwargs)
+
+        with patch.object(
+            Transport, "perform_request", counting_perform_request
+        ):
+            yield
+
+        self.assertEqual(counter.count, expected)
 
 
 class WagtailSignalProcessor(RealTimeSignalProcessor):

--- a/cfgov/v1/documents.py
+++ b/cfgov/v1/documents.py
@@ -221,20 +221,36 @@ class FilterablePagesDocumentSearch:
             self._count = self.search_obj.count()
         return self._count
 
-    def get_raw_results(self):
-        """Get the Elasticsearch DSL Response object for current results.
+    TOPICS_AGGREGATION_SIZE = 10000
+    LANGUAGES_AGGREGATION_SIZE = 100
+
+    def get_aggregations(self):
+        """Get the aggregations used to build the filterable form's options.
+
+        Only aggregations are needed to populate the form's topic, language,
+        and date filters, so this makes a 0-size search that doesn't actually
+        return any document content.
 
         This can be called any time, before, between, or after calls to
         filter() or search().
-
-        See the Elasticsearch DSL documentation for more on the Response
-        object:
-        https://elasticsearch-dsl.readthedocs.io/en/latest/search_dsl.html#response
         """
-        search = self.search_obj[0 : self.count()]
+        search = self.search_obj[0:0]
+
+        # Aggregate the distinct topics (by tag slug) in the result.
+        search.aggs.bucket(
+            "topics",
+            "terms",
+            field="tags.slug",
+            size=self.TOPICS_AGGREGATION_SIZE,
+        )
 
         # Aggregate unique languages in the result.
-        search.aggs.bucket("languages", "terms", field="language")
+        search.aggs.bucket(
+            "languages",
+            "terms",
+            field="language",
+            size=self.LANGUAGES_AGGREGATION_SIZE,
+        )
 
         # Determine the earliest page date.
         search.aggs.metric("min_start_date", "min", field="start_date")

--- a/cfgov/v1/forms.py
+++ b/cfgov/v1/forms.py
@@ -3,7 +3,6 @@ from operator import itemgetter
 
 from django import forms
 from django.conf import settings
-from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.forms import widgets
 
@@ -128,56 +127,20 @@ class FilterableListForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.filterable_search = kwargs.pop("filterable_search")
 
-        # This cache key is used for caching the topics, page_ids,
-        # and the full set of Elasticsearch results for this form used to
-        # generate them.
-        # Default the cache key prefix to this form's hash if it's not
-        # provided.
-        self.cache_key_prefix = kwargs.pop("cache_key_prefix", hash(self))
-
         super().__init__(*args, **kwargs)
 
         clean_categories(selected_categories=self.data.get("categories"))
 
-        self.all_filterable_results = self.get_all_filterable_results()
-        page_ids = self.get_all_page_ids()
-        self.set_topics(page_ids)
+        # When the form is created, it needs to make a request to the search
+        # backend to be able to populate some of its fields: topics, languages,
+        # and the minimum page date.
+        self.aggregations = self.filterable_search.get_aggregations()
+
+        self.set_topics()
         self.set_languages()
 
-    def get_all_filterable_results(self):
-        """Get all filterable document results from Elasticsearch
-
-        This set of results is used to populate the list of all page_ids,
-        below, which is in turn used for populating the topics
-        relevant to those pages.
-
-        This first document in this result set is also used to determine the
-        earliest post date, also below, when a to_date is given but
-        from_date is not.
-        """
-        # Cache the full list of filterable results. This avoids having to
-        # generate the same list with every request. When a filterable page is
-        # is saved, the cache key for this fix prefix will be deleted.
-        all_filterable_results = cache.get(
-            f"{self.cache_key_prefix}-all_filterable_results"
-        )
-        if not all_filterable_results:
-            all_filterable_results = self.filterable_search.get_raw_results()
-            cache.set(
-                f"{self.cache_key_prefix}-all_filterable_results",
-                all_filterable_results,
-            )
-        return all_filterable_results
-
-    def get_all_page_ids(self):
-        """Return a list of all possible filterable page ids"""
-        page_ids = cache.get(f"{self.cache_key_prefix}-page_ids")
-        if not page_ids:
-            page_ids = [
-                result.meta.id for result in self.all_filterable_results
-            ]
-            cache.set(f"{self.cache_key_prefix}-page_ids", page_ids)
-        return page_ids
+    def has_unfiltered_results(self):
+        return self.aggregations.hits.total.value > 0
 
     def get_page_set(self):
         self.filterable_search.filter(
@@ -193,40 +156,37 @@ class FilterableListForm(forms.Form):
         return results
 
     def first_page_date(self):
-        if not self.all_filterable_results:
+        if not self.has_unfiltered_results():
             return date(2010, 1, 1)
 
         min_start_date = parser.parse(
-            self.all_filterable_results.aggregations.min_start_date.value_as_string
+            self.aggregations.aggregations.min_start_date.value_as_string
         )
 
         return min_start_date.date()
 
     @staticmethod
-    def get_filterable_topics(page_ids):
-        """Given a set of page IDs, return the list of filterable topics"""
-        tags = Tag.objects.filter(
-            v1_cfgovtaggedpages_items__content_object__id__in=page_ids
-        ).values_list("slug", "name")
+    def get_filterable_topics(slugs):
+        """Given a set of tag slugs, return the list of filterable topics.
+
+        The slugs come from an aggregation over the indexed pages, so this
+        only needs to look up the human-readable names for display.
+        """
+        tags = Tag.objects.filter(slug__in=slugs).values_list("slug", "name")
 
         return tags.distinct().order_by("name")
 
-    def set_topics(self, page_ids):
-        # Cache the topics for this filterable list form to avoid
-        # repeated database lookups of the same data.
-        topics = cache.get(f"{self.cache_key_prefix}-topics")
-        if not topics:
-            topics = self.get_filterable_topics(page_ids)
-            cache.set(f"{self.cache_key_prefix}-topics", topics)
-
-        self.fields["topics"].choices = topics
+    def set_topics(self):
+        slugs = [
+            bucket.key
+            for bucket in (self.aggregations.aggregations.topics.buckets)
+        ]
+        self.fields["topics"].choices = self.get_filterable_topics(slugs)
 
     # Populate language choices
     def set_languages(self):
         # Get the list of codes in the full set of searchable pages.
-        language_aggregation = (
-            self.all_filterable_results.aggregations.languages
-        )
+        language_aggregation = self.aggregations.aggregations.languages
         language_codes = {b.key for b in language_aggregation.buckets}
 
         # Grab the language names from the reference list.

--- a/cfgov/v1/models/filterable_page.py
+++ b/cfgov/v1/models/filterable_page.py
@@ -136,20 +136,15 @@ class AbstractFilterablePage(ShareableRoutablePageMixin, models.Model):
 
         return search
 
-    def get_cache_key_prefix(self, request=None):
-        return self.get_url(request=request)
-
     def get_context(self, request, *args, **kwargs):
         context = super().get_context(request, *args, **kwargs)
 
         form_data, has_active_filters = self.get_form_data(request.GET)
         filterable_search = self.get_filterable_search()
-        has_unfiltered_results = filterable_search.count() > 0
 
         form = self.get_form_class()(
             form_data,
             filterable_search=filterable_search,
-            cache_key_prefix=self.get_cache_key_prefix(request),
         )
         form_valid = form.is_valid()
 
@@ -157,7 +152,7 @@ class AbstractFilterablePage(ShareableRoutablePageMixin, models.Model):
             {
                 "form": form,
                 "form_valid": form_valid,
-                "has_unfiltered_results": has_unfiltered_results,
+                "has_unfiltered_results": form.has_unfiltered_results(),
                 "has_active_filters": has_active_filters,
             }
         )

--- a/cfgov/v1/signals.py
+++ b/cfgov/v1/signals.py
@@ -1,6 +1,5 @@
 from itertools import chain
 
-from django.core.cache import cache
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -62,17 +61,11 @@ def invalidate_filterable_list_caches(sender, **kwargs):
         chain(filterable_list_pages, category_filterable_list_pages)
     )
 
-    cache_tags_to_purge = []
-    for filterable_list_page in filterable_list_pages:
-        cache_key_prefix = filterable_list_page.get_cache_key_prefix()
-
-        # Delete internal cache for the filterable list page
-        cache.delete(f"{cache_key_prefix}-all_filterable_results")
-        cache.delete(f"{cache_key_prefix}-page_ids")
-        cache.delete(f"{cache_key_prefix}-topics")
-
-        # Add the filterable list's slug to the list of cache tags to purge
-        cache_tags_to_purge.append(filterable_list_page.slug)
+    # Collect each filterable list page's slug as a CDN cache tag to purge.
+    cache_tags_to_purge = [
+        filterable_list_page.slug
+        for filterable_list_page in filterable_list_pages
+    ]
 
     # Get the cache backend and purge filterable list page cache tags if this
     # page belongs to any

--- a/cfgov/v1/tests/models/test_filterable_page.py
+++ b/cfgov/v1/tests/models/test_filterable_page.py
@@ -238,29 +238,17 @@ class FilterableResultsRenderingTests(
         page = self.page_tree[0]
         request = RequestFactory().get("/")
 
-        # Page rendering requires 8 database queries in total.
+        # Page rendering requires 7 database queries in total.
+        # We start with a list of matching page IDs from an OpenSearch query.
         #
-        # 2 are needed for Wagtail page URL generation:
-        #
-        #   1. Fetching Wagtail Site root paths.
-        #   2. Fetching the root page of the default Wagtail Site.
-        #
-        # 1 is needed to render our filterable form:
-        #
-        #   3. Retrieving the list of page tags to populate the form topic
-        #      choices.
-        #
-        # 2 are needed to fetch page results from the database:
-        #
-        #   4. Fetching Page content types based on search result IDs.
-        #   5. Fetching specific Page model instances.
-        #
-        # 3 are needed for efficient page rendering:
-        #
-        #   6. Prefetching all authors for all result pages.
-        #   7. Prefecthing all categories for all result pages.
-        #   8. Prefetching all topic tags for all result pages.
-        with self.assertNumQueries(8):
+        #   1. django-opensearch-dsl fetches AbstractFilterPages matching those
+        #      page IDs.
+        #   2. Our custom SearchResultsPaginator then fetches the specific()
+        #      versions of those pages.
+        #   3,4,5. The paginator does a prefetch_related for authors,
+        #      categories, and tags.
+        #   6,7. Lookups for Wagtail Site root paths to render full page URLs.
+        with self.assertNumQueries(7):
             response = page.render(request)
 
         # All data is fetched as part of the response context. No additional

--- a/cfgov/v1/tests/test_documents.py
+++ b/cfgov/v1/tests/test_documents.py
@@ -10,7 +10,9 @@ from wagtail.models import Page, Site
 from dateutil.relativedelta import relativedelta
 
 from core.testutils.test_cases import WagtailPageTreeTestCase
-from search.elasticsearch_helpers import ElasticsearchTestsMixin
+from search.elasticsearch_helpers import (
+    ElasticsearchTestsMixin,
+)
 from v1.documents import (
     EnforcementActionFilterablePagesDocumentSearch,
     EventFilterablePagesDocumentSearch,
@@ -187,10 +189,16 @@ class FilterableSearchTests(ElasticsearchWagtailPageTreeTestCase):
         self.assertEqual(search.search(title="child1").count(), 2)
         self.assertEqual(search.search(title="child3").count(), 0)
 
-    def test_get_raw_results(self):
+    def test_get_aggregations_fetches_no_documents(self):
         search = FilterablePagesDocumentSearch(self.page_tree[0])
-        results = search.get_raw_results()
-        self.assertEqual(len(results.hits), 2)
+
+        with self.assertNumElasticsearchRequests(1):
+            results = search.get_aggregations()
+            self.assertEqual(len(results.hits), 0)
+            self.assertEqual(results.hits.total.value, 2)
+            self.assertIn("topics", results.aggregations)
+            self.assertIn("languages", results.aggregations)
+            self.assertIn("min_start_date", results.aggregations)
 
     # Mocking is necessary here because unfortunately it's not currently
     # possible to use override_settings with DOD autosync. See

--- a/cfgov/v1/tests/test_filterable_list_form.py
+++ b/cfgov/v1/tests/test_filterable_list_form.py
@@ -173,21 +173,55 @@ class TestFilterableListForm(ElasticsearchTestsMixin, TestCase):
     def test_first_page_date(self):
         form = self.setUpFilterableForm()
         self.assertEqual(form.first_page_date(), self.blog1.date_published)
-        form.all_filterable_results = []
+        form.aggregations.hits.total.value = 0
         self.assertEqual(form.first_page_date(), date(2010, 1, 1))
 
     def test_get_topics_sorts_alphabetically(self):
         form = self.setUpFilterableForm()
 
         self.assertEqual(
-            list(form.get_filterable_topics([self.blog1.pk])),
+            list(form.get_filterable_topics(["foo"])),
             [("foo", "foo")],
         )
 
         self.assertEqual(
-            list(form.get_filterable_topics([self.blog1.pk, self.blog2.pk])),
+            list(form.get_filterable_topics(["foo", "blah"])),
             [("blah", "blah"), ("foo", "foo")],
         )
+
+    def test_get_filterable_topics_makes_single_db_query(self):
+        form = self.setUpFilterableForm()
+        with self.assertNumQueries(1):
+            list(form.get_filterable_topics(["foo", "blah"]))
+
+    def test_topics_choices_built_from_aggregation(self):
+        form = self.setUpFilterableForm()
+        self.assertEqual(
+            sorted(form.fields["topics"].choices),
+            [("bar", "bar"), ("blah", "blah"), ("foo", "foo")],
+        )
+
+    def test_form_construction_issues_single_opensearch_request(self):
+        # Constructing the form should make exactly one OpenSearch request
+        # to fetch aggregations needed to build the filter options.
+        site_root = Site.objects.get(is_default_site=True).root_page
+        search = FilterablePagesDocumentSearch(site_root)
+        with self.assertNumElasticsearchRequests(1):
+            FilterableListForm(filterable_search=search)
+
+    def test_has_unfiltered_results(self):
+        form = self.setUpFilterableForm()
+        self.assertTrue(form.has_unfiltered_results())
+
+    def test_get_page_set_pagination_request_count(self):
+        # Fetching a page of results takes two search requests: one count (for
+        # the paginator) and one source-excluded search that returns only the
+        # document IDs needed to build the database queryset.
+        form = self.setUpFilterableForm(data={"categories": []})
+        page_set = form.get_page_set()
+        with self.assertNumElasticsearchRequests(2):
+            page_set.count()
+            page_set[0:25].to_queryset()
 
 
 @override_settings(OPENSEARCH_DSL_AUTOSYNC=True)

--- a/cfgov/v1/tests/test_signals.py
+++ b/cfgov/v1/tests/test_signals.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.test import TestCase, override_settings
 
 from wagtail.models import Site
@@ -53,31 +51,18 @@ class FilterableListInvalidationTestCase(TestCase):
         # Reset cache purged URLs after each test
         MOCK_PURGED[:] = []
 
-    @mock.patch("v1.signals.cache")
-    def test_invalidate_filterable_list_caches(
-        self,
-        mock_cache,
-    ):
+    def test_invalidate_filterable_list_caches(self):
         invalidate_filterable_list_caches(None, instance=self.blog_page)
 
-        for cache_key_prefix in (
-            self.filterable_list_page.get_cache_key_prefix(),
-            self.category_filterable_list_page.get_cache_key_prefix(),
-        ):
-            mock_cache.delete.assert_any_call(
-                f"{cache_key_prefix}-all_filterable_results"
-            )
-            mock_cache.delete.assert_any_call(f"{cache_key_prefix}-page_ids")
-            mock_cache.delete.assert_any_call(f"{cache_key_prefix}-topics")
-
+        # The CDN cache for each filterable list page the blog page belongs to
+        # is purged by the page's slug.
         self.assertIn(self.filterable_list_page.slug, MOCK_PURGED)
+        self.assertIn(self.category_filterable_list_page.slug, MOCK_PURGED)
 
-    @mock.patch("django.core.cache.cache")
-    def test_invalidate_filterable_list_caches_does_nothing(self, mock_cache):
+    def test_invalidate_filterable_list_caches_does_nothing(self):
         invalidate_filterable_list_caches(
             None, instance=self.non_filterable_page
         )
-        mock_cache.delete.assert_not_called()
         self.assertEqual(MOCK_PURGED, [])
 
 


### PR DESCRIPTION
Filterable list pages need to query OpenSearch in order to populate their forms with topics, categories, languages, and date ranges. This commit optimizes that query to significantly reduce data transfer between OS and Python, and also removes an application-level cache that wasn't adding much value.

The current code constructs a FilterableListForm and makes up to three separate OpenSearch requests:

1. A count() to determine the total number of pages.
2. A search using that count to pull back all documents INCLUDING FULL PAGE CONTENT just to aggregate topics slugs, languages, and dates.
3. A duplicate count() for a has_unfiltered_results method.

This second query is extremely expensive, especially if there are many pages to be searched. The current code tried to use the Django cache to avoid hitting OS, but in that case we are still pulling back this large dataset from Postgres. In either case, the full page content is all discarded because the only reason for the query is to get the aggregations.

This commit modifies the search logic to use `size=0` so that way ONLY the aggregations are returned from OS. It also removes the duplicative second count() call, which isn't actually needed. With this change, we can drop the use of Django cache entirely, as its savings no longer outweigh its complexity.

I've also added a helpful assertNumElasticsearchRequests test case method to assert how many OpenSearch requests are made by a test (the naming has been kept as "Elasticsearch" for consistency with existing code).