### PR TITLE
Fix Mortgage Performance Trends download URLs

### DIFF
--- a/cfgov/data_research/scripts/export_public_csvs.py
+++ b/cfgov/data_research/scripts/export_public_csvs.py
@@ -62,7 +62,7 @@ def save_metadata(csv_size, slug, thru_month, days_late, geo_type):
     """Save slug, URL, thru_month and file size of a new CSV download file."""
     pub_date = datetime.date.today().strftime("%B %Y")
     thru_month_formatted = parser.parse(thru_month).strftime("%B %Y")
-    csv_url = f"{PUBLIC_DOWNLOAD_BUCKET}/{DOWNLOAD_KEY}/{slug}.csv"
+    csv_url = f"https://{PUBLIC_DOWNLOAD_BUCKET}/{DOWNLOAD_KEY}/{slug}.csv"
     download_meta_file, cr = MortgageMetaData.objects.get_or_create(
         name="download_files"
     )


### PR DESCRIPTION
Fix Mortgage Performance Trends download links. See GHE/Design-Development/cfgov/issues/4678 for details, but the upshot is a change to `AWS_S3_CUSTOM_DOMAIN` when we migrated to Alto means we have to include the protocol when we generate the download URLs now.

---

## Changes

- Include the protocol when generating MPT download URLs

## How to test this PR

1. `cfgov/manage.py runscript export_public_csvs` (assuming you have the most recent data locally) should generate correct download links in the form of `href="https://files.consumerfinance.gov…"` instead of just `href="files.consumerfinance.gov…"`

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)