### PR TITLE
Add flexibility to purge_cache command params

### DIFF
--- a/cfgov/cdntools/management/commands/purge_cache.py
+++ b/cfgov/cdntools/management/commands/purge_cache.py
@@ -12,6 +12,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             "--backend",
+            action="extend",
             nargs="+",
             help="Limit the purge to the given frontend cache backend name",
         )
@@ -22,11 +23,13 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--cache-tag",
+            action="extend",
             nargs="+",
             help="The cache tag to invalidate (can specify multiple).",
         )
         parser.add_argument(
             "--url",
+            action="extend",
             nargs="+",
             help=(
                 "The full URL for the page cache to invalidate "

--- a/cfgov/cdntools/tests/test_management_commands_purge_cache.py
+++ b/cfgov/cdntools/tests/test_management_commands_purge_cache.py
@@ -28,6 +28,17 @@ class PurgeCacheTestCase(TestCase):
         self.assertIn("https://server/bar", MOCK_PURGED)
         self.assertIn("https://server/foo", MOCK_PURGED)
 
+    def test_purge_with_multiple_url_params(self):
+        call_command(
+            "purge_cache",
+            "--url",
+            "https://server/foo",
+            "--url",
+            "https://server/bar",
+        )
+        self.assertIn("https://server/bar", MOCK_PURGED)
+        self.assertIn("https://server/foo", MOCK_PURGED)
+
     def test_purge_with_cache_tag(self):
         call_command(
             "purge_cache",
@@ -37,6 +48,19 @@ class PurgeCacheTestCase(TestCase):
                 "complaints",
                 "foo",
             ],
+        )
+        self.assertIn("complaints", MOCK_PURGED)
+        self.assertIn("foo", MOCK_PURGED)
+
+    def test_purge_with_multiple_cache_tag_params(self):
+        call_command(
+            "purge_cache",
+            "--backend",
+            "akamai",
+            "--cache-tag",
+            "complaints",
+            "--cache-tag",
+            "foo",
         )
         self.assertIn("complaints", MOCK_PURGED)
         self.assertIn("foo", MOCK_PURGED)
@@ -63,6 +87,18 @@ class PurgeCacheTestCase(TestCase):
         err = StringIO()
         call_command("purge_cache", "--all", "--backend", "other", stderr=err)
         self.assertIn("Cannot purge all from backend: other", err.getvalue())
+
+    def test_purge_with_multiple_backend_params(self):
+        call_command(
+            "purge_cache",
+            "--backend",
+            "akamai",
+            "--backend",
+            "other",
+            "--url",
+            "https://server/foo",
+        )
+        self.assertIn("https://server/foo", MOCK_PURGED)
 
     def test_purge_nebackend(self):
         err = StringIO()


### PR DESCRIPTION
Currently if you call the purge_cache management command like this:

```
--url url1 --url url2
```

only the second URL gets purged. This is due to unexpected behavior in Python argparse when using `nargs="+"`, which expects

```
--url url1 url2
```

https://docs.python.org/3/library/argparse.html#nargs

By adding `action="extend"`, we can support both cases:

https://docs.python.org/3/library/argparse.html#action

Regression tests added to cover this behavior.

Fixes internal cfgov#4750.