### PR TITLE
Bump ccdb-api to 1.16.0

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -42,4 +42,4 @@ wagtailcharts==0.6.2
 whitenoise==6.7.0
 
 # This package is installed from GitHub.
-https://github.com/cfpb/ccdb5-api/releases/download/1.15.1/ccdb5_api-1.15.1-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.16.0/ccdb5_api-1.16.0-py3-none-any.whl


### PR DESCRIPTION
See https://github.com/cfpb/ccdb5-api/releases/tag/1.16.0