### PR TITLE
CCDB-API bug fix

### DIFF
--- a/requirements/libraries.txt
+++ b/requirements/libraries.txt
@@ -42,4 +42,4 @@ wagtailcharts==0.6.2
 whitenoise==6.7.0
 
 # This package is installed from GitHub.
-https://github.com/cfpb/ccdb5-api/releases/download/1.17.0/ccdb5_api-1.17.0-py3-none-any.whl
+https://github.com/cfpb/ccdb5-api/releases/download/1.18.0/ccdb5_api-1.18.0-py3-none-any.whl


### PR DESCRIPTION
Addresses: DATAP-2049

Update ccdb api to fixed version with correct parameters to restore CSV downloads.
https://github.com/cfpb/ccdb5-api/pull/255

