### PR TITLE
Fix icons in dark banners to make them white

### DIFF
--- a/cfgov/unprocessed/css/enhancements/alerts.scss
+++ b/cfgov/unprocessed/css/enhancements/alerts.scss
@@ -13,6 +13,14 @@
   color: var(--green);
 }
 
+.o-banner--dark {
+  .m-notification--error cfpb-icon,
+  .m-notification--warning cfpb-icon,
+  .m-notification--success cfpb-icon {
+    color: var(--white);
+  }
+}
+
 .m-notification cfpb-icon {
   // Tablet and above.
   @include respond-to-min($bp-sm-min) {


### PR DESCRIPTION
A small addition to #9132 to make icons in `.o-banner--dark` elements white.

---

## Changes

- Make icons in `.o-banner--dark` elements white

## How to test this PR

1. Go to http://localhost:8000/archive/ (or any archvied page) and confirm the icon in the banner is white, not gold

## Screenshots

| Before | After  |
| ------ | ------ |
| <img width="1304" height="194" alt="before" src="https://github.com/user-attachments/assets/3d02b7f6-48aa-4a7f-99e5-a20525a1462c" /> | <img width="1288" height="196" alt="after" src="https://github.com/user-attachments/assets/e1b71ab3-fad9-4565-bc4e-b1bc122790fd" /> |

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)