### PR TITLE
Provide default frontend build for local Docker

### DIFF
--- a/.env_SAMPLE
+++ b/.env_SAMPLE
@@ -63,6 +63,16 @@ export WAGTAILSHARING_HOST=content.localhost:8000
 # Value is development or production.
 export NODE_ENV=development
 
+# When running Django using Docker, uncomment this line to serve your locally
+# built frontend assets instead of the ones built into the container.
+#
+# Leaving the variable commented out tells Django to use the prebuilt frontend
+# assets from the Docker image.
+#
+# Setting the variable empty tells Django not to use the prebuilt assets, and
+# instead use ones from cfgov/static_built (built with yarn).
+#export PREBUILT_STATIC_PATH=
+
 ###############################
 # Amazon Web Services (AWS) S3.
 ###############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ENV PYTHONUNBUFFERED=1
 # Set the APP_HOME, our working directory
 ENV APP_HOME=/src/consumerfinance.gov
 
+# Where frontend assets get built by the node-builder stage below
+ENV PREBUILT_STATIC_PATH=/srv/cfgov-static-built
+
 # Add our top-level Python path to the PYTHONPATH
 ENV PYTHONPATH=${APP_HOME}/cfgov
 
@@ -146,7 +149,7 @@ RUN pip install -r requirements/local.txt
 # these files do not change.
 COPY cfgov ./cfgov/
 COPY docker-entrypoint.sh ./docker-entrypoint.sh
-COPY --from=node-builder ${APP_HOME} ${APP_HOME}
+COPY --from=node-builder ${APP_HOME}/cfgov/static_built ${PREBUILT_STATIC_PATH}
 
 # Run our initial data entrypoint script
 ENTRYPOINT ["./docker-entrypoint.sh"]
@@ -179,7 +182,7 @@ COPY index.sh .
 COPY test.sql.gz .
 
 # Copy our static build over from node-builder
-COPY --from=node-builder ${APP_HOME} ${APP_HOME}
+COPY --from=node-builder ${APP_HOME}/cfgov/static_built ${PREBUILT_STATIC_PATH}
 
 # Delete unprocessed frontend code, which was only needed by node-builder.
 # This avoids false positive image vulnerabilities in source Node packages.

--- a/cfgov/cfgov/settings/base.py
+++ b/cfgov/cfgov/settings/base.py
@@ -15,6 +15,12 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 # This is the root of the Django project, 'cfgov'
 PROJECT_ROOT = REPOSITORY_ROOT.joinpath("cfgov")
 
+# Location of built frontend assets.
+# Defaults to cfgov/static_built but can be overridden, as we do in Docker.
+STATIC_BUILT_PATH = Path(
+    os.getenv("PREBUILT_STATIC_PATH") or PROJECT_ROOT / "static_built"
+)
+
 # Templates that are not scoped to specific Django apps will live here
 GLOBAL_TEMPLATE_ROOT = PROJECT_ROOT.joinpath("jinja2")
 
@@ -177,7 +183,6 @@ TEMPLATES = [
         # Look for Jinja2 templates in these directories
         "DIRS": [
             GLOBAL_TEMPLATE_ROOT,
-            PROJECT_ROOT.joinpath("static_built"),
         ],
         # Look for Jinja2 templates in each app under a jinja2 subdirectory
         "APP_DIRS": True,
@@ -285,7 +290,7 @@ STORAGES = {
 
 # Add the frontend build output to static files.
 STATICFILES_DIRS = [
-    PROJECT_ROOT.joinpath("static_built"),
+    STATIC_BUILT_PATH,
 ]
 
 # Collect static files into, and serve them from, cfgov/collectstatic,

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,8 +3,7 @@ services:
     build:
       target: dev
     ports:
-      - '127.0.0.1:8000:8000' # Django
-    volumes: &python_volumes
+      - "127.0.0.1:8000:8000" # Django
+    volumes:
       - ./:/src/consumerfinance.gov/
-      - ./.env:/etc/profile.d/dev-env.sh
       - ./extend-environment.sh:/etc/profile.d/extend-environment.sh

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,9 +2,9 @@ volumes:
   postgres_data:
 
 services:
-  elasticsearch:
+  opensearch:
     environment:
-      ES_JAVA_OPTS: '-Xms1g -Xmx1g'
+      OPENSEARCH_JAVA_OPTS: "-Xms1g -Xmx1g"
 
   python:
     image: cfgov_python:prod
@@ -19,5 +19,8 @@ services:
       SECRET_KEY: abcdefghijklmnopqrstuvwxyz
       MEDIA_ROOT: /src/consumerfinance.gov/cfgov/f/
       GUNICORN_RELOAD: 1
+    env_file:
+      - path: .env
+        required: false
     ports:
-      - '8000:8000'
+      - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - opensearch_data:/usr/share/opensearch/data/
     environment:
       discovery.type: single-node
-      OPENSEARCH_JAVA_OPTS: '-Xms512m -Xmx512m'
+      OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
       # Disables the need for an admin password and TLS.
       # We only ever run this locally in development.
       DISABLE_SECURITY_PLUGIN: true
@@ -58,3 +58,6 @@ services:
       ES_HOST: opensearch
       SECRET_KEY: abcdefghijklmnopqrstuvwxyz
       COMPLAINT_ES_INDEX: complaint-public
+    env_file:
+      - path: .env
+        required: false

--- a/docs/development-tips.md
+++ b/docs/development-tips.md
@@ -19,6 +19,36 @@ Feel free to [install a plugin](https://editorconfig.org/#download) for your edi
     After running `yarn build` (or `./setup.sh`) the site's assets are copied over to `cfgov/static_built`,
     ready to be served by Django.
 
+## Serving a local frontend build in Docker
+
+Our Docker image builds the frontend when the image is built,
+and stores the result in `/srv/cfgov-static-built` inside the container.
+Django serves assets from there, so a plain `docker compose up` works without
+requiring a local frontend build.
+
+That location lives outside of the container's `/src/consumerfinance.gov` working directory,
+which `docker-compose.override.yml` replaces with a mount of your local repository.
+This means that the assets built into the image aren't hidden by, and don't get confused with,
+anything in your local `cfgov/static_built`.
+
+If you're working on the frontend, you'll instead want Django to ignore that build
+and serve the assets that you build yourself. Uncomment this line in your `.env` file
+to clear the path to the prebuilt assets:
+
+```sh
+export PREBUILT_STATIC_PATH=
+```
+
+and restart the container. With this variable unset, Django will read assets from the
+`cfgov/static_built` directory in your mounted repository.
+`yarn build` and `yarn watch` will then reflect changes on your local machine.
+
+!!! note
+
+    Only our Docker image ships prebuilt assets via the `PREBUILT_STATIC_PATH` variable.
+    If you run the site outside of Docker, in a virtualenv, nothing should set that variable.
+    Django will read from `cfgov/static_built` in that case as well.
+
 ## Adding new Javascript entrypoints
 
 - In order to build standalone javascript files that are to be included in a template, they

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -153,6 +153,13 @@ to assist developers with linting without thinking.
 
 !!! note
 
+    If you're running the site in Docker, you can skip this section.
+    Our Docker image builds the frontend for you, and Django serves those assets. See
+    [serving a local frontend build in Docker](development-tips.md#serving-a-local-frontend-build-in-docker)
+    if you're working on the frontend and want Docker to serve assets that you build yourself.
+
+!!! note
+
     Our frontend requires [Node](https://nodejs.org/en/)
     with
     [Yarn](https://yarnpkg.com/).

--- a/setup.sh
+++ b/setup.sh
@@ -19,8 +19,6 @@ standalone() {
 }
 
 dockerized() {
-    ./frontend.sh $2
-
     ENVVAR=.env
     if [ ! -f $ENVVAR ]; then
         echo 'Creating default environment variables...'


### PR DESCRIPTION
New users of this repository who do a "docker compose up" and try to access the site will find that frontend assets are missing. Although the Docker build does a frontend build (in the node-builder stage), those built assets get covered up by the repository volume mount, which pulls in the user's local cfgov/static_built folder.

If the user hasn't done a local frontend build, there are no assets to serve. The frontend assets which were already built by Docker are essentially thrown away. This also means that it's not possible to run the website locally unless you have installed frontend build tools like Yarn, partially defeating the point of using containers for development.

This commit changes things so that the image's frontend build lives outside of the repository tree, in the image at /srv/cfgov-static-built. Django is pointed to the build location via a new PREBUILT_STATIC_PATH environment variable, which is set in the Dockerfile. Django will fall back to cfgov/static_built when that variable is empty or unset, so devs who prefer running Django outside of Docker in a virtualenv can keep their existing behavior.

Devs who do use Docker but want to work on the frontend locally can clear PREBUILT_STATIC_PATH in their .env to go back to serving assets they build themselves. This variable has been added to .env_SAMPLE.

Since the image now uses its existing frontend build, setup.sh no longer needs to run the build when running with Docker.

Documentation has been updated to reflect these changes.

**Note: I've added a lot of reviewers here since this could impact anyone who works with cf.gov, depending on how you like to manage your frontend build.**

## Testing

1. With no local build and no .env file, frontend assets should work:

```sh
rm -rf cfgov/static_built
docker compose build python
docker compose up
```

- http://localhost:8000 should look fully styled.
- With the container running, `docker compose exec python cfgov/manage.py findstatic js/routes/common.js` should return `/srv/cfgov-static-built/js/routes/common.js`, indicating that the default build is being used.

2. Frontend dev's local build should take precedence when desired:

```sh
./frontend.sh
cp .env_SAMPLE .env
# uncomment "export PREBUILT_STATIC_PATH=" line in .env
docker compose up -d
```

- With the container running, `docker compose exec python cfgov/manage.py findstatic js/routes/common.js` should return `/src/consumerfinance.gov/cfgov/static_built/js/routes/common.js`, indicating that the mapped local build is being used.
- Changes to local frontend (followed by a local rebuild) should be reflected in your localhost:8000 site.

3. Running the "prod-like" Docker image works properly:

```sh
# delete .env or re-comment the PREBUILT_STATIC_PATH line
docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build python
```

- http://localhost:8000 should look fully styled.

4. Running locally in a virtualenv should work unchanged:

- `cfgov/manage.py findstatic js/routes/common.js` should return the path to your local `cfgov/static_built` folder.
