### PR TITLE
Remove negotiated error responses

### DIFF
--- a/cfgov/core/tests/views/test_errors.py
+++ b/cfgov/core/tests/views/test_errors.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 from django.http import HttpResponse
@@ -46,67 +45,23 @@ BROWSER_ACCEPT = (
 
 @override_settings(DEBUG=False)
 class ErrorHandlerTestCase(TestCase):
-    def get(self, path, accept=None):
-        headers = {"accept": accept} if accept else {}
-        return self.client.get(path, headers=headers)
-
     def test_well_known_probe_gets_empty_response(self):
-        response = self.get("/.well-known/passkey-endpoints")
+        response = self.client.get("/.well-known/passkey-endpoints")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.content, b"")
         self.assertEqual(response["Content-Type"], "text/plain; charset=utf-8")
 
     def test_missing_static_file_gets_empty_response(self):
-        response = self.get("/static/does-not-exist.css")
+        response = self.client.get("/static/does-not-exist.css")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.content, b"")
 
-    def test_json_client_gets_problem_details(self):
-        response = self.get("/does not exist/", accept="application/json")
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response["Content-Type"], "application/problem+json")
-        self.assertEqual(
-            json.loads(response.content),
-            {
-                "type": "about:blank",
-                "title": "Not Found",
-                "status": 404,
-                "instance": "/does%20not%20exist/",
-            },
-        )
-
-    def test_browser_gets_full_html_page(self):
-        response = self.get("/does-not-exist/", accept=BROWSER_ACCEPT)
+    def test_other_404s_get_full_html_page(self):
+        response = self.client.get("/does-not-exist/")
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
         self.assertContains(response, "404: Page not found", status_code=404)
 
-    def test_wildcard_accept_gets_html(self):
-        response = self.get("/does-not-exist/", accept="*/*")
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response["Content-Type"], "text/html; charset=utf-8")
-
-    def test_text_client_gets_plain_text(self):
-        response = self.get("/does-not-exist/", accept="text/plain")
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response["Content-Type"], "text/plain; charset=utf-8")
-        self.assertEqual(response.content, b"404 Not Found\n")
-
-    def test_unsupported_accept_gets_plain_text(self):
-        response = self.get(
-            "/does-not-exist/", accept="application/vnd.unsupported"
-        )
-        self.assertEqual(response.status_code, 404)
-        self.assertEqual(response["Content-Type"], "text/plain; charset=utf-8")
-
-    def test_negotiated_responses_vary_on_accept(self):
-        for accept in (BROWSER_ACCEPT, "application/json", "text/plain"):
-            with self.subTest(accept=accept):
-                response = self.get("/does-not-exist/", accept=accept)
-                self.assertIn("Accept", response["Vary"])
-
     def test_content_404_still_gets_the_full_html_page(self):
-        response = self.get(
-            "/about-us/newsroom/does-not-exist/", accept=BROWSER_ACCEPT
-        )
+        response = self.client.get("/about-us/newsroom/does-not-exist/")
         self.assertContains(response, "404: Page not found", status_code=404)

--- a/cfgov/core/views/errors.py
+++ b/cfgov/core/views/errors.py
@@ -1,21 +1,6 @@
-from http import HTTPStatus
-from urllib.parse import quote
-
 from django.conf import settings
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.shortcuts import render
-from django.utils.cache import patch_vary_headers
-
-
-HTML = "text/html"
-JSON = "application/json"
-# https://www.rfc-editor.org/rfc/rfc9457
-PROBLEM_JSON = "application/problem+json"
-TEXT = "text/plain"
-
-# Clients sending "Accept: */*" get the first entry in this list.
-# Default to full HTML page, but also support simpler responses when possible.
-ERROR_RESPONSE_TYPES = [HTML, JSON, PROBLEM_JSON, TEXT]
 
 
 def _is_simple_404_path(path):
@@ -32,31 +17,6 @@ def _is_simple_404_path(path):
     ]
 
     return path.startswith(tuple(prefixes))
-
-
-def _problem_json_error(code, request):
-    """An RFC 9457 problem details response.
-
-    https://www.rfc-editor.org/rfc/rfc9457
-    """
-    return JsonResponse(
-        {
-            "type": "about:blank",
-            "title": HTTPStatus(code).phrase,
-            "status": code,
-            "instance": quote(request.path),
-        },
-        status=code,
-        content_type=PROBLEM_JSON,
-    )
-
-
-def _text_error(code):
-    return HttpResponse(
-        f"{code} {HTTPStatus(code).phrase}\n".encode(),
-        status=code,
-        content_type="text/plain; charset=utf-8",
-    )
 
 
 def _html_error(code, request):
@@ -91,20 +51,5 @@ def handle_error(code, request, exception=None):
             status=404, content_type="text/plain; charset=utf-8"
         )
 
-    # Return a different response type for different Accept: headers.
-    media_type = request.get_preferred_type(ERROR_RESPONSE_TYPES)
-
-    if media_type in (JSON, PROBLEM_JSON):
-        response = _problem_json_error(code, request)
-    elif media_type == HTML:
-        response = _html_error(code, request)
-    else:
-        # Either the client asked for text/plain, or it accepts nothing we
-        # can produce. Plain text is the safest thing to send.
-        response = _text_error(code)
-
-    # Make sure anything that might be caching this response knows to vary its
-    # cache by the Accept header.
-    patch_vary_headers(response, ("Accept",))
-
-    return response
+    # Otherwise return the full HTML error page.
+    return _html_error(code, request)


### PR DESCRIPTION
Commit b4258c2d56a9548e40df69371ff7d6bf3ced1597 (#9167) introduced the concept of error responses (404s, 500s) that vary based on content-type, so that clients requesting JSON via the Accept header would receive a JSON error response, not an HTML page.

Akamai's ["Cache HTTP Error Responses" behavior](https://techdocs.akamai.com/property-mgr/docs/cache-http-err-responses) unfortunately doesn't honor the Vary header, so that breaks this functionality. Clients requesting a 404 with one content-type cause that 404 to be cached, which then gets returned to all clients for the next 10 seconds.

This commit rolls back that piece of that commit, while keeping the other logic that returns simpler empty 404s for well-known URLs.

See internal cfgov#4737 for additional context.