### PR TITLE
Automatically retry failing Cypress tests

### DIFF
--- a/cypress.template.js
+++ b/cypress.template.js
@@ -33,4 +33,11 @@ export default defineConfig({
   expose: {
     ENVIRONMENT: 'local-machine',
   },
+  retries: {
+    /* Sometimes a flaky test will fail in `cypress run`, which will cause
+       all subsequent tests to be pending. Retry a failing test twice to
+       make sure it's not just flaky. */
+    runMode: 2,
+    openMode: 0,
+  }
 });


### PR DESCRIPTION
Sometimes our Cypress tests can be flaky, failing because of a passing blip instead of because something is actually broken. When that happens in an automated run (i.e. `yarn cy run`), a failed test in one spec will cause **all** tests is **all** specs that haven't run yet to be marked as pending. That leads to extra runs if you're trying to verify that all Cypress tests pass locally.

Cypress lets you configure how many times a failing test will be rerun before it's actually marked as a failure: https://docs.cypress.io/app/guides/test-retries. This change sets that to two for tests invoked via `cypress run`/`yarn cy run`, so a test will run a total of three times before it fails and causes all subsequent tests to be marked as pending. Since we (or at least I) don't usually run all tests specs with `cypress open`—usually just one or two at a time to watch how they work—I've left the number of retires there at the default of 0.

---

## Changes

- Retry failing Cypress tests twice if they fail before they're marked as failing

## How to test this PR

1. Temporarily modify a Cypress test to fail (I'd recommend something in `admin.cy.js` since that one runs first with `yarn cy run`)
2. `yarn cy run` and confirm the failing test is tried a total of three times before being marked as a failure

## Checklist

- [x] PR has an informative and human-readable title
  - PR titles are used to generate the change log in [releases](../../releases); good ones make that easier to scan.
  - Consider prefixing, e.g., "Mega Menu: fix layout bug", or "Docs: Update Docker installation instructions".
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)